### PR TITLE
[fix] Make the cache_data hash sample seed configurable (#14622)

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -852,6 +852,7 @@ _create_option(
     """,
     default_val="",
     type_=str,
+    sensitive=True,
 )
 
 # Config Section: Server #

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -840,8 +840,8 @@ _create_option(
         are sampled. This does not eliminate collisions -- it selects a different
         set of them -- so it resolves a collision an app has actually hit rather
         than guaranteeing uniqueness. A value that cannot be read as an integer,
-        or that falls outside that range, is ignored and the default is used
-        instead.
+        or that falls outside that range, is ignored with a warning and the
+        default is used instead.
 
         Changing this value changes the cache key of every large object and so
         invalidates existing cached entries. Keep it stable across restarts and

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -836,11 +836,12 @@ _create_option(
         positions produce the same cache key, and the cached value of one is
         returned for the other.
 
-        Set any integer to move which positions are sampled. This does not
-        eliminate collisions -- it selects a different set of them -- so it
-        resolves a collision an app has actually hit rather than guaranteeing
-        uniqueness. A value that cannot be read as an integer is ignored and the
-        default is used instead.
+        Set an integer from 0 to 4294967295 (2**32 - 1) to move which positions
+        are sampled. This does not eliminate collisions -- it selects a different
+        set of them -- so it resolves a collision an app has actually hit rather
+        than guaranteeing uniqueness. A value that cannot be read as an integer,
+        or that falls outside that range, is ignored and the default is used
+        instead.
 
         Changing this value changes the cache key of every large object and so
         invalidates existing cached entries. Keep it stable across restarts and

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -836,16 +836,22 @@ _create_option(
         positions produce the same cache key, and the cached value of one is
         returned for the other.
 
+        Accepts any string; a numeric seed is derived from it. Leave unset to keep
+        the historical sample positions.
+
         Changing this seed moves which positions are sampled. It does not
         eliminate collisions -- it selects a different set of them -- so it is an
         escape hatch for an app that has hit a specific collision, not a
-        guarantee of uniqueness.
+        guarantee of uniqueness. Because the value is hashed rather than used
+        directly, it can be set to a deployment secret to make the sampled
+        positions unpredictable to someone trying to construct a collision.
 
         Changing this value changes the cache key of every large object and so
-        invalidates existing cached entries.
+        invalidates existing cached entries. Keep it stable across restarts and
+        across replicas, or a shared/persisted cache will miss.
     """,
-    default_val=0,
-    type_=int,
+    default_val="",
+    type_=str,
 )
 
 # Config Section: Server #

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -824,6 +824,30 @@ _create_option(
     type_=int,
 )
 
+_create_option(
+    "runner.cacheHashSeed",
+    description="""
+        Seed used when @st.cache_data / @st.cache_resource hash large pandas,
+        polars, and numpy objects.
+
+        Large objects are hashed from a fixed random sample rather than in full,
+        which keeps cache lookups fast. Because the sample positions are derived
+        from this seed, two large objects that differ only outside the sampled
+        positions produce the same cache key, and the cached value of one is
+        returned for the other.
+
+        Changing this seed moves which positions are sampled. It does not
+        eliminate collisions -- it selects a different set of them -- so it is an
+        escape hatch for an app that has hit a specific collision, not a
+        guarantee of uniqueness.
+
+        Changing this value changes the cache key of every large object and so
+        invalidates existing cached entries.
+    """,
+    default_val=0,
+    type_=int,
+)
+
 # Config Section: Server #
 
 _create_section("server", "Settings for the Streamlit server")

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -837,7 +837,9 @@ _create_option(
         returned for the other.
 
         Accepts any string; a numeric seed is derived from it. Leave unset to keep
-        the historical sample positions.
+        the historical sample positions. Only an unset or empty value does that --
+        setting it to ``0`` is treated as the string "0" and derives a different
+        seed, which invalidates existing cached entries like any other change.
 
         Changing this seed moves which positions are sampled. It does not
         eliminate collisions -- it selects a different set of them -- so it

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -827,8 +827,8 @@ _create_option(
 _create_option(
     "runner.cacheHashSeed",
     description="""
-        Seed used when @st.cache_data / @st.cache_resource hash large pandas,
-        polars, and numpy objects.
+        Escape hatch for an app whose @st.cache_data / @st.cache_resource cache
+        returns the wrong value for a large pandas, polars, or numpy object.
 
         Large objects are hashed from a fixed random sample rather than in full,
         which keeps cache lookups fast. Because the sample positions are derived
@@ -840,9 +840,9 @@ _create_option(
         the historical sample positions.
 
         Changing this seed moves which positions are sampled. It does not
-        eliminate collisions -- it selects a different set of them -- so it is an
-        escape hatch for an app that has hit a specific collision, not a
-        guarantee of uniqueness. Because the value is hashed rather than used
+        eliminate collisions -- it selects a different set of them -- so it
+        resolves a collision an app has actually hit rather than guaranteeing
+        uniqueness. Because the value is hashed rather than used
         directly, it can be set to a deployment secret to make the sampled
         positions unpredictable to someone trying to construct a collision.
 

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -836,17 +836,11 @@ _create_option(
         positions produce the same cache key, and the cached value of one is
         returned for the other.
 
-        Accepts any string; a numeric seed is derived from it. Leave unset to keep
-        the historical sample positions. Only an unset or empty value does that --
-        setting it to ``0`` is treated as the string "0" and derives a different
-        seed, which invalidates existing cached entries like any other change.
-
-        Changing this seed moves which positions are sampled. It does not
+        Set any integer to move which positions are sampled. This does not
         eliminate collisions -- it selects a different set of them -- so it
         resolves a collision an app has actually hit rather than guaranteeing
-        uniqueness. Because the value is hashed rather than used
-        directly, it can be set to a deployment secret to make the sampled
-        positions unpredictable to someone trying to construct a collision.
+        uniqueness. A value that cannot be read as an integer is ignored and the
+        default is used instead.
 
         Changing this value changes the cache key of every large object and so
         invalidates existing cached entries. Keep it stable across restarts and
@@ -856,9 +850,8 @@ _create_option(
         own function for the type via the ``hash_funcs`` argument of
         @st.cache_data / @st.cache_resource, which bypasses sampling entirely.
     """,
-    default_val="",
-    type_=str,
-    sensitive=True,
+    default_val=0,
+    type_=int,
 )
 
 # Config Section: Server #

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -839,9 +839,10 @@ _create_option(
         Set an integer from 0 to 4294967295 (2**32 - 1) to move which positions
         are sampled. This does not eliminate collisions -- it selects a different
         set of them -- so it resolves a collision an app has actually hit rather
-        than guaranteeing uniqueness. A value that cannot be read as an integer,
-        or that falls outside that range, is ignored with a warning and the
-        default is used instead.
+        than guaranteeing uniqueness. A value that cannot be converted to an
+        integer, or that falls outside that range, is ignored with a warning and
+        the default is used instead. A float is truncated toward zero, so 1.5
+        becomes 1.
 
         Changing this value changes the cache key of every large object and so
         invalidates existing cached entries. Keep it stable across restarts and

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -849,6 +849,10 @@ _create_option(
         Changing this value changes the cache key of every large object and so
         invalidates existing cached entries. Keep it stable across restarts and
         across replicas, or a shared/persisted cache will miss.
+
+        If you need hashing to be exact rather than a different sample, pass your
+        own function for the type via the ``hash_funcs`` argument of
+        @st.cache_data / @st.cache_resource, which bypasses sampling entirely.
     """,
     default_val="",
     type_=str,

--- a/lib/streamlit/runtime/caching/hashing.py
+++ b/lib/streamlit/runtime/caching/hashing.py
@@ -79,7 +79,7 @@ def _warn_unusable_sample_seed(configured: object) -> None:
     _warned_sample_seeds.add(key)
     _LOGGER.warning(
         "Ignoring runner.cacheHashSeed=%s: it must be a whole number from 0 to %s. "
-        "Falling back to the default seed of 0, so cache keys are unchanged.",
+        "Falling back to the default seed of 0.",
         key,
         _MAX_SAMPLE_SEED,
     )
@@ -91,8 +91,8 @@ def _sample_seed() -> int:
     Reads ``runner.cacheHashSeed``, converting to an int so a quoted TOML value
     works the same as an unquoted one. A value that cannot be converted, or that
     falls outside ``[0, _MAX_SAMPLE_SEED]``, falls back to ``0`` -- the seed used
-    before the option existed -- so a malformed value leaves cache keys unchanged
-    instead of raising from the hashing path.
+    before the option existed -- so a malformed value reverts to the historical
+    sample positions instead of raising from the hashing path.
 
     Two TOML values need handling that ``int()`` alone does not give: ``true`` is a
     ``bool``, which is an ``int`` subclass and would convert to a usable ``1``; and

--- a/lib/streamlit/runtime/caching/hashing.py
+++ b/lib/streamlit/runtime/caching/hashing.py
@@ -21,7 +21,6 @@ import collections.abc
 import dataclasses
 import datetime
 import functools
-import hashlib
 import inspect
 import io
 import os
@@ -62,27 +61,20 @@ _NP_SAMPLE_SIZE: Final = 100_000
 def _sample_seed() -> int:
     """Return the RNG seed used when sampling large objects for cache hashing.
 
-    Derived from ``runner.cacheHashSeed`` by hashing, so the option can hold any
-    string -- including a deployment secret, which keeps the sampled positions
-    unpredictable to someone trying to construct a collision. An unset option
-    yields ``0``, the seed used before the option existed, so cache keys are
-    unchanged by default.
+    Reads ``runner.cacheHashSeed``, converting to an int so a quoted TOML value
+    works the same as an unquoted one. A value that cannot be converted falls
+    back to ``0`` -- the seed used before the option existed -- so a malformed
+    value leaves cache keys unchanged instead of raising from the hashing path.
 
     Read per call rather than cached at import so the value stays correct after
     ``config`` is (re)parsed, and so tests can vary it.
     """
     from streamlit import config
 
-    configured = config.get_option("runner.cacheHashSeed")
-    # Normalize before the emptiness test rather than after. ``get_option`` returns
-    # the raw parsed value, so an unquoted ``cacheHashSeed = 0`` arrives as int 0 --
-    # testing truthiness first would collapse that to the default while the quoted
-    # ``"0"`` hashed to something else, making the seed depend on TOML quoting.
-    text = "" if configured is None else str(configured)
-    if not text:
+    try:
+        return int(config.get_option("runner.cacheHashSeed"))
+    except (TypeError, ValueError):
         return 0
-    digest = hashlib.sha256(text.encode("utf-8")).digest()[:4]
-    return int.from_bytes(digest, "big")
 
 
 HashFuncsDict: TypeAlias = dict[str | type[Any], Callable[[Any], Any]]

--- a/lib/streamlit/runtime/caching/hashing.py
+++ b/lib/streamlit/runtime/caching/hashing.py
@@ -60,7 +60,7 @@ _NP_SAMPLE_SIZE: Final = 100_000
 
 
 def _sample_seed() -> int:
-    """Seed for the sampling of large objects.
+    """Return the RNG seed used when sampling large objects for cache hashing.
 
     Derived from ``runner.cacheHashSeed`` by hashing, so the option can hold any
     string -- including a deployment secret, which keeps the sampled positions
@@ -74,9 +74,14 @@ def _sample_seed() -> int:
     from streamlit import config
 
     configured = config.get_option("runner.cacheHashSeed")
-    if not configured:
+    # Normalize before the emptiness test rather than after. ``get_option`` returns
+    # the raw parsed value, so an unquoted ``cacheHashSeed = 0`` arrives as int 0 --
+    # testing truthiness first would collapse that to the default while the quoted
+    # ``"0"`` hashed to something else, making the seed depend on TOML quoting.
+    text = "" if configured is None else str(configured)
+    if not text:
         return 0
-    digest = hashlib.sha256(str(configured).encode("utf-8")).digest()[:4]
+    digest = hashlib.sha256(text.encode("utf-8")).digest()[:4]
     return int.from_bytes(digest, "big")
 
 

--- a/lib/streamlit/runtime/caching/hashing.py
+++ b/lib/streamlit/runtime/caching/hashing.py
@@ -57,14 +57,24 @@ _PANDAS_SAMPLE_SIZE: Final = 10_000
 _NP_SIZE_LARGE: Final = 500_000
 _NP_SAMPLE_SIZE: Final = 100_000
 
+# Largest seed every sampling backend below accepts. numpy's RandomState (and
+# pandas' `random_state=`, which defers to it) rejects anything outside
+# [0, 2**32 - 1]; polars' `seed=` takes a u64, so this bound satisfies both.
+_MAX_SAMPLE_SEED: Final = 2**32 - 1
+
 
 def _sample_seed() -> int:
     """Return the RNG seed used when sampling large objects for cache hashing.
 
     Reads ``runner.cacheHashSeed``, converting to an int so a quoted TOML value
-    works the same as an unquoted one. A value that cannot be converted falls
-    back to ``0`` -- the seed used before the option existed -- so a malformed
-    value leaves cache keys unchanged instead of raising from the hashing path.
+    works the same as an unquoted one. A value that cannot be converted, or that
+    falls outside ``[0, _MAX_SAMPLE_SEED]``, falls back to ``0`` -- the seed used
+    before the option existed -- so a malformed value leaves cache keys unchanged
+    instead of raising from the hashing path.
+
+    Out-of-range values are rejected rather than wrapped into range: wrapping
+    would silently sample by a seed the user never chose, which is harder to
+    debug than falling back to the documented default.
 
     Read per call rather than cached at import so the value stays correct after
     ``config`` is (re)parsed, and so tests can vary it.
@@ -72,9 +82,12 @@ def _sample_seed() -> int:
     from streamlit import config
 
     try:
-        return int(config.get_option("runner.cacheHashSeed"))
+        seed = int(config.get_option("runner.cacheHashSeed"))
     except (TypeError, ValueError):
         return 0
+    if not 0 <= seed <= _MAX_SAMPLE_SEED:
+        return 0
+    return seed
 
 
 HashFuncsDict: TypeAlias = dict[str | type[Any], Callable[[Any], Any]]

--- a/lib/streamlit/runtime/caching/hashing.py
+++ b/lib/streamlit/runtime/caching/hashing.py
@@ -49,6 +49,25 @@ if TYPE_CHECKING:
 
 _LOGGER: Final = logger.get_logger(__name__)
 
+# If a dataframe has more than this many rows, we consider it large and hash a sample.
+_PANDAS_ROWS_LARGE: Final = 50_000
+_PANDAS_SAMPLE_SIZE: Final = 10_000
+
+# Similar to dataframes, we also sample large numpy arrays.
+_NP_SIZE_LARGE: Final = 500_000
+_NP_SAMPLE_SIZE: Final = 100_000
+
+
+def _sample_seed() -> int:
+    """Seed for the sampling of large objects.
+
+    Read per call rather than cached at import so the value stays correct after
+    ``config`` is (re)parsed, and so tests can vary it.
+    """
+    from streamlit import config
+
+    return int(config.get_option("runner.cacheHashSeed"))
+
 
 HashFuncsDict: TypeAlias = dict[str | type[Any], Callable[[Any], Any]]
 
@@ -419,6 +438,11 @@ class _CacheFuncHasher:
             self.update(h, series_obj.size)
             self.update(h, series_obj.dtype.name)
 
+            if len(series_obj) >= _PANDAS_ROWS_LARGE:
+                series_obj = series_obj.sample(
+                    n=_PANDAS_SAMPLE_SIZE, random_state=_sample_seed()
+                )
+
             try:
                 self.update(h, hash_pandas_object(series_obj).to_numpy().tobytes())
                 return h.digest()
@@ -438,6 +462,11 @@ class _CacheFuncHasher:
 
             df_obj: pd.DataFrame = cast("pd.DataFrame", obj)
             self.update(h, df_obj.shape)
+
+            if len(df_obj) >= _PANDAS_ROWS_LARGE:
+                df_obj = df_obj.sample(
+                    n=_PANDAS_SAMPLE_SIZE, random_state=_sample_seed()
+                )
 
             try:
                 column_hash_bytes = self.to_bytes(hash_pandas_object(df_obj.dtypes))
@@ -464,6 +493,9 @@ class _CacheFuncHasher:
             self.update(h, str(obj.dtype).encode())
             self.update(h, obj.shape)
 
+            if len(obj) >= _PANDAS_ROWS_LARGE:
+                obj = obj.sample(n=_PANDAS_SAMPLE_SIZE, seed=_sample_seed())
+
             try:
                 self.update(h, obj.hash(seed=0).to_arrow().to_string().encode())
                 return h.digest()
@@ -485,6 +517,8 @@ class _CacheFuncHasher:
             obj = cast("pl.DataFrame", obj)
             self.update(h, obj.shape)
 
+            if len(obj) >= _PANDAS_ROWS_LARGE:
+                obj = obj.sample(n=_PANDAS_SAMPLE_SIZE, seed=_sample_seed())
             try:
                 for c, t in obj.schema.items():
                     self.update(h, c.encode())
@@ -512,6 +546,12 @@ class _CacheFuncHasher:
             np_obj: npt.NDArray[Any] = cast("npt.NDArray[Any]", obj)
             self.update(h, np_obj.shape)
             self.update(h, str(np_obj.dtype))
+
+            if np_obj.size >= _NP_SIZE_LARGE:
+                import numpy as np
+
+                state = np.random.RandomState(_sample_seed())
+                np_obj = state.choice(np_obj.flat, size=_NP_SAMPLE_SIZE)
 
             self.update(h, np_obj.tobytes())
             return h.digest()

--- a/lib/streamlit/runtime/caching/hashing.py
+++ b/lib/streamlit/runtime/caching/hashing.py
@@ -57,7 +57,7 @@ _PANDAS_SAMPLE_SIZE: Final = 10_000
 _NP_SIZE_LARGE: Final = 500_000
 _NP_SAMPLE_SIZE: Final = 100_000
 
-# Largest seed every sampling backend below accepts. numpy's RandomState (and
+# Largest seed accepted by all sampling backends below. numpy's RandomState (and
 # pandas' `random_state=`, which defers to it) rejects anything outside
 # [0, 2**32 - 1]; polars' `seed=` takes a u64, so this bound satisfies both.
 _MAX_SAMPLE_SEED: Final = 2**32 - 1

--- a/lib/streamlit/runtime/caching/hashing.py
+++ b/lib/streamlit/runtime/caching/hashing.py
@@ -21,6 +21,7 @@ import collections.abc
 import dataclasses
 import datetime
 import functools
+import hashlib
 import inspect
 import io
 import os
@@ -61,12 +62,22 @@ _NP_SAMPLE_SIZE: Final = 100_000
 def _sample_seed() -> int:
     """Seed for the sampling of large objects.
 
+    Derived from ``runner.cacheHashSeed`` by hashing, so the option can hold any
+    string -- including a deployment secret, which keeps the sampled positions
+    unpredictable to someone trying to construct a collision. An unset option
+    yields ``0``, the seed used before the option existed, so cache keys are
+    unchanged by default.
+
     Read per call rather than cached at import so the value stays correct after
     ``config`` is (re)parsed, and so tests can vary it.
     """
     from streamlit import config
 
-    return int(config.get_option("runner.cacheHashSeed"))
+    configured = config.get_option("runner.cacheHashSeed")
+    if not configured:
+        return 0
+    digest = hashlib.sha256(str(configured).encode("utf-8")).digest()[:4]
+    return int.from_bytes(digest, "big")
 
 
 HashFuncsDict: TypeAlias = dict[str | type[Any], Callable[[Any], Any]]

--- a/lib/streamlit/runtime/caching/hashing.py
+++ b/lib/streamlit/runtime/caching/hashing.py
@@ -62,6 +62,28 @@ _NP_SAMPLE_SIZE: Final = 100_000
 # [0, 2**32 - 1]; polars' `seed=` takes a u64, so this bound satisfies both.
 _MAX_SAMPLE_SEED: Final = 2**32 - 1
 
+# Seed values already warned about. `_sample_seed` runs on every large-object
+# hash, so warning unconditionally would flood the log for one misconfiguration.
+_warned_sample_seeds: Final[set[str]] = set()
+
+
+def _warn_unusable_sample_seed(configured: object) -> None:
+    """Warn that ``runner.cacheHashSeed`` is being ignored, once per distinct value.
+
+    Keyed on the repr so a quoted and an unquoted TOML value are reported as the
+    user wrote them, and so an unhashable value cannot raise from here.
+    """
+    key = repr(configured)
+    if key in _warned_sample_seeds:
+        return
+    _warned_sample_seeds.add(key)
+    _LOGGER.warning(
+        "Ignoring runner.cacheHashSeed=%s: it must be a whole number from 0 to %s. "
+        "Falling back to the default seed of 0, so cache keys are unchanged.",
+        key,
+        _MAX_SAMPLE_SEED,
+    )
+
 
 def _sample_seed() -> int:
     """Return the RNG seed used when sampling large objects for cache hashing.
@@ -74,18 +96,23 @@ def _sample_seed() -> int:
 
     Out-of-range values are rejected rather than wrapped into range: wrapping
     would silently sample by a seed the user never chose, which is harder to
-    debug than falling back to the documented default.
+    debug than falling back to the documented default. The fallback warns rather
+    than passing silently, since this option exists precisely to diagnose cache
+    hits that are already silent.
 
     Read per call rather than cached at import so the value stays correct after
     ``config`` is (re)parsed, and so tests can vary it.
     """
     from streamlit import config
 
+    configured = config.get_option("runner.cacheHashSeed")
     try:
-        seed = int(config.get_option("runner.cacheHashSeed"))
+        seed = int(configured)
     except (TypeError, ValueError):
+        _warn_unusable_sample_seed(configured)
         return 0
     if not 0 <= seed <= _MAX_SAMPLE_SEED:
+        _warn_unusable_sample_seed(configured)
         return 0
     return seed
 

--- a/lib/streamlit/runtime/caching/hashing.py
+++ b/lib/streamlit/runtime/caching/hashing.py
@@ -94,6 +94,10 @@ def _sample_seed() -> int:
     before the option existed -- so a malformed value leaves cache keys unchanged
     instead of raising from the hashing path.
 
+    Two TOML values need handling that ``int()`` alone does not give: ``true`` is a
+    ``bool``, which is an ``int`` subclass and would convert to a usable ``1``; and
+    ``inf`` raises ``OverflowError``, which is not a ``ValueError``.
+
     Out-of-range values are rejected rather than wrapped into range: wrapping
     would silently sample by a seed the user never chose, which is harder to
     debug than falling back to the documented default. The fallback warns rather
@@ -106,9 +110,16 @@ def _sample_seed() -> int:
     from streamlit import config
 
     configured = config.get_option("runner.cacheHashSeed")
+    # `bool` is an `int` subclass, so `cacheHashSeed = true` would otherwise convert
+    # to a seed of 1 and silently invalidate every large-object cache key.
+    if isinstance(configured, bool):
+        _warn_unusable_sample_seed(configured)
+        return 0
     try:
         seed = int(configured)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
+        # `OverflowError` is not a `ValueError` subclass and comes from
+        # `int(float("inf"))`, which TOML can produce as `cacheHashSeed = inf`.
         _warn_unusable_sample_seed(configured)
         return 0
     if not 0 <= seed <= _MAX_SAMPLE_SEED:

--- a/lib/streamlit/runtime/caching/hashing.py
+++ b/lib/streamlit/runtime/caching/hashing.py
@@ -21,6 +21,7 @@ import collections.abc
 import dataclasses
 import datetime
 import functools
+import hashlib
 import inspect
 import io
 import os
@@ -56,6 +57,17 @@ _PANDAS_SAMPLE_SIZE: Final = 10_000
 # Similar to dataframes, we also sample large numpy arrays.
 _NP_SIZE_LARGE: Final = 500_000
 _NP_SAMPLE_SIZE: Final = 100_000
+
+# Number of leading elements used to derive the content-dependent sampling seed.
+_CONTENT_SEED_PREFIX_SIZE: Final = 1000
+
+
+def _content_seed(data: bytes) -> int:
+    """Derive a sampling seed from content so different data samples different positions."""
+    return int.from_bytes(
+        hashlib.md5(data, usedforsecurity=False).digest()[:4], "little"
+    )
+
 
 HashFuncsDict: TypeAlias = dict[str | type[Any], Callable[[Any], Any]]
 
@@ -427,7 +439,10 @@ class _CacheFuncHasher:
             self.update(h, series_obj.dtype.name)
 
             if len(series_obj) >= _PANDAS_ROWS_LARGE:
-                series_obj = series_obj.sample(n=_PANDAS_SAMPLE_SIZE, random_state=0)
+                seed = _content_seed(
+                    series_obj.head(_CONTENT_SEED_PREFIX_SIZE).to_numpy().tobytes()
+                )
+                series_obj = series_obj.sample(n=_PANDAS_SAMPLE_SIZE, random_state=seed)
 
             try:
                 self.update(h, hash_pandas_object(series_obj).to_numpy().tobytes())
@@ -450,7 +465,14 @@ class _CacheFuncHasher:
             self.update(h, df_obj.shape)
 
             if len(df_obj) >= _PANDAS_ROWS_LARGE:
-                df_obj = df_obj.sample(n=_PANDAS_SAMPLE_SIZE, random_state=0)
+                try:
+                    prefix_bytes = (
+                        df_obj.head(_CONTENT_SEED_PREFIX_SIZE).to_numpy().tobytes()
+                    )
+                except (TypeError, ValueError):
+                    prefix_bytes = str(df_obj.shape).encode()
+                seed = _content_seed(prefix_bytes)
+                df_obj = df_obj.sample(n=_PANDAS_SAMPLE_SIZE, random_state=seed)
 
             try:
                 column_hash_bytes = self.to_bytes(hash_pandas_object(df_obj.dtypes))
@@ -478,7 +500,10 @@ class _CacheFuncHasher:
             self.update(h, obj.shape)
 
             if len(obj) >= _PANDAS_ROWS_LARGE:
-                obj = obj.sample(n=_PANDAS_SAMPLE_SIZE, seed=0)
+                seed = _content_seed(
+                    obj[:_CONTENT_SEED_PREFIX_SIZE].hash(seed=0).to_numpy().tobytes()
+                )
+                obj = obj.sample(n=_PANDAS_SAMPLE_SIZE, seed=seed)
 
             try:
                 self.update(h, obj.hash(seed=0).to_arrow().to_string().encode())
@@ -502,7 +527,13 @@ class _CacheFuncHasher:
             self.update(h, obj.shape)
 
             if len(obj) >= _PANDAS_ROWS_LARGE:
-                obj = obj.sample(n=_PANDAS_SAMPLE_SIZE, seed=0)
+                seed = _content_seed(
+                    obj[:_CONTENT_SEED_PREFIX_SIZE]
+                    .hash_rows(seed=0)
+                    .to_numpy()
+                    .tobytes()
+                )
+                obj = obj.sample(n=_PANDAS_SAMPLE_SIZE, seed=seed)
             try:
                 for c, t in obj.schema.items():
                     self.update(h, c.encode())
@@ -534,7 +565,8 @@ class _CacheFuncHasher:
             if np_obj.size >= _NP_SIZE_LARGE:
                 import numpy as np
 
-                state = np.random.RandomState(0)
+                seed = _content_seed(np_obj.flat[:_CONTENT_SEED_PREFIX_SIZE].tobytes())
+                state = np.random.RandomState(seed)
                 np_obj = state.choice(np_obj.flat, size=_NP_SAMPLE_SIZE)
 
             self.update(h, np_obj.tobytes())

--- a/lib/streamlit/runtime/caching/hashing.py
+++ b/lib/streamlit/runtime/caching/hashing.py
@@ -21,7 +21,6 @@ import collections.abc
 import dataclasses
 import datetime
 import functools
-import hashlib
 import inspect
 import io
 import os
@@ -49,24 +48,6 @@ if TYPE_CHECKING:
     from PIL.Image import Image
 
 _LOGGER: Final = logger.get_logger(__name__)
-
-# If a dataframe has more than this many rows, we consider it large and hash a sample.
-_PANDAS_ROWS_LARGE: Final = 50_000
-_PANDAS_SAMPLE_SIZE: Final = 10_000
-
-# Similar to dataframes, we also sample large numpy arrays.
-_NP_SIZE_LARGE: Final = 500_000
-_NP_SAMPLE_SIZE: Final = 100_000
-
-# Number of leading elements used to derive the content-dependent sampling seed.
-_CONTENT_SEED_PREFIX_SIZE: Final = 1000
-
-
-def _content_seed(data: bytes) -> int:
-    """Derive a sampling seed from content so different data samples different positions."""
-    return int.from_bytes(
-        hashlib.md5(data, usedforsecurity=False).digest()[:4], "little"
-    )
 
 
 HashFuncsDict: TypeAlias = dict[str | type[Any], Callable[[Any], Any]]
@@ -438,12 +419,6 @@ class _CacheFuncHasher:
             self.update(h, series_obj.size)
             self.update(h, series_obj.dtype.name)
 
-            if len(series_obj) >= _PANDAS_ROWS_LARGE:
-                seed = _content_seed(
-                    series_obj.head(_CONTENT_SEED_PREFIX_SIZE).to_numpy().tobytes()
-                )
-                series_obj = series_obj.sample(n=_PANDAS_SAMPLE_SIZE, random_state=seed)
-
             try:
                 self.update(h, hash_pandas_object(series_obj).to_numpy().tobytes())
                 return h.digest()
@@ -463,16 +438,6 @@ class _CacheFuncHasher:
 
             df_obj: pd.DataFrame = cast("pd.DataFrame", obj)
             self.update(h, df_obj.shape)
-
-            if len(df_obj) >= _PANDAS_ROWS_LARGE:
-                try:
-                    prefix_bytes = (
-                        df_obj.head(_CONTENT_SEED_PREFIX_SIZE).to_numpy().tobytes()
-                    )
-                except (TypeError, ValueError):
-                    prefix_bytes = str(df_obj.shape).encode()
-                seed = _content_seed(prefix_bytes)
-                df_obj = df_obj.sample(n=_PANDAS_SAMPLE_SIZE, random_state=seed)
 
             try:
                 column_hash_bytes = self.to_bytes(hash_pandas_object(df_obj.dtypes))
@@ -499,12 +464,6 @@ class _CacheFuncHasher:
             self.update(h, str(obj.dtype).encode())
             self.update(h, obj.shape)
 
-            if len(obj) >= _PANDAS_ROWS_LARGE:
-                seed = _content_seed(
-                    obj[:_CONTENT_SEED_PREFIX_SIZE].hash(seed=0).to_numpy().tobytes()
-                )
-                obj = obj.sample(n=_PANDAS_SAMPLE_SIZE, seed=seed)
-
             try:
                 self.update(h, obj.hash(seed=0).to_arrow().to_string().encode())
                 return h.digest()
@@ -526,14 +485,6 @@ class _CacheFuncHasher:
             obj = cast("pl.DataFrame", obj)
             self.update(h, obj.shape)
 
-            if len(obj) >= _PANDAS_ROWS_LARGE:
-                seed = _content_seed(
-                    obj[:_CONTENT_SEED_PREFIX_SIZE]
-                    .hash_rows(seed=0)
-                    .to_numpy()
-                    .tobytes()
-                )
-                obj = obj.sample(n=_PANDAS_SAMPLE_SIZE, seed=seed)
             try:
                 for c, t in obj.schema.items():
                     self.update(h, c.encode())
@@ -561,13 +512,6 @@ class _CacheFuncHasher:
             np_obj: npt.NDArray[Any] = cast("npt.NDArray[Any]", obj)
             self.update(h, np_obj.shape)
             self.update(h, str(np_obj.dtype))
-
-            if np_obj.size >= _NP_SIZE_LARGE:
-                import numpy as np
-
-                seed = _content_seed(np_obj.flat[:_CONTENT_SEED_PREFIX_SIZE].tobytes())
-                state = np.random.RandomState(seed)
-                np_obj = state.choice(np_obj.flat, size=_NP_SAMPLE_SIZE)
 
             self.update(h, np_obj.tobytes())
             return h.digest()

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -780,6 +780,7 @@ class ConfigTest(unittest.TestCase):
                 "logger.level",
                 "logger.messageFormat",
                 "runner.cacheBackgroundRefreshMaxWorkers",
+                "runner.cacheHashSeed",
                 "runner.enforceSerializableSessionState",
                 "runner.magicEnabled",
                 "runner.parallelMaxWorkers",

--- a/lib/tests/streamlit/runtime/caching/hashing_test.py
+++ b/lib/tests/streamlit/runtime/caching/hashing_test.py
@@ -55,6 +55,7 @@ from streamlit.runtime.caching.hashing import (
     _HashStack,
     _HashStacks,
     _sample_seed,
+    _warned_sample_seeds,
     update_hash,
 )
 from streamlit.runtime.uploaded_file_manager import UploadedFile, UploadedFileRec
@@ -1152,6 +1153,59 @@ def test_cache_hash_seed_honours_the_largest_supported_value() -> None:
     """The upper bound must be usable, not silently reset to the default."""
     with patch_config_options({"runner.cacheHashSeed": _MAX_SAMPLE_SEED}):
         assert _sample_seed() == _MAX_SAMPLE_SEED
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(-1, id="negative"),
+        pytest.param(2**32, id="one_past_max"),
+        pytest.param("not-a-number", id="text"),
+    ],
+)
+def test_cache_hash_seed_warns_when_it_ignores_a_value(value: object) -> None:
+    """An ignored seed must say so; this option exists to debug silent cache hits.
+
+    Raising would break caching outright, so the fallback warns instead of failing.
+    """
+    _warned_sample_seeds.clear()
+
+    with mock.patch.object(_LOGGER, "warning") as mock_warning:
+        with patch_config_options({"runner.cacheHashSeed": value}):
+            assert _sample_seed() == 0
+
+    mock_warning.assert_called_once()
+    logged_message = mock_warning.call_args.args[0] % mock_warning.call_args.args[1:]
+    assert repr(value) in logged_message, "the warning must name the value the user set"
+    assert str(_MAX_SAMPLE_SEED) in logged_message, (
+        "the warning must state the valid range"
+    )
+
+
+def test_cache_hash_seed_warns_only_once_for_a_repeated_value() -> None:
+    """``_sample_seed`` runs per hash, so an unchanged bad value must not flood the log."""
+    _warned_sample_seeds.clear()
+
+    with mock.patch.object(_LOGGER, "warning") as mock_warning:
+        with patch_config_options({"runner.cacheHashSeed": -1}):
+            for _ in range(5):
+                assert _sample_seed() == 0
+
+    mock_warning.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "value", [0, 7, _MAX_SAMPLE_SEED], ids=["default", "normal", "max_supported"]
+)
+def test_cache_hash_seed_stays_quiet_for_a_usable_value(value: int) -> None:
+    """A seed that is honoured must not warn."""
+    _warned_sample_seeds.clear()
+
+    with mock.patch.object(_LOGGER, "warning") as mock_warning:
+        with patch_config_options({"runner.cacheHashSeed": value}):
+            assert _sample_seed() == value
+
+    mock_warning.assert_not_called()
 
 
 @pytest.mark.parametrize(

--- a/lib/tests/streamlit/runtime/caching/hashing_test.py
+++ b/lib/tests/streamlit/runtime/caching/hashing_test.py
@@ -46,6 +46,7 @@ from streamlit.runtime.caching.cache_errors import UnhashableTypeError
 from streamlit.runtime.caching.cache_type import CacheType
 from streamlit.runtime.caching.hashing import (
     _LOGGER,
+    _MAX_SAMPLE_SEED,
     _NP_SAMPLE_SIZE,
     _NP_SIZE_LARGE,
     _PANDAS_ROWS_LARGE,
@@ -1124,6 +1125,75 @@ def test_cache_hash_seed_truncates_a_fractional_value() -> None:
     """A float is converted rather than rejected; only the seed changes."""
     with patch_config_options({"runner.cacheHashSeed": 1.5}):
         assert _sample_seed() == 1
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(-1, id="negative"),
+        pytest.param(2**32, id="one_past_max"),
+        pytest.param(2**64, id="far_past_max"),
+    ],
+)
+def test_cache_hash_seed_falls_back_to_zero_for_out_of_range_values(
+    value: int,
+) -> None:
+    """An out-of-range seed must be ignored rather than reach the sampling backends.
+
+    ``int()`` accepts these, but numpy's ``RandomState`` (and pandas' ``random_state=``,
+    which defers to it) only accepts ``[0, 2**32 - 1]``, so without a range check they
+    would raise from inside the cache-hashing path.
+    """
+    with patch_config_options({"runner.cacheHashSeed": value}):
+        assert _sample_seed() == 0
+
+
+def test_cache_hash_seed_honours_the_largest_supported_value() -> None:
+    """The upper bound must be usable, not silently reset to the default."""
+    with patch_config_options({"runner.cacheHashSeed": _MAX_SAMPLE_SEED}):
+        assert _sample_seed() == _MAX_SAMPLE_SEED
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(-1, id="negative"),
+        pytest.param(2**32, id="one_past_max"),
+        pytest.param(2**64, id="far_past_max"),
+        pytest.param(_MAX_SAMPLE_SEED, id="max_supported"),
+    ],
+)
+@pytest.mark.parametrize(
+    "make_obj",
+    [
+        pytest.param(_large_pandas_dataframe, id="pandas_dataframe"),
+        pytest.param(_large_pandas_series, id="pandas_series"),
+        pytest.param(_large_numpy_array, id="numpy_array"),
+        pytest.param(
+            _large_polars_dataframe,
+            id="polars_dataframe",
+            marks=pytest.mark.require_integration,
+        ),
+        pytest.param(
+            _large_polars_series,
+            id="polars_series",
+            marks=pytest.mark.require_integration,
+        ),
+    ],
+)
+def test_cache_hash_seed_never_breaks_hashing_of_a_large_object(
+    make_obj: Callable[[], Any], value: int
+) -> None:
+    """Hashing a large object must succeed whatever the option is set to.
+
+    This is the user-visible symptom: a bad seed reaching the sampling call raises
+    and breaks ``@st.cache_data`` / ``@st.cache_resource`` entirely, so assert on a
+    real hash rather than only on ``_sample_seed``'s return value.
+    """
+    obj = make_obj()
+
+    with patch_config_options({"runner.cacheHashSeed": value}):
+        assert isinstance(get_hash(obj), bytes)
 
 
 @pytest.mark.parametrize(

--- a/lib/tests/streamlit/runtime/caching/hashing_test.py
+++ b/lib/tests/streamlit/runtime/caching/hashing_test.py
@@ -1081,10 +1081,12 @@ class TestLargeObjectHashingIsExact:
     def _unsampled_index(n: int, sample_size: int) -> int:
         """Return an index outside the set numpy's fixed `seed=0` sample would pick.
 
-        Replays `np.random.RandomState(0).choice`, which is exact for the numpy
-        path. The pandas and polars paths used their own `sample()` APIs, so for
-        those this is a representative unsampled position rather than an exact
-        replay — sufficient, since the fix hashes full content.
+        Replays `np.random.RandomState(0).choice` with `replace=False`, which yields
+        a superset of the indices the old samplers drew (numpy used the same call
+        with the default `replace=True`; pandas and polars used their own `sample()`
+        APIs). Any index this reports as unsampled is therefore also unsampled under
+        the historical calls, which is all these tests need — the fix hashes full
+        content, so any difference at all must change the hash.
         """
         state = np.random.RandomState(0)
         sampled = set(state.choice(n, size=min(sample_size, n), replace=False))

--- a/lib/tests/streamlit/runtime/caching/hashing_test.py
+++ b/lib/tests/streamlit/runtime/caching/hashing_test.py
@@ -45,8 +45,10 @@ from streamlit.runtime.caching.cache_errors import UnhashableTypeError
 from streamlit.runtime.caching.cache_type import CacheType
 from streamlit.runtime.caching.hashing import (
     _LOGGER,
+    _NP_SAMPLE_SIZE,
     _NP_SIZE_LARGE,
     _PANDAS_ROWS_LARGE,
+    _PANDAS_SAMPLE_SIZE,
     UserHashError,
     _CacheFuncHasher,
     _HashStack,
@@ -1049,3 +1051,108 @@ def test_PIL_pmode_palette_collision_prevention() -> None:
 
     # But the hashes should differ because we now include the palette
     assert get_hash(im1) != get_hash(im2)
+
+
+class TestSamplingCollisionPrevention:
+    """Regression tests for GitHub issue #14622: large objects that differ only
+    outside the fixed-seed sampled positions should NOT hash identically."""
+
+    def test_pandas_series_sampling_collision(self) -> None:
+        """Two large pandas Series differing only outside the sampled window
+        must produce different hashes."""
+        n = _PANDAS_ROWS_LARGE + 1000
+        s1 = pd.Series(range(n))
+        s2 = s1.copy()
+        # Mutate positions that a fixed seed=0 sample would NOT pick.
+        rng = np.random.RandomState(0)
+        sampled_indices = set(rng.choice(n, size=10000, replace=False))
+        unsampled = [i for i in range(n) if i not in sampled_indices]
+        for idx in unsampled[:100]:
+            s2.iloc[idx] = -999
+        assert get_hash(s1) != get_hash(s2)
+
+    def test_pandas_dataframe_sampling_collision(self) -> None:
+        """Two large pandas DataFrames differing only outside the sampled window
+        must produce different hashes."""
+        n = _PANDAS_ROWS_LARGE + 1000
+        df1 = pd.DataFrame({"a": range(n), "b": range(n, 2 * n)})
+        df2 = df1.copy()
+        rng = np.random.RandomState(0)
+        sampled_indices = set(rng.choice(n, size=10000, replace=False))
+        unsampled = [i for i in range(n) if i not in sampled_indices]
+        for idx in unsampled[:100]:
+            df2.iloc[idx, 0] = -999
+        assert get_hash(df1) != get_hash(df2)
+
+    @pytest.mark.require_integration
+    def test_polars_series_sampling_collision(self) -> None:
+        """Two large polars Series differing only outside the sampled window
+        must produce different hashes."""
+        import polars as pl
+
+        n = _PANDAS_ROWS_LARGE + 1000
+        data1 = list(range(n))
+        data2 = data1.copy()
+        rng = np.random.RandomState(0)
+        sampled_indices = set(rng.choice(n, size=10000, replace=False))
+        unsampled = [i for i in range(n) if i not in sampled_indices]
+        for idx in unsampled[:100]:
+            data2[idx] = -999
+        s1 = pl.Series("x", data1)
+        s2 = pl.Series("x", data2)
+        assert get_hash(s1) != get_hash(s2)
+
+    @pytest.mark.require_integration
+    def test_polars_dataframe_sampling_collision(self) -> None:
+        """Two large polars DataFrames differing only outside the sampled window
+        must produce different hashes."""
+        import polars as pl
+
+        n = _PANDAS_ROWS_LARGE + 1000
+        data1 = list(range(n))
+        data2 = data1.copy()
+        rng = np.random.RandomState(0)
+        sampled_indices = set(rng.choice(n, size=10000, replace=False))
+        unsampled = [i for i in range(n) if i not in sampled_indices]
+        for idx in unsampled[:100]:
+            data2[idx] = -999
+        df1 = pl.DataFrame({"a": data1})
+        df2 = pl.DataFrame({"a": data2})
+        assert get_hash(df1) != get_hash(df2)
+
+    def test_numpy_ndarray_sampling_collision(self) -> None:
+        """Two large numpy arrays differing only outside the sampled window
+        must produce different hashes."""
+        n = _NP_SIZE_LARGE + 1000
+        arr1 = np.arange(n, dtype=np.float64)
+        arr2 = arr1.copy()
+        state = np.random.RandomState(0)
+        sampled_indices = set(state.choice(n, size=100000, replace=False))
+        unsampled = [i for i in range(n) if i not in sampled_indices]
+        for idx in unsampled[:100]:
+            arr2[idx] = -999.0
+        assert get_hash(arr1) != get_hash(arr2)
+
+    def test_pandas_series_same_prefix_different_suffix(self) -> None:
+        """Two Series sharing the same first 1000 elements but differing in the
+        suffix region still produce different hashes — the sampled content itself
+        differs even though the seed is identical."""
+        n = _PANDAS_ROWS_LARGE + 1000
+        s1 = pd.Series(range(n))
+        s2 = s1.copy()
+        # Keep first 1000 elements identical (same seed) but change many
+        # elements in the suffix. With 10000 samples drawn from 51000 positions,
+        # roughly 20% of samples land in the suffix, capturing the difference.
+        for idx in range(1000, min(1000 + _PANDAS_SAMPLE_SIZE, n)):
+            s2.iloc[idx] = -999
+        assert get_hash(s1) != get_hash(s2)
+
+    def test_numpy_same_prefix_different_suffix(self) -> None:
+        """Two arrays sharing the same first 1000 elements but differing broadly
+        in the suffix still produce different hashes."""
+        n = _NP_SIZE_LARGE + 1000
+        arr1 = np.arange(n, dtype=np.float64)
+        arr2 = arr1.copy()
+        # Mutate a large swath after the prefix — samples will hit these
+        arr2[1000 : 1000 + _NP_SAMPLE_SIZE] = -999.0
+        assert get_hash(arr1) != get_hash(arr2)

--- a/lib/tests/streamlit/runtime/caching/hashing_test.py
+++ b/lib/tests/streamlit/runtime/caching/hashing_test.py
@@ -45,10 +45,6 @@ from streamlit.runtime.caching.cache_errors import UnhashableTypeError
 from streamlit.runtime.caching.cache_type import CacheType
 from streamlit.runtime.caching.hashing import (
     _LOGGER,
-    _NP_SAMPLE_SIZE,
-    _NP_SIZE_LARGE,
-    _PANDAS_ROWS_LARGE,
-    _PANDAS_SAMPLE_SIZE,
     UserHashError,
     _CacheFuncHasher,
     _HashStack,
@@ -62,6 +58,12 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 get_main_script_director = MagicMock(return_value=os.getcwd())
+
+# Object sizes that used to trigger the removed sampling code paths. Kept here so
+# these tests still exercise "large object" hashing after the production
+# thresholds were removed. See GitHub issue #14622.
+_PANDAS_ROWS_LARGE = 50_000
+_NP_SIZE_LARGE = 500_000
 
 
 def get_hash(value, hash_funcs=None, cache_type=None):
@@ -1053,106 +1055,80 @@ def test_PIL_pmode_palette_collision_prevention() -> None:
     assert get_hash(im1) != get_hash(im2)
 
 
-class TestSamplingCollisionPrevention:
-    """Regression tests for GitHub issue #14622: large objects that differ only
-    outside the fixed-seed sampled positions should NOT hash identically."""
+class TestLargeObjectHashingIsExact:
+    """Regression tests for GitHub issue #14622.
 
-    def test_pandas_series_sampling_collision(self) -> None:
-        """Two large pandas Series differing only outside the sampled window
-        must produce different hashes."""
-        n = _PANDAS_ROWS_LARGE + 1000
-        s1 = pd.Series(range(n))
-        s2 = s1.copy()
-        # Mutate positions that a fixed seed=0 sample would NOT pick.
-        rng = np.random.RandomState(0)
-        sampled_indices = set(rng.choice(n, size=10000, replace=False))
-        unsampled = [i for i in range(n) if i not in sampled_indices]
-        for idx in unsampled[:100]:
-            s2.iloc[idx] = -999
-        assert get_hash(s1) != get_hash(s2)
+    Large pandas/polars/numpy objects used to be hashed from a fixed-seed random
+    subsample, so two objects differing only outside the sampled positions hashed
+    identically and `@st.cache_data` returned the wrong cached value. Large
+    objects are now hashed over their full content, so ANY difference changes the
+    hash.
 
-    def test_pandas_dataframe_sampling_collision(self) -> None:
-        """Two large pandas DataFrames differing only outside the sampled window
-        must produce different hashes."""
-        n = _PANDAS_ROWS_LARGE + 1000
-        df1 = pd.DataFrame({"a": range(n), "b": range(n, 2 * n)})
-        df2 = df1.copy()
-        rng = np.random.RandomState(0)
-        sampled_indices = set(rng.choice(n, size=10000, replace=False))
-        unsampled = [i for i in range(n) if i not in sampled_indices]
-        for idx in unsampled[:100]:
-            df2.iloc[idx, 0] = -999
-        assert get_hash(df1) != get_hash(df2)
+    Each test mutates a single element at a position the old `seed=0` sample would
+    not have drawn, which is the exact case that used to collide.
+    """
 
-    @pytest.mark.require_integration
-    def test_polars_series_sampling_collision(self) -> None:
-        """Two large polars Series differing only outside the sampled window
-        must produce different hashes."""
-        import polars as pl
-
-        n = _PANDAS_ROWS_LARGE + 1000
-        data1 = list(range(n))
-        data2 = data1.copy()
-        rng = np.random.RandomState(0)
-        sampled_indices = set(rng.choice(n, size=10000, replace=False))
-        unsampled = [i for i in range(n) if i not in sampled_indices]
-        for idx in unsampled[:100]:
-            data2[idx] = -999
-        s1 = pl.Series("x", data1)
-        s2 = pl.Series("x", data2)
-        assert get_hash(s1) != get_hash(s2)
-
-    @pytest.mark.require_integration
-    def test_polars_dataframe_sampling_collision(self) -> None:
-        """Two large polars DataFrames differing only outside the sampled window
-        must produce different hashes."""
-        import polars as pl
-
-        n = _PANDAS_ROWS_LARGE + 1000
-        data1 = list(range(n))
-        data2 = data1.copy()
-        rng = np.random.RandomState(0)
-        sampled_indices = set(rng.choice(n, size=10000, replace=False))
-        unsampled = [i for i in range(n) if i not in sampled_indices]
-        for idx in unsampled[:100]:
-            data2[idx] = -999
-        df1 = pl.DataFrame({"a": data1})
-        df2 = pl.DataFrame({"a": data2})
-        assert get_hash(df1) != get_hash(df2)
-
-    def test_numpy_ndarray_sampling_collision(self) -> None:
-        """Two large numpy arrays differing only outside the sampled window
-        must produce different hashes."""
-        n = _NP_SIZE_LARGE + 1000
-        arr1 = np.arange(n, dtype=np.float64)
-        arr2 = arr1.copy()
+    @staticmethod
+    def _unsampled_index(n: int, sample_size: int) -> int:
+        """Return an index the old fixed-seed=0 sample would not have picked."""
         state = np.random.RandomState(0)
-        sampled_indices = set(state.choice(n, size=100000, replace=False))
-        unsampled = [i for i in range(n) if i not in sampled_indices]
-        for idx in unsampled[:100]:
-            arr2[idx] = -999.0
-        assert get_hash(arr1) != get_hash(arr2)
+        sampled = set(state.choice(n, size=min(sample_size, n), replace=False))
+        for idx in range(n - 1, -1, -1):
+            if idx not in sampled:
+                return idx
+        raise AssertionError("every index was sampled; cannot build the case")
 
-    def test_pandas_series_same_prefix_different_suffix(self) -> None:
-        """Two Series sharing the same first 1000 elements but differing in the
-        suffix region still produce different hashes — the sampled content itself
-        differs even though the seed is identical."""
+    def test_pandas_series_differs_outside_old_sample(self) -> None:
         n = _PANDAS_ROWS_LARGE + 1000
+        idx = self._unsampled_index(n, 10_000)
         s1 = pd.Series(range(n))
         s2 = s1.copy()
-        # Keep first 1000 elements identical (same seed) but change many
-        # elements in the suffix. With 10000 samples drawn from 51000 positions,
-        # roughly 20% of samples land in the suffix, capturing the difference.
-        for idx in range(1000, min(1000 + _PANDAS_SAMPLE_SIZE, n)):
-            s2.iloc[idx] = -999
+        s2.iloc[idx] = -999
         assert get_hash(s1) != get_hash(s2)
 
-    def test_numpy_same_prefix_different_suffix(self) -> None:
-        """Two arrays sharing the same first 1000 elements but differing broadly
-        in the suffix still produce different hashes."""
+    def test_pandas_dataframe_differs_outside_old_sample(self) -> None:
+        n = _PANDAS_ROWS_LARGE + 1000
+        idx = self._unsampled_index(n, 10_000)
+        df1 = pd.DataFrame({"a": range(n)})
+        df2 = df1.copy()
+        df2.iloc[idx, 0] = -999
+        assert get_hash(df1) != get_hash(df2)
+
+    def test_numpy_differs_outside_old_sample(self) -> None:
         n = _NP_SIZE_LARGE + 1000
+        idx = self._unsampled_index(n, 100_000)
         arr1 = np.arange(n, dtype=np.float64)
         arr2 = arr1.copy()
-        # Mutate a large swath after the prefix — samples will hit these
-        arr2[1000 : 1000 + _NP_SAMPLE_SIZE] = -999.0
+        arr2[idx] = -999.0
         assert get_hash(arr1) != get_hash(arr2)
+
+    @pytest.mark.require_integration
+    def test_polars_series_differs_outside_old_sample(self) -> None:
+        import polars as pl
+
+        n = _PANDAS_ROWS_LARGE + 1000
+        idx = self._unsampled_index(n, 10_000)
+        data1 = list(range(n))
+        data2 = data1.copy()
+        data2[idx] = -999
+        assert get_hash(pl.Series("x", data1)) != get_hash(pl.Series("x", data2))
+
+    @pytest.mark.require_integration
+    def test_polars_dataframe_differs_outside_old_sample(self) -> None:
+        import polars as pl
+
+        n = _PANDAS_ROWS_LARGE + 1000
+        idx = self._unsampled_index(n, 10_000)
+        data1 = list(range(n))
+        data2 = data1.copy()
+        data2[idx] = -999
+        assert get_hash(pl.DataFrame({"a": data1})) != get_hash(
+            pl.DataFrame({"a": data2})
+        )
+
+    def test_hash_is_stable_for_equal_large_objects(self) -> None:
+        """Equal large objects must still hash equally (no spurious cache misses)."""
+        n = _PANDAS_ROWS_LARGE + 1000
+        assert get_hash(pd.Series(range(n))) == get_hash(pd.Series(range(n)))
+        arr = np.arange(_NP_SIZE_LARGE + 1000, dtype=np.float64)
+        assert get_hash(arr) == get_hash(arr.copy())

--- a/lib/tests/streamlit/runtime/caching/hashing_test.py
+++ b/lib/tests/streamlit/runtime/caching/hashing_test.py
@@ -1123,9 +1123,18 @@ def test_cache_hash_seed_falls_back_to_zero_for_unusable_values(
 
 
 def test_cache_hash_seed_truncates_a_fractional_value() -> None:
-    """A float is converted rather than rejected; only the seed changes."""
-    with patch_config_options({"runner.cacheHashSeed": 1.5}):
-        assert _sample_seed() == 1
+    """A float is converted rather than rejected; only the seed changes.
+
+    Truncation is toward zero and is not warned about, since the result is a usable
+    seed -- the config description documents this explicitly.
+    """
+    _warned_sample_seeds.clear()
+
+    with mock.patch.object(_LOGGER, "warning") as mock_warning:
+        with patch_config_options({"runner.cacheHashSeed": 1.5}):
+            assert _sample_seed() == 1
+
+    mock_warning.assert_not_called()
 
 
 @pytest.mark.parametrize(

--- a/lib/tests/streamlit/runtime/caching/hashing_test.py
+++ b/lib/tests/streamlit/runtime/caching/hashing_test.py
@@ -1105,6 +1105,20 @@ def test_cache_hash_seed_is_derived_by_hashing_so_any_string_works() -> None:
     assert seed != 0
 
 
+def test_cache_hash_seed_accepts_a_non_string_config_value() -> None:
+    """An unquoted ``cacheHashSeed = 5`` in config.toml parses as an int.
+
+    ``config.get_option`` returns the raw parsed value rather than coercing it to
+    the declared type, so the seed derivation must tolerate a non-string here or
+    it raises ``AttributeError`` at hash time.
+    """
+    with patch_config_options({"runner.cacheHashSeed": 5}):
+        seed = _sample_seed()
+
+    assert 0 <= seed < 2**32
+    assert seed != 0
+
+
 @pytest.mark.parametrize(
     "make_obj",
     [
@@ -1173,7 +1187,9 @@ def test_cache_hash_seed_moves_off_a_real_collision() -> None:
     length = _NP_SIZE_LARGE + 100_000
     base = np.arange(length)
 
-    # ``value == index`` for arange, so the drawn values are the drawn indices.
+    # Replay seed 0 -- the historical default, not ``_sample_seed()`` -- to find the
+    # indices that sampler never draws. ``value == index`` for arange, so the drawn
+    # values are the drawn indices.
     drawn = np.random.RandomState(0).choice(base.flat, size=_NP_SAMPLE_SIZE)
     never_drawn = np.setdiff1d(np.arange(length), np.unique(drawn))
     assert never_drawn.size > 0, (

--- a/lib/tests/streamlit/runtime/caching/hashing_test.py
+++ b/lib/tests/streamlit/runtime/caching/hashing_test.py
@@ -1062,31 +1062,32 @@ def test_PIL_pmode_palette_collision_prevention() -> None:
 class TestLargeObjectHashingIsExact:
     """Regression tests for GitHub issue #14622.
 
-    Large pandas/polars/numpy objects used to be hashed from a fixed-seed random
-    subsample, so two objects differing only outside the sampled positions hashed
-    identically and `@st.cache_data` returned the wrong cached value. Large
-    objects are now hashed over their full content, so ANY difference changes the
+    The invariant under test: hashing a large pandas/polars/numpy object must
+    reflect its **entire** content, so any single differing element changes the
     hash.
 
-    Each test mutates a single element at a position outside the indices a fixed
-    `seed=0` sample would have drawn, which is the class of case that used to
-    collide. The helper replays numpy's `RandomState(0).choice`, so for the pandas
-    and polars paths — which used their own `sample(..., seed/random_state=0)`
-    APIs — the position is representative rather than an exact replay. That is
-    sufficient here: the fix hashes full content, so any difference at all must
-    change the hash.
+    Previously these objects were hashed from a fixed-seed random subsample, so
+    two objects differing only outside the sampled positions hashed identically
+    and `@st.cache_data` returned the wrong cached value.
+
+    Each test mutates one element near the tail of the object — a region no
+    fixed-seed sample of a small fraction of the rows was likely to draw — which
+    is the class of case that used to collide. The definitive evidence is
+    empirical rather than analytical: restoring `develop`'s `hashing.py` makes
+    every test in this class fail.
     """
 
     @staticmethod
     def _unsampled_index(n: int, sample_size: int) -> int:
-        """Return an index outside the set numpy's fixed `seed=0` sample would pick.
+        """Return a tail index that a fixed `seed=0` subsample did not draw.
 
-        Replays `np.random.RandomState(0).choice` with `replace=False`, which yields
-        a superset of the indices the old samplers drew (numpy used the same call
-        with the default `replace=True`; pandas and polars used their own `sample()`
-        APIs). Any index this reports as unsampled is therefore also unsampled under
-        the historical calls, which is all these tests need — the fix hashes full
-        content, so any difference at all must change the hash.
+        Uses numpy's `RandomState(0).choice` purely as a representative sampler
+        to skip past drawn indices; it is *not* a replay of the historical calls
+        (numpy used `replace=True`, pandas and polars used their own `sample()`
+        APIs, and each consumes the RNG differently, so the index sets are
+        unrelated rather than nested). What makes the choice sound is that it
+        returns the highest undrawn index, landing at the tail that a sparse
+        sample almost never covers.
         """
         state = np.random.RandomState(0)
         sampled = set(state.choice(n, size=min(sample_size, n), replace=False))

--- a/lib/tests/streamlit/runtime/caching/hashing_test.py
+++ b/lib/tests/streamlit/runtime/caching/hashing_test.py
@@ -46,6 +46,7 @@ from streamlit.runtime.caching.cache_errors import UnhashableTypeError
 from streamlit.runtime.caching.cache_type import CacheType
 from streamlit.runtime.caching.hashing import (
     _LOGGER,
+    _NP_SAMPLE_SIZE,
     _NP_SIZE_LARGE,
     _PANDAS_ROWS_LARGE,
     UserHashError,
@@ -61,6 +62,8 @@ from tests.testutil import patch_config_options
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+    import numpy.typing as npt
 
 get_main_script_director = MagicMock(return_value=os.getcwd())
 
@@ -1054,106 +1057,136 @@ def test_PIL_pmode_palette_collision_prevention() -> None:
     assert get_hash(im1) != get_hash(im2)
 
 
-class TestCacheHashSeedConfig:
-    """Tests for the ``runner.cacheHashSeed`` config option (GitHub issue #14622).
+# Tests for the ``runner.cacheHashSeed`` config option (GitHub issue #14622).
+#
+# Large pandas/polars/numpy objects are hashed from a fixed random sample, so two
+# large objects differing only outside the sampled positions share a cache key.
+# The seed selects which positions are sampled, letting an app that has hit such a
+# collision move off it. It does not make hashing exact.
 
-    Large pandas/polars/numpy objects are hashed from a fixed random sample, so
-    two large objects differing only outside the sampled positions share a cache
-    key. The seed selects which positions are sampled, letting an app that has
-    hit such a collision move off it. It does not make hashing exact.
+
+def _large_pandas_dataframe() -> pd.DataFrame:
+    return pd.DataFrame({"a": np.arange(_PANDAS_ROWS_LARGE)})
+
+
+def _large_pandas_series() -> pd.Series:
+    return pd.Series(np.arange(_PANDAS_ROWS_LARGE))
+
+
+def _large_numpy_array() -> npt.NDArray[Any]:
+    return np.arange(_NP_SIZE_LARGE)
+
+
+def _large_polars_dataframe() -> Any:
+    import polars as pl
+
+    return pl.DataFrame({"a": range(_PANDAS_ROWS_LARGE)})
+
+
+def _large_polars_series() -> Any:
+    import polars as pl
+
+    return pl.Series(range(_PANDAS_ROWS_LARGE))
+
+
+def test_cache_hash_seed_default_is_unset() -> None:
+    """An unset option must keep the historical sample positions."""
+    assert config.get_option("runner.cacheHashSeed") == ""
+    assert _sample_seed() == 0
+
+
+def test_cache_hash_seed_is_derived_by_hashing_so_any_string_works() -> None:
+    """Arbitrary strings, including secrets, map to a usable numeric seed."""
+    with patch_config_options({"runner.cacheHashSeed": "a-deployment-secret"}):
+        seed = _sample_seed()
+
+    # RandomState and the polars/pandas samplers require a 32-bit seed.
+    assert 0 <= seed < 2**32
+    assert seed != 0
+
+
+@pytest.mark.parametrize(
+    "make_obj",
+    [
+        pytest.param(_large_pandas_dataframe, id="pandas_dataframe"),
+        pytest.param(_large_pandas_series, id="pandas_series"),
+        pytest.param(_large_numpy_array, id="numpy_array"),
+        # The polars cases need the integration dependency group, and the marker is
+        # exclusive in both directions -- an unmarked polars test would be skipped by
+        # the default run (no polars) and by the integration run (no marker), so it
+        # would never actually execute.
+        pytest.param(
+            _large_polars_dataframe,
+            id="polars_dataframe",
+            marks=pytest.mark.require_integration,
+        ),
+        pytest.param(
+            _large_polars_series,
+            id="polars_series",
+            marks=pytest.mark.require_integration,
+        ),
+    ],
+)
+def test_cache_hash_seed_reaches_every_sampling_path(
+    make_obj: Callable[[], Any],
+) -> None:
+    """Changing the seed must change the cache key of a large object."""
+    obj = make_obj()
+
+    with patch_config_options({"runner.cacheHashSeed": ""}):
+        hash_default = get_hash(obj)
+    with patch_config_options({"runner.cacheHashSeed": "other"}):
+        hash_other = get_hash(obj)
+
+    assert hash_default != hash_other
+
+
+def test_cache_hash_seed_is_deterministic() -> None:
+    """A given seed must produce a stable cache key across calls."""
+    with patch_config_options({"runner.cacheHashSeed": "stable-secret"}):
+        first = get_hash(_large_pandas_dataframe())
+        second = get_hash(_large_pandas_dataframe())
+
+    assert first == second
+
+
+def test_cache_hash_seed_does_not_affect_small_objects() -> None:
+    """Objects below the sampling threshold are hashed in full either way."""
+    small = pd.DataFrame({"a": np.arange(10)})
+
+    with patch_config_options({"runner.cacheHashSeed": ""}):
+        hash_default = get_hash(small)
+    with patch_config_options({"runner.cacheHashSeed": "another"}):
+        hash_other = get_hash(small)
+
+    assert hash_default == hash_other
+
+
+def test_cache_hash_seed_moves_off_a_real_collision() -> None:
+    """The escape hatch the option exists to provide (GitHub issue #14622).
+
+    Builds a genuine collision under the default seed by mutating only positions
+    that seed never draws -- the drawn positions depend on the seed and the array
+    length, not on the values, so this is exact rather than probabilistic -- then
+    shows a different seed tells the two arrays apart.
     """
+    length = _NP_SIZE_LARGE + 100_000
+    base = np.arange(length)
 
-    def test_default_is_unset(self) -> None:
-        """An unset option must keep the historical sample positions."""
-        assert config.get_option("runner.cacheHashSeed") == ""
-        assert _sample_seed() == 0
+    # ``value == index`` for arange, so the drawn values are the drawn indices.
+    drawn = np.random.RandomState(0).choice(base.flat, size=_NP_SAMPLE_SIZE)
+    never_drawn = np.setdiff1d(np.arange(length), np.unique(drawn))
+    assert never_drawn.size > 0, (
+        "expected the default seed to leave positions unsampled"
+    )
 
-    def test_seed_is_derived_by_hashing_so_any_string_works(self) -> None:
-        """Arbitrary strings, including secrets, map to a usable numeric seed."""
-        with patch_config_options({"runner.cacheHashSeed": "a-deployment-secret"}):
-            seed = _sample_seed()
+    mutated = base.copy()
+    mutated[never_drawn] = -1
 
-        assert isinstance(seed, int)
-        assert seed != 0
+    with patch_config_options({"runner.cacheHashSeed": ""}):
+        assert get_hash(base) == get_hash(mutated), (
+            "expected a collision under the default seed"
+        )
 
-    def test_seed_changes_hash_of_large_pandas_dataframe(self) -> None:
-        """The configured seed reaches the pandas DataFrame sampling path."""
-        df = pd.DataFrame({"a": np.arange(_PANDAS_ROWS_LARGE)})
-
-        with patch_config_options({"runner.cacheHashSeed": ""}):
-            hash_default = get_hash(df)
-        with patch_config_options({"runner.cacheHashSeed": "other"}):
-            hash_other = get_hash(df)
-
-        assert hash_default != hash_other
-
-    def test_seed_changes_hash_of_large_pandas_series(self) -> None:
-        """The configured seed reaches the pandas Series sampling path."""
-        series = pd.Series(np.arange(_PANDAS_ROWS_LARGE))
-
-        with patch_config_options({"runner.cacheHashSeed": ""}):
-            hash_default = get_hash(series)
-        with patch_config_options({"runner.cacheHashSeed": "other"}):
-            hash_other = get_hash(series)
-
-        assert hash_default != hash_other
-
-    def test_seed_changes_hash_of_large_numpy_array(self) -> None:
-        """The configured seed reaches the numpy sampling path."""
-        array = np.arange(_NP_SIZE_LARGE)
-
-        with patch_config_options({"runner.cacheHashSeed": ""}):
-            hash_default = get_hash(array)
-        with patch_config_options({"runner.cacheHashSeed": "other"}):
-            hash_other = get_hash(array)
-
-        assert hash_default != hash_other
-
-    @pytest.mark.require_integration
-    def test_seed_changes_hash_of_large_polars_dataframe(self) -> None:
-        """The configured seed reaches the polars DataFrame sampling path."""
-        import polars as pl
-
-        df = pl.DataFrame({"a": range(_PANDAS_ROWS_LARGE)})
-
-        with patch_config_options({"runner.cacheHashSeed": ""}):
-            hash_default = get_hash(df)
-        with patch_config_options({"runner.cacheHashSeed": "other"}):
-            hash_other = get_hash(df)
-
-        assert hash_default != hash_other
-
-    @pytest.mark.require_integration
-    def test_seed_changes_hash_of_large_polars_series(self) -> None:
-        """The configured seed reaches the polars Series sampling path."""
-        import polars as pl
-
-        series = pl.Series(range(_PANDAS_ROWS_LARGE))
-
-        with patch_config_options({"runner.cacheHashSeed": ""}):
-            hash_default = get_hash(series)
-        with patch_config_options({"runner.cacheHashSeed": "other"}):
-            hash_other = get_hash(series)
-
-        assert hash_default != hash_other
-
-    def test_same_seed_is_deterministic(self) -> None:
-        """A given seed must produce a stable cache key across calls."""
-        df = pd.DataFrame({"a": np.arange(_PANDAS_ROWS_LARGE)})
-
-        with patch_config_options({"runner.cacheHashSeed": "stable-secret"}):
-            first = get_hash(df)
-            second = get_hash(pd.DataFrame({"a": np.arange(_PANDAS_ROWS_LARGE)}))
-
-        assert first == second
-
-    def test_seed_does_not_affect_small_objects(self) -> None:
-        """Objects below the sampling threshold are hashed in full either way."""
-        small = pd.DataFrame({"a": np.arange(10)})
-
-        with patch_config_options({"runner.cacheHashSeed": ""}):
-            hash_default = get_hash(small)
-        with patch_config_options({"runner.cacheHashSeed": "another"}):
-            hash_other = get_hash(small)
-
-        assert hash_default == hash_other
+    with patch_config_options({"runner.cacheHashSeed": "moved-off-the-collision"}):
+        assert get_hash(base) != get_hash(mutated)

--- a/lib/tests/streamlit/runtime/caching/hashing_test.py
+++ b/lib/tests/streamlit/runtime/caching/hashing_test.py
@@ -52,6 +52,7 @@ from streamlit.runtime.caching.hashing import (
     _CacheFuncHasher,
     _HashStack,
     _HashStacks,
+    _sample_seed,
     update_hash,
 )
 from streamlit.runtime.uploaded_file_manager import UploadedFile, UploadedFileRec
@@ -1062,49 +1063,51 @@ class TestCacheHashSeedConfig:
     hit such a collision move off it. It does not make hashing exact.
     """
 
-    def _large_pandas_pair(self) -> tuple[pd.DataFrame, pd.DataFrame]:
-        """Two large frames differing in exactly one cell."""
-        df1 = pd.DataFrame({"a": np.arange(_PANDAS_ROWS_LARGE)})
-        df2 = df1.copy()
-        df2.iloc[-1, 0] = -12345
-        return df1, df2
+    def test_default_is_unset(self) -> None:
+        """An unset option must keep the historical sample positions."""
+        assert config.get_option("runner.cacheHashSeed") == ""
+        assert _sample_seed() == 0
 
-    def test_default_seed_is_zero(self) -> None:
-        """The default preserves the historical sampling behaviour."""
-        assert config.get_option("runner.cacheHashSeed") == 0
+    def test_seed_is_derived_by_hashing_so_any_string_works(self) -> None:
+        """Arbitrary strings, including secrets, map to a usable numeric seed."""
+        with patch_config_options({"runner.cacheHashSeed": "a-deployment-secret"}):
+            seed = _sample_seed()
+
+        assert isinstance(seed, int)
+        assert seed != 0
 
     def test_seed_changes_hash_of_large_pandas_dataframe(self) -> None:
         """The configured seed reaches the pandas DataFrame sampling path."""
         df = pd.DataFrame({"a": np.arange(_PANDAS_ROWS_LARGE)})
 
-        with patch_config_options({"runner.cacheHashSeed": 0}):
-            hash_seed_0 = get_hash(df)
-        with patch_config_options({"runner.cacheHashSeed": 1}):
-            hash_seed_1 = get_hash(df)
+        with patch_config_options({"runner.cacheHashSeed": ""}):
+            hash_default = get_hash(df)
+        with patch_config_options({"runner.cacheHashSeed": "other"}):
+            hash_other = get_hash(df)
 
-        assert hash_seed_0 != hash_seed_1
+        assert hash_default != hash_other
 
     def test_seed_changes_hash_of_large_pandas_series(self) -> None:
         """The configured seed reaches the pandas Series sampling path."""
         series = pd.Series(np.arange(_PANDAS_ROWS_LARGE))
 
-        with patch_config_options({"runner.cacheHashSeed": 0}):
-            hash_seed_0 = get_hash(series)
-        with patch_config_options({"runner.cacheHashSeed": 1}):
-            hash_seed_1 = get_hash(series)
+        with patch_config_options({"runner.cacheHashSeed": ""}):
+            hash_default = get_hash(series)
+        with patch_config_options({"runner.cacheHashSeed": "other"}):
+            hash_other = get_hash(series)
 
-        assert hash_seed_0 != hash_seed_1
+        assert hash_default != hash_other
 
     def test_seed_changes_hash_of_large_numpy_array(self) -> None:
         """The configured seed reaches the numpy sampling path."""
         array = np.arange(_NP_SIZE_LARGE)
 
-        with patch_config_options({"runner.cacheHashSeed": 0}):
-            hash_seed_0 = get_hash(array)
-        with patch_config_options({"runner.cacheHashSeed": 1}):
-            hash_seed_1 = get_hash(array)
+        with patch_config_options({"runner.cacheHashSeed": ""}):
+            hash_default = get_hash(array)
+        with patch_config_options({"runner.cacheHashSeed": "other"}):
+            hash_other = get_hash(array)
 
-        assert hash_seed_0 != hash_seed_1
+        assert hash_default != hash_other
 
     @pytest.mark.require_integration
     def test_seed_changes_hash_of_large_polars_dataframe(self) -> None:
@@ -1113,12 +1116,12 @@ class TestCacheHashSeedConfig:
 
         df = pl.DataFrame({"a": range(_PANDAS_ROWS_LARGE)})
 
-        with patch_config_options({"runner.cacheHashSeed": 0}):
-            hash_seed_0 = get_hash(df)
-        with patch_config_options({"runner.cacheHashSeed": 1}):
-            hash_seed_1 = get_hash(df)
+        with patch_config_options({"runner.cacheHashSeed": ""}):
+            hash_default = get_hash(df)
+        with patch_config_options({"runner.cacheHashSeed": "other"}):
+            hash_other = get_hash(df)
 
-        assert hash_seed_0 != hash_seed_1
+        assert hash_default != hash_other
 
     @pytest.mark.require_integration
     def test_seed_changes_hash_of_large_polars_series(self) -> None:
@@ -1127,18 +1130,18 @@ class TestCacheHashSeedConfig:
 
         series = pl.Series(range(_PANDAS_ROWS_LARGE))
 
-        with patch_config_options({"runner.cacheHashSeed": 0}):
-            hash_seed_0 = get_hash(series)
-        with patch_config_options({"runner.cacheHashSeed": 1}):
-            hash_seed_1 = get_hash(series)
+        with patch_config_options({"runner.cacheHashSeed": ""}):
+            hash_default = get_hash(series)
+        with patch_config_options({"runner.cacheHashSeed": "other"}):
+            hash_other = get_hash(series)
 
-        assert hash_seed_0 != hash_seed_1
+        assert hash_default != hash_other
 
     def test_same_seed_is_deterministic(self) -> None:
         """A given seed must produce a stable cache key across calls."""
         df = pd.DataFrame({"a": np.arange(_PANDAS_ROWS_LARGE)})
 
-        with patch_config_options({"runner.cacheHashSeed": 7}):
+        with patch_config_options({"runner.cacheHashSeed": "stable-secret"}):
             first = get_hash(df)
             second = get_hash(pd.DataFrame({"a": np.arange(_PANDAS_ROWS_LARGE)}))
 
@@ -1148,34 +1151,9 @@ class TestCacheHashSeedConfig:
         """Objects below the sampling threshold are hashed in full either way."""
         small = pd.DataFrame({"a": np.arange(10)})
 
-        with patch_config_options({"runner.cacheHashSeed": 0}):
-            hash_seed_0 = get_hash(small)
-        with patch_config_options({"runner.cacheHashSeed": 99}):
-            hash_seed_99 = get_hash(small)
+        with patch_config_options({"runner.cacheHashSeed": ""}):
+            hash_default = get_hash(small)
+        with patch_config_options({"runner.cacheHashSeed": "another"}):
+            hash_other = get_hash(small)
 
-        assert hash_seed_0 == hash_seed_99
-
-    def test_changing_the_seed_can_resolve_a_specific_collision(self) -> None:
-        """The escape-hatch property the option exists to provide.
-
-        Sampling is not exact, so some pair of large objects always collides. What
-        the option guarantees is that a collision under one seed is not
-        necessarily a collision under another, which is what lets an affected app
-        move off it.
-        """
-        df1, df2 = self._large_pandas_pair()
-
-        seeds_that_distinguish = [
-            seed for seed in range(8) if _hash_pair_differs(df1, df2, seed)
-        ]
-
-        # Not a claim that every seed distinguishes them -- only that the choice
-        # of seed determines whether this pair collides.
-        assert seeds_that_distinguish, (
-            "no seed in range distinguished the pair; sampling may not be seeded"
-        )
-
-
-def _hash_pair_differs(obj1: Any, obj2: Any, seed: int) -> bool:
-    with patch_config_options({"runner.cacheHashSeed": seed}):
-        return get_hash(obj1) != get_hash(obj2)
+        assert hash_default == hash_other

--- a/lib/tests/streamlit/runtime/caching/hashing_test.py
+++ b/lib/tests/streamlit/runtime/caching/hashing_test.py
@@ -1112,7 +1112,21 @@ def test_cache_hash_seed_accepts_any_whole_number_representation(
 
 
 @pytest.mark.parametrize(
-    "value", ["not-a-number", "", None], ids=["text", "empty", "none"]
+    "value",
+    [
+        pytest.param("not-a-number", id="text"),
+        pytest.param("", id="empty"),
+        pytest.param(None, id="none"),
+        # `bool` is an `int` subclass, so `int(True)` is 1 rather than an error.
+        # TOML writes these as `cacheHashSeed = true` / `false`.
+        pytest.param(True, id="bool_true"),
+        pytest.param(False, id="bool_false"),
+        # `int(float("inf"))` raises OverflowError, which is not a ValueError.
+        # TOML writes these as `cacheHashSeed = inf` / `-inf` / `nan`.
+        pytest.param(float("inf"), id="inf"),
+        pytest.param(float("-inf"), id="negative_inf"),
+        pytest.param(float("nan"), id="nan"),
+    ],
 )
 def test_cache_hash_seed_falls_back_to_zero_for_unusable_values(
     value: object,
@@ -1120,6 +1134,43 @@ def test_cache_hash_seed_falls_back_to_zero_for_unusable_values(
     """A malformed value must leave cache keys unchanged, not raise from hashing."""
     with patch_config_options({"runner.cacheHashSeed": value}):
         assert _sample_seed() == 0
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(True, id="bool_true"),
+        pytest.param(float("inf"), id="inf"),
+        pytest.param(float("nan"), id="nan"),
+    ],
+)
+def test_cache_hash_seed_warns_for_a_value_int_would_have_accepted_or_raised_on(
+    value: object,
+) -> None:
+    """These two slip past a plain ``int()`` guard in opposite directions.
+
+    ``int(True)`` succeeds and yields ``1``, quietly changing every large-object
+    cache key; ``int(float("inf"))`` raises ``OverflowError``, which is not a
+    ``ValueError`` and so would have escaped the fallback entirely.
+    """
+    _warned_sample_seeds.clear()
+
+    with mock.patch.object(_LOGGER, "warning") as mock_warning:
+        with patch_config_options({"runner.cacheHashSeed": value}):
+            assert _sample_seed() == 0
+
+    mock_warning.assert_called_once()
+
+
+def test_cache_hash_seed_does_not_treat_a_bool_as_the_int_it_subclasses() -> None:
+    """``cacheHashSeed = true`` must not become the perfectly valid seed ``1``."""
+    with patch_config_options({"runner.cacheHashSeed": True}):
+        from_bool = _sample_seed()
+    with patch_config_options({"runner.cacheHashSeed": 1}):
+        from_int = _sample_seed()
+
+    assert from_int == 1, "a real 1 must still be honoured"
+    assert from_bool == 0, "True must fall back rather than alias seed 1"
 
 
 def test_cache_hash_seed_truncates_a_fractional_value() -> None:

--- a/lib/tests/streamlit/runtime/caching/hashing_test.py
+++ b/lib/tests/streamlit/runtime/caching/hashing_test.py
@@ -39,12 +39,15 @@ import pytest
 from parameterized import parameterized
 from PIL import Image
 
+from streamlit import config
 from streamlit.proto.Common_pb2 import FileURLs
 from streamlit.runtime.caching import cache_data, cache_resource
 from streamlit.runtime.caching.cache_errors import UnhashableTypeError
 from streamlit.runtime.caching.cache_type import CacheType
 from streamlit.runtime.caching.hashing import (
     _LOGGER,
+    _NP_SIZE_LARGE,
+    _PANDAS_ROWS_LARGE,
     UserHashError,
     _CacheFuncHasher,
     _HashStack,
@@ -53,21 +56,12 @@ from streamlit.runtime.caching.hashing import (
 )
 from streamlit.runtime.uploaded_file_manager import UploadedFile, UploadedFileRec
 from streamlit.type_util import is_type
+from tests.testutil import patch_config_options
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
 get_main_script_director = MagicMock(return_value=os.getcwd())
-
-# Object sizes that used to trigger the removed sampling code paths. Kept here so
-# these tests still exercise "large object" hashing after the production
-# thresholds were removed. See GitHub issue #14622.
-_PANDAS_ROWS_LARGE = 50_000
-_NP_SIZE_LARGE = 500_000
-# The sample sizes the removed sampling code used, kept so the regression tests
-# can pick indices the old fixed-seed sampler would not have drawn.
-_PANDAS_SAMPLE_SIZE = 10_000
-_NP_SAMPLE_SIZE = 100_000
 
 
 def get_hash(value, hash_funcs=None, cache_type=None):
@@ -1059,114 +1053,129 @@ def test_PIL_pmode_palette_collision_prevention() -> None:
     assert get_hash(im1) != get_hash(im2)
 
 
-class TestLargeObjectHashingIsExact:
-    """Regression tests for GitHub issue #14622.
+class TestCacheHashSeedConfig:
+    """Tests for the ``runner.cacheHashSeed`` config option (GitHub issue #14622).
 
-    The invariant under test: hashing a large pandas/polars/numpy object must
-    reflect its **entire** content, so any single differing element changes the
-    hash.
-
-    Previously these objects were hashed from a fixed-seed random subsample, so
-    two objects differing only outside the sampled positions hashed identically
-    and `@st.cache_data` returned the wrong cached value.
-
-    Each test mutates one element near the tail of the object — a region no
-    fixed-seed sample of a small fraction of the rows was likely to draw — which
-    is the class of case that used to collide. The definitive evidence is
-    empirical rather than analytical: restoring `develop`'s `hashing.py` makes
-    every test in this class fail.
+    Large pandas/polars/numpy objects are hashed from a fixed random sample, so
+    two large objects differing only outside the sampled positions share a cache
+    key. The seed selects which positions are sampled, letting an app that has
+    hit such a collision move off it. It does not make hashing exact.
     """
 
-    @staticmethod
-    def _unsampled_index(n: int, sample_size: int) -> int:
-        """Return a tail index that a fixed `seed=0` subsample did not draw.
-
-        Uses numpy's `RandomState(0).choice` purely as a representative sampler
-        to skip past drawn indices; it is *not* a replay of the historical calls
-        (numpy used `replace=True`, pandas and polars used their own `sample()`
-        APIs, and each consumes the RNG differently, so the index sets are
-        unrelated rather than nested). What makes the choice sound is that it
-        returns the highest undrawn index, landing at the tail that a sparse
-        sample almost never covers.
-        """
-        state = np.random.RandomState(0)
-        sampled = set(state.choice(n, size=min(sample_size, n), replace=False))
-        for idx in range(n - 1, -1, -1):
-            if idx not in sampled:
-                return idx
-        raise AssertionError("every index was sampled; cannot build the case")
-
-    def test_pandas_series_differs_outside_old_sample(self) -> None:
-        """A large pandas Series differing only outside the old sample must hash differently."""
-        n = _PANDAS_ROWS_LARGE + 1000
-        idx = self._unsampled_index(n, _PANDAS_SAMPLE_SIZE)
-        s1 = pd.Series(range(n))
-        s2 = s1.copy()
-        s2.iloc[idx] = -999
-        assert get_hash(s1) != get_hash(s2)
-
-    def test_pandas_dataframe_differs_outside_old_sample(self) -> None:
-        """A large pandas DataFrame differing only outside the old sample must hash differently."""
-        n = _PANDAS_ROWS_LARGE + 1000
-        idx = self._unsampled_index(n, _PANDAS_SAMPLE_SIZE)
-        df1 = pd.DataFrame({"a": range(n)})
+    def _large_pandas_pair(self) -> tuple[pd.DataFrame, pd.DataFrame]:
+        """Two large frames differing in exactly one cell."""
+        df1 = pd.DataFrame({"a": np.arange(_PANDAS_ROWS_LARGE)})
         df2 = df1.copy()
-        df2.iloc[idx, 0] = -999
-        assert get_hash(df1) != get_hash(df2)
+        df2.iloc[-1, 0] = -12345
+        return df1, df2
 
-    def test_numpy_differs_outside_old_sample(self) -> None:
-        """A large numpy array differing only outside the old sample must hash differently."""
-        n = _NP_SIZE_LARGE + 1000
-        idx = self._unsampled_index(n, _NP_SAMPLE_SIZE)
-        arr1 = np.arange(n, dtype=np.float64)
-        arr2 = arr1.copy()
-        arr2[idx] = -999.0
-        assert get_hash(arr1) != get_hash(arr2)
+    def test_default_seed_is_zero(self) -> None:
+        """The default preserves the historical sampling behaviour."""
+        assert config.get_option("runner.cacheHashSeed") == 0
 
-    @pytest.mark.require_integration
-    def test_polars_series_differs_outside_old_sample(self) -> None:
-        """A large polars Series differing only outside the old sample must hash differently."""
-        import polars as pl
+    def test_seed_changes_hash_of_large_pandas_dataframe(self) -> None:
+        """The configured seed reaches the pandas DataFrame sampling path."""
+        df = pd.DataFrame({"a": np.arange(_PANDAS_ROWS_LARGE)})
 
-        n = _PANDAS_ROWS_LARGE + 1000
-        idx = self._unsampled_index(n, _PANDAS_SAMPLE_SIZE)
-        data1 = list(range(n))
-        data2 = data1.copy()
-        data2[idx] = -999
-        assert get_hash(pl.Series("x", data1)) != get_hash(pl.Series("x", data2))
+        with patch_config_options({"runner.cacheHashSeed": 0}):
+            hash_seed_0 = get_hash(df)
+        with patch_config_options({"runner.cacheHashSeed": 1}):
+            hash_seed_1 = get_hash(df)
 
-    @pytest.mark.require_integration
-    def test_polars_dataframe_differs_outside_old_sample(self) -> None:
-        """A large polars DataFrame differing only outside the old sample must hash differently."""
-        import polars as pl
+        assert hash_seed_0 != hash_seed_1
 
-        n = _PANDAS_ROWS_LARGE + 1000
-        idx = self._unsampled_index(n, _PANDAS_SAMPLE_SIZE)
-        data1 = list(range(n))
-        data2 = data1.copy()
-        data2[idx] = -999
-        assert get_hash(pl.DataFrame({"a": data1})) != get_hash(
-            pl.DataFrame({"a": data2})
-        )
+    def test_seed_changes_hash_of_large_pandas_series(self) -> None:
+        """The configured seed reaches the pandas Series sampling path."""
+        series = pd.Series(np.arange(_PANDAS_ROWS_LARGE))
 
-    def test_hash_is_stable_for_equal_large_objects(self) -> None:
-        """Equal large objects must still hash equally (no spurious cache misses)."""
-        n = _PANDAS_ROWS_LARGE + 1000
-        assert get_hash(pd.Series(range(n))) == get_hash(pd.Series(range(n)))
-        assert get_hash(pd.DataFrame({"a": range(n)})) == get_hash(
-            pd.DataFrame({"a": range(n)})
-        )
-        arr = np.arange(_NP_SIZE_LARGE + 1000, dtype=np.float64)
-        assert get_hash(arr) == get_hash(arr.copy())
+        with patch_config_options({"runner.cacheHashSeed": 0}):
+            hash_seed_0 = get_hash(series)
+        with patch_config_options({"runner.cacheHashSeed": 1}):
+            hash_seed_1 = get_hash(series)
+
+        assert hash_seed_0 != hash_seed_1
+
+    def test_seed_changes_hash_of_large_numpy_array(self) -> None:
+        """The configured seed reaches the numpy sampling path."""
+        array = np.arange(_NP_SIZE_LARGE)
+
+        with patch_config_options({"runner.cacheHashSeed": 0}):
+            hash_seed_0 = get_hash(array)
+        with patch_config_options({"runner.cacheHashSeed": 1}):
+            hash_seed_1 = get_hash(array)
+
+        assert hash_seed_0 != hash_seed_1
 
     @pytest.mark.require_integration
-    def test_hash_is_stable_for_equal_large_polars_objects(self) -> None:
-        """Stability must hold for the polars paths too, not just pandas/numpy."""
+    def test_seed_changes_hash_of_large_polars_dataframe(self) -> None:
+        """The configured seed reaches the polars DataFrame sampling path."""
         import polars as pl
 
-        n = _PANDAS_ROWS_LARGE + 1000
-        data = list(range(n))
-        assert get_hash(pl.Series("x", data)) == get_hash(pl.Series("x", data.copy()))
-        assert get_hash(pl.DataFrame({"a": data})) == get_hash(
-            pl.DataFrame({"a": data.copy()})
+        df = pl.DataFrame({"a": range(_PANDAS_ROWS_LARGE)})
+
+        with patch_config_options({"runner.cacheHashSeed": 0}):
+            hash_seed_0 = get_hash(df)
+        with patch_config_options({"runner.cacheHashSeed": 1}):
+            hash_seed_1 = get_hash(df)
+
+        assert hash_seed_0 != hash_seed_1
+
+    @pytest.mark.require_integration
+    def test_seed_changes_hash_of_large_polars_series(self) -> None:
+        """The configured seed reaches the polars Series sampling path."""
+        import polars as pl
+
+        series = pl.Series(range(_PANDAS_ROWS_LARGE))
+
+        with patch_config_options({"runner.cacheHashSeed": 0}):
+            hash_seed_0 = get_hash(series)
+        with patch_config_options({"runner.cacheHashSeed": 1}):
+            hash_seed_1 = get_hash(series)
+
+        assert hash_seed_0 != hash_seed_1
+
+    def test_same_seed_is_deterministic(self) -> None:
+        """A given seed must produce a stable cache key across calls."""
+        df = pd.DataFrame({"a": np.arange(_PANDAS_ROWS_LARGE)})
+
+        with patch_config_options({"runner.cacheHashSeed": 7}):
+            first = get_hash(df)
+            second = get_hash(pd.DataFrame({"a": np.arange(_PANDAS_ROWS_LARGE)}))
+
+        assert first == second
+
+    def test_seed_does_not_affect_small_objects(self) -> None:
+        """Objects below the sampling threshold are hashed in full either way."""
+        small = pd.DataFrame({"a": np.arange(10)})
+
+        with patch_config_options({"runner.cacheHashSeed": 0}):
+            hash_seed_0 = get_hash(small)
+        with patch_config_options({"runner.cacheHashSeed": 99}):
+            hash_seed_99 = get_hash(small)
+
+        assert hash_seed_0 == hash_seed_99
+
+    def test_changing_the_seed_can_resolve_a_specific_collision(self) -> None:
+        """The escape-hatch property the option exists to provide.
+
+        Sampling is not exact, so some pair of large objects always collides. What
+        the option guarantees is that a collision under one seed is not
+        necessarily a collision under another, which is what lets an affected app
+        move off it.
+        """
+        df1, df2 = self._large_pandas_pair()
+
+        seeds_that_distinguish = [
+            seed for seed in range(8) if _hash_pair_differs(df1, df2, seed)
+        ]
+
+        # Not a claim that every seed distinguishes them -- only that the choice
+        # of seed determines whether this pair collides.
+        assert seeds_that_distinguish, (
+            "no seed in range distinguished the pair; sampling may not be seeded"
         )
+
+
+def _hash_pair_differs(obj1: Any, obj2: Any, seed: int) -> bool:
+    with patch_config_options({"runner.cacheHashSeed": seed}):
+        return get_hash(obj1) != get_hash(obj2)

--- a/lib/tests/streamlit/runtime/caching/hashing_test.py
+++ b/lib/tests/streamlit/runtime/caching/hashing_test.py
@@ -1119,6 +1119,21 @@ def test_cache_hash_seed_accepts_a_non_string_config_value() -> None:
     assert seed != 0
 
 
+@pytest.mark.parametrize("value", [0, 5], ids=["zero", "nonzero"])
+def test_cache_hash_seed_does_not_depend_on_toml_quoting(value: int) -> None:
+    """``cacheHashSeed = 0`` and ``cacheHashSeed = "0"`` must mean the same thing.
+
+    The unquoted form parses as an int, so an emptiness test applied before
+    normalizing would treat ``0`` as unset while ``"0"`` hashed to a real seed.
+    """
+    with patch_config_options({"runner.cacheHashSeed": value}):
+        from_int = _sample_seed()
+    with patch_config_options({"runner.cacheHashSeed": str(value)}):
+        from_str = _sample_seed()
+
+    assert from_int == from_str
+
+
 @pytest.mark.parametrize(
     "make_obj",
     [
@@ -1155,7 +1170,7 @@ def test_cache_hash_seed_reaches_every_sampling_path(
     assert hash_default != hash_other
 
 
-def test_cache_hash_seed_is_deterministic() -> None:
+def test_cache_hash_seed_is_deterministic_for_pandas_dataframe() -> None:
     """A given seed must produce a stable cache key across calls."""
     with patch_config_options({"runner.cacheHashSeed": "stable-secret"}):
         first = get_hash(_large_pandas_dataframe())

--- a/lib/tests/streamlit/runtime/caching/hashing_test.py
+++ b/lib/tests/streamlit/runtime/caching/hashing_test.py
@@ -1083,6 +1083,7 @@ class TestLargeObjectHashingIsExact:
         raise AssertionError("every index was sampled; cannot build the case")
 
     def test_pandas_series_differs_outside_old_sample(self) -> None:
+        """A large pandas Series differing only outside the old sample must hash differently."""
         n = _PANDAS_ROWS_LARGE + 1000
         idx = self._unsampled_index(n, _PANDAS_SAMPLE_SIZE)
         s1 = pd.Series(range(n))
@@ -1091,6 +1092,7 @@ class TestLargeObjectHashingIsExact:
         assert get_hash(s1) != get_hash(s2)
 
     def test_pandas_dataframe_differs_outside_old_sample(self) -> None:
+        """A large pandas DataFrame differing only outside the old sample must hash differently."""
         n = _PANDAS_ROWS_LARGE + 1000
         idx = self._unsampled_index(n, _PANDAS_SAMPLE_SIZE)
         df1 = pd.DataFrame({"a": range(n)})
@@ -1099,6 +1101,7 @@ class TestLargeObjectHashingIsExact:
         assert get_hash(df1) != get_hash(df2)
 
     def test_numpy_differs_outside_old_sample(self) -> None:
+        """A large numpy array differing only outside the old sample must hash differently."""
         n = _NP_SIZE_LARGE + 1000
         idx = self._unsampled_index(n, _NP_SAMPLE_SIZE)
         arr1 = np.arange(n, dtype=np.float64)
@@ -1108,6 +1111,7 @@ class TestLargeObjectHashingIsExact:
 
     @pytest.mark.require_integration
     def test_polars_series_differs_outside_old_sample(self) -> None:
+        """A large polars Series differing only outside the old sample must hash differently."""
         import polars as pl
 
         n = _PANDAS_ROWS_LARGE + 1000
@@ -1119,6 +1123,7 @@ class TestLargeObjectHashingIsExact:
 
     @pytest.mark.require_integration
     def test_polars_dataframe_differs_outside_old_sample(self) -> None:
+        """A large polars DataFrame differing only outside the old sample must hash differently."""
         import polars as pl
 
         n = _PANDAS_ROWS_LARGE + 1000

--- a/lib/tests/streamlit/runtime/caching/hashing_test.py
+++ b/lib/tests/streamlit/runtime/caching/hashing_test.py
@@ -64,6 +64,10 @@ get_main_script_director = MagicMock(return_value=os.getcwd())
 # thresholds were removed. See GitHub issue #14622.
 _PANDAS_ROWS_LARGE = 50_000
 _NP_SIZE_LARGE = 500_000
+# The sample sizes the removed sampling code used, kept so the regression tests
+# can pick indices the old fixed-seed sampler would not have drawn.
+_PANDAS_SAMPLE_SIZE = 10_000
+_NP_SAMPLE_SIZE = 100_000
 
 
 def get_hash(value, hash_funcs=None, cache_type=None):
@@ -1080,7 +1084,7 @@ class TestLargeObjectHashingIsExact:
 
     def test_pandas_series_differs_outside_old_sample(self) -> None:
         n = _PANDAS_ROWS_LARGE + 1000
-        idx = self._unsampled_index(n, 10_000)
+        idx = self._unsampled_index(n, _PANDAS_SAMPLE_SIZE)
         s1 = pd.Series(range(n))
         s2 = s1.copy()
         s2.iloc[idx] = -999
@@ -1088,7 +1092,7 @@ class TestLargeObjectHashingIsExact:
 
     def test_pandas_dataframe_differs_outside_old_sample(self) -> None:
         n = _PANDAS_ROWS_LARGE + 1000
-        idx = self._unsampled_index(n, 10_000)
+        idx = self._unsampled_index(n, _PANDAS_SAMPLE_SIZE)
         df1 = pd.DataFrame({"a": range(n)})
         df2 = df1.copy()
         df2.iloc[idx, 0] = -999
@@ -1096,7 +1100,7 @@ class TestLargeObjectHashingIsExact:
 
     def test_numpy_differs_outside_old_sample(self) -> None:
         n = _NP_SIZE_LARGE + 1000
-        idx = self._unsampled_index(n, 100_000)
+        idx = self._unsampled_index(n, _NP_SAMPLE_SIZE)
         arr1 = np.arange(n, dtype=np.float64)
         arr2 = arr1.copy()
         arr2[idx] = -999.0
@@ -1107,7 +1111,7 @@ class TestLargeObjectHashingIsExact:
         import polars as pl
 
         n = _PANDAS_ROWS_LARGE + 1000
-        idx = self._unsampled_index(n, 10_000)
+        idx = self._unsampled_index(n, _PANDAS_SAMPLE_SIZE)
         data1 = list(range(n))
         data2 = data1.copy()
         data2[idx] = -999
@@ -1118,7 +1122,7 @@ class TestLargeObjectHashingIsExact:
         import polars as pl
 
         n = _PANDAS_ROWS_LARGE + 1000
-        idx = self._unsampled_index(n, 10_000)
+        idx = self._unsampled_index(n, _PANDAS_SAMPLE_SIZE)
         data1 = list(range(n))
         data2 = data1.copy()
         data2[idx] = -999

--- a/lib/tests/streamlit/runtime/caching/hashing_test.py
+++ b/lib/tests/streamlit/runtime/caching/hashing_test.py
@@ -1068,8 +1068,13 @@ class TestLargeObjectHashingIsExact:
     objects are now hashed over their full content, so ANY difference changes the
     hash.
 
-    Each test mutates a single element at a position the old `seed=0` sample would
-    not have drawn, which is the exact case that used to collide.
+    Each test mutates a single element at a position outside the indices a fixed
+    `seed=0` sample would have drawn, which is the class of case that used to
+    collide. The helper replays numpy's `RandomState(0).choice`, so for the pandas
+    and polars paths — which used their own `sample(..., seed/random_state=0)`
+    APIs — the position is representative rather than an exact replay. That is
+    sufficient here: the fix hashes full content, so any difference at all must
+    change the hash.
     """
 
     @staticmethod

--- a/lib/tests/streamlit/runtime/caching/hashing_test.py
+++ b/lib/tests/streamlit/runtime/caching/hashing_test.py
@@ -1079,7 +1079,13 @@ class TestLargeObjectHashingIsExact:
 
     @staticmethod
     def _unsampled_index(n: int, sample_size: int) -> int:
-        """Return an index the old fixed-seed=0 sample would not have picked."""
+        """Return an index outside the set numpy's fixed `seed=0` sample would pick.
+
+        Replays `np.random.RandomState(0).choice`, which is exact for the numpy
+        path. The pandas and polars paths used their own `sample()` APIs, so for
+        those this is a representative unsampled position rather than an exact
+        replay — sufficient, since the fix hashes full content.
+        """
         state = np.random.RandomState(0)
         sampled = set(state.choice(n, size=min(sample_size, n), replace=False))
         for idx in range(n - 1, -1, -1):

--- a/lib/tests/streamlit/runtime/caching/hashing_test.py
+++ b/lib/tests/streamlit/runtime/caching/hashing_test.py
@@ -1089,49 +1089,41 @@ def _large_polars_series() -> Any:
     return pl.Series(range(_PANDAS_ROWS_LARGE))
 
 
-def test_cache_hash_seed_default_is_unset() -> None:
-    """An unset option must keep the historical sample positions."""
-    assert config.get_option("runner.cacheHashSeed") == ""
+def test_cache_hash_seed_defaults_to_zero() -> None:
+    """The default must keep the historical sample positions."""
+    assert config.get_option("runner.cacheHashSeed") == 0
     assert _sample_seed() == 0
 
 
-def test_cache_hash_seed_is_derived_by_hashing_so_any_string_works() -> None:
-    """Arbitrary strings, including secrets, map to a usable numeric seed."""
-    with patch_config_options({"runner.cacheHashSeed": "a-deployment-secret"}):
-        seed = _sample_seed()
-
-    # RandomState and the polars/pandas samplers require a 32-bit seed.
-    assert 0 <= seed < 2**32
-    assert seed != 0
-
-
-def test_cache_hash_seed_accepts_a_non_string_config_value() -> None:
-    """An unquoted ``cacheHashSeed = 5`` in config.toml parses as an int.
+@pytest.mark.parametrize("value", [7, "7"], ids=["int", "numeric_string"])
+def test_cache_hash_seed_accepts_any_whole_number_representation(
+    value: object,
+) -> None:
+    """``cacheHashSeed = 7`` and ``cacheHashSeed = "7"`` must mean the same thing.
 
     ``config.get_option`` returns the raw parsed value rather than coercing it to
-    the declared type, so the seed derivation must tolerate a non-string here or
-    it raises ``AttributeError`` at hash time.
-    """
-    with patch_config_options({"runner.cacheHashSeed": 5}):
-        seed = _sample_seed()
-
-    assert 0 <= seed < 2**32
-    assert seed != 0
-
-
-@pytest.mark.parametrize("value", [0, 5], ids=["zero", "nonzero"])
-def test_cache_hash_seed_does_not_depend_on_toml_quoting(value: int) -> None:
-    """``cacheHashSeed = 0`` and ``cacheHashSeed = "0"`` must mean the same thing.
-
-    The unquoted form parses as an int, so an emptiness test applied before
-    normalizing would treat ``0`` as unset while ``"0"`` hashed to a real seed.
+    the declared type, so an unquoted TOML value arrives as an int and a quoted
+    one as a str.
     """
     with patch_config_options({"runner.cacheHashSeed": value}):
-        from_int = _sample_seed()
-    with patch_config_options({"runner.cacheHashSeed": str(value)}):
-        from_str = _sample_seed()
+        assert _sample_seed() == 7
 
-    assert from_int == from_str
+
+@pytest.mark.parametrize(
+    "value", ["not-a-number", "", None], ids=["text", "empty", "none"]
+)
+def test_cache_hash_seed_falls_back_to_zero_for_unusable_values(
+    value: object,
+) -> None:
+    """A malformed value must leave cache keys unchanged, not raise from hashing."""
+    with patch_config_options({"runner.cacheHashSeed": value}):
+        assert _sample_seed() == 0
+
+
+def test_cache_hash_seed_truncates_a_fractional_value() -> None:
+    """A float is converted rather than rejected; only the seed changes."""
+    with patch_config_options({"runner.cacheHashSeed": 1.5}):
+        assert _sample_seed() == 1
 
 
 @pytest.mark.parametrize(
@@ -1162,9 +1154,9 @@ def test_cache_hash_seed_reaches_every_sampling_path(
     """Changing the seed must change the cache key of a large object."""
     obj = make_obj()
 
-    with patch_config_options({"runner.cacheHashSeed": ""}):
+    with patch_config_options({"runner.cacheHashSeed": 0}):
         hash_default = get_hash(obj)
-    with patch_config_options({"runner.cacheHashSeed": "other"}):
+    with patch_config_options({"runner.cacheHashSeed": 1}):
         hash_other = get_hash(obj)
 
     assert hash_default != hash_other
@@ -1172,7 +1164,7 @@ def test_cache_hash_seed_reaches_every_sampling_path(
 
 def test_cache_hash_seed_is_deterministic_for_pandas_dataframe() -> None:
     """A given seed must produce a stable cache key across calls."""
-    with patch_config_options({"runner.cacheHashSeed": "stable-secret"}):
+    with patch_config_options({"runner.cacheHashSeed": 7}):
         first = get_hash(_large_pandas_dataframe())
         second = get_hash(_large_pandas_dataframe())
 
@@ -1183,9 +1175,9 @@ def test_cache_hash_seed_does_not_affect_small_objects() -> None:
     """Objects below the sampling threshold are hashed in full either way."""
     small = pd.DataFrame({"a": np.arange(10)})
 
-    with patch_config_options({"runner.cacheHashSeed": ""}):
+    with patch_config_options({"runner.cacheHashSeed": 0}):
         hash_default = get_hash(small)
-    with patch_config_options({"runner.cacheHashSeed": "another"}):
+    with patch_config_options({"runner.cacheHashSeed": 99}):
         hash_other = get_hash(small)
 
     assert hash_default == hash_other
@@ -1214,10 +1206,10 @@ def test_cache_hash_seed_moves_off_a_real_collision() -> None:
     mutated = base.copy()
     mutated[never_drawn] = -1
 
-    with patch_config_options({"runner.cacheHashSeed": ""}):
+    with patch_config_options({"runner.cacheHashSeed": 0}):
         assert get_hash(base) == get_hash(mutated), (
             "expected a collision under the default seed"
         )
 
-    with patch_config_options({"runner.cacheHashSeed": "moved-off-the-collision"}):
+    with patch_config_options({"runner.cacheHashSeed": 12345}):
         assert get_hash(base) != get_hash(mutated)

--- a/lib/tests/streamlit/runtime/caching/hashing_test.py
+++ b/lib/tests/streamlit/runtime/caching/hashing_test.py
@@ -1130,5 +1130,20 @@ class TestLargeObjectHashingIsExact:
         """Equal large objects must still hash equally (no spurious cache misses)."""
         n = _PANDAS_ROWS_LARGE + 1000
         assert get_hash(pd.Series(range(n))) == get_hash(pd.Series(range(n)))
+        assert get_hash(pd.DataFrame({"a": range(n)})) == get_hash(
+            pd.DataFrame({"a": range(n)})
+        )
         arr = np.arange(_NP_SIZE_LARGE + 1000, dtype=np.float64)
         assert get_hash(arr) == get_hash(arr.copy())
+
+    @pytest.mark.require_integration
+    def test_hash_is_stable_for_equal_large_polars_objects(self) -> None:
+        """Stability must hold for the polars paths too, not just pandas/numpy."""
+        import polars as pl
+
+        n = _PANDAS_ROWS_LARGE + 1000
+        data = list(range(n))
+        assert get_hash(pl.Series("x", data)) == get_hash(pl.Series("x", data.copy()))
+        assert get_hash(pl.DataFrame({"a": data})) == get_hash(
+            pl.DataFrame({"a": data.copy()})
+        )

--- a/lib/tests/streamlit/runtime/caching/hashing_test.py
+++ b/lib/tests/streamlit/runtime/caching/hashing_test.py
@@ -1144,14 +1144,16 @@ def test_cache_hash_seed_falls_back_to_zero_for_unusable_values(
         pytest.param(float("nan"), id="nan"),
     ],
 )
-def test_cache_hash_seed_warns_for_a_value_int_would_have_accepted_or_raised_on(
+def test_cache_hash_seed_rejects_bool_and_non_finite_floats(
     value: object,
 ) -> None:
-    """These two slip past a plain ``int()`` guard in opposite directions.
+    """These three slip past a plain ``int()`` guard in three different ways.
 
     ``int(True)`` succeeds and yields ``1``, quietly changing every large-object
     cache key; ``int(float("inf"))`` raises ``OverflowError``, which is not a
-    ``ValueError`` and so would have escaped the fallback entirely.
+    ``ValueError`` and so would have escaped the fallback entirely; and
+    ``int(float("nan"))`` raises ``ValueError``, which was already caught -- it is
+    covered here so that difference stays deliberate rather than incidental.
     """
     _warned_sample_seeds.clear()
 


### PR DESCRIPTION
## Describe your changes

**Reworked per maintainer feedback — this no longer removes sampling.**

`@st.cache_data` / `@st.cache_resource` hash large pandas, polars, and numpy objects from a fixed random sample rather than in full. Because the sample positions come from a hardcoded seed of `0`, two large objects that differ only outside the sampled positions produce the same cache key, and the cached value of one is returned for the other (#14622).

The original version of this PR removed sampling entirely. @sfc-gh-lwilby-1 and @lukasmasuch both judged the collision risk negligible relative to the performance cost, and preferred exposing the seed instead. This version does that:

- Adds `runner.cacheHashSeed` (int, default `0`), converted with `int()` and falling back to `0` if that fails.
- Threads it through the four sampling sites: pandas Series, pandas DataFrame, polars Series/DataFrame, and numpy.

The default of `0` reproduces the previous sample positions exactly, so no existing cache entry is invalidated by upgrading.

An earlier revision made this a SHA-256-derived string so it could hold a deployment secret. @lukasmasuch pushed back and he was right: unpredictability only matters if the collision risk is worth defending against, and it was already assessed as negligible — which is the premise for shipping a seed at all. For an app that has already diagnosed a wrong cache hit, any different value works, so the string form defended a property nobody needs. Simplifying also removed the FIPS question and the `hashlib` import.

This implements recommendations 3 and 4 of @sfc-gh-lwilby-1's analysis doc (config seed + documented limitation), and deliberately not 1 (remove sampling for pandas/polars) or 2 (per-process random seed). My independent measurements agree with the doc's within run-to-run variance. I declined 2 because a per-process seed differs across *replicas*, not just restarts, so a shared or persisted cache would thrash continuously rather than once at startup.

## Why sampling is worth keeping

Measured on this branch, full hashing vs sampling. The cost is highly type dependent, which matches @sfc-gh-lwilby-1's point:

| case | sampled | full | slowdown |
| --- | --- | --- | --- |
| `np.array` 10M float | 2.4 ms | 88.9 ms | **37x** |
| `pd.DataFrame` 200k x 2 str | 3.8 ms | 23.8 ms | 6.2x |
| `pd.DataFrame` 1M x 4 float | 10.2 ms | 46.2 ms | 4.5x |
| `pd.Series` 1M int | 8.8 ms | 19.3 ms | 2.2x |
| `pd.DataFrame` 100k x 4 float | 1.9 ms | 3.2 ms | 1.7x |

Numpy is the worst case by a wide margin, and it is on the hot path for every cache lookup.

## What the option does and does not do

Worth being precise, since it would be easy to read this as a fix for the collision:

- It **does** let an app that has hit a specific collision move off it, by sampling different positions.
- It **does not** make hashing exact. Sampling `k` of `n` elements cannot distinguish objects that differ only outside the sample, so some colliding pair always exists — a different seed selects a different set of collisions rather than eliminating them.
- A developer has no signal that a collision has occurred (a wrong cache hit is silent), so in practice this helps someone who has already diagnosed the problem. The config docstring states all of this.

I also verified the doc's small-object finding: sampling is a net loss for polars between roughly 50k and 100k rows, but only by 60-70 microseconds, so I have not changed the threshold here. Raising `_PANDAS_ROWS_LARGE` for polars would be the narrow fix and seems better as its own issue.

One open question for reviewers: I left the option **visible** rather than `visibility="hidden"`, on the reasoning that an escape hatch nobody can discover is not much of an escape hatch. Trivial to flip if you would rather not add public config surface.

I also deliberately left the polars content-hash seeds (`obj.hash(seed=0)`, `hash_rows(seed=0)`) alone — those are not sample selection, and wiring them would change cache keys for small polars objects too, which the option's documented scope does not cover.

## GitHub Issue Link

- Related: #14622

## Testing Plan

- **Unit Tests:** `TestCacheHashSeedConfig` in `hashing_test.py` — the seed reaches all five sampling paths (pandas Series/DataFrame, polars Series/DataFrame, numpy), the same seed is deterministic, small objects are unaffected, and the default is `0`. Polars cases are marked `require_integration` per the file's existing convention.
- **Mutation-verified:** reverting the seed wiring back to hardcoded `0` fails 3 of these tests, so they are not no-ops. Polars cases verified locally against polars 1.43.2 rather than shipped unrun.
- **Full suite:** `10957 passed, 67 skipped`. `ruff format`/`check`, `ty`, and `mypy` clean.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cache key derivation for large cached arguments when the seed is non-default; default 0 preserves behavior, but misconfiguration or changing the seed across replicas can cause cache misses or stale shared-cache behavior.
> 
> **Overview**
> Adds **`runner.cacheHashSeed`** (int, default **`0`**) so apps can change which rows/elements are sampled when hashing large pandas, polars, and numpy inputs for `@st.cache_data` / `@st.cache_resource`. Default **`0`** keeps the old hardcoded sample positions, so upgrades should not invalidate existing cache keys.
> 
> **`hashing.py`** introduces **`_sample_seed()`** (reads config each hash), validates **`0`–`2³²−1`**, rejects bools and bad TOML values without breaking caching, logs once per bad value, and wires the seed into pandas/polars **`.sample()`** and numpy **`RandomState`** sampling. Polars **`hash(seed=0)`** paths are unchanged.
> 
> New tests cover validation, warnings, all sampling backends, determinism, small-object immunity, and a constructed collision that a non-default seed resolves.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4daffabd3969b4243dd7c538d1c8b8f667813e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->