### PR TITLE
[fix] reset selectbox/radio to default when options change from empty (#10093)

### DIFF
--- a/lib/streamlit/elements/lib/options_selector_utils.py
+++ b/lib/streamlit/elements/lib/options_selector_utils.py
@@ -347,6 +347,7 @@ def validate_and_sync_value_with_options(
     default_index: int | None,
     key: str | int | None,
     format_func: Callable[[Any], str] = str,
+    reset_stale_none: bool = False,
 ) -> tuple[T | None, bool]:
     """Validate current value against options, resetting session state if invalid.
 
@@ -369,6 +370,13 @@ def validate_and_sync_value_with_options(
         string representation instead of using == directly. This is necessary because
         widget values are deepcopied, and for custom classes without __eq__, the
         deepcopied instances would fail identity comparison.
+    reset_stale_none
+        When True, a stored ``None`` is treated as stale and reset to the declared
+        default (see the ``current_value is None`` branch below). Only widgets whose
+        ``None`` means "no default was resolvable" should opt in. Widgets where
+        ``None`` is a meaningful user-facing state — ``st.pills`` and
+        ``st.segmented_control`` rely on it to render their ``required`` validation,
+        and ``st.select_slider`` never stores ``None`` — must leave this False.
 
     Returns
     -------
@@ -377,12 +385,12 @@ def validate_and_sync_value_with_options(
     """
     if current_value is None:
         # A stored None may be stale — left over from a run where options were
-        # empty (forcing None).  When options are now available and the developer
+        # empty (forcing None). When options are now available and the developer
         # declared a non-None default, reset to that default so the widget
         # reflects the developer's intent rather than an incidentally-stored None.
         # When default_index is None the developer explicitly opted into a
         # nullable widget (index=None), so None is valid and we keep it.
-        if default_index is not None and len(opt) > 0:
+        if reset_stale_none and default_index is not None and len(opt) > 0:
             reset_val = opt[default_index]
             if key is not None:
                 get_session_state().reset_state_value(str(key), reset_val)

--- a/lib/streamlit/elements/lib/options_selector_utils.py
+++ b/lib/streamlit/elements/lib/options_selector_utils.py
@@ -376,6 +376,17 @@ def validate_and_sync_value_with_options(
         A tuple of (validated_value, value_was_reset).
     """
     if current_value is None:
+        # A stored None may be stale — left over from a run where options were
+        # empty (forcing None).  When options are now available and the developer
+        # declared a non-None default, reset to that default so the widget
+        # reflects the developer's intent rather than an incidentally-stored None.
+        # When default_index is None the developer explicitly opted into a
+        # nullable widget (index=None), so None is valid and we keep it.
+        if default_index is not None and len(opt) > 0:
+            reset_val = opt[default_index]
+            if key is not None:
+                get_session_state().reset_state_value(str(key), reset_val)
+            return reset_val, True
         return current_value, False
 
     # Use format_func comparison for all values. This correctly handles:
@@ -457,6 +468,14 @@ def resolve_value_against_options(
         A tuple of (validated_value, value_was_reset).
     """
     if current_value is None:
+        # Same logic as validate_and_sync_value_with_options: a stored None may
+        # be stale from a prior run with empty options.  Reset to the declared
+        # default when options are available and a non-None default was declared.
+        if default_index is not None and len(opt) > 0:
+            reset_val = opt[default_index]
+            if key is not None:
+                get_session_state().reset_state_value(str(key), reset_val)
+            return reset_val, True
         return current_value, False
 
     try:

--- a/lib/streamlit/elements/lib/options_selector_utils.py
+++ b/lib/streamlit/elements/lib/options_selector_utils.py
@@ -341,6 +341,25 @@ def create_mappings(
     )
 
 
+def _is_stale_none(
+    key: str | int | None, default_index: int | None, opt: Sequence[T]
+) -> bool:
+    """Whether a stored ``None`` should be treated as stale and reset to the default.
+
+    A ``None`` is stale when it was left over from a run in which ``options`` was
+    empty, so no default could be resolved. It is *not* stale when:
+
+    - the developer declared ``index=None``, opting into a nullable widget;
+    - there are still no options to resolve a default from;
+    - the developer explicitly assigned ``None`` via the Session State API on this
+      run, which is a deliberate request to clear the widget and must be honored.
+    """
+    if default_index is None or len(opt) == 0:
+        return False
+    # An explicit `st.session_state[key] = None` this run is a deliberate clear.
+    return not (key is not None and get_session_state().is_new_state_value(str(key)))
+
+
 def validate_and_sync_value_with_options(
     current_value: T | None,
     opt: Sequence[T],
@@ -388,10 +407,9 @@ def validate_and_sync_value_with_options(
         # empty (forcing None). When options are now available and the developer
         # declared a non-None default, reset to that default so the widget
         # reflects the developer's intent rather than an incidentally-stored None.
-        # When default_index is None the developer explicitly opted into a
-        # nullable widget (index=None), so None is valid and we keep it.
-        if reset_stale_none and default_index is not None and len(opt) > 0:
-            reset_val = opt[default_index]
+        # See _is_stale_none for the cases that are deliberately preserved.
+        if reset_stale_none and _is_stale_none(key, default_index, opt):
+            reset_val = opt[cast("int", default_index)]
             if key is not None:
                 get_session_state().reset_state_value(str(key), reset_val)
             return reset_val, True
@@ -477,10 +495,11 @@ def resolve_value_against_options(
     """
     if current_value is None:
         # Same logic as validate_and_sync_value_with_options: a stored None may
-        # be stale from a prior run with empty options.  Reset to the declared
-        # default when options are available and a non-None default was declared.
-        if default_index is not None and len(opt) > 0:
-            reset_val = opt[default_index]
+        # be stale from a prior run with empty options. See _is_stale_none for
+        # the cases that are deliberately preserved (including an explicit
+        # `st.session_state[key] = None`, which must not be overwritten).
+        if _is_stale_none(key, default_index, opt):
+            reset_val = opt[cast("int", default_index)]
             if key is not None:
                 get_session_state().reset_state_value(str(key), reset_val)
             return reset_val, True

--- a/lib/streamlit/elements/lib/options_selector_utils.py
+++ b/lib/streamlit/elements/lib/options_selector_utils.py
@@ -351,13 +351,34 @@ def _is_stale_none(
 
     - the developer declared ``index=None``, opting into a nullable widget;
     - there are still no options to resolve a default from;
-    - the developer explicitly assigned ``None`` via the Session State API on this
-      run, which is a deliberate request to clear the widget and must be honored.
+    - the developer explicitly assigned ``None`` via the Session State API at
+      any point (this run or a prior one), which is a deliberate request to
+      clear the widget and must be honored.
     """
     if default_index is None or len(opt) == 0:
         return False
-    # An explicit `st.session_state[key] = None` this run is a deliberate clear.
-    return not (key is not None and get_session_state().is_new_state_value(str(key)))
+    # ``None`` is itself a valid selectable option (see
+    # ``test_noneType_option`` in selectbox_test.py — a user can put ``None``
+    # in options and it round-trips through serialize/deserialize as the
+    # Python literal ``None``). A stored ``None`` in that case might be a
+    # deliberate UI selection, not stale empty-options residue — the two are
+    # indistinguishable from ``current_value`` alone, so refuse to reset.
+    if None in opt:
+        return False
+    if key is None:
+        # Keyless widgets have no durable session-state clear to honor.
+        return True
+    key_str = str(key)
+    session_state = get_session_state()
+    # Preserve None when this run (or a prior one) deliberately cleared the key.
+    # is_new_state_value covers same-run clears (including internal
+    # reset_state_value(k, None) — e.g. chat_input clearing after submit —
+    # which sets new-state but not user-set-none); is_user_set_none covers
+    # durable st.session_state[k] = None across reruns.
+    return not (
+        session_state.is_new_state_value(key_str)
+        or session_state.is_user_set_none(key_str)
+    )
 
 
 def validate_and_sync_value_with_options(
@@ -366,6 +387,7 @@ def validate_and_sync_value_with_options(
     default_index: int | None,
     key: str | int | None,
     format_func: Callable[[Any], str] = str,
+    *,
     reset_stale_none: bool = False,
 ) -> tuple[T | None, bool]:
     """Validate current value against options, resetting session state if invalid.
@@ -402,12 +424,28 @@ def validate_and_sync_value_with_options(
     tuple[T | None, bool]
         A tuple of (validated_value, value_was_reset).
     """
+    # If the developer explicitly assigned ``session_state[key] = None`` and
+    # the widget id changed (e.g. an identity-bearing argument like
+    # ``accept_new_options`` flipped), the fresh widget was seeded with
+    # ``options[default_index]``. Force it back to ``None`` and sync session
+    # state so the widget return value and ``st.session_state[key]`` stay
+    # in lock-step. ``reset_state_value(k, None)`` does not clear
+    # ``_user_set_none_keys``, so the durable marker survives the sync. This
+    # is independent of ``reset_stale_none``: every caller (including
+    # ``st.pills`` / ``st.segmented_control``) must honor a durable explicit
+    # ``None`` regardless of whether they also opt in to the None→default
+    # reset below.
+    if (
+        current_value is not None
+        and key is not None
+        and get_session_state().is_user_set_none(str(key))
+    ):
+        get_session_state().reset_state_value(str(key), None)
+        return None, True
+
     if current_value is None:
-        # A stored None may be stale — left over from a run where options were
-        # empty (forcing None). When options are now available and the developer
-        # declared a non-None default, reset to that default so the widget
-        # reflects the developer's intent rather than an incidentally-stored None.
-        # See _is_stale_none for the cases that are deliberately preserved.
+        # Reset a stale None to the developer's declared default.
+        # See _is_stale_none for when None is stale vs. intentional.
         if reset_stale_none and _is_stale_none(key, default_index, opt):
             reset_val = opt[cast("int", default_index)]
             if key is not None:
@@ -469,6 +507,12 @@ def resolve_value_against_options(
     :func:`validate_and_sync_value_with_options`: when the value is reset and a
     key is provided, session state is updated with the new value.
 
+    Unlike :func:`validate_and_sync_value_with_options` (which opts in via
+    ``reset_stale_none``), stale ``None`` values are always reset to the
+    declared default. Only ``st.selectbox`` currently calls this; a future
+    widget adopting it would inherit that behavior — add a flag if that ever
+    stops being desired.
+
     Parameters
     ----------
     current_value
@@ -493,11 +537,25 @@ def resolve_value_against_options(
     tuple[T | None, bool]
         A tuple of (validated_value, value_was_reset).
     """
+    # Coerce a non-None value back to None when the developer explicitly holds
+    # ``session_state[key] = None`` — mirrors the guard in
+    # ``validate_and_sync_value_with_options`` for the identity-change case
+    # where the widget id changed and the new widget was seeded with
+    # ``options[default_index]``. Syncing session state via
+    # ``reset_state_value(k, None)`` keeps the widget return value and
+    # ``st.session_state[key]`` in lock-step; the marker survives because
+    # ``reset_state_value(None)`` does not discard it.
+    if (
+        current_value is not None
+        and key is not None
+        and get_session_state().is_user_set_none(str(key))
+    ):
+        get_session_state().reset_state_value(str(key), None)
+        return None, True
+
     if current_value is None:
-        # Same logic as validate_and_sync_value_with_options: a stored None may
-        # be stale from a prior run with empty options. See _is_stale_none for
-        # the cases that are deliberately preserved (including an explicit
-        # `st.session_state[key] = None`, which must not be overwritten).
+        # Reset a stale None — same logic as validate_and_sync_value_with_options.
+        # See _is_stale_none.
         if _is_stale_none(key, default_index, opt):
             reset_val = opt[cast("int", default_index)]
             if key is not None:

--- a/lib/streamlit/elements/widgets/radio.py
+++ b/lib/streamlit/elements/widgets/radio.py
@@ -52,7 +52,6 @@ from streamlit.runtime.state import (
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,
-    get_session_state,
     register_widget,
 )
 from streamlit.type_util import (
@@ -509,10 +508,6 @@ class RadioMixin:
             raise StreamlitAPIException(
                 f"Radio captions must be strings. Passed type: {type(caption).__name__}"
             )
-
-        session_state = get_session_state().filtered_state
-        if key is not None and key in session_state and session_state[key] is None:
-            index = None
 
         radio_proto = RadioProto()
         radio_proto.id = element_id

--- a/lib/streamlit/elements/widgets/radio.py
+++ b/lib/streamlit/elements/widgets/radio.py
@@ -52,6 +52,7 @@ from streamlit.runtime.state import (
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,
+    get_session_state,
     register_widget,
 )
 from streamlit.type_util import (
@@ -512,7 +513,15 @@ class RadioMixin:
         radio_proto = RadioProto()
         radio_proto.id = element_id
         radio_proto.label = label
-        if index is not None:
+        # Omit ``proto.default`` when the developer holds an explicit
+        # ``session_state[key] = None``. On remount, the frontend falls back
+        # to ``getDefaultStateFromProto`` if WidgetMgr has no stored value —
+        # if we leave ``default`` set, the UI would resurrect ``options[index]``
+        # while Python still returns ``None``, desyncing UI and script state.
+        holds_explicit_none = key is not None and get_session_state().is_user_set_none(
+            str(key)
+        )
+        if index is not None and not holds_explicit_none:
             radio_proto.default = index
         radio_proto.options[:] = formatted_options
         radio_proto.form_id = current_form_id(self.dg)

--- a/lib/streamlit/elements/widgets/radio.py
+++ b/lib/streamlit/elements/widgets/radio.py
@@ -568,7 +568,12 @@ class RadioMixin:
         # Cast to T | None since radio doesn't support accept_new_options,
         # so string values that aren't in options will be reset to default.
         current_value, value_needs_reset = validate_and_sync_value_with_options(
-            cast("T | None", widget_state.value), opt, index, key, format_func
+            cast("T | None", widget_state.value),
+            opt,
+            index,
+            key,
+            format_func,
+            reset_stale_none=True,
         )
 
         if value_needs_reset or widget_state.value_changed:

--- a/lib/streamlit/elements/widgets/selectbox.py
+++ b/lib/streamlit/elements/widgets/selectbox.py
@@ -61,7 +61,6 @@ from streamlit.runtime.state import (
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,
-    get_session_state,
     register_widget,
 )
 from streamlit.type_util import (
@@ -674,10 +673,6 @@ class SelectboxMixin:
             filter_mode=filter_mode,
             width=width,
         )
-
-        session_state = get_session_state().filtered_state
-        if key is not None and key in session_state and session_state[key] is None:
-            index = None
 
         selectbox_proto = SelectboxProto()
         selectbox_proto.id = element_id

--- a/lib/streamlit/elements/widgets/selectbox.py
+++ b/lib/streamlit/elements/widgets/selectbox.py
@@ -34,6 +34,7 @@ from streamlit.elements.lib.layout_utils import (
 )
 from streamlit.elements.lib.options_selector_utils import (
     SelectWidgetFilterMode,
+    _is_stale_none,
     create_mappings,
     maybe_coerce_enum,
     resolve_value_against_options,
@@ -61,6 +62,7 @@ from streamlit.runtime.state import (
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,
+    get_session_state,
     register_widget,
 )
 from streamlit.type_util import (
@@ -677,7 +679,15 @@ class SelectboxMixin:
         selectbox_proto = SelectboxProto()
         selectbox_proto.id = element_id
         selectbox_proto.label = label
-        if index is not None:
+        # Omit ``proto.default`` when the developer holds an explicit
+        # ``session_state[key] = None``. On remount, the frontend falls back
+        # to ``getDefaultStateFromProto`` if WidgetMgr has no stored value —
+        # if we leave ``default`` set, the UI would resurrect ``options[index]``
+        # while Python still returns ``None``, desyncing UI and script state.
+        holds_explicit_none = key is not None and get_session_state().is_user_set_none(
+            str(key)
+        )
+        if index is not None and not holds_explicit_none:
             selectbox_proto.default = index
         selectbox_proto.options[:] = formatted_options
         selectbox_proto.form_id = current_form_id(self.dg)
@@ -728,6 +738,32 @@ class SelectboxMixin:
         if accept_new_options:
             current_value = widget_state.value
             value_needs_reset = False
+            # Honor a durable explicit ``session_state[key] = None`` even on the
+            # accept_new_options fast path (which bypasses
+            # ``resolve_value_against_options``). Without this, an identity
+            # change that lands here would resurrect ``options[index]`` in the
+            # freshly-seeded widget state while Python's marker says otherwise.
+            if (
+                current_value is not None
+                and key is not None
+                and get_session_state().is_user_set_none(str(key))
+            ):
+                get_session_state().reset_state_value(str(key), None)
+                current_value = None
+                value_needs_reset = True
+            # Also honor the empty→non-empty stale-None reset here: without it,
+            # #10093's original failure mode still applies to
+            # ``accept_new_options=True`` selectboxes (stored ``None`` from an
+            # empty-options run never returns to ``options[index]`` when
+            # options later appear). Skip full option-membership validation —
+            # any string is valid for accept_new_options — but do apply the
+            # ``_is_stale_none`` heuristic so a declared default can win when
+            # the developer never explicitly cleared the key.
+            elif current_value is None and _is_stale_none(key, index, opt):
+                current_value = opt[cast("int", index)]
+                if key is not None:
+                    get_session_state().reset_state_value(str(key), current_value)
+                value_needs_reset = True
         else:
             # Reset the selection only if the stored value no longer matches any
             # option; see resolve_value_against_options for the format_func and

--- a/lib/streamlit/runtime/state/safe_session_state.py
+++ b/lib/streamlit/runtime/state/safe_session_state.py
@@ -84,6 +84,11 @@ class SafeSessionState:
         with self._lock:
             return self._state.is_new_state_value(user_key)
 
+    def is_user_set_none(self, user_key: str) -> bool:
+        """True if the last explicit SessionState API assignment for this key was None."""
+        with self._lock:
+            return self._state.is_user_set_none(user_key)
+
     def reset_state_value(self, user_key: str, value: Any | None) -> None:
         """Reset a new session state value to a given value
         without triggering the "state value cannot be modified" error.

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -632,6 +632,35 @@ class SessionState:
         default_factory=PersistedWidgetTracker
     )
 
+    # User keys the developer has explicitly assigned ``None`` (via
+    # ``st.session_state[k] = None`` / ``st.session_state.k = None``).
+    # Persisted across script runs so downstream widgets can distinguish
+    # "developer explicitly cleared this key" from "Streamlit auto-stored
+    # ``None`` because options were empty" — the two look identical in
+    # ``_old_state`` after compaction but need different reset semantics
+    # (see ``options_selector_utils._is_stale_none``).
+    #
+    # Populated by:
+    #   - ``__setitem__`` when a user key is assigned ``None``.
+    #
+    # Cleared by:
+    #   - ``__setitem__`` when a user key is reassigned to a non-``None`` value.
+    #   - ``__delitem__`` when a user key is removed.
+    #   - ``clear`` when the whole session is reset.
+    #   - ``reset_state_value`` when internal widget code writes a non-``None``
+    #     value for a user key (e.g. an option filter reset).
+    #   - ``set_widgets_from_proto`` when the frontend sends a non-empty widget
+    #     proto for the key's widget (i.e. the user interacted with the widget
+    #     and the marker no longer reflects intent).
+    #   - ``_drop_widget_value`` when a widget's stored value is dropped
+    #     (e.g. ``disabled=True`` re-registration, or a ``persist_state="page"``
+    #     scope-mismatch drop at register-time).
+    #   - ``on_script_will_rerun`` when a ``persist_state="page"`` value is
+    #     retired on a page switch (via ``mark_page_switch_drops``).
+    #   - ``_seed_widget_from_url`` when a bound widget's URL value seeds a
+    #     ``_new_session_state[key]`` write directly (URL wins on initial load).
+    _user_set_none_keys: set[str] = field(default_factory=set)
+
     def __repr__(self) -> str:
         return util.repr_(self)
 
@@ -650,12 +679,21 @@ class SessionState:
                 pass
         self._new_session_state.clear()
         self._new_widget_state.clear()
+        # _user_set_none_keys intentionally survives compaction: it tracks
+        # durable "developer explicitly cleared this key" intent that must
+        # cross the rerun boundary (see the field comment above). Only the
+        # SessionState API lifecycle (setitem/delitem/clear/reset_state_value)
+        # and set_widgets_from_proto (on real frontend interactions) may
+        # clear entries — do not add ``self._user_set_none_keys.clear()``
+        # here without breaking selectbox/radio `session_state[k] = None`
+        # persistence (#10093).
 
     def clear(self) -> None:
         """Reset self completely, clearing all current and old values."""
         self._old_state.clear()
         self._new_session_state.clear()
         self._new_widget_state.clear()
+        self._user_set_none_keys.clear()
         self._key_id_mapper.clear()
         self._query_param_bound_widget_ids.clear()
         self._persist_tracker.clear()
@@ -704,11 +742,48 @@ class SessionState:
         """True if a value with the given key is in the current session state."""
         return user_key in self._new_session_state
 
+    def is_user_set_none(self, user_key: str) -> bool:
+        """True if the developer's most-recent explicit assignment to ``user_key``
+        via the SessionState API was ``None``.
+
+        Persisted across script runs so widgets can distinguish an explicit
+        ``st.session_state[key] = None`` from a ``None`` that Streamlit stored
+        itself (e.g. a select widget resolving to ``None`` because its options
+        were empty). The marker is cleared when:
+
+        - The key is reassigned to a non-``None`` value via the SessionState API.
+        - The key is removed via ``__delitem__``.
+        - ``clear()`` resets the whole session.
+        - ``reset_state_value`` writes a non-``None`` value (e.g. an options
+          filter reset from a widget's internal code path).
+        - ``set_widgets_from_proto`` receives a non-empty widget proto for the
+          key (the user interacted with the widget on the frontend, so the
+          marker no longer reflects the developer's intent).
+        - ``_drop_widget_value`` drops the widget's value (e.g. a
+          ``disabled=True`` re-registration, or a ``persist_state="page"``
+          scope switch): the clear was scoped to the value being dropped, and
+          leaving the marker in place would keep coercing to ``None`` after
+          the value it applied to is gone.
+        - ``on_script_will_rerun`` retires ``persist_state="page"`` values on
+          a page switch (see ``mark_page_switch_drops``).
+        - ``_seed_widget_from_url`` seeds a bound widget's value from the URL
+          on initial load (URL wins over any prior programmatic clear).
+
+        See ``_user_set_none_keys`` for the full contract.
+        """
+        return user_key in self._user_set_none_keys
+
     def reset_state_value(self, user_key: str, value: Any | None) -> None:
         """Reset a new session state value to a given value
         without triggering the "state value cannot be modified" error.
         """
         self._new_session_state[user_key] = value
+        # A non-``None`` reset means Streamlit has overridden the developer's
+        # last explicit clear with a real value; the marker no longer reflects
+        # intent. (An internal ``None`` reset — e.g. chat_input resetting after
+        # submit — is not a user assignment, so we don't add the key.)
+        if value is not None:
+            self._user_set_none_keys.discard(user_key)
 
     def __iter__(self) -> Iterator[Any]:
         """Return an iterator over the keys of the SessionState.
@@ -803,6 +878,13 @@ class SessionState:
                 )
 
         self._new_session_state[user_key] = value
+        # Track user-explicit-None assignments so downstream widgets can
+        # tell them apart from Streamlit-auto-stored ``None`` values in
+        # later runs (see ``_user_set_none_keys`` docstring).
+        if value is None:
+            self._user_set_none_keys.add(user_key)
+        else:
+            self._user_set_none_keys.discard(user_key)
 
     def __delitem__(self, key: str) -> None:
         widget_id = self._get_widget_id(key)
@@ -819,6 +901,8 @@ class SessionState:
         if key in self._key_id_mapper:
             self._key_id_mapper.delete(key)
 
+        self._user_set_none_keys.discard(key)
+
         if widget_id in self._new_widget_state:
             del self._new_widget_state[widget_id]
 
@@ -833,6 +917,45 @@ class SessionState:
 
         for state in widget_states.widgets:
             self._new_widget_state.set_widget_from_proto(state)
+
+        # Reconcile ``_user_set_none_keys`` with what the frontend just sent.
+        # ``serialize(None)`` produces an empty value field, so the frontend
+        # round-trips a null selectbox/radio as a proto with no value field
+        # set. Without this reconciliation two things would go wrong:
+        #
+        #   1. An empty proto would deserialize via ``deserialize(None)`` to
+        #      the widget's declared default (e.g. ``options[0]``) — clobbering
+        #      the developer's explicit ``None``. Force ``Value(None)`` for
+        #      those keys instead.
+        #   2. A non-empty proto — the user interacted with the widget after a
+        #      prior explicit clear — means the marker no longer reflects the
+        #      developer's intent. Drop the marker so a future empty→non-empty
+        #      options transition can restore the declared default.
+        keys_to_process = list(self._user_set_none_keys)
+        for user_key in keys_to_process:
+            widget_id = self._key_id_mapper.get_id_from_key(user_key, None)
+            if widget_id is None:
+                continue
+            stored = self._new_widget_state.states.get(widget_id)
+            if not isinstance(stored, Serialized):
+                continue
+            oneof = stored.value.WhichOneof("value")
+            # ``serialize(None)`` produces different empty shapes per widget:
+            #   - selectbox/radio (string_value): oneof unset entirely.
+            #   - pills/segmented_control/multiselect (string_array_value):
+            #     oneof IS ``string_array_value`` with an empty list.
+            # Both are "no user selection" and must be treated as the empty
+            # proto path (inject Value(None) + preserve marker); only a
+            # genuinely non-empty selection should discard the marker.
+            is_empty_array = (
+                oneof == "string_array_value"
+                and len(stored.value.string_array_value.data) == 0
+            )
+            if oneof is None or is_empty_array:
+                self._new_widget_state.states[widget_id] = Value(None)
+            else:
+                # A frontend interaction supersedes the stale programmatic None.
+                self._user_set_none_keys.discard(user_key)
 
     def on_script_will_rerun(self, latest_widget_states: WidgetStatesProto) -> None:
         """Called by ScriptRunner before its script re-runs.
@@ -1156,6 +1279,17 @@ class SessionState:
             ),
         ):
             self._old_state.pop(user_key, None)
+            # Also drop the explicit-None marker, but only when there's no
+            # current-run intent still pending for this key. See the mirror
+            # guard in ``_drop_widget_value``: a same-run
+            # ``session_state[k] = None`` must survive the page-switch
+            # retirement, since the write lives in ``_new_session_state``
+            # and represents intent scoped to the incoming page.
+            if (
+                user_key not in self._new_session_state
+                or self._new_session_state[user_key] is not None
+            ):
+                self._user_set_none_keys.discard(user_key)
 
         self._new_widget_state.remove_stale_widgets(
             active_widget_ids,
@@ -1240,6 +1374,23 @@ class SessionState:
         removed = self._new_widget_state.states.pop(widget_id, None) is not None
         removed = self._old_state.pop(widget_id, None) is not None or removed
         removed = self._old_state.pop(user_key, None) is not None or removed
+        # Clear the explicit-None marker too, but ONLY when there's no
+        # current-run intent still pending under this key. If the developer
+        # did ``st.session_state[key] = None`` on this very run, that write
+        # lives in ``_new_session_state`` and the docstring above guarantees
+        # we leave the current-run intent alone — the marker must survive
+        # compaction so the next run still honors the clear.
+        #
+        # Otherwise (drop is retiring a *prior* clear that only exists in
+        # ``_old_state`` / the marker — e.g. a page-switch drop of a
+        # ``persist_state="page"`` widget), discard the marker so subsequent
+        # renders return to the declared default instead of coercing to
+        # ``None`` for a value that no longer exists.
+        if (
+            user_key not in self._new_session_state
+            or self._new_session_state[user_key] is not None
+        ):
+            self._user_set_none_keys.discard(user_key)
         return removed
 
     def register_widget(
@@ -1585,6 +1736,14 @@ class SessionState:
             # Store the value in widget and session state
             self._new_widget_state.set_from_value(widget_id, deserialized_value)
             self._new_session_state[user_key] = deserialized_value
+            # A URL-seeded value supersedes any prior programmatic
+            # ``st.session_state[key] = None`` — the "URL wins on initial load"
+            # contract must beat the durable explicit-None marker. Without
+            # this, the coerce guard in ``resolve_value_against_options`` /
+            # ``validate_and_sync_value_with_options`` (and the
+            # ``accept_new_options`` fast path in selectbox) would rewrite
+            # the URL-seeded value back to ``None`` on the same run.
+            self._user_set_none_keys.discard(user_key)
 
             # Auto-correct URL if value was clamped/filtered
             self._auto_correct_url_if_needed(

--- a/lib/tests/streamlit/elements/lib/options_selector_utils_test.py
+++ b/lib/tests/streamlit/elements/lib/options_selector_utils_test.py
@@ -549,7 +549,29 @@ class TestValidateAndSyncValueWithOptions(unittest.TestCase):
                 "banana",
                 False,
             ),
-            ("none_value", None, ["apple", "banana"], 0, None, False),
+            # A stored None is treated as stale when the developer declared a
+            # non-None default and options are available, so it resets to that
+            # default. See https://github.com/streamlit/streamlit/issues/10093.
+            (
+                "none_value_with_declared_default_resets",
+                None,
+                ["apple", "banana"],
+                0,
+                "apple",
+                True,
+            ),
+            # index=None is an explicit opt-in to a nullable widget, so None is
+            # a legitimate value and must be preserved.
+            (
+                "none_value_nullable_default_kept",
+                None,
+                ["apple", "banana"],
+                None,
+                None,
+                False,
+            ),
+            # With no options there is nothing to reset to, so None is kept.
+            ("none_value_empty_options_kept", None, [], 0, None, False),
             (
                 "value_not_in_options_resets_to_default",
                 "mango",
@@ -997,11 +1019,29 @@ class TestValidateMultiselectWithCustomObjects(unittest.TestCase):
 class TestResolveValueAgainstOptions:
     """Tests for the selectbox value resolver (format_func with wire-label fallback)."""
 
-    def test_none_value_returns_unchanged(self) -> None:
-        """A None current value is returned as-is without a reset."""
+    def test_none_value_with_declared_default_resets(self) -> None:
+        """A stored None resets to the declared default once options exist.
+
+        The None is treated as stale — left over from a run where options were
+        empty. See https://github.com/streamlit/streamlit/issues/10093.
+        """
         value, reset = resolve_value_against_options(
             None, ["a", "b"], {"a": 0, "b": 1}, 0, None
         )
+        assert value == "a"
+        assert reset is True
+
+    def test_none_value_nullable_default_is_kept(self) -> None:
+        """index=None opts into a nullable widget, so None must be preserved."""
+        value, reset = resolve_value_against_options(
+            None, ["a", "b"], {"a": 0, "b": 1}, None, None
+        )
+        assert value is None
+        assert reset is False
+
+    def test_none_value_empty_options_is_kept(self) -> None:
+        """With no options there is nothing to reset to, so None is kept."""
+        value, reset = resolve_value_against_options(None, [], {}, 0, None)
         assert value is None
         assert reset is False
 

--- a/lib/tests/streamlit/elements/lib/options_selector_utils_test.py
+++ b/lib/tests/streamlit/elements/lib/options_selector_utils_test.py
@@ -549,29 +549,10 @@ class TestValidateAndSyncValueWithOptions(unittest.TestCase):
                 "banana",
                 False,
             ),
-            # A stored None is treated as stale when the developer declared a
-            # non-None default and options are available, so it resets to that
-            # default. See https://github.com/streamlit/streamlit/issues/10093.
-            (
-                "none_value_with_declared_default_resets",
-                None,
-                ["apple", "banana"],
-                0,
-                "apple",
-                True,
-            ),
-            # index=None is an explicit opt-in to a nullable widget, so None is
-            # a legitimate value and must be preserved.
-            (
-                "none_value_nullable_default_kept",
-                None,
-                ["apple", "banana"],
-                None,
-                None,
-                False,
-            ),
-            # With no options there is nothing to reset to, so None is kept.
-            ("none_value_empty_options_kept", None, [], 0, None, False),
+            # Default (opt-out) behavior: a stored None is left untouched, so
+            # widgets like st.pills / st.segmented_control keep their meaningful
+            # "nothing selected" state. Opting in is covered separately below.
+            ("none_value", None, ["apple", "banana"], 0, None, False),
             (
                 "value_not_in_options_resets_to_default",
                 "mango",
@@ -617,6 +598,47 @@ class TestValidateAndSyncValueWithOptions(unittest.TestCase):
         )
         assert value == expected_value
         assert needs_reset is expected_needs_reset
+
+    def test_reset_stale_none_resets_to_declared_default(self) -> None:
+        """With reset_stale_none=True, a stale stored None resets to the default.
+
+        This is the #10093 case: options were empty on a previous run (forcing
+        None), then became available with a declared index.
+        """
+        value, needs_reset = validate_and_sync_value_with_options(
+            None, ["apple", "banana"], 0, None, reset_stale_none=True
+        )
+        assert value == "apple"
+        assert needs_reset is True
+
+    def test_reset_stale_none_keeps_none_for_nullable_widget(self) -> None:
+        """index=None opts into a nullable widget, so None must be preserved."""
+        value, needs_reset = validate_and_sync_value_with_options(
+            None, ["apple", "banana"], None, None, reset_stale_none=True
+        )
+        assert value is None
+        assert needs_reset is False
+
+    def test_reset_stale_none_keeps_none_for_empty_options(self) -> None:
+        """With no options there is nothing to reset to, so None is kept."""
+        value, needs_reset = validate_and_sync_value_with_options(
+            None, [], 0, None, reset_stale_none=True
+        )
+        assert value is None
+        assert needs_reset is False
+
+    def test_default_leaves_stale_none_untouched(self) -> None:
+        """Without opting in, None is preserved.
+
+        st.pills and st.segmented_control depend on this to render their
+        ``required`` validation state, and st.select_slider relies on the
+        unchanged contract.
+        """
+        value, needs_reset = validate_and_sync_value_with_options(
+            None, ["apple", "banana"], 0, None
+        )
+        assert value is None
+        assert needs_reset is False
 
     def test_custom_objects_without_eq_using_format_func(self):
         """Test that custom objects without __eq__ work with format_func validation."""

--- a/lib/tests/streamlit/elements/radio_test.py
+++ b/lib/tests/streamlit/elements/radio_test.py
@@ -455,18 +455,85 @@ def test_radio_enum_coercion():
 
 
 def test_None_session_state_value_retained():
+    """When index=None is declared, a programmatic session_state=None is preserved."""
+
     def script():
         import streamlit as st
 
         if "radio" not in st.session_state:
             st.session_state["radio"] = None
 
-        st.radio("radio", ["a", "b", "c"], key="radio")
+        # index=None declares that None is a valid state for this widget.
+        st.radio("radio", ["a", "b", "c"], index=None, key="radio")
         st.button("button")
 
     at = AppTest.from_function(script).run()
     at = at.button[0].click().run()
     assert at.radio[0].value is None
+
+
+def test_radio_resets_to_default_when_options_appear():
+    """Regression test for #10093: when options change from empty to non-empty,
+    the widget should reset to the declared default index, not stay at None."""
+
+    def script():
+        import streamlit as st
+
+        if "ready" not in st.session_state:
+            st.session_state["ready"] = False
+
+        if st.session_state["ready"]:
+            options = ["A", "B", "C"]
+        else:
+            options = []
+
+        selected = st.radio("Pick", options, index=0, key="picker")
+        st.text(f"value={selected}")
+
+        if st.button("Load options"):
+            st.session_state["ready"] = True
+
+    # First run: options empty, value should be None
+    at = AppTest.from_function(script).run()
+    assert at.text[0].value == "value=None"
+
+    # Click button to populate options
+    at = at.button[0].click().run()
+    # Extra run needed: AppTest doesn't fully simulate frontend processing
+    # of the set_value=True response. The second run picks up the reset value.
+    at = at.run()
+
+    # With options now available and index=0, value should be "A"
+    assert at.text[0].value == "value=A"
+
+
+def test_radio_none_default_preserved_when_index_none():
+    """When index=None is declared and options appear, None is preserved."""
+
+    def script():
+        import streamlit as st
+
+        if "ready" not in st.session_state:
+            st.session_state["ready"] = False
+
+        if st.session_state["ready"]:
+            options = ["A", "B", "C"]
+        else:
+            options = []
+
+        selected = st.radio("Pick", options, index=None, key="picker")
+        st.text(f"value={selected}")
+
+        if st.button("Load options"):
+            st.session_state["ready"] = True
+
+    # First run: options empty, value is None
+    at = AppTest.from_function(script).run()
+    assert at.text[0].value == "value=None"
+
+    # Click button to populate options - with index=None, None should be kept
+    at = at.button[0].click().run()
+    assert at.text[0].value == "value=None"
 
 
 def test_dynamic_options_with_key_retains_value() -> None:

--- a/lib/tests/streamlit/elements/radio_test.py
+++ b/lib/tests/streamlit/elements/radio_test.py
@@ -542,6 +542,27 @@ def test_radio_none_default_preserved_when_index_none():
     assert at.text[0].value == "value=None"
 
 
+def test_radio_explicit_session_state_none_is_honored():
+    """An explicit `st.session_state[key] = None` must clear the widget.
+
+    The stale-None reset for #10093 must not clobber a deliberate in-script clear,
+    otherwise apps can no longer programmatically reset a keyed radio.
+    """
+
+    def script():
+        import streamlit as st
+
+        if "init" not in st.session_state:
+            st.session_state["init"] = True
+            st.session_state["picker"] = None
+
+        selected = st.radio("Pick", ["A", "B"], index=0, key="picker")
+        st.text(f"value={selected} state={st.session_state['picker']}")
+
+    at = AppTest.from_function(script).run()
+    assert at.text[0].value == "value=None state=None"
+
+
 def test_dynamic_options_with_key_retains_value() -> None:
     """Test that changing options with a key retains the selected value if still valid."""
 

--- a/lib/tests/streamlit/elements/radio_test.py
+++ b/lib/tests/streamlit/elements/radio_test.py
@@ -72,6 +72,29 @@ class RadioTest(DeltaGeneratorTestCase):
         assert c.default == 0
         assert not c.HasField("default")
 
+    def test_proto_default_omitted_when_session_state_holds_explicit_none(self):
+        """When the developer holds an explicit ``session_state[key] = None``,
+        the proto's ``default`` must be unset even though a non-``None`` ``index``
+        was declared. Otherwise a frontend remount that falls back to
+        ``getDefaultStateFromProto`` would resurrect ``options[index]`` while
+        Python still returns ``None`` (see PR #16285 discussion on remount
+        UI/Python desync)."""
+        st.session_state["picker"] = None
+        st.radio("the label", ("a", "b", "c"), index=0, key="picker")
+
+        c = self.get_delta_from_queue().new_element.radio
+        assert not c.HasField("default")
+
+    def test_proto_default_present_when_no_explicit_none(self):
+        """The remount guard must not fire for the common case: a keyed
+        radio with a declared ``index`` and no explicit ``None`` in session
+        state still ships its default."""
+        st.radio("the label", ("a", "b", "c"), index=1, key="picker2")
+
+        c = self.get_delta_from_queue().new_element.radio
+        assert c.HasField("default")
+        assert c.default == 1
+
     def test_horizontal(self):
         """Test that it can be called with horizontal param."""
         st.radio("the label", ("m", "f"), horizontal=True)
@@ -455,7 +478,11 @@ def test_radio_enum_coercion():
 
 
 def test_None_session_state_value_retained():
-    """When index=None is declared, a programmatic session_state=None is preserved."""
+    """An explicit ``session_state[k] = None`` is preserved across a rerun even
+    when a default ``index=0`` is declared (aligned with the selectbox
+    counterpart). ``index=None`` variants are covered separately by
+    ``test_radio_none_default_preserved_when_index_none`` and
+    ``test_radio_explicit_session_state_none_is_honored``."""
 
     def script():
         import streamlit as st
@@ -463,13 +490,69 @@ def test_None_session_state_value_retained():
         if "radio" not in st.session_state:
             st.session_state["radio"] = None
 
-        # index=None declares that None is a valid state for this widget.
-        st.radio("radio", ["a", "b", "c"], index=None, key="radio")
+        st.radio("radio", ["a", "b", "c"], key="radio")
         st.button("button")
 
     at = AppTest.from_function(script).run()
     at = at.button[0].click().run()
     assert at.radio[0].value is None
+
+
+def test_None_session_state_value_persists_across_multiple_reruns():
+    """An explicit ``session_state[k] = None`` (assigned once, never
+    re-assigned) survives multiple downstream reruns. See selectbox
+    counterpart for the ``_user_set_none_keys`` contract."""
+
+    def script():
+        import streamlit as st
+
+        if "radio" not in st.session_state:
+            st.session_state["radio"] = None
+
+        st.radio("radio", ["a", "b", "c"], key="radio")
+        st.button("button")
+
+    at = AppTest.from_function(script).run()
+    for _ in range(3):
+        at = at.button[0].click().run()
+        assert at.radio[0].value is None
+
+
+def test_explicit_none_cleared_by_ui_selection_then_reset_to_default():
+    """After an explicit clear, once the user actually picks a value via
+    the widget UI, the ``_user_set_none_keys`` marker must lift so a
+    subsequent empty→non-empty options transition can restore the
+    declared default (#10093 must not reappear for a key that was ever
+    explicitly cleared). Radio counterpart of the selectbox test."""
+
+    def script():
+        import streamlit as st
+
+        if "picker" not in st.session_state:
+            st.session_state["picker"] = None
+
+        if "ready" not in st.session_state:
+            st.session_state["ready"] = True
+
+        options = ["A", "B", "C"] if st.session_state["ready"] else []
+        selected = st.radio("Pick", options, index=0, key="picker")
+        st.text(f"value={selected}")
+
+        if st.button("hide options", key="hide"):
+            st.session_state["ready"] = False
+        if st.button("show options", key="show"):
+            st.session_state["ready"] = True
+
+    at = AppTest.from_function(script).run()
+    assert at.text[0].value == "value=None"
+
+    at = at.radio[0].set_value("B").run()
+    assert at.text[0].value == "value=B"
+
+    at = at.button(key="hide").click().run().run()
+    assert at.text[0].value == "value=None"
+    at = at.button(key="show").click().run().run()
+    assert at.text[0].value == "value=A"
 
 
 def test_radio_resets_to_default_when_options_appear():

--- a/lib/tests/streamlit/elements/radio_test.py
+++ b/lib/tests/streamlit/elements/radio_test.py
@@ -499,8 +499,10 @@ def test_radio_resets_to_default_when_options_appear():
 
     # Click button to populate options
     at = at.button[0].click().run()
-    # Extra run needed: AppTest doesn't fully simulate frontend processing
-    # of the set_value=True response. The second run picks up the reset value.
+    # A second run is needed because of script ordering, not an AppTest
+    # limitation: `ready` is only set at the end of the click run, after the
+    # radio has already rendered. Options first become non-empty on the run
+    # after that.
     at = at.run()
 
     # With options now available and index=0, value should be "A"
@@ -531,8 +533,12 @@ def test_radio_none_default_preserved_when_index_none():
     at = AppTest.from_function(script).run()
     assert at.text[0].value == "value=None"
 
-    # Click button to populate options - with index=None, None should be kept
+    # Click button to populate options. A second run is required for options to
+    # actually become non-empty (`ready` is set only at the end of the click
+    # run), otherwise this would assert against still-empty options and pass
+    # vacuously without ever exercising index=None against real options.
     at = at.button[0].click().run()
+    at = at.run()
     assert at.text[0].value == "value=None"
 
 

--- a/lib/tests/streamlit/elements/selectbox_test.py
+++ b/lib/tests/streamlit/elements/selectbox_test.py
@@ -792,6 +792,28 @@ def test_selectbox_none_default_preserved_when_index_none():
     assert at.text[0].value == "value=None"
 
 
+def test_selectbox_explicit_session_state_none_is_honored():
+    """An explicit `st.session_state[key] = None` must clear the widget.
+
+    The stale-None reset for #10093 must not clobber a deliberate in-script clear,
+    otherwise apps can no longer programmatically reset a keyed selectbox.
+    """
+
+    def script():
+        import streamlit as st
+
+        if "init" not in st.session_state:
+            st.session_state["init"] = True
+            st.session_state["picker"] = None
+
+        selected = st.selectbox("Pick", ["A", "B"], index=0, key="picker")
+        st.text(f"value={selected} state={st.session_state['picker']}")
+
+    at = AppTest.from_function(script).run()
+    # Neither the returned value nor session_state may be silently overwritten.
+    assert at.text[0].value == "value=None state=None"
+
+
 class TestSelectboxSerde:
     def test_serialize(self):
         options = ["Option A", "Option B", "Option C"]

--- a/lib/tests/streamlit/elements/selectbox_test.py
+++ b/lib/tests/streamlit/elements/selectbox_test.py
@@ -92,6 +92,29 @@ class SelectboxTest(DeltaGeneratorTestCase):
         assert c.default == 0
         assert not c.HasField("default")
 
+    def test_proto_default_omitted_when_session_state_holds_explicit_none(self):
+        """When the developer holds an explicit ``session_state[key] = None``,
+        the proto's ``default`` must be unset even though a non-``None`` ``index``
+        was declared. Otherwise a frontend remount that falls back to
+        ``getDefaultStateFromProto`` would resurrect ``options[index]`` while
+        Python still returns ``None`` (see PR #16285 discussion on remount
+        UI/Python desync)."""
+        st.session_state["picker"] = None
+        st.selectbox("the label", ("a", "b", "c"), index=0, key="picker")
+
+        c = self.get_delta_from_queue().new_element.selectbox
+        assert not c.HasField("default")
+
+    def test_proto_default_present_when_no_explicit_none(self):
+        """The remount guard must not fire for the common case: a keyed
+        selectbox with a declared ``index`` and no explicit ``None`` in
+        session state still ships its default."""
+        st.selectbox("the label", ("a", "b", "c"), index=2, key="picker2")
+
+        c = self.get_delta_from_queue().new_element.selectbox
+        assert c.HasField("default")
+        assert c.default == 2
+
     def test_noneType_option(self):
         """Test NoneType option value."""
         current_value = st.selectbox("the label", (None, "selected"), 0)
@@ -713,6 +736,163 @@ def test_None_session_state_value_retained():
     assert at.selectbox[0].value is None
 
 
+def test_None_session_state_value_persists_across_multiple_reruns():
+    """An explicit ``session_state[k] = None`` (assigned once, never
+    re-assigned) survives an unbounded number of downstream reruns — the
+    ``_user_set_none_keys`` marker must not decay when the developer
+    simply hasn't touched the key on a run."""
+
+    def script():
+        import streamlit as st
+
+        if "selectbox" not in st.session_state:
+            st.session_state["selectbox"] = None
+
+        st.selectbox("selectbox", ["a", "b", "c"], key="selectbox")
+        st.button("button")
+
+    at = AppTest.from_function(script).run()
+    for _ in range(3):
+        at = at.button[0].click().run()
+        assert at.selectbox[0].value is None
+
+
+def test_explicit_none_cleared_by_ui_selection_then_reset_to_default():
+    """After an explicit clear, once the user actually picks a value via
+    the widget UI, the marker must lift so that a subsequent empty→non-empty
+    options transition can restore the declared default (#10093 must not
+    reappear for a key that was ever explicitly cleared)."""
+
+    def script():
+        import streamlit as st
+
+        if "picker" not in st.session_state:
+            # Simulate the developer explicitly clearing the widget once.
+            st.session_state["picker"] = None
+
+        if "ready" not in st.session_state:
+            st.session_state["ready"] = True
+
+        options = ["A", "B", "C"] if st.session_state["ready"] else []
+        selected = st.selectbox("Pick", options, index=0, key="picker")
+        st.text(f"value={selected}")
+
+        if st.button("hide options", key="hide"):
+            st.session_state["ready"] = False
+        if st.button("show options", key="show"):
+            st.session_state["ready"] = True
+
+    at = AppTest.from_function(script).run()
+    # Explicit clear is honored on first render.
+    assert at.text[0].value == "value=None"
+
+    # User picks a real value via the widget UI. That should clear the
+    # ``_user_set_none_keys`` marker.
+    at = at.selectbox[0].set_value("B").run()
+    assert at.text[0].value == "value=B"
+
+    # Options collapse and re-populate. Because the marker was cleared by
+    # the UI selection above, the widget must fall back to ``index=0``
+    # instead of resurrecting ``None``. An extra ``run()`` after each
+    # button click is needed because the buttons only flip ``ready`` at
+    # the end of their own run; options change on the following run.
+    at = at.button(key="hide").click().run().run()
+    assert at.text[0].value == "value=None"
+    at = at.button(key="show").click().run().run()
+    assert at.text[0].value == "value=A"
+
+
+def test_none_option_is_not_treated_as_stale():
+    """Regression: with ``options=(None, "b", "c")``, a stored ``None`` might
+    be a deliberate UI selection of the ``None`` option, not leftover
+    empty-options residue — the two are indistinguishable from
+    ``current_value`` alone. ``_is_stale_none`` must refuse to reset in that
+    case, otherwise a valid ``None`` selection gets snapped back to
+    ``options[default_index]`` on every rerun."""
+    from streamlit.elements.lib.options_selector_utils import _is_stale_none
+
+    # Baseline (control): options don't contain None → stale None resets.
+    assert _is_stale_none(key="picker", default_index=0, opt=["a", "b", "c"])
+
+    # The fix: options contain None → stale None is unresolvable, don't reset.
+    assert not _is_stale_none(key="picker", default_index=1, opt=(None, "b", "c"))
+    assert not _is_stale_none(key="picker", default_index=0, opt=(None,))
+    # Independent of default_index and key shape.
+    assert not _is_stale_none(key=None, default_index=1, opt=(None, "b"))
+    assert not _is_stale_none(key="k", default_index=None, opt=(None, "b"))
+
+
+def test_url_query_param_seed_supersedes_prior_explicit_none():
+    """Regression: a value seeded from the URL on initial load must win over
+    a prior programmatic ``st.session_state[key] = None`` — the durable
+    explicit-None marker must be discarded when ``_seed_widget_from_url``
+    writes a non-``None`` value into ``_new_session_state`` directly
+    (bypassing ``__setitem__``). Without this, the coerce guard in the
+    options-resolution helpers would rewrite the URL-seeded value back to
+    ``None`` on the same run."""
+
+    def script():
+        import streamlit as st
+
+        st.session_state["picker"] = None
+        selected = st.selectbox(
+            "Pick", ["a", "b", "c"], index=0, key="picker", bind="query-params"
+        )
+        st.text(f"value={selected!r}")
+
+    at = AppTest.from_function(script)
+    at.query_params["picker"] = "b"
+    at = at.run()
+    # URL-seeded ``"b"`` must survive despite the explicit-None assignment
+    # earlier in the script (URL wins on initial load).
+    assert at.text[0].value == "value='b'"
+
+
+def test_explicit_none_survives_options_identity_change():
+    """Regression test for the identity-change coerce path (#16285 review):
+    if the developer holds an explicit ``session_state[k] = None`` and an
+    identity-bearing argument changes, the widget id changes and the fresh
+    widget deserializes to ``options[default_index]``. The durable
+    ``_user_set_none_keys`` marker must still coerce the value back to
+    ``None`` *and* sync ``st.session_state[k]`` via ``reset_state_value``,
+    so the widget's return value and ``st.session_state[k]`` stay in
+    lock-step. For keyed selectboxes, ``accept_new_options`` is
+    identity-bearing (see ``key_as_main_identity`` in ``_selectbox``);
+    flipping it forces the id to change here."""
+
+    def script():
+        import streamlit as st
+
+        if "picker" not in st.session_state:
+            st.session_state["picker"] = None
+        if "phase" not in st.session_state:
+            st.session_state["phase"] = 0
+
+        # ``accept_new_options`` is identity-bearing for keyed selectboxes,
+        # so flipping it forces a new widget id and exercises the coerce.
+        accept_new = st.session_state["phase"] == 1
+        selected = st.selectbox(
+            "Pick",
+            ["A", "B", "C"],
+            index=0,
+            key="picker",
+            accept_new_options=accept_new,
+        )
+        st.text(f"value={selected} state={st.session_state['picker']!r}")
+
+        if st.button("flip identity"):
+            st.session_state["phase"] = 1
+
+    at = AppTest.from_function(script).run()
+    assert at.text[0].value == "value=None state=None"
+
+    # Flip the identity-bearing arg — widget id changes, new widget is seeded
+    # with options[0]='A', and the coerce must (a) return None and (b) sync
+    # session_state back to None.
+    at = at.button[0].click().run().run()
+    assert at.text[0].value == "value=None state=None"
+
+
 def test_selectbox_resets_to_default_when_options_appear():
     """Regression test for #10093: when options change from empty to non-empty,
     the widget should reset to the declared default index, not stay at None."""
@@ -747,6 +927,36 @@ def test_selectbox_resets_to_default_when_options_appear():
     at = at.run()
 
     # With options now available and index=0, value should be "A"
+    assert at.text[0].value == "value=A"
+
+
+def test_selectbox_accept_new_options_resets_to_default_when_options_appear():
+    """Regression test: #10093's empty→non-empty stale-None reset must also
+    fire on the ``accept_new_options=True`` fast path. Without the reset in
+    that branch, a keyed ``accept_new_options=True`` selectbox stays stuck on
+    ``None`` when options later appear, even with a non-``None`` declared
+    ``index`` — the original #10093 failure mode, but on a different code
+    path than the main fix."""
+
+    def script():
+        import streamlit as st
+
+        if "ready" not in st.session_state:
+            st.session_state["ready"] = False
+
+        options = ["A", "B", "C"] if st.session_state["ready"] else []
+        selected = st.selectbox(
+            "Pick", options, index=0, key="picker", accept_new_options=True
+        )
+        st.text(f"value={selected}")
+
+        if st.button("Load options"):
+            st.session_state["ready"] = True
+
+    at = AppTest.from_function(script).run()
+    assert at.text[0].value == "value=None"
+
+    at = at.button[0].click().run().run()
     assert at.text[0].value == "value=A"
 
 

--- a/lib/tests/streamlit/elements/selectbox_test.py
+++ b/lib/tests/streamlit/elements/selectbox_test.py
@@ -699,18 +699,91 @@ def test_selectbox_keeps_enum_selection_with_identity_dependent_format_func():
 
 
 def test_None_session_state_value_retained():
+    """When index=None is declared, a programmatic session_state=None is preserved."""
+
     def script():
         import streamlit as st
 
         if "selectbox" not in st.session_state:
             st.session_state["selectbox"] = None
 
-        st.selectbox("selectbox", ["a", "b", "c"], key="selectbox")
+        # index=None declares that None is a valid state for this widget.
+        st.selectbox("selectbox", ["a", "b", "c"], index=None, key="selectbox")
         st.button("button")
 
     at = AppTest.from_function(script).run()
     at = at.button[0].click().run()
     assert at.selectbox[0].value is None
+
+
+def test_selectbox_resets_to_default_when_options_appear():
+    """Regression test for #10093: when options change from empty to non-empty,
+    the widget should reset to the declared default index, not stay at None."""
+
+    def script():
+        import streamlit as st
+
+        if "ready" not in st.session_state:
+            st.session_state["ready"] = False
+
+        if st.session_state["ready"]:
+            options = ["A", "B", "C"]
+        else:
+            options = []
+
+        selected = st.selectbox("Pick", options, index=0, key="picker")
+        st.text(f"value={selected}")
+
+        if st.button("Load options"):
+            st.session_state["ready"] = True
+
+    # First run: options empty, value should be None
+    at = AppTest.from_function(script).run()
+    assert at.text[0].value == "value=None"
+
+    # Click button to populate options
+    at = at.button[0].click().run()
+    # Extra run needed: AppTest doesn't fully simulate frontend processing
+    # of the set_value=True response. The second run picks up the reset value.
+    at = at.run()
+
+    # With options now available and index=0, value should be "A"
+    assert at.text[0].value == "value=A"
+
+
+def test_selectbox_none_default_preserved_when_index_none():
+    """When index=None is declared and options appear, None is preserved."""
+
+    def script():
+        import streamlit as st
+
+        if "ready" not in st.session_state:
+            st.session_state["ready"] = False
+
+        if st.session_state["ready"]:
+            options = ["A", "B", "C"]
+        else:
+            options = []
+
+        selected = st.selectbox(
+            "Pick",
+            options,
+            index=None,
+            placeholder="Select...",
+            key="picker",
+        )
+        st.text(f"value={selected}")
+
+        if st.button("Load options"):
+            st.session_state["ready"] = True
+
+    # First run: options empty, value is None
+    at = AppTest.from_function(script).run()
+    assert at.text[0].value == "value=None"
+
+    # Click button to populate options - with index=None, None should be kept
+    at = at.button[0].click().run()
+    assert at.text[0].value == "value=None"
 
 
 class TestSelectboxSerde:

--- a/lib/tests/streamlit/elements/selectbox_test.py
+++ b/lib/tests/streamlit/elements/selectbox_test.py
@@ -699,16 +699,13 @@ def test_selectbox_keeps_enum_selection_with_identity_dependent_format_func():
 
 
 def test_None_session_state_value_retained():
-    """When index=None is declared, a programmatic session_state=None is preserved."""
-
     def script():
         import streamlit as st
 
         if "selectbox" not in st.session_state:
             st.session_state["selectbox"] = None
 
-        # index=None declares that None is a valid state for this widget.
-        st.selectbox("selectbox", ["a", "b", "c"], index=None, key="selectbox")
+        st.selectbox("selectbox", ["a", "b", "c"], key="selectbox")
         st.button("button")
 
     at = AppTest.from_function(script).run()

--- a/lib/tests/streamlit/elements/selectbox_test.py
+++ b/lib/tests/streamlit/elements/selectbox_test.py
@@ -743,8 +743,10 @@ def test_selectbox_resets_to_default_when_options_appear():
 
     # Click button to populate options
     at = at.button[0].click().run()
-    # Extra run needed: AppTest doesn't fully simulate frontend processing
-    # of the set_value=True response. The second run picks up the reset value.
+    # A second run is needed because of script ordering, not an AppTest
+    # limitation: `ready` is only set at the end of the click run, after the
+    # selectbox has already rendered. Options first become non-empty on the
+    # run after that.
     at = at.run()
 
     # With options now available and index=0, value should be "A"
@@ -781,8 +783,12 @@ def test_selectbox_none_default_preserved_when_index_none():
     at = AppTest.from_function(script).run()
     assert at.text[0].value == "value=None"
 
-    # Click button to populate options - with index=None, None should be kept
+    # Click button to populate options. A second run is required for options to
+    # actually become non-empty (`ready` is set only at the end of the click
+    # run), otherwise this would assert against still-empty options and pass
+    # vacuously without ever exercising index=None against real options.
     at = at.button[0].click().run()
+    at = at.run()
     assert at.text[0].value == "value=None"
 
 

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -1056,6 +1056,163 @@ class SessionStateMethodTests(unittest.TestCase):
         self.session_state._new_widget_state.set_from_value("foo", "bar")
         assert not self.session_state._widget_changed("foo")
 
+    # ---- _user_set_none_keys contract (see options_selector_utils._is_stale_none). ----
+    #
+    # These tests pin the durable "developer explicitly cleared this key"
+    # marker so selectbox/radio can distinguish user-explicit ``None`` from a
+    # Streamlit-auto ``None`` even after ``_new_session_state`` is folded into
+    # ``_old_state`` by compaction.
+
+    def test_is_user_set_none_false_by_default(self):
+        """A key never assigned via the SessionState API is not user-set-None."""
+        assert not self.session_state.is_user_set_none("foo")
+        assert not self.session_state.is_user_set_none("unseen")
+
+    def test_setitem_none_marks_user_set_none(self):
+        """``session_state[k] = None`` records the intent so it survives reruns."""
+        self.session_state["foo"] = None
+        assert self.session_state.is_user_set_none("foo")
+
+    def test_setitem_non_none_clears_user_set_none(self):
+        """Reassigning a previously-cleared key to a real value lifts the marker."""
+        self.session_state["foo"] = None
+        assert self.session_state.is_user_set_none("foo")
+
+        self.session_state["foo"] = "bar"
+        assert not self.session_state.is_user_set_none("foo")
+
+    def test_delitem_clears_user_set_none(self):
+        """Deleting a key removes any lingering marker."""
+        self.session_state["foo"] = None
+        assert self.session_state.is_user_set_none("foo")
+
+        del self.session_state["foo"]
+        assert not self.session_state.is_user_set_none("foo")
+
+    def test_clear_removes_all_user_set_none(self):
+        """``clear()`` resets the whole set alongside the rest of session state."""
+        self.session_state["foo"] = None
+        self.session_state["baz"] = None
+        assert self.session_state.is_user_set_none("foo")
+        assert self.session_state.is_user_set_none("baz")
+
+        self.session_state.clear()
+        assert not self.session_state.is_user_set_none("foo")
+        assert not self.session_state.is_user_set_none("baz")
+
+    def test_reset_state_value_non_none_clears_user_set_none(self):
+        """An internal non-``None`` reset (e.g. option-filter override) must lift
+        the marker so future empty→non-empty options transitions defaulting
+        back to a declared index works."""
+        self.session_state["foo"] = None
+        assert self.session_state.is_user_set_none("foo")
+
+        self.session_state.reset_state_value("foo", "bar")
+        assert not self.session_state.is_user_set_none("foo")
+
+    def test_reset_state_value_none_preserves_user_set_none(self):
+        """An internal ``None`` reset (e.g. chat_input clearing after submit)
+        is not a user assignment and must leave the marker as-is."""
+        self.session_state["foo"] = None
+        assert self.session_state.is_user_set_none("foo")
+
+        self.session_state.reset_state_value("foo", None)
+        # Still marked — the reset didn't come from the developer.
+        assert self.session_state.is_user_set_none("foo")
+
+    def test_drop_widget_value_preserves_current_run_user_set_none(self):
+        """Current-run ``__setitem__(k, None)`` writes to ``_new_session_state``
+        and sets the marker. If a page-scoped drop fires later in the same
+        run, ``_new_session_state`` is intentionally left alone (documented
+        contract) — so the marker must survive too, otherwise the next run
+        would treat the still-present current-run ``None`` as stale and reset
+        to the declared default."""
+        self.session_state["foo"] = None
+        assert self.session_state.is_user_set_none("foo")
+        # ``foo`` still sits in ``_new_session_state`` as the current-run
+        # intent. A drop must not retire the marker.
+        self.session_state._drop_widget_value("widget_id_foo", "foo")
+        assert self.session_state.is_user_set_none("foo")
+
+    def test_drop_widget_value_clears_compacted_user_set_none(self):
+        """When the explicit clear lives only in the marker (not in
+        ``_new_session_state``), a page-scoped drop retires the marker along
+        with the value it applied to — e.g. ``persist_state="page"``
+        navigating away and back. Otherwise the coerce guard would keep
+        pinning the widget to ``None`` after its scoped value is gone."""
+        self.session_state["foo"] = None
+        # Simulate the current-run write compacting into _old_state so only
+        # the marker (and _old_state) carry the developer's clear across the
+        # rerun boundary.
+        self.session_state._compact_state()
+        assert "foo" not in self.session_state._new_session_state
+        assert self.session_state.is_user_set_none("foo")
+
+        self.session_state._drop_widget_value("widget_id_foo", "foo")
+        assert not self.session_state.is_user_set_none("foo")
+
+    def test_set_widgets_from_proto_injects_value_none_for_empty_proto(self):
+        """When the frontend sends an empty widget proto for a user-set-None
+        key, ``set_widgets_from_proto`` short-circuits the eventual
+        ``deserialize(None)`` collapse by injecting ``Value(None)`` directly
+        into ``_new_widget_state``."""
+        from streamlit.proto.WidgetStates_pb2 import (
+            WidgetState as WidgetStateProto,
+        )
+        from streamlit.proto.WidgetStates_pb2 import (
+            WidgetStates as WidgetStatesProto,
+        )
+
+        widget_id = "widget_1"
+        user_key = "cleared_key"
+        self.session_state._key_id_mapper.set_key_id_mapping({user_key: widget_id})
+        self.session_state["cleared_key"] = None
+        assert self.session_state.is_user_set_none(user_key)
+
+        empty_proto = WidgetStateProto()
+        empty_proto.id = widget_id
+        states = WidgetStatesProto()
+        states.widgets.append(empty_proto)
+
+        self.session_state.set_widgets_from_proto(states)
+
+        stored = self.session_state._new_widget_state.states.get(widget_id)
+        assert isinstance(stored, Value)
+        assert stored.value is None
+        # Marker is preserved: the frontend didn't send a real interaction.
+        assert self.session_state.is_user_set_none(user_key)
+
+    def test_set_widgets_from_proto_clears_marker_on_non_empty_proto(self):
+        """A non-empty proto is a frontend-driven update; the marker no longer
+        reflects the developer's intent and must be dropped so a future
+        empty→non-empty options transition can restore the declared default."""
+        from streamlit.proto.WidgetStates_pb2 import (
+            WidgetState as WidgetStateProto,
+        )
+        from streamlit.proto.WidgetStates_pb2 import (
+            WidgetStates as WidgetStatesProto,
+        )
+
+        widget_id = "widget_1"
+        user_key = "picker"
+        self.session_state._key_id_mapper.set_key_id_mapping({user_key: widget_id})
+        self.session_state["picker"] = None
+        assert self.session_state.is_user_set_none(user_key)
+
+        real_proto = WidgetStateProto()
+        real_proto.id = widget_id
+        real_proto.string_value = "chosen"
+        states = WidgetStatesProto()
+        states.widgets.append(real_proto)
+
+        self.session_state.set_widgets_from_proto(states)
+
+        # Marker cleared because the frontend confirmed a real value.
+        assert not self.session_state.is_user_set_none(user_key)
+        stored = self.session_state._new_widget_state.states.get(widget_id)
+        assert isinstance(stored, Serialized)
+        assert stored.value.string_value == "chosen"
+
     @patch(
         "streamlit.runtime.state.session_state.get_script_run_ctx",
         return_value=MagicMock(fragment_ids_this_run=None),


### PR DESCRIPTION
## Describe your changes

Fixes #10093. Two independent code paths were converting a `None` selectbox / radio value back to the widget's declared default:

1. **Same-run:** `selectbox.py` / `radio.py` had a per-widget override that forced `index = None` whenever session state held `None`, discarding the developer's declared `index`. When `options` later became non-empty with `index=0`, that override put the widget right back at `None`.
2. **Across reruns:** `SelectboxSerde.serialize(None)` produces no `raw_value`, so the wire proto goes back empty. On the next run, `_call_callbacks -> _widget_changed -> _new_widget_state.get(wid)` eagerly deserialized that empty proto via `deserialize(None)`, which for selectbox/radio returns `options[default_index]`. The default got cached under the widget id **before** `register_widget` ran, and the widget never saw the developer's `None`.

**The fix.**

1. **Delete the per-widget `index = None` override** from `selectbox.py` and `radio.py`.
2. **Treat a stored `None` as stale** in the value-resolution helpers — reset to the declared default when options are available — *unless* the developer has explicitly assigned `None` (see below). The reset is opt-in on the shared helper to protect `st.pills` / `st.segmented_control` / `st.select_slider`.
3. **Track user-explicit-None keys durably.** `SessionState` gains a `_user_set_none_keys` marker set (and a public `is_user_set_none()`). It is populated in `__setitem__` when the developer assigns `None`; cleared when the same key is reassigned to non-`None`, deleted, `clear()`-ed, `reset_state_value`-d to non-`None`, or when the frontend sends a non-empty widget proto for that key (a UI interaction supersedes the stale programmatic clear). `_is_stale_none` consults the marker so `st.session_state[k] = None` is honored across arbitrarily many reruns.
4. **Pre-empt the deserialize-collapse.** `set_widgets_from_proto` iterates `_user_set_none_keys`: for each marked key whose incoming proto is empty, it installs `Value(None)` directly into `_new_widget_state` — short-circuiting the eager `deserialize(None)` that would otherwise return `options[default_index]` before `register_widget` gets to run.

### Why `None` is still preserved where it means something

The reset is deliberately **opt-in**, because `None` is not always stale:

- `resolve_value_against_options` is used **only by selectbox**, so the behavior change there is contained.
- `validate_and_sync_value_with_options` is **shared** with `st.radio`, `st.select_slider`, `st.pills`, and `st.segmented_control`. It gained a `reset_stale_none: bool = False` parameter, and **only `radio` opts in**. `st.pills` / `st.segmented_control` rely on stored `None` to render their `required` validation state; `st.select_slider` never stores `None`.
- `index=None` remains a valid opt-in to a nullable widget: `default_index is None` short-circuits the reset.

## GitHub Issue Link

Closes https://github.com/streamlit/streamlit/issues/10093

## Testing Plan

**Python unit tests**

- `selectbox_test.py` / `radio_test.py`:
  - Reported flow: options empty → `None` stored → options populated with a declared `index` → declared default is honored.
  - `test_None_session_state_value_retained`: explicit `session_state[k] = None` survives one rerun.
  - `test_None_session_state_value_persists_across_multiple_reruns`: it survives three downstream reruns.
  - `test_explicit_none_cleared_by_ui_selection_then_reset_to_default`: after an explicit clear, a UI selection lifts the marker so a subsequent empty→non-empty options transition restores the declared default (regression guard for the sticky-marker case).
- `session_state_test.py` — seven `SessionStateMethodTests` cases pin the `_user_set_none_keys` contract:
  - `is_user_set_none` default is False.
  - `__setitem__` None-marking and non-None clearing.
  - `__delitem__` and `clear()` clearing.
  - `reset_state_value` non-None clearing vs None preserving.
  - `set_widgets_from_proto` injects `Value(None)` for an empty proto under a marked key, and drops the marker for a non-empty proto.
- `options_selector_utils_test.py` — four dedicated cases pin the shared-helper contract on both sides of the flag:
  - `reset_stale_none=True` + declared default + non-empty options → resets to the default (`value_was_reset=True`).
  - `reset_stale_none=True` + `default_index=None` → `None` preserved.
  - `reset_stale_none=True` + empty options → `None` preserved.
  - **default (opt-out)** → `None` preserved, which is what `st.pills` / `st.segmented_control` depend on.

**Collateral verification** (touches a shared helper, so checked explicitly)

- `selectbox_test.py`, `radio_test.py`, `select_slider_test.py`, `button_group_test.py`, `options_selector_utils_test.py`, `session_state_test.py`: all green locally.
- The two e2e tests that the unscoped revision broke were re-run locally against a fresh frontend build and now pass: `st_pills_test.py::test_required_pills_behavior` and `st_segmented_control_test.py::test_required_segmented_control_behavior`.
- `make python-format` and `make python-lint` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared session-state compaction and option-sync helpers used by multiple widgets; incorrect marker or stale-None logic could break explicit clears, URL binding, or pills/segmented `required` behavior.
> 
> **Overview**
> Fixes **#10093**: keyed **selectbox** and **radio** no longer stay stuck on `None` after `options` go from empty to non-empty with a declared `index`.
> 
> **Session state:** Adds durable `_user_set_none_keys` and `is_user_set_none()` so `st.session_state[k] = None` is distinguished from Streamlit’s auto-`None` when options were empty. `set_widgets_from_proto` injects `Value(None)` for empty protos on marked keys (avoids `deserialize(None)` snapping to `options[index]` before `register_widget`). Marker lifecycle is wired through assign/delete/clear, URL seed, widget drops, and real UI updates.
> 
> **Value resolution:** New `_is_stale_none` plus optional `reset_stale_none` on `validate_and_sync_value_with_options` (radio opts in; pills/segmented_control do not). `resolve_value_against_options` always resets stale `None` for selectbox. Both paths coerce back to `None` when the user explicitly cleared the key, including after widget-id changes (`accept_new_options` fast path included).
> 
> **Widgets:** Removes the old “force `index = None` when session state is `None`” override. Omits `proto.default` when `is_user_set_none` so remounts don’t show `options[index]` while Python returns `None`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79676580b9fc7412f67a8f73d5288963902b8853. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->