### PR TITLE
[fix] Re-derive heading anchor when heading text changes on rerun (#8793)

### DIFF
--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
@@ -650,6 +650,41 @@ describe("StreamlitMarkdown", () => {
         "second-heading"
       )
     })
+    // The stale anchor must be gone, not merely joined by the new one.
+    expect(screen.getByRole("heading")).not.toHaveAttribute(
+      "id",
+      "first-heading"
+    )
+  })
+
+  it("keeps an explicit anchor when heading text changes across reruns", async () => {
+    const { rerender } = render(
+      <IsSidebarContext.Provider value={false}>
+        <IsDialogContext.Provider value={false}>
+          <HeadingWithActionElements tag="h2" anchor="my-anchor">
+            First Heading
+          </HeadingWithActionElements>
+        </IsDialogContext.Provider>
+      </IsSidebarContext.Provider>
+    )
+
+    expect(screen.getByRole("heading")).toHaveAttribute("id", "my-anchor")
+
+    rerender(
+      <IsSidebarContext.Provider value={false}>
+        <IsDialogContext.Provider value={false}>
+          <HeadingWithActionElements tag="h2" anchor="my-anchor">
+            Second Heading
+          </HeadingWithActionElements>
+        </IsDialogContext.Provider>
+      </IsSidebarContext.Provider>
+    )
+
+    // A developer-supplied anchor is never re-derived from the text.
+    await waitFor(() => {
+      expect(screen.getByRole("heading")).toHaveTextContent("Second Heading")
+    })
+    expect(screen.getByRole("heading")).toHaveAttribute("id", "my-anchor")
   })
 
   it("propagates header attributes to custom header", async () => {

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
@@ -14,19 +14,19 @@
  * limitations under the License.
  */
 
-import { ReactElement } from "react";
+import { ReactElement } from "react"
 
-import { cleanup, screen, within } from "@testing-library/react";
-import { transparentize } from "color2k";
-import type { Element } from "hast";
-import ReactMarkdown from "react-markdown";
+import { cleanup, screen, within } from "@testing-library/react"
+import { transparentize } from "color2k"
+import type { Element } from "hast"
+import ReactMarkdown from "react-markdown"
 
-import IsDialogContext from "~lib/components/core/IsDialogContext";
-import IsSidebarContext from "~lib/components/core/IsSidebarContext";
-import { mockTheme } from "~lib/mocks/mockTheme";
-import { render, renderWithContexts } from "~lib/test_util";
-import { getThemeBackgroundColors } from "~lib/theme/getColors";
-import { colors } from "~lib/theme/primitives/colors";
+import IsDialogContext from "~lib/components/core/IsDialogContext"
+import IsSidebarContext from "~lib/components/core/IsSidebarContext"
+import { mockTheme } from "~lib/mocks/mockTheme"
+import { render, renderWithContexts } from "~lib/test_util"
+import { getThemeBackgroundColors } from "~lib/theme/getColors"
+import { colors } from "~lib/theme/primitives/colors"
 
 import StreamlitMarkdown, {
   containsEmojiShortcodes,
@@ -39,26 +39,26 @@ import StreamlitMarkdown, {
   HeadingWithActionElements,
   isValidCssColor,
   LinkWithTargetBlank,
-} from "./StreamlitMarkdown";
+} from "./StreamlitMarkdown"
 
 // Mock StreamlitConfig using global mock state (see vitest.setup.ts)
 vi.mock("@streamlit/utils", async () => {
-  const actual = await vi.importActual("@streamlit/utils");
+  const actual = await vi.importActual("@streamlit/utils")
   return {
     ...actual,
     get StreamlitConfig() {
-      return globalThis.__mockStreamlitConfig;
+      return globalThis.__mockStreamlitConfig
     },
-  };
-});
+  }
+})
 
 // Fixture Generator
 const getMarkdownElement = (body: string): ReactElement => {
   const components = {
     a: LinkWithTargetBlank,
-  };
-  return <ReactMarkdown components={components}>{body}</ReactMarkdown>;
-};
+  }
+  return <ReactMarkdown components={components}>{body}</ReactMarkdown>
+}
 
 describe("createAnchorFromText", () => {
   it.each([
@@ -95,9 +95,9 @@ describe("createAnchorFromText", () => {
     ["---", "6110bfd"],
     ["___", "647ce586"],
   ])("converts '%s' to '%s'", (input, expected) => {
-    expect(createAnchorFromText(input)).toEqual(expected);
-  });
-});
+    expect(createAnchorFromText(input)).toEqual(expected)
+  })
+})
 
 describe("containsMathSyntax", () => {
   it.each([
@@ -165,10 +165,10 @@ describe("containsMathSyntax", () => {
   ])(
     "detects $description correctly",
     ({ input, expected }: { input: string; expected: boolean }) => {
-      expect(containsMathSyntax(input)).toBe(expected);
-    },
-  );
-});
+      expect(containsMathSyntax(input)).toBe(expected)
+    }
+  )
+})
 
 describe("containsEmojiShortcodes", () => {
   it.each([
@@ -290,10 +290,10 @@ describe("containsEmojiShortcodes", () => {
   ])(
     "detects $description correctly",
     ({ input, expected }: { input: string; expected: boolean }) => {
-      expect(containsEmojiShortcodes(input)).toBe(expected);
-    },
-  );
-});
+      expect(containsEmojiShortcodes(input)).toBe(expected)
+    }
+  )
+})
 
 describe("isValidCssColor", () => {
   it.each([
@@ -367,65 +367,62 @@ describe("isValidCssColor", () => {
       description: "CSS expression",
     },
   ])("validates $description correctly", ({ input, expected }) => {
-    expect(isValidCssColor(input)).toBe(expected);
-  });
-});
+    expect(isValidCssColor(input)).toBe(expected)
+  })
+})
 
 describe("linkReference", () => {
   it("renders a link with _blank target", () => {
-    const body = "Some random URL like [Streamlit](https://streamlit.io/)";
-    render(getMarkdownElement(body));
+    const body = "Some random URL like [Streamlit](https://streamlit.io/)"
+    render(getMarkdownElement(body))
     expect(screen.getByText("Streamlit")).toHaveAttribute(
       "href",
-      "https://streamlit.io/",
-    );
-    expect(screen.getByText("Streamlit")).toHaveAttribute("target", "_blank");
-  });
+      "https://streamlit.io/"
+    )
+    expect(screen.getByText("Streamlit")).toHaveAttribute("target", "_blank")
+  })
 
   it("renders a link without title", () => {
     const body =
-      "Everybody loves [The Internet Archive](https://archive.org/).";
-    render(getMarkdownElement(body));
-    const link = screen.getByText("The Internet Archive");
-    expect(link).toHaveAttribute("href", "https://archive.org/");
-    expect(link).not.toHaveAttribute("title");
-  });
+      "Everybody loves [The Internet Archive](https://archive.org/)."
+    render(getMarkdownElement(body))
+    const link = screen.getByText("The Internet Archive")
+    expect(link).toHaveAttribute("href", "https://archive.org/")
+    expect(link).not.toHaveAttribute("title")
+  })
 
   it("renders a link containing a title", () => {
     const body =
       "My favorite search engine is " +
-      '[Duck Duck Go](https://duckduckgo.com/ "The best search engine for privacy").';
-    render(getMarkdownElement(body));
-    const link = screen.getByText("Duck Duck Go");
-    expect(link).toHaveAttribute("href", "https://duckduckgo.com/");
-    expect(link).toHaveAttribute(
-      "title",
-      "The best search engine for privacy",
-    );
-  });
+      '[Duck Duck Go](https://duckduckgo.com/ "The best search engine for privacy").'
+    render(getMarkdownElement(body))
+    const link = screen.getByText("Duck Duck Go")
+    expect(link).toHaveAttribute("href", "https://duckduckgo.com/")
+    expect(link).toHaveAttribute("title", "The best search engine for privacy")
+  })
 
   it("renders a link containing parentheses", () => {
     const body =
-      "Here's a link containing parentheses [Yikes](http://msdn.microsoft.com/en-us/library/aa752574(VS.85).aspx)";
-    render(getMarkdownElement(body));
-    const link = screen.getByText("Yikes");
-    expect(link instanceof HTMLAnchorElement).toBe(true);
+      "Here's a link containing parentheses [Yikes](http://msdn.microsoft.com/en-us/library/aa752574(VS.85).aspx)"
+    render(getMarkdownElement(body))
+    const link = screen.getByText("Yikes")
+    expect(link instanceof HTMLAnchorElement).toBe(true)
     expect(link).toHaveAttribute(
       "href",
-      "http://msdn.microsoft.com/en-us/library/aa752574(VS.85).aspx",
-    );
-  });
+      "http://msdn.microsoft.com/en-us/library/aa752574(VS.85).aspx"
+    )
+  })
 
   it("does not render a link if only [text] and no (href)", () => {
-    const body = "Don't convert to a link if only [text] and missing (href)";
-    render(getMarkdownElement(body));
-    const element = screen.getByText("text", { exact: false });
+    const body = "Don't convert to a link if only [text] and missing (href)"
+    render(getMarkdownElement(body))
+    const element = screen.getByText("text", { exact: false })
     expect(element).toHaveTextContent(
-      "Don't convert to a link if only [text] and missing (href)",
-    );
-    expect(element instanceof HTMLAnchorElement).toBe(false);
-  });
-});
+      "Don't convert to a link if only [text] and missing (href)"
+    )
+    expect(element instanceof HTMLAnchorElement).toBe(false)
+  })
+})
 
 describe("link URL scheme security", () => {
   it.each([
@@ -435,18 +432,18 @@ describe("link URL scheme security", () => {
     "javascript:alert(1)  ", // trailing whitespace
     "vbscript:msgbox(1)",
     "VBScript:execute()", // case-insensitive
-  ])("blocks dangerous URL: %s", (url) => {
+  ])("blocks dangerous URL: %s", url => {
     render(
-      <StreamlitMarkdown source={`[Click me](${url})`} allowHTML={false} />,
-    );
+      <StreamlitMarkdown source={`[Click me](${url})`} allowHTML={false} />
+    )
     // Returns "#" to prevent navigation (empty href with target="_blank"
     // would open current page in new tab)
-    const link = screen.getByText("Click me");
-    expect(link).toHaveAttribute("href", "#");
+    const link = screen.getByText("Click me")
+    expect(link).toHaveAttribute("href", "#")
     // Verify blocked links don't open in new tab (LinkWithTargetBlank returns
     // target="_self" for URLs starting with "#")
-    expect(link).not.toHaveAttribute("target", "_blank");
-  });
+    expect(link).not.toHaveAttribute("target", "_blank")
+  })
 
   // Raw HTML links go through rehype-raw and reach transformLinkUri.
   // Test C0 control characters and internal whitespace bypasses in this context.
@@ -465,13 +462,13 @@ describe("link URL scheme security", () => {
     '<a href="java&#9;script:alert(1)">link</a>', // tab via HTML entity
     '<a href="java&#10;script:alert(1)">link</a>', // newline via HTML entity
     '<a href="java&#13;script:alert(1)">link</a>', // CR via HTML entity
-  ])("blocks dangerous raw HTML URLs: %s", async (source) => {
-    render(<StreamlitMarkdown source={source} allowHTML={true} />);
-    const link = await screen.findByText("link");
-    expect(link).toHaveAttribute("href", "#");
+  ])("blocks dangerous raw HTML URLs: %s", async source => {
+    render(<StreamlitMarkdown source={source} allowHTML={true} />)
+    const link = await screen.findByText("link")
+    expect(link).toHaveAttribute("href", "#")
     // Verify blocked links don't open in new tab
-    expect(link).not.toHaveAttribute("target", "_blank");
-  });
+    expect(link).not.toHaveAttribute("target", "_blank")
+  })
 
   it.each([
     "https://example.com",
@@ -482,21 +479,21 @@ describe("link URL scheme security", () => {
     "data:text/plain,hello",
     "/relative/path",
     "#anchor",
-  ])("allows safe URL: %s", (url) => {
+  ])("allows safe URL: %s", url => {
     render(
-      <StreamlitMarkdown source={`[Click me](${url})`} allowHTML={false} />,
-    );
-    expect(screen.getByText("Click me")).toHaveAttribute("href", url);
-  });
-});
+      <StreamlitMarkdown source={`[Click me](${url})`} allowHTML={false} />
+    )
+    expect(screen.getByText("Click me")).toHaveAttribute("href", url)
+  })
+})
 
 describe("StreamlitMarkdown", () => {
-  let bgColors: ReturnType<typeof getThemeBackgroundColors>;
-  let backgroundColorMapping: Map<string, string>;
+  let bgColors: ReturnType<typeof getThemeBackgroundColors>
+  let backgroundColorMapping: Map<string, string>
 
   beforeAll(() => {
     // Use the actual implementation to get background colors
-    bgColors = getThemeBackgroundColors(mockTheme.emotion);
+    bgColors = getThemeBackgroundColors(mockTheme.emotion)
 
     backgroundColorMapping = new Map([
       ["red", bgColors.redbg],
@@ -507,65 +504,65 @@ describe("StreamlitMarkdown", () => {
       ["violet", bgColors.violetbg],
       ["gray", bgColors.graybg],
       ["grey", bgColors.graybg],
-    ]);
-  });
+    ])
+  })
 
   it("renders header anchors when isInSidebar is false", () => {
-    const source = "# header";
+    const source = "# header"
     render(
       <IsSidebarContext.Provider value={false}>
         <StreamlitMarkdown source={source} allowHTML={false} />
-      </IsSidebarContext.Provider>,
-    );
+      </IsSidebarContext.Provider>
+    )
     expect(
-      screen.getByTestId("stHeadingWithActionElements"),
-    ).toBeInTheDocument();
-  });
+      screen.getByTestId("stHeadingWithActionElements")
+    ).toBeInTheDocument()
+  })
 
   it("renders header anchors when isInDialog is false", () => {
-    const source = "# header";
+    const source = "# header"
     render(
       <IsDialogContext.Provider value={false}>
         <StreamlitMarkdown source={source} allowHTML={false} />
-      </IsDialogContext.Provider>,
-    );
+      </IsDialogContext.Provider>
+    )
     expect(
-      screen.getByTestId("stHeadingWithActionElements"),
-    ).toBeInTheDocument();
-  });
+      screen.getByTestId("stHeadingWithActionElements")
+    ).toBeInTheDocument()
+  })
 
   it("passes props properly", async () => {
     const source =
-      "<a class='nav_item' href='//0.0.0.0:8501/?p=some_page' target='_self'>Some Page</a>";
-    render(<StreamlitMarkdown source={source} allowHTML={true} />);
-    const link = await screen.findByText("Some Page");
-    expect(link).toHaveAttribute("href", "//0.0.0.0:8501/?p=some_page");
-    expect(link).toHaveAttribute("target", "_self");
-  });
+      "<a class='nav_item' href='//0.0.0.0:8501/?p=some_page' target='_self'>Some Page</a>"
+    render(<StreamlitMarkdown source={source} allowHTML={true} />)
+    const link = await screen.findByText("Some Page")
+    expect(link).toHaveAttribute("href", "//0.0.0.0:8501/?p=some_page")
+    expect(link).toHaveAttribute("target", "_self")
+  })
 
   it("doesn't render header anchors when isInSidebar is true", () => {
-    const source = "# header";
+    const source = "# header"
     render(
       <IsSidebarContext.Provider value={true}>
         <StreamlitMarkdown source={source} allowHTML={false} />
-      </IsSidebarContext.Provider>,
-    );
+      </IsSidebarContext.Provider>
+    )
     expect(
-      screen.queryByTestId("stHeadingWithActionElements"),
-    ).not.toBeInTheDocument();
-  });
+      screen.queryByTestId("stHeadingWithActionElements")
+    ).not.toBeInTheDocument()
+  })
 
   it("doesn't render header anchors when isInDialog is true", () => {
-    const source = "# header";
+    const source = "# header"
     render(
       <IsDialogContext.Provider value={true}>
         <StreamlitMarkdown source={source} allowHTML={false} />
-      </IsDialogContext.Provider>,
-    );
+      </IsDialogContext.Provider>
+    )
     expect(
-      screen.queryByTestId("stHeadingWithActionElements"),
-    ).not.toBeInTheDocument();
-  });
+      screen.queryByTestId("stHeadingWithActionElements")
+    ).not.toBeInTheDocument()
+  })
 
   it("uses aria-labelledby when help is present in the sidebar (no anchor id)", () => {
     render(
@@ -575,17 +572,17 @@ describe("StreamlitMarkdown", () => {
             Hello
           </HeadingWithActionElements>
         </IsDialogContext.Provider>
-      </IsSidebarContext.Provider>,
-    );
+      </IsSidebarContext.Provider>
+    )
 
-    const heading = screen.getByRole("heading", { name: "Hello" });
-    expect(heading).toHaveAttribute("aria-labelledby");
-    expect(heading).not.toHaveAttribute("id");
+    const heading = screen.getByRole("heading", { name: "Hello" })
+    expect(heading).toHaveAttribute("aria-labelledby")
+    expect(heading).not.toHaveAttribute("id")
 
-    const labelId = heading.getAttribute("aria-labelledby");
-    expect(labelId).toBeTruthy();
-    expect(within(heading).getByText("Hello")).toHaveAttribute("id", labelId);
-  });
+    const labelId = heading.getAttribute("aria-labelledby")
+    expect(labelId).toBeTruthy()
+    expect(within(heading).getByText("Hello")).toHaveAttribute("id", labelId)
+  })
 
   it("uses aria-labelledby when the anchor icon is present (non-sidebar)", () => {
     render(
@@ -595,17 +592,17 @@ describe("StreamlitMarkdown", () => {
             Hello
           </HeadingWithActionElements>
         </IsDialogContext.Provider>
-      </IsSidebarContext.Provider>,
-    );
+      </IsSidebarContext.Provider>
+    )
 
-    const heading = screen.getByRole("heading", { name: "Hello" });
-    expect(heading).toHaveAttribute("id", "my-anchor");
-    expect(heading).toHaveAttribute("aria-labelledby");
+    const heading = screen.getByRole("heading", { name: "Hello" })
+    expect(heading).toHaveAttribute("id", "my-anchor")
+    expect(heading).toHaveAttribute("aria-labelledby")
 
-    const labelId = heading.getAttribute("aria-labelledby");
-    expect(labelId).toBeTruthy();
-    expect(within(heading).getByText("Hello")).toHaveAttribute("id", labelId);
-  });
+    const labelId = heading.getAttribute("aria-labelledby")
+    expect(labelId).toBeTruthy()
+    expect(within(heading).getByText("Hello")).toHaveAttribute("id", labelId)
+  })
 
   it("does not use aria-labelledby when no action elements are present", () => {
     render(
@@ -615,13 +612,13 @@ describe("StreamlitMarkdown", () => {
             Hello
           </HeadingWithActionElements>
         </IsDialogContext.Provider>
-      </IsSidebarContext.Provider>,
-    );
+      </IsSidebarContext.Provider>
+    )
 
-    const heading = screen.getByRole("heading", { name: "Hello" });
-    expect(heading).toHaveAttribute("id", "my-anchor");
-    expect(heading).not.toHaveAttribute("aria-labelledby");
-  });
+    const heading = screen.getByRole("heading", { name: "Hello" })
+    expect(heading).toHaveAttribute("id", "my-anchor")
+    expect(heading).not.toHaveAttribute("aria-labelledby")
+  })
 
   it("updates heading anchor when text changes across reruns (no explicit anchor)", () => {
     const { rerender } = render(
@@ -631,11 +628,11 @@ describe("StreamlitMarkdown", () => {
             First Heading
           </HeadingWithActionElements>
         </IsDialogContext.Provider>
-      </IsSidebarContext.Provider>,
-    );
+      </IsSidebarContext.Provider>
+    )
 
-    const heading = screen.getByRole("heading");
-    expect(heading).toHaveAttribute("id", "first-heading");
+    const heading = screen.getByRole("heading")
+    expect(heading).toHaveAttribute("id", "first-heading")
 
     rerender(
       <IsSidebarContext.Provider value={false}>
@@ -644,21 +641,18 @@ describe("StreamlitMarkdown", () => {
             Second Heading
           </HeadingWithActionElements>
         </IsDialogContext.Provider>
-      </IsSidebarContext.Provider>,
-    );
+      </IsSidebarContext.Provider>
+    )
 
     // useLayoutEffect commits the re-derived id before paint, so the assertion
     // can be direct -- no waitFor needed.
-    expect(screen.getByRole("heading")).toHaveAttribute(
-      "id",
-      "second-heading",
-    );
+    expect(screen.getByRole("heading")).toHaveAttribute("id", "second-heading")
     // The stale anchor must be gone, not merely joined by the new one.
     expect(screen.getByRole("heading")).not.toHaveAttribute(
       "id",
-      "first-heading",
-    );
-  });
+      "first-heading"
+    )
+  })
 
   it("keeps an explicit anchor when heading text changes across reruns", () => {
     const { rerender } = render(
@@ -668,10 +662,10 @@ describe("StreamlitMarkdown", () => {
             First Heading
           </HeadingWithActionElements>
         </IsDialogContext.Provider>
-      </IsSidebarContext.Provider>,
-    );
+      </IsSidebarContext.Provider>
+    )
 
-    expect(screen.getByRole("heading")).toHaveAttribute("id", "my-anchor");
+    expect(screen.getByRole("heading")).toHaveAttribute("id", "my-anchor")
 
     rerender(
       <IsSidebarContext.Provider value={false}>
@@ -680,27 +674,27 @@ describe("StreamlitMarkdown", () => {
             Second Heading
           </HeadingWithActionElements>
         </IsDialogContext.Provider>
-      </IsSidebarContext.Provider>,
-    );
+      </IsSidebarContext.Provider>
+    )
 
     // A developer-supplied anchor is never re-derived from the text.
-    expect(screen.getByRole("heading")).toHaveTextContent("Second Heading");
-    expect(screen.getByRole("heading")).toHaveAttribute("id", "my-anchor");
-  });
+    expect(screen.getByRole("heading")).toHaveTextContent("Second Heading")
+    expect(screen.getByRole("heading")).toHaveAttribute("id", "my-anchor")
+  })
 
   it("propagates header attributes to custom header", async () => {
-    const source = '<h1 data-test="lol">alsdkjhflaf</h1>';
-    render(<StreamlitMarkdown source={source} allowHTML />);
-    const h1 = await screen.findByRole("heading");
-    expect(h1).toHaveAttribute("data-test", "lol");
-  });
+    const source = '<h1 data-test="lol">alsdkjhflaf</h1>'
+    render(<StreamlitMarkdown source={source} allowHTML />)
+    const h1 = await screen.findByRole("heading")
+    expect(h1).toHaveAttribute("data-test", "lol")
+  })
 
   it("displays captions correctly", () => {
-    const source = "hello this is a caption";
-    render(<StreamlitMarkdown allowHTML={false} source={source} isCaption />);
-    const caption = screen.getByTestId("stCaptionContainer");
-    expect(caption).toHaveTextContent("hello this is a caption");
-  });
+    const source = "hello this is a caption"
+    render(<StreamlitMarkdown allowHTML={false} source={source} isCaption />)
+    const caption = screen.getByTestId("stCaptionContainer")
+    expect(caption).toHaveTextContent("hello this is a caption")
+  })
 
   // Valid Markdown - italics, bold, strikethrough, code, links, emojis, shortcodes
   const validCases = [
@@ -716,51 +710,51 @@ describe("StreamlitMarkdown", () => {
     { input: "🐶", tag: "p", expected: "🐶" },
     { input: ":joy:", tag: "p", expected: "😂" },
     { input: ":material/search:", tag: "span", expected: "search" },
-  ];
+  ]
 
   it.each(validCases)(
     "renders valid markdown when isLabel is true - $tag",
     async ({ input, tag, expected }) => {
-      render(<StreamlitMarkdown source={input} allowHTML={false} isLabel />);
+      render(<StreamlitMarkdown source={input} allowHTML={false} isLabel />)
       // Use findByText for emoji shortcodes since remark-emoji is lazy-loaded
       const markdownText =
         input === ":joy:"
           ? await screen.findByText(expected)
-          : screen.getByText(expected);
-      expect(markdownText).toBeInTheDocument();
+          : screen.getByText(expected)
+      expect(markdownText).toBeInTheDocument()
 
-      const expectedTag = markdownText.nodeName.toLowerCase();
-      expect(expectedTag).toEqual(tag);
+      const expectedTag = markdownText.nodeName.toLowerCase()
+      expect(expectedTag).toEqual(tag)
 
       // Removes rendered StreamlitMarkdown component before next case run
-      cleanup();
-    },
-  );
+      cleanup()
+    }
+  )
 
   it("renders streamlit logo in markdown when isLabel is true", () => {
     render(
-      <StreamlitMarkdown source={":streamlit:"} allowHTML={false} isLabel />,
-    );
-    const image = screen.getByRole("img");
-    expect(image).toHaveAttribute("alt", "Streamlit logo");
-  });
+      <StreamlitMarkdown source={":streamlit:"} allowHTML={false} isLabel />
+    )
+    const image = screen.getByRole("img")
+    expect(image).toHaveAttribute("alt", "Streamlit logo")
+  })
 
   it("renders streamlit logo with allowHTML=true", async () => {
-    render(<StreamlitMarkdown source={":streamlit:"} allowHTML={true} />);
-    const image = await screen.findByRole("img");
-    expect(image).toHaveAttribute("alt", "Streamlit logo");
-    expect(image).toHaveStyle("display: inline-block");
-    expect(image).toHaveStyle("user-select: none");
-  });
+    render(<StreamlitMarkdown source={":streamlit:"} allowHTML={true} />)
+    const image = await screen.findByRole("img")
+    expect(image).toHaveAttribute("alt", "Streamlit logo")
+    expect(image).toHaveStyle("display: inline-block")
+    expect(image).toHaveStyle("user-select: none")
+  })
 
   it("renders material icons with allowHTML=true", async () => {
-    const source = `:material/search: Icon`;
-    render(<StreamlitMarkdown source={source} allowHTML={true} />);
-    const markdown = await screen.findByText("search");
-    const tagName = markdown.nodeName.toLowerCase();
-    expect(tagName).toBe("span");
-    expect(markdown).toHaveStyle("font-family: Material Symbols Rounded");
-  });
+    const source = `:material/search: Icon`
+    render(<StreamlitMarkdown source={source} allowHTML={true} />)
+    const markdown = await screen.findByText("search")
+    const tagName = markdown.nodeName.toLowerCase()
+    expect(tagName).toBe("span")
+    expect(markdown).toHaveStyle("font-family: Material Symbols Rounded")
+  })
 
   // Typographical symbol replacements
   const symbolReplacementCases = [
@@ -777,35 +771,35 @@ describe("StreamlitMarkdown", () => {
       expected: "Link ->",
     },
     { input: "`Code ->`", tag: "code", expected: "Code ->" },
-  ];
+  ]
 
   it.each(symbolReplacementCases)(
     "replaces symbols with nicer typographical symbols - $input",
     ({ input, tag, expected }) => {
-      render(<StreamlitMarkdown source={input} allowHTML={false} isLabel />);
-      const markdownText = screen.getByText(expected);
-      expect(markdownText).toBeInTheDocument();
+      render(<StreamlitMarkdown source={input} allowHTML={false} isLabel />)
+      const markdownText = screen.getByText(expected)
+      expect(markdownText).toBeInTheDocument()
 
-      const expectedTag = markdownText.nodeName.toLowerCase();
-      expect(expectedTag).toEqual(tag);
+      const expectedTag = markdownText.nodeName.toLowerCase()
+      expect(expectedTag).toEqual(tag)
 
       // Removes rendered StreamlitMarkdown component before next case run
-      cleanup();
-    },
-  );
+      cleanup()
+    }
+  )
 
   // Invalid Markdown - images, table elements, headings, unordered/ordered lists, task lists, horizontal rules, & blockquotes
   const table = `| Syntax | Description |
   | ----------- | ----------- |
   | Header      | Title       |
-  | Paragraph   | Text        |`;
-  const tableText = "Syntax Description Header Title Paragraph Text";
+  | Paragraph   | Text        |`
+  const tableText = "Syntax Description Header Title Paragraph Text"
   const horizontalRule = `
 
   ---
 
   Horizontal rule
-  `;
+  `
 
   const invalidCases = [
     { input: table, tag: "table", expected: tableText },
@@ -833,37 +827,37 @@ describe("StreamlitMarkdown", () => {
     },
     { input: horizontalRule, tag: "hr", expected: "Horizontal rule" },
     { input: "> Blockquote", tag: "blockquote", expected: "> Blockquote" },
-  ];
+  ]
 
   it.each(invalidCases)(
     "does NOT render invalid markdown when isLabel is true - $tag",
     ({ input, tag, expected }) => {
-      render(<StreamlitMarkdown source={input} allowHTML={false} isLabel />);
-      const markdownText = screen.getByText(expected);
-      expect(markdownText).toBeInTheDocument();
+      render(<StreamlitMarkdown source={input} allowHTML={false} isLabel />)
+      const markdownText = screen.getByText(expected)
+      expect(markdownText).toBeInTheDocument()
 
-      const expectedTag = markdownText.nodeName.toLowerCase();
-      expect(expectedTag).not.toEqual(tag);
+      const expectedTag = markdownText.nodeName.toLowerCase()
+      expect(expectedTag).not.toEqual(tag)
 
       // Removes rendered StreamlitMarkdown component before next case run
-      cleanup();
-    },
-  );
+      cleanup()
+    }
+  )
 
   it("doesn't render links when disableLinks is true", () => {
     // Valid markdown further restricted with buttons to eliminate links
-    const source = "[Link text](www.example.com)";
+    const source = "[Link text](www.example.com)"
     render(
       <StreamlitMarkdown
         source={source}
         allowHTML={false}
         isLabel
         disableLinks
-      />,
-    );
-    const tag = screen.getByText("Link text");
-    expect(tag instanceof HTMLAnchorElement).toBe(false);
-  });
+      />
+    )
+    const tag = screen.getByText("Link text")
+    expect(tag instanceof HTMLAnchorElement).toBe(false)
+  })
 
   // Test for markdown syntax escaping in labels (https://github.com/streamlit/streamlit/issues/7359)
   // These characters/patterns would normally create markdown elements that get stripped,
@@ -901,22 +895,22 @@ describe("StreamlitMarkdown", () => {
     { input: "#", expected: "#", description: "single hash" },
     { input: "##", expected: "##", description: "double hash" },
     { input: "# text", expected: "# text", description: "heading with text" },
-  ];
+  ]
 
   it.each(markdownEscapingCases)(
     "preserves markdown syntax in labels - $description",
     ({ input, expected }) => {
-      render(<StreamlitMarkdown source={input} allowHTML={false} isLabel />);
-      const markdownText = screen.getByText(expected);
-      expect(markdownText).toBeInTheDocument();
+      render(<StreamlitMarkdown source={input} allowHTML={false} isLabel />)
+      const markdownText = screen.getByText(expected)
+      expect(markdownText).toBeInTheDocument()
 
       // Should be rendered as plain paragraph text, not special elements
-      const tagName = markdownText.nodeName.toLowerCase();
-      expect(tagName).toBe("p");
+      const tagName = markdownText.nodeName.toLowerCase()
+      expect(tagName).toBe("p")
 
-      cleanup();
-    },
-  );
+      cleanup()
+    }
+  )
 
   // Patterns that should NOT be escaped (no space after marker)
   const nonEscapingCases = [
@@ -941,70 +935,65 @@ describe("StreamlitMarkdown", () => {
       expected: "- Already escaped",
       description: "pre-escaped unordered list",
     },
-  ];
+  ]
 
   it.each(nonEscapingCases)(
     "does not escape non-markdown patterns in labels - $description",
     ({ input, expected }) => {
-      render(<StreamlitMarkdown source={input} allowHTML={false} isLabel />);
-      const markdownText = screen.getByText(expected);
-      expect(markdownText).toBeInTheDocument();
-      cleanup();
-    },
-  );
+      render(<StreamlitMarkdown source={input} allowHTML={false} isLabel />)
+      const markdownText = screen.getByText(expected)
+      expect(markdownText).toBeInTheDocument()
+      cleanup()
+    }
+  )
 
   it("renders emphasis markdown in labels", () => {
     // *italic label* should render as emphasized text, not be escaped
     render(
-      <StreamlitMarkdown source="*italic label*" allowHTML={false} isLabel />,
-    );
-    const emphasisText = screen.getByText("italic label");
-    expect(emphasisText).toBeInTheDocument();
-    expect(emphasisText.tagName.toLowerCase()).toBe("em");
-    cleanup();
-  });
+      <StreamlitMarkdown source="*italic label*" allowHTML={false} isLabel />
+    )
+    const emphasisText = screen.getByText("italic label")
+    expect(emphasisText).toBeInTheDocument()
+    expect(emphasisText.tagName.toLowerCase()).toBe("em")
+    cleanup()
+  })
 
   it("renders smaller text sizing when isLabel is true", () => {
-    const source = "Here is some label text";
-    render(<StreamlitMarkdown source={source} allowHTML={false} isLabel />);
+    const source = "Here is some label text"
+    render(<StreamlitMarkdown source={source} allowHTML={false} isLabel />)
 
-    const textTag = screen.getByText("Here is some label text");
-    expect(textTag).toBeInTheDocument();
+    const textTag = screen.getByText("Here is some label text")
+    expect(textTag).toBeInTheDocument()
 
     // All widget labels use the smaller font size for the markdown container
-    const markdownContainer = screen.getByTestId("stMarkdownContainer");
-    expect(markdownContainer).toHaveStyle("font-size: 0.875rem");
-  });
+    const markdownContainer = screen.getByTestId("stMarkdownContainer")
+    expect(markdownContainer).toHaveStyle("font-size: 0.875rem")
+  })
 
   it("renders smaller text sizing when isToast is true", () => {
-    const source = "Here is some toast text";
-    render(<StreamlitMarkdown source={source} allowHTML={false} isToast />);
+    const source = "Here is some toast text"
+    render(<StreamlitMarkdown source={source} allowHTML={false} isToast />)
 
-    const textTag = screen.getByText("Here is some toast text");
-    expect(textTag).toBeInTheDocument();
+    const textTag = screen.getByText("Here is some toast text")
+    expect(textTag).toBeInTheDocument()
 
     // Use the smaller font size for the markdown container
-    const markdownContainer = screen.getByTestId("stMarkdownContainer");
-    expect(markdownContainer).toHaveStyle("font-size: 0.875rem");
-  });
+    const markdownContainer = screen.getByTestId("stMarkdownContainer")
+    expect(markdownContainer).toHaveStyle("font-size: 0.875rem")
+  })
 
   it("renders bold label text when boldLabel is true", () => {
-    const source = "Here is some checkbox label text";
+    const source = "Here is some checkbox label text"
     render(
-      <StreamlitMarkdown
-        source={source}
-        allowHTML={false}
-        isLabel
-        boldLabel
-      />,
-    );
+      <StreamlitMarkdown source={source} allowHTML={false} isLabel boldLabel />
+    )
 
-    const textTag = screen.getByText("Here is some checkbox label text");
-    expect(textTag).toHaveStyle("font-weight: 600");
-  });
+    const textTag = screen.getByText("Here is some checkbox label text")
+    expect(textTag).toHaveStyle("font-weight: 600")
+  })
 
   it("colours text properly", () => {
-    const grayTextColor = transparentize(colors.gray85, 0.4);
+    const grayTextColor = transparentize(colors.gray85, 0.4)
 
     const colorMapping = new Map([
       ["red", colors.red90],
@@ -1016,317 +1005,315 @@ describe("StreamlitMarkdown", () => {
       ["gray", grayTextColor],
       ["grey", grayTextColor],
       ["rainbow", "rgba(0, 0, 0, 0)"],
-    ]);
+    ])
 
     colorMapping.forEach(function (style, color) {
-      const source = `:${color}[text]`;
-      render(<StreamlitMarkdown source={source} allowHTML={false} />);
-      const markdown = screen.getByText("text");
-      const tagName = markdown.nodeName.toLowerCase();
-      expect(tagName).toBe("span");
-      expect(markdown).toHaveStyle(`color: ${style}`);
-      expect(markdown).toHaveClass("stMarkdownColoredText");
+      const source = `:${color}[text]`
+      render(<StreamlitMarkdown source={source} allowHTML={false} />)
+      const markdown = screen.getByText("text")
+      const tagName = markdown.nodeName.toLowerCase()
+      expect(tagName).toBe("span")
+      expect(markdown).toHaveStyle(`color: ${style}`)
+      expect(markdown).toHaveClass("stMarkdownColoredText")
 
       // Removes rendered StreamlitMarkdown component before next case run
-      cleanup();
-    });
-  });
+      cleanup()
+    })
+  })
 
   it("properly adds custom material icon", () => {
-    const source = `:material/search: Icon`;
-    render(<StreamlitMarkdown source={source} allowHTML={false} />);
-    const markdown = screen.getByText("search");
-    const tagName = markdown.nodeName.toLowerCase();
-    expect(tagName).toBe("span");
-    expect(markdown).toHaveStyle(`font-family: Material Symbols Rounded`);
-    expect(markdown).toHaveStyle(`user-select: none`);
-    expect(markdown).toHaveStyle(`vertical-align: bottom`);
-    expect(markdown).toHaveAttribute("translate", "no");
-  });
+    const source = `:material/search: Icon`
+    render(<StreamlitMarkdown source={source} allowHTML={false} />)
+    const markdown = screen.getByText("search")
+    const tagName = markdown.nodeName.toLowerCase()
+    expect(tagName).toBe("span")
+    expect(markdown).toHaveStyle(`font-family: Material Symbols Rounded`)
+    expect(markdown).toHaveStyle(`user-select: none`)
+    expect(markdown).toHaveStyle(`vertical-align: bottom`)
+    expect(markdown).toHaveAttribute("translate", "no")
+  })
 
   it("does not remove unknown directive", () => {
-    const source = `test :foo test:test :`;
-    render(<StreamlitMarkdown source={source} allowHTML={false} />);
-    const markdown = screen.getByText("test :foo test:test :");
-    expect(markdown).toBeInTheDocument();
-  });
+    const source = `test :foo test:test :`
+    render(<StreamlitMarkdown source={source} allowHTML={false} />)
+    const markdown = screen.getByText("test :foo test:test :")
+    expect(markdown).toBeInTheDocument()
+  })
 
   it("converts unsupported text directives to plain text", () => {
     // Text directives use the syntax :name[content]
     // Unsupported ones should render as :name (prefix only, content lost)
-    const source = `test :unknown[content] end`;
-    render(<StreamlitMarkdown source={source} allowHTML={false} />);
-    const markdown = screen.getByText("test :unknown end");
-    expect(markdown).toBeVisible();
-  });
+    const source = `test :unknown[content] end`
+    render(<StreamlitMarkdown source={source} allowHTML={false} />)
+    const markdown = screen.getByText("test :unknown end")
+    expect(markdown).toBeVisible()
+  })
 
   it("properly adds background colors", () => {
     backgroundColorMapping.forEach(function (style, color) {
-      const source = `:${color}-background[text]`;
-      render(<StreamlitMarkdown source={source} allowHTML={false} />);
-      const markdown = screen.getByText("text");
-      const tagName = markdown.nodeName.toLowerCase();
-      expect(tagName).toBe("span");
-      expect(markdown).toHaveStyle(`background-color: ${style}`);
+      const source = `:${color}-background[text]`
+      render(<StreamlitMarkdown source={source} allowHTML={false} />)
+      const markdown = screen.getByText("text")
+      const tagName = markdown.nodeName.toLowerCase()
+      expect(tagName).toBe("span")
+      expect(markdown).toHaveStyle(`background-color: ${style}`)
 
       // Removes rendered StreamlitMarkdown component before next case run
-      cleanup();
-    });
-  });
+      cleanup()
+    })
+  })
 
   it("properly adds rainbow background color", () => {
     const { redbg, orangebg, yellowbg, greenbg, bluebg, violetbg, purplebg } =
-      bgColors;
-    const rainbowGradient = `linear-gradient(to right, ${redbg}, ${orangebg}, ${yellowbg}, ${greenbg}, ${bluebg}, ${violetbg}, ${purplebg})`;
+      bgColors
+    const rainbowGradient = `linear-gradient(to right, ${redbg}, ${orangebg}, ${yellowbg}, ${greenbg}, ${bluebg}, ${violetbg}, ${purplebg})`
 
-    const source = `:rainbow-background[text]`;
-    render(<StreamlitMarkdown source={source} allowHTML={false} />);
-    const markdown = screen.getByText("text");
-    const tagName = markdown.nodeName.toLowerCase();
-    expect(tagName).toBe("span");
-    expect(markdown).toHaveStyle(`background: ${rainbowGradient}`);
-  });
+    const source = `:rainbow-background[text]`
+    render(<StreamlitMarkdown source={source} allowHTML={false} />)
+    const markdown = screen.getByText("text")
+    const tagName = markdown.nodeName.toLowerCase()
+    expect(tagName).toBe("span")
+    expect(markdown).toHaveStyle(`background: ${rainbowGradient}`)
+  })
 
   it("renders small text properly", () => {
-    const source = `:small[text]`;
-    render(<StreamlitMarkdown source={source} allowHTML={false} />);
-    const markdown = screen.getByText("text");
-    const tagName = markdown.nodeName.toLowerCase();
-    expect(tagName).toBe("span");
+    const source = `:small[text]`
+    render(<StreamlitMarkdown source={source} allowHTML={false} />)
+    const markdown = screen.getByText("text")
+    const tagName = markdown.nodeName.toLowerCase()
+    expect(tagName).toBe("span")
     expect(markdown).toHaveStyle(
-      `font-size: ${mockTheme.emotion.fontSizes.sm}`,
-    );
-  });
+      `font-size: ${mockTheme.emotion.fontSizes.sm}`
+    )
+  })
 
   it("renders shimmer text with correct class", () => {
     render(
-      <StreamlitMarkdown source=":shimmer[Loading...]" allowHTML={false} />,
-    );
-    const element = screen.getByText("Loading...");
-    expect(element.tagName.toLowerCase()).toBe("span");
-    expect(element).toHaveClass("stMarkdownShimmer");
-  });
+      <StreamlitMarkdown source=":shimmer[Loading...]" allowHTML={false} />
+    )
+    const element = screen.getByText("Loading...")
+    expect(element.tagName.toLowerCase()).toBe("span")
+    expect(element).toHaveClass("stMarkdownShimmer")
+  })
 
   it("does not apply shimmer class to regular text", () => {
     render(
       <StreamlitMarkdown
         source="Regular text without shimmer"
         allowHTML={false}
-      />,
-    );
-    const element = screen.getByText("Regular text without shimmer");
-    expect(element).not.toHaveClass("stMarkdownShimmer");
-  });
+      />
+    )
+    const element = screen.getByText("Regular text without shimmer")
+    expect(element).not.toHaveClass("stMarkdownShimmer")
+  })
 
   it("renders shimmer nested inside color directive with correct DOM structure", () => {
     render(
       <StreamlitMarkdown
         source=":red[:shimmer[Loading...]]"
         allowHTML={false}
-      />,
-    );
-    const shimmerElement = screen.getByText("Loading...");
-    expect(shimmerElement).toHaveClass("stMarkdownShimmer");
+      />
+    )
+    const shimmerElement = screen.getByText("Loading...")
+    expect(shimmerElement).toHaveClass("stMarkdownShimmer")
     // Verify the parent span has the color directive class (shimmer uses fadedText60,
     // but the outer :red[] span still has its color class applied)
-    const parentSpan = shimmerElement.parentElement;
-    expect(parentSpan).not.toBeNull();
-    expect(parentSpan).toHaveClass("stMarkdownColoredText");
+    const parentSpan = shimmerElement.parentElement
+    expect(parentSpan).not.toBeNull()
+    expect(parentSpan).toHaveClass("stMarkdownColoredText")
     // The color style should be applied (the exact value comes from the theme)
-    expect(parentSpan).toHaveAttribute("style");
-    expect(parentSpan?.getAttribute("style")).toContain("color:");
-  });
+    expect(parentSpan).toHaveAttribute("style")
+    expect(parentSpan?.getAttribute("style")).toContain("color:")
+  })
 
   it("applies truncate styles when truncate is true", () => {
-    const source = "This is some text that should be truncated";
-    render(<StreamlitMarkdown source={source} allowHTML={false} truncate />);
-    const container = screen.getByTestId("stMarkdownContainer");
-    expect(container).toHaveStyle("overflow: hidden");
-    expect(container).toHaveStyle("white-space: nowrap");
-    expect(container).toHaveStyle("text-overflow: ellipsis");
-  });
+    const source = "This is some text that should be truncated"
+    render(<StreamlitMarkdown source={source} allowHTML={false} truncate />)
+    const container = screen.getByTestId("stMarkdownContainer")
+    expect(container).toHaveStyle("overflow: hidden")
+    expect(container).toHaveStyle("white-space: nowrap")
+    expect(container).toHaveStyle("text-overflow: ellipsis")
+  })
 
   it("does not apply truncate styles when truncate is false", () => {
-    const source = "This is some text that should not be truncated";
-    render(<StreamlitMarkdown source={source} allowHTML={false} />);
-    const container = screen.getByTestId("stMarkdownContainer");
-    expect(container).not.toHaveStyle("white-space: nowrap");
-  });
+    const source = "This is some text that should not be truncated"
+    render(<StreamlitMarkdown source={source} allowHTML={false} />)
+    const container = screen.getByTestId("stMarkdownContainer")
+    expect(container).not.toHaveStyle("white-space: nowrap")
+  })
 
   // Custom color directive tests
   describe("custom color directive", () => {
     it("applies custom foreground color with hex value", () => {
-      const source = `:color[custom text]{foreground="#FF5733"}`;
-      render(<StreamlitMarkdown source={source} allowHTML={false} />);
-      const markdown = screen.getByText("custom text");
-      expect(markdown.tagName.toLowerCase()).toBe("span");
-      expect(markdown).toHaveStyle("color: #FF5733");
-      expect(markdown).toHaveClass("stMarkdownColoredText");
-    });
+      const source = `:color[custom text]{foreground="#FF5733"}`
+      render(<StreamlitMarkdown source={source} allowHTML={false} />)
+      const markdown = screen.getByText("custom text")
+      expect(markdown.tagName.toLowerCase()).toBe("span")
+      expect(markdown).toHaveStyle("color: #FF5733")
+      expect(markdown).toHaveClass("stMarkdownColoredText")
+    })
 
     it("applies custom background color with hex value", () => {
-      const source = `:color[custom text]{background="#FF5733"}`;
-      render(<StreamlitMarkdown source={source} allowHTML={false} />);
-      const markdown = screen.getByText("custom text");
-      expect(markdown.tagName.toLowerCase()).toBe("span");
-      expect(markdown).toHaveStyle("background-color: #FF5733");
-      expect(markdown).toHaveClass("stMarkdownColoredBackground");
-    });
+      const source = `:color[custom text]{background="#FF5733"}`
+      render(<StreamlitMarkdown source={source} allowHTML={false} />)
+      const markdown = screen.getByText("custom text")
+      expect(markdown.tagName.toLowerCase()).toBe("span")
+      expect(markdown).toHaveStyle("background-color: #FF5733")
+      expect(markdown).toHaveClass("stMarkdownColoredBackground")
+    })
 
     it("applies both foreground and background colors", () => {
       // Note: directive attributes are space-separated, not comma-separated
-      const source = `:color[text]{foreground="#FFFFFF" background="#000000"}`;
-      render(<StreamlitMarkdown source={source} allowHTML={false} />);
-      const markdown = screen.getByText("text");
-      expect(markdown.tagName.toLowerCase()).toBe("span");
-      expect(markdown).toHaveStyle("color: #FFFFFF");
-      expect(markdown).toHaveStyle("background-color: #000000");
+      const source = `:color[text]{foreground="#FFFFFF" background="#000000"}`
+      render(<StreamlitMarkdown source={source} allowHTML={false} />)
+      const markdown = screen.getByText("text")
+      expect(markdown.tagName.toLowerCase()).toBe("span")
+      expect(markdown).toHaveStyle("color: #FFFFFF")
+      expect(markdown).toHaveStyle("background-color: #000000")
       // Should use background class when both are present for proper styling
-      expect(markdown).toHaveClass("stMarkdownColoredBackground");
-    });
+      expect(markdown).toHaveClass("stMarkdownColoredBackground")
+    })
 
     it("applies custom color with 3-digit hex", () => {
-      const source = `:color[text]{foreground="#F00"}`;
-      render(<StreamlitMarkdown source={source} allowHTML={false} />);
-      const markdown = screen.getByText("text");
-      expect(markdown).toHaveStyle("color: #F00");
-    });
+      const source = `:color[text]{foreground="#F00"}`
+      render(<StreamlitMarkdown source={source} allowHTML={false} />)
+      const markdown = screen.getByText("text")
+      expect(markdown).toHaveStyle("color: #F00")
+    })
 
     it("applies custom color with named color", () => {
-      const source = `:color[text]{foreground="red"}`;
-      render(<StreamlitMarkdown source={source} allowHTML={false} />);
-      const markdown = screen.getByText("text");
+      const source = `:color[text]{foreground="red"}`
+      render(<StreamlitMarkdown source={source} allowHTML={false} />)
+      const markdown = screen.getByText("text")
       // Named colors are normalized by the browser to rgb() format
-      expect(markdown).toHaveStyle("color: rgb(255, 0, 0)");
-    });
+      expect(markdown).toHaveStyle("color: rgb(255, 0, 0)")
+    })
 
     it("renders content as plain text when color values are invalid", () => {
-      const source = `:color[text]{foreground="notacolor"}`;
-      render(<StreamlitMarkdown source={source} allowHTML={false} />);
+      const source = `:color[text]{foreground="notacolor"}`
+      render(<StreamlitMarkdown source={source} allowHTML={false} />)
       // Invalid colors should still render the content as plain text
-      const markdown = screen.getByText("text");
-      expect(markdown.tagName.toLowerCase()).toBe("span");
+      const markdown = screen.getByText("text")
+      expect(markdown.tagName.toLowerCase()).toBe("span")
       // Should not have any style attribute when color is invalid
-      expect(markdown).not.toHaveAttribute("style");
-    });
+      expect(markdown).not.toHaveAttribute("style")
+    })
 
     it("ignores potential XSS in color values and renders content safely", () => {
-      const source = `:color[text]{foreground="javascript:alert(1)"}`;
-      render(<StreamlitMarkdown source={source} allowHTML={false} />);
+      const source = `:color[text]{foreground="javascript:alert(1)"}`
+      render(<StreamlitMarkdown source={source} allowHTML={false} />)
       // Invalid/dangerous colors should still render the content as plain text
-      const markdown = screen.getByText("text");
-      expect(markdown.tagName.toLowerCase()).toBe("span");
+      const markdown = screen.getByText("text")
+      expect(markdown.tagName.toLowerCase()).toBe("span")
       // Should not have the dangerous value in any attribute
-      expect(markdown).not.toHaveAttribute("style");
-    });
+      expect(markdown).not.toHaveAttribute("style")
+    })
 
     it("applies only valid colors when mixed with invalid colors", () => {
       // Test partial validity: foreground is valid, background is invalid
-      const source = `:color[text]{foreground="red" background="notacolor"}`;
-      render(<StreamlitMarkdown source={source} allowHTML={false} />);
-      const markdown = screen.getByText("text");
-      expect(markdown.tagName.toLowerCase()).toBe("span");
+      const source = `:color[text]{foreground="red" background="notacolor"}`
+      render(<StreamlitMarkdown source={source} allowHTML={false} />)
+      const markdown = screen.getByText("text")
+      expect(markdown.tagName.toLowerCase()).toBe("span")
       // Only the valid foreground color should be applied
-      expect(markdown).toHaveStyle("color: rgb(255, 0, 0)");
+      expect(markdown).toHaveStyle("color: rgb(255, 0, 0)")
       // Background should not be applied since it's invalid
-      expect(markdown).not.toHaveStyle("background-color: notacolor");
+      expect(markdown).not.toHaveStyle("background-color: notacolor")
       // Should use text class since no valid background
-      expect(markdown).toHaveClass("stMarkdownColoredText");
-    });
+      expect(markdown).toHaveClass("stMarkdownColoredText")
+    })
 
     it("renders as plain span when used without attributes", () => {
-      const source = `:color[text]`;
-      render(<StreamlitMarkdown source={source} allowHTML={false} />);
-      const markdown = screen.getByText("text");
-      expect(markdown.tagName.toLowerCase()).toBe("span");
+      const source = `:color[text]`
+      render(<StreamlitMarkdown source={source} allowHTML={false} />)
+      const markdown = screen.getByText("text")
+      expect(markdown.tagName.toLowerCase()).toBe("span")
       // Should not have any style when no attributes are provided
-      expect(markdown).not.toHaveAttribute("style");
+      expect(markdown).not.toHaveAttribute("style")
       // Should not have the colored text class
-      expect(markdown).not.toHaveClass("stMarkdownColoredText");
-      expect(markdown).not.toHaveClass("stMarkdownColoredBackground");
-    });
-  });
-});
+      expect(markdown).not.toHaveClass("stMarkdownColoredText")
+      expect(markdown).not.toHaveClass("stMarkdownColoredBackground")
+    })
+  })
+})
 
 const getCustomCodeTagProps = (
-  props: Partial<CustomCodeTagProps> = {},
+  props: Partial<CustomCodeTagProps> = {}
 ): CustomCodeTagProps => ({
   children: `import streamlit as st
 
 st.write("Hello")
 `,
   ...props,
-});
+})
 
 describe("CustomCodeTag Element", () => {
   beforeAll(async () => {
-    await import("~lib/components/elements/CodeBlock/StreamlitSyntaxHighlighter");
-  }, 30_000);
+    await import("~lib/components/elements/CodeBlock/StreamlitSyntaxHighlighter")
+  }, 30_000)
 
   it("should render without crashing", async () => {
-    const props = getCustomCodeTagProps();
-    render(<CustomCodeTag {...props} />);
+    const props = getCustomCodeTagProps()
+    render(<CustomCodeTag {...props} />)
 
-    const stCode = await screen.findByTestId("stCode");
-    expect(stCode).toBeVisible();
-  });
+    const stCode = await screen.findByTestId("stCode")
+    expect(stCode).toBeVisible()
+  })
 
   it("should render as plaintext", async () => {
-    const props = getCustomCodeTagProps({ className: "language-plaintext" });
-    render(<CustomCodeTag {...props} />);
+    const props = getCustomCodeTagProps({ className: "language-plaintext" })
+    render(<CustomCodeTag {...props} />)
 
-    const stCode = await screen.findByTestId("stCode");
-    expect(stCode.innerHTML.indexOf(`class="language-plaintext"`)).not.toBe(
-      -1,
-    );
-  });
+    const stCode = await screen.findByTestId("stCode")
+    expect(stCode.innerHTML.indexOf(`class="language-plaintext"`)).not.toBe(-1)
+  })
 
   it("should render copy button when code block has content", async () => {
     const props = getCustomCodeTagProps({
       children: "i am not empty",
-    });
-    render(<CustomCodeTag {...props} />);
-    await screen.findByTestId("stCode");
+    })
+    render(<CustomCodeTag {...props} />)
+    await screen.findByTestId("stCode")
     const copyButton = screen.getByLabelText(/copy to clipboard/i, {
       selector: "button",
-    });
+    })
 
-    expect(copyButton).toBeEnabled();
+    expect(copyButton).toBeEnabled()
     expect(
-      screen.queryByRole("button", { name: /copy to clipboard/i }),
-    ).not.toBeInTheDocument();
-  });
+      screen.queryByRole("button", { name: /copy to clipboard/i })
+    ).not.toBeInTheDocument()
+  })
 
   it("should not render copy button when code block is empty", async () => {
     const props = getCustomCodeTagProps({
       children: "",
-    });
-    render(<CustomCodeTag {...props} />);
+    })
+    render(<CustomCodeTag {...props} />)
 
     // Wait for the component to load
-    await screen.findByTestId("stCode");
+    await screen.findByTestId("stCode")
 
     // queryBy returns null vs. error
-    const copyButton = screen.queryByRole("button");
+    const copyButton = screen.queryByRole("button")
 
-    expect(copyButton).toBeNull();
-  });
+    expect(copyButton).toBeNull()
+  })
 
   it("should render inline", () => {
-    const props = getCustomCodeTagProps({ inline: true });
-    const { baseElement } = render(<CustomCodeTag {...props} />);
+    const props = getCustomCodeTagProps({ inline: true })
+    const { baseElement } = render(<CustomCodeTag {...props} />)
     const codeWithoutClass = baseElement.innerHTML.replace(
       /class="(.*)"/,
-      'class="foo"',
-    );
+      'class="foo"'
+    )
 
     expect(codeWithoutClass).toBe(
       '<div><code class="foo">' +
         "import streamlit as st\n\n" +
         'st.write("Hello")\n' +
-        "</code></div>",
-    );
-  });
+        "</code></div>"
+    )
+  })
 
   it.each([
     [null, ""],
@@ -1334,23 +1321,23 @@ describe("CustomCodeTag Element", () => {
     ["null", "null"],
     ["undefined", "undefined"],
   ])("renders children '%s' as '%s'", (children, expected) => {
-    const props = getCustomCodeTagProps({ children });
-    render(<CustomCodeTag {...props} />);
-    expect(screen.getByTestId("stCode")).toHaveTextContent(expected);
-  });
-});
+    const props = getCustomCodeTagProps({ children })
+    render(<CustomCodeTag {...props} />)
+    expect(screen.getByTestId("stCode")).toHaveTextContent(expected)
+  })
+})
 
 describe("mermaid code blocks", () => {
-  const mermaidSource = "```mermaid\ngraph TD\n  A-->B\n```";
+  const mermaidSource = "```mermaid\ngraph TD\n  A-->B\n```"
 
   it("renders a mermaid code block as a diagram when not streaming", async () => {
-    render(<StreamlitMarkdown source={mermaidSource} allowHTML={false} />);
+    render(<StreamlitMarkdown source={mermaidSource} allowHTML={false} />)
 
     // The lazy-loaded MermaidChart renders with the stMermaidChart test id.
-    expect(await screen.findByTestId("stMermaidChart")).toBeVisible();
+    expect(await screen.findByTestId("stMermaidChart")).toBeVisible()
     // It must not fall back to a syntax-highlighted code block.
-    expect(screen.queryByTestId("stCode")).not.toBeInTheDocument();
-  });
+    expect(screen.queryByTestId("stCode")).not.toBeInTheDocument()
+  })
 
   it("renders a mermaid code block as syntax-highlighted code while streaming", async () => {
     render(
@@ -1358,30 +1345,30 @@ describe("mermaid code blocks", () => {
         source={mermaidSource}
         allowHTML={false}
         unterminatedParsing={true}
-      />,
-    );
+      />
+    )
 
     // While streaming, the (possibly partial) mermaid block is shown as code
     // to avoid flickering and error states from incomplete diagram source.
-    expect(await screen.findByTestId("stCode")).toBeVisible();
-    expect(screen.queryByTestId("stMermaidChart")).not.toBeInTheDocument();
-  });
-});
+    expect(await screen.findByTestId("stCode")).toBeVisible()
+    expect(screen.queryByTestId("stMermaidChart")).not.toBeInTheDocument()
+  })
+})
 
 describe("CustomPreTag", () => {
   it("should render without crashing", () => {
-    const props = getCustomCodeTagProps();
-    render(<CustomPreTag {...props} />);
+    const props = getCustomCodeTagProps()
+    render(<CustomPreTag {...props} />)
 
-    const preTag = screen.getByTestId("stMarkdownPre");
-    const tagName = preTag.nodeName.toLowerCase();
+    const preTag = screen.getByTestId("stMarkdownPre")
+    const tagName = preTag.nodeName.toLowerCase()
 
-    expect(preTag).toBeInTheDocument();
-    expect(tagName).toBe("div");
+    expect(preTag).toBeInTheDocument()
+    expect(tagName).toBe("div")
     expect(preTag).toHaveTextContent(
-      'import streamlit as st st.write("Hello")',
-    );
-  });
+      'import streamlit as st st.write("Hello")'
+    )
+  })
 
   describe("remend integration (streaming markdown)", () => {
     it.each([
@@ -1397,13 +1384,13 @@ describe("CustomPreTag", () => {
             source={`This is ${source}`}
             allowHTML={false}
             unterminatedParsing={true}
-          />,
-        );
-        const element = screen.getByText(expectedText);
-        expect(element).toBeVisible();
-        expect(element.tagName).toBe(expectedTag);
-      },
-    );
+          />
+        )
+        const element = screen.getByText(expectedText)
+        expect(element).toBeVisible()
+        expect(element.tagName).toBe(expectedTag)
+      }
+    )
 
     it.each([
       [
@@ -1420,14 +1407,14 @@ describe("CustomPreTag", () => {
       ],
       ["unterminatedParsing not set", { isLabel: false, allowHTML: false }],
     ])("does NOT apply remend when %s", async (_, props) => {
-      const source = "Content with **incomplete bold";
-      render(<StreamlitMarkdown source={source} {...props} />);
+      const source = "Content with **incomplete bold"
+      render(<StreamlitMarkdown source={source} {...props} />)
       // Wait for content to render (allowHTML=true triggers async plugin load)
-      const textElement = await screen.findByText(source, { exact: false });
-      expect(textElement).toBeVisible();
-      const container = screen.getByTestId("stMarkdownContainer");
-      expect(container.querySelector("strong")).toBeNull();
-    });
+      const textElement = await screen.findByText(source, { exact: false })
+      expect(textElement).toBeVisible()
+      const container = screen.getByTestId("stMarkdownContainer")
+      expect(container.querySelector("strong")).toBeNull()
+    })
 
     describe("directive completion during streaming", () => {
       it.each([
@@ -1446,17 +1433,17 @@ describe("CustomPreTag", () => {
               source={`This is ${source}`}
               allowHTML={false}
               unterminatedParsing={true}
-            />,
-          );
+            />
+          )
 
-          expect(screen.getByText(expectedText)).toBeVisible();
+          expect(screen.getByText(expectedText)).toBeVisible()
 
-          const container = screen.getByTestId("stMarkdownContainer");
+          const container = screen.getByTestId("stMarkdownContainer")
           expect(container.textContent).not.toContain(
-            "streamdown:incomplete-link",
-          );
-        },
-      );
+            "streamdown:incomplete-link"
+          )
+        }
+      )
 
       it("completes nested incomplete directives", () => {
         render(
@@ -1464,15 +1451,15 @@ describe("CustomPreTag", () => {
             source=":red-background[:rainbow[nested text"
             allowHTML={false}
             unterminatedParsing={true}
-          />,
-        );
+          />
+        )
 
-        const container = screen.getByTestId("stMarkdownContainer");
-        expect(container.textContent).toContain("nested text");
+        const container = screen.getByTestId("stMarkdownContainer")
+        expect(container.textContent).toContain("nested text")
         expect(container.textContent).not.toContain(
-          "streamdown:incomplete-link",
-        );
-      });
+          "streamdown:incomplete-link"
+        )
+      })
 
       it("does not close non-directive brackets in markdown links", () => {
         // This tests the fix for the issue where `:red[text] and [link`
@@ -1483,19 +1470,19 @@ describe("CustomPreTag", () => {
             source=":red[red text] and [incomplete link"
             allowHTML={false}
             unterminatedParsing={true}
-          />,
-        );
+          />
+        )
 
-        const container = screen.getByTestId("stMarkdownContainer");
-        expect(container.textContent).toContain("red text");
+        const container = screen.getByTestId("stMarkdownContainer")
+        expect(container.textContent).toContain("red text")
         // The important thing is that no streamdown artifact appears and no extra ]
         // is appended that would break the rendering
         expect(container.textContent).not.toContain(
-          "streamdown:incomplete-link",
-        );
+          "streamdown:incomplete-link"
+        )
         // Should not have extra closing brackets added for non-directive [
-        expect(container.textContent).not.toContain("link]");
-      });
+        expect(container.textContent).not.toContain("link]")
+      })
 
       it("handles nested brackets inside directives", () => {
         // This tests the fix for `:red[text [link` where a non-directive `[`
@@ -1506,26 +1493,26 @@ describe("CustomPreTag", () => {
             source=":red[text [link"
             allowHTML={false}
             unterminatedParsing={true}
-          />,
-        );
+          />
+        )
 
-        const container = screen.getByTestId("stMarkdownContainer");
+        const container = screen.getByTestId("stMarkdownContainer")
         // The text should be rendered without the artifact
-        expect(container.textContent).toContain("text [link");
+        expect(container.textContent).toContain("text [link")
         expect(container.textContent).not.toContain(
-          "streamdown:incomplete-link",
-        );
-      });
-    });
-  });
-});
+          "streamdown:incomplete-link"
+        )
+      })
+    })
+  })
+})
 
 describe("CustomMediaTag", () => {
-  const mockNode = { tagName: "img" } as Element;
+  const mockNode = { tagName: "img" } as Element
   const mockProps = {
     src: "test-image.jpg",
     alt: "Test image",
-  };
+  }
 
   it.each([
     { resourceCrossOriginMode: "anonymous" },
@@ -1538,25 +1525,25 @@ describe("CustomMediaTag", () => {
         libConfigContext: {
           resourceCrossOriginMode,
         },
-      });
+      })
 
-      const imgElement = screen.getByRole("img");
+      const imgElement = screen.getByRole("img")
 
-      expect(imgElement).not.toHaveAttribute("crossOrigin");
-      expect(imgElement).toHaveAttribute("src", "test-image.jpg");
-      expect(imgElement).toHaveAttribute("alt", "Test image");
-    },
-  );
+      expect(imgElement).not.toHaveAttribute("crossOrigin")
+      expect(imgElement).toHaveAttribute("src", "test-image.jpg")
+      expect(imgElement).toHaveAttribute("alt", "Test image")
+    }
+  )
 
   describe("with BACKEND_BASE_URL set", () => {
     beforeEach(() => {
       globalThis.__mockStreamlitConfig.BACKEND_BASE_URL =
-        "https://backend.example.com:8080/app";
-    });
+        "https://backend.example.com:8080/app"
+    })
 
     afterEach(() => {
-      globalThis.__mockStreamlitConfig = {};
-    });
+      globalThis.__mockStreamlitConfig = {}
+    })
 
     it.each([
       {
@@ -1596,8 +1583,8 @@ describe("CustomMediaTag", () => {
     ])(
       "should render $tagName element with crossOrigin='$expected' when $scenario",
       ({ tagName, expected, resourceCrossOriginMode, src, extraProps }) => {
-        const node = { tagName } as Element;
-        const props = { src, ...extraProps };
+        const node = { tagName } as Element
+        const props = { src, ...extraProps }
 
         const { container } = renderWithContexts(
           <CustomMediaTag node={node} {...props} />,
@@ -1605,19 +1592,19 @@ describe("CustomMediaTag", () => {
             libConfigContext: {
               resourceCrossOriginMode,
             },
-          },
-        );
+          }
+        )
 
         const element =
           tagName === "img"
             ? screen.getByRole("img")
-            : container.querySelector(tagName);
+            : container.querySelector(tagName)
 
-        expect(element).toBeTruthy();
-        expect(element).toHaveAttribute("crossOrigin", expected);
-        expect(element).toHaveAttribute("src", src);
-      },
-    );
+        expect(element).toBeTruthy()
+        expect(element).toHaveAttribute("crossOrigin", expected)
+        expect(element).toHaveAttribute("src", src)
+      }
+    )
 
     it.each([
       {
@@ -1661,8 +1648,8 @@ describe("CustomMediaTag", () => {
     ])(
       "should render $tagName element without crossOrigin when $scenario",
       ({ tagName, resourceCrossOriginMode, src, extraProps }) => {
-        const node = { tagName } as Element;
-        const props = { src, ...extraProps };
+        const node = { tagName } as Element
+        const props = { src, ...extraProps }
 
         const { container } = renderWithContexts(
           <CustomMediaTag node={node} {...props} />,
@@ -1670,18 +1657,18 @@ describe("CustomMediaTag", () => {
             libConfigContext: {
               resourceCrossOriginMode,
             },
-          },
-        );
+          }
+        )
 
         const element =
           tagName === "img"
             ? screen.getByRole("img")
-            : container.querySelector(tagName);
+            : container.querySelector(tagName)
 
-        expect(element).toBeTruthy();
-        expect(element).not.toHaveAttribute("crossOrigin");
-        expect(element).toHaveAttribute("src", src);
-      },
-    );
-  });
-});
+        expect(element).toBeTruthy()
+        expect(element).not.toHaveAttribute("crossOrigin")
+        expect(element).toHaveAttribute("src", src)
+      }
+    )
+  })
+})

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
@@ -645,7 +645,10 @@ describe("StreamlitMarkdown", () => {
     )
 
     await waitFor(() => {
-      expect(screen.getByRole("heading")).toHaveAttribute("id", "second-heading")
+      expect(screen.getByRole("heading")).toHaveAttribute(
+        "id",
+        "second-heading"
+      )
     })
   })
 

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
@@ -647,6 +647,10 @@ describe("StreamlitMarkdown", () => {
     // useLayoutEffect commits the re-derived id before paint, so the assertion
     // can be direct -- no waitFor needed.
     expect(screen.getByRole("heading")).toHaveAttribute("id", "second-heading")
+    // #8793 was reported through the anchor link, so assert its href too.
+    expect(
+      screen.getByRole("link", { name: "Link to heading" })
+    ).toHaveAttribute("href", "#second-heading")
     // The stale anchor must be gone, not merely joined by the new one.
     expect(screen.getByRole("heading")).not.toHaveAttribute(
       "id",

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
@@ -16,7 +16,7 @@
 
 import { ReactElement } from "react"
 
-import { cleanup, screen, within } from "@testing-library/react"
+import { cleanup, screen, waitFor, within } from "@testing-library/react"
 import { transparentize } from "color2k"
 import type { Element } from "hast"
 import ReactMarkdown from "react-markdown"
@@ -618,6 +618,35 @@ describe("StreamlitMarkdown", () => {
     const heading = screen.getByRole("heading", { name: "Hello" })
     expect(heading).toHaveAttribute("id", "my-anchor")
     expect(heading).not.toHaveAttribute("aria-labelledby")
+  })
+
+  it("updates heading anchor when text changes across reruns (no explicit anchor)", async () => {
+    const { rerender } = render(
+      <IsSidebarContext.Provider value={false}>
+        <IsDialogContext.Provider value={false}>
+          <HeadingWithActionElements tag="h2">
+            First Heading
+          </HeadingWithActionElements>
+        </IsDialogContext.Provider>
+      </IsSidebarContext.Provider>
+    )
+
+    const heading = screen.getByRole("heading")
+    expect(heading).toHaveAttribute("id", "first-heading")
+
+    rerender(
+      <IsSidebarContext.Provider value={false}>
+        <IsDialogContext.Provider value={false}>
+          <HeadingWithActionElements tag="h2">
+            Second Heading
+          </HeadingWithActionElements>
+        </IsDialogContext.Provider>
+      </IsSidebarContext.Provider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading")).toHaveAttribute("id", "second-heading")
+    })
   })
 
   it("propagates header attributes to custom header", async () => {

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
@@ -14,19 +14,19 @@
  * limitations under the License.
  */
 
-import { ReactElement } from "react"
+import { ReactElement } from "react";
 
-import { cleanup, screen, waitFor, within } from "@testing-library/react"
-import { transparentize } from "color2k"
-import type { Element } from "hast"
-import ReactMarkdown from "react-markdown"
+import { cleanup, screen, within } from "@testing-library/react";
+import { transparentize } from "color2k";
+import type { Element } from "hast";
+import ReactMarkdown from "react-markdown";
 
-import IsDialogContext from "~lib/components/core/IsDialogContext"
-import IsSidebarContext from "~lib/components/core/IsSidebarContext"
-import { mockTheme } from "~lib/mocks/mockTheme"
-import { render, renderWithContexts } from "~lib/test_util"
-import { getThemeBackgroundColors } from "~lib/theme/getColors"
-import { colors } from "~lib/theme/primitives/colors"
+import IsDialogContext from "~lib/components/core/IsDialogContext";
+import IsSidebarContext from "~lib/components/core/IsSidebarContext";
+import { mockTheme } from "~lib/mocks/mockTheme";
+import { render, renderWithContexts } from "~lib/test_util";
+import { getThemeBackgroundColors } from "~lib/theme/getColors";
+import { colors } from "~lib/theme/primitives/colors";
 
 import StreamlitMarkdown, {
   containsEmojiShortcodes,
@@ -39,26 +39,26 @@ import StreamlitMarkdown, {
   HeadingWithActionElements,
   isValidCssColor,
   LinkWithTargetBlank,
-} from "./StreamlitMarkdown"
+} from "./StreamlitMarkdown";
 
 // Mock StreamlitConfig using global mock state (see vitest.setup.ts)
 vi.mock("@streamlit/utils", async () => {
-  const actual = await vi.importActual("@streamlit/utils")
+  const actual = await vi.importActual("@streamlit/utils");
   return {
     ...actual,
     get StreamlitConfig() {
-      return globalThis.__mockStreamlitConfig
+      return globalThis.__mockStreamlitConfig;
     },
-  }
-})
+  };
+});
 
 // Fixture Generator
 const getMarkdownElement = (body: string): ReactElement => {
   const components = {
     a: LinkWithTargetBlank,
-  }
-  return <ReactMarkdown components={components}>{body}</ReactMarkdown>
-}
+  };
+  return <ReactMarkdown components={components}>{body}</ReactMarkdown>;
+};
 
 describe("createAnchorFromText", () => {
   it.each([
@@ -95,9 +95,9 @@ describe("createAnchorFromText", () => {
     ["---", "6110bfd"],
     ["___", "647ce586"],
   ])("converts '%s' to '%s'", (input, expected) => {
-    expect(createAnchorFromText(input)).toEqual(expected)
-  })
-})
+    expect(createAnchorFromText(input)).toEqual(expected);
+  });
+});
 
 describe("containsMathSyntax", () => {
   it.each([
@@ -165,10 +165,10 @@ describe("containsMathSyntax", () => {
   ])(
     "detects $description correctly",
     ({ input, expected }: { input: string; expected: boolean }) => {
-      expect(containsMathSyntax(input)).toBe(expected)
-    }
-  )
-})
+      expect(containsMathSyntax(input)).toBe(expected);
+    },
+  );
+});
 
 describe("containsEmojiShortcodes", () => {
   it.each([
@@ -290,10 +290,10 @@ describe("containsEmojiShortcodes", () => {
   ])(
     "detects $description correctly",
     ({ input, expected }: { input: string; expected: boolean }) => {
-      expect(containsEmojiShortcodes(input)).toBe(expected)
-    }
-  )
-})
+      expect(containsEmojiShortcodes(input)).toBe(expected);
+    },
+  );
+});
 
 describe("isValidCssColor", () => {
   it.each([
@@ -367,62 +367,65 @@ describe("isValidCssColor", () => {
       description: "CSS expression",
     },
   ])("validates $description correctly", ({ input, expected }) => {
-    expect(isValidCssColor(input)).toBe(expected)
-  })
-})
+    expect(isValidCssColor(input)).toBe(expected);
+  });
+});
 
 describe("linkReference", () => {
   it("renders a link with _blank target", () => {
-    const body = "Some random URL like [Streamlit](https://streamlit.io/)"
-    render(getMarkdownElement(body))
+    const body = "Some random URL like [Streamlit](https://streamlit.io/)";
+    render(getMarkdownElement(body));
     expect(screen.getByText("Streamlit")).toHaveAttribute(
       "href",
-      "https://streamlit.io/"
-    )
-    expect(screen.getByText("Streamlit")).toHaveAttribute("target", "_blank")
-  })
+      "https://streamlit.io/",
+    );
+    expect(screen.getByText("Streamlit")).toHaveAttribute("target", "_blank");
+  });
 
   it("renders a link without title", () => {
     const body =
-      "Everybody loves [The Internet Archive](https://archive.org/)."
-    render(getMarkdownElement(body))
-    const link = screen.getByText("The Internet Archive")
-    expect(link).toHaveAttribute("href", "https://archive.org/")
-    expect(link).not.toHaveAttribute("title")
-  })
+      "Everybody loves [The Internet Archive](https://archive.org/).";
+    render(getMarkdownElement(body));
+    const link = screen.getByText("The Internet Archive");
+    expect(link).toHaveAttribute("href", "https://archive.org/");
+    expect(link).not.toHaveAttribute("title");
+  });
 
   it("renders a link containing a title", () => {
     const body =
       "My favorite search engine is " +
-      '[Duck Duck Go](https://duckduckgo.com/ "The best search engine for privacy").'
-    render(getMarkdownElement(body))
-    const link = screen.getByText("Duck Duck Go")
-    expect(link).toHaveAttribute("href", "https://duckduckgo.com/")
-    expect(link).toHaveAttribute("title", "The best search engine for privacy")
-  })
+      '[Duck Duck Go](https://duckduckgo.com/ "The best search engine for privacy").';
+    render(getMarkdownElement(body));
+    const link = screen.getByText("Duck Duck Go");
+    expect(link).toHaveAttribute("href", "https://duckduckgo.com/");
+    expect(link).toHaveAttribute(
+      "title",
+      "The best search engine for privacy",
+    );
+  });
 
   it("renders a link containing parentheses", () => {
     const body =
-      "Here's a link containing parentheses [Yikes](http://msdn.microsoft.com/en-us/library/aa752574(VS.85).aspx)"
-    render(getMarkdownElement(body))
-    const link = screen.getByText("Yikes")
-    expect(link instanceof HTMLAnchorElement).toBe(true)
+      "Here's a link containing parentheses [Yikes](http://msdn.microsoft.com/en-us/library/aa752574(VS.85).aspx)";
+    render(getMarkdownElement(body));
+    const link = screen.getByText("Yikes");
+    expect(link instanceof HTMLAnchorElement).toBe(true);
     expect(link).toHaveAttribute(
       "href",
-      "http://msdn.microsoft.com/en-us/library/aa752574(VS.85).aspx"
-    )
-  })
+      "http://msdn.microsoft.com/en-us/library/aa752574(VS.85).aspx",
+    );
+  });
 
   it("does not render a link if only [text] and no (href)", () => {
-    const body = "Don't convert to a link if only [text] and missing (href)"
-    render(getMarkdownElement(body))
-    const element = screen.getByText("text", { exact: false })
+    const body = "Don't convert to a link if only [text] and missing (href)";
+    render(getMarkdownElement(body));
+    const element = screen.getByText("text", { exact: false });
     expect(element).toHaveTextContent(
-      "Don't convert to a link if only [text] and missing (href)"
-    )
-    expect(element instanceof HTMLAnchorElement).toBe(false)
-  })
-})
+      "Don't convert to a link if only [text] and missing (href)",
+    );
+    expect(element instanceof HTMLAnchorElement).toBe(false);
+  });
+});
 
 describe("link URL scheme security", () => {
   it.each([
@@ -432,18 +435,18 @@ describe("link URL scheme security", () => {
     "javascript:alert(1)  ", // trailing whitespace
     "vbscript:msgbox(1)",
     "VBScript:execute()", // case-insensitive
-  ])("blocks dangerous URL: %s", url => {
+  ])("blocks dangerous URL: %s", (url) => {
     render(
-      <StreamlitMarkdown source={`[Click me](${url})`} allowHTML={false} />
-    )
+      <StreamlitMarkdown source={`[Click me](${url})`} allowHTML={false} />,
+    );
     // Returns "#" to prevent navigation (empty href with target="_blank"
     // would open current page in new tab)
-    const link = screen.getByText("Click me")
-    expect(link).toHaveAttribute("href", "#")
+    const link = screen.getByText("Click me");
+    expect(link).toHaveAttribute("href", "#");
     // Verify blocked links don't open in new tab (LinkWithTargetBlank returns
     // target="_self" for URLs starting with "#")
-    expect(link).not.toHaveAttribute("target", "_blank")
-  })
+    expect(link).not.toHaveAttribute("target", "_blank");
+  });
 
   // Raw HTML links go through rehype-raw and reach transformLinkUri.
   // Test C0 control characters and internal whitespace bypasses in this context.
@@ -462,13 +465,13 @@ describe("link URL scheme security", () => {
     '<a href="java&#9;script:alert(1)">link</a>', // tab via HTML entity
     '<a href="java&#10;script:alert(1)">link</a>', // newline via HTML entity
     '<a href="java&#13;script:alert(1)">link</a>', // CR via HTML entity
-  ])("blocks dangerous raw HTML URLs: %s", async source => {
-    render(<StreamlitMarkdown source={source} allowHTML={true} />)
-    const link = await screen.findByText("link")
-    expect(link).toHaveAttribute("href", "#")
+  ])("blocks dangerous raw HTML URLs: %s", async (source) => {
+    render(<StreamlitMarkdown source={source} allowHTML={true} />);
+    const link = await screen.findByText("link");
+    expect(link).toHaveAttribute("href", "#");
     // Verify blocked links don't open in new tab
-    expect(link).not.toHaveAttribute("target", "_blank")
-  })
+    expect(link).not.toHaveAttribute("target", "_blank");
+  });
 
   it.each([
     "https://example.com",
@@ -479,21 +482,21 @@ describe("link URL scheme security", () => {
     "data:text/plain,hello",
     "/relative/path",
     "#anchor",
-  ])("allows safe URL: %s", url => {
+  ])("allows safe URL: %s", (url) => {
     render(
-      <StreamlitMarkdown source={`[Click me](${url})`} allowHTML={false} />
-    )
-    expect(screen.getByText("Click me")).toHaveAttribute("href", url)
-  })
-})
+      <StreamlitMarkdown source={`[Click me](${url})`} allowHTML={false} />,
+    );
+    expect(screen.getByText("Click me")).toHaveAttribute("href", url);
+  });
+});
 
 describe("StreamlitMarkdown", () => {
-  let bgColors: ReturnType<typeof getThemeBackgroundColors>
-  let backgroundColorMapping: Map<string, string>
+  let bgColors: ReturnType<typeof getThemeBackgroundColors>;
+  let backgroundColorMapping: Map<string, string>;
 
   beforeAll(() => {
     // Use the actual implementation to get background colors
-    bgColors = getThemeBackgroundColors(mockTheme.emotion)
+    bgColors = getThemeBackgroundColors(mockTheme.emotion);
 
     backgroundColorMapping = new Map([
       ["red", bgColors.redbg],
@@ -504,65 +507,65 @@ describe("StreamlitMarkdown", () => {
       ["violet", bgColors.violetbg],
       ["gray", bgColors.graybg],
       ["grey", bgColors.graybg],
-    ])
-  })
+    ]);
+  });
 
   it("renders header anchors when isInSidebar is false", () => {
-    const source = "# header"
+    const source = "# header";
     render(
       <IsSidebarContext.Provider value={false}>
         <StreamlitMarkdown source={source} allowHTML={false} />
-      </IsSidebarContext.Provider>
-    )
+      </IsSidebarContext.Provider>,
+    );
     expect(
-      screen.getByTestId("stHeadingWithActionElements")
-    ).toBeInTheDocument()
-  })
+      screen.getByTestId("stHeadingWithActionElements"),
+    ).toBeInTheDocument();
+  });
 
   it("renders header anchors when isInDialog is false", () => {
-    const source = "# header"
+    const source = "# header";
     render(
       <IsDialogContext.Provider value={false}>
         <StreamlitMarkdown source={source} allowHTML={false} />
-      </IsDialogContext.Provider>
-    )
+      </IsDialogContext.Provider>,
+    );
     expect(
-      screen.getByTestId("stHeadingWithActionElements")
-    ).toBeInTheDocument()
-  })
+      screen.getByTestId("stHeadingWithActionElements"),
+    ).toBeInTheDocument();
+  });
 
   it("passes props properly", async () => {
     const source =
-      "<a class='nav_item' href='//0.0.0.0:8501/?p=some_page' target='_self'>Some Page</a>"
-    render(<StreamlitMarkdown source={source} allowHTML={true} />)
-    const link = await screen.findByText("Some Page")
-    expect(link).toHaveAttribute("href", "//0.0.0.0:8501/?p=some_page")
-    expect(link).toHaveAttribute("target", "_self")
-  })
+      "<a class='nav_item' href='//0.0.0.0:8501/?p=some_page' target='_self'>Some Page</a>";
+    render(<StreamlitMarkdown source={source} allowHTML={true} />);
+    const link = await screen.findByText("Some Page");
+    expect(link).toHaveAttribute("href", "//0.0.0.0:8501/?p=some_page");
+    expect(link).toHaveAttribute("target", "_self");
+  });
 
   it("doesn't render header anchors when isInSidebar is true", () => {
-    const source = "# header"
+    const source = "# header";
     render(
       <IsSidebarContext.Provider value={true}>
         <StreamlitMarkdown source={source} allowHTML={false} />
-      </IsSidebarContext.Provider>
-    )
+      </IsSidebarContext.Provider>,
+    );
     expect(
-      screen.queryByTestId("stHeadingWithActionElements")
-    ).not.toBeInTheDocument()
-  })
+      screen.queryByTestId("stHeadingWithActionElements"),
+    ).not.toBeInTheDocument();
+  });
 
   it("doesn't render header anchors when isInDialog is true", () => {
-    const source = "# header"
+    const source = "# header";
     render(
       <IsDialogContext.Provider value={true}>
         <StreamlitMarkdown source={source} allowHTML={false} />
-      </IsDialogContext.Provider>
-    )
+      </IsDialogContext.Provider>,
+    );
     expect(
-      screen.queryByTestId("stHeadingWithActionElements")
-    ).not.toBeInTheDocument()
-  })
+      screen.queryByTestId("stHeadingWithActionElements"),
+    ).not.toBeInTheDocument();
+  });
 
   it("uses aria-labelledby when help is present in the sidebar (no anchor id)", () => {
     render(
@@ -572,17 +575,17 @@ describe("StreamlitMarkdown", () => {
             Hello
           </HeadingWithActionElements>
         </IsDialogContext.Provider>
-      </IsSidebarContext.Provider>
-    )
+      </IsSidebarContext.Provider>,
+    );
 
-    const heading = screen.getByRole("heading", { name: "Hello" })
-    expect(heading).toHaveAttribute("aria-labelledby")
-    expect(heading).not.toHaveAttribute("id")
+    const heading = screen.getByRole("heading", { name: "Hello" });
+    expect(heading).toHaveAttribute("aria-labelledby");
+    expect(heading).not.toHaveAttribute("id");
 
-    const labelId = heading.getAttribute("aria-labelledby")
-    expect(labelId).toBeTruthy()
-    expect(within(heading).getByText("Hello")).toHaveAttribute("id", labelId)
-  })
+    const labelId = heading.getAttribute("aria-labelledby");
+    expect(labelId).toBeTruthy();
+    expect(within(heading).getByText("Hello")).toHaveAttribute("id", labelId);
+  });
 
   it("uses aria-labelledby when the anchor icon is present (non-sidebar)", () => {
     render(
@@ -592,17 +595,17 @@ describe("StreamlitMarkdown", () => {
             Hello
           </HeadingWithActionElements>
         </IsDialogContext.Provider>
-      </IsSidebarContext.Provider>
-    )
+      </IsSidebarContext.Provider>,
+    );
 
-    const heading = screen.getByRole("heading", { name: "Hello" })
-    expect(heading).toHaveAttribute("id", "my-anchor")
-    expect(heading).toHaveAttribute("aria-labelledby")
+    const heading = screen.getByRole("heading", { name: "Hello" });
+    expect(heading).toHaveAttribute("id", "my-anchor");
+    expect(heading).toHaveAttribute("aria-labelledby");
 
-    const labelId = heading.getAttribute("aria-labelledby")
-    expect(labelId).toBeTruthy()
-    expect(within(heading).getByText("Hello")).toHaveAttribute("id", labelId)
-  })
+    const labelId = heading.getAttribute("aria-labelledby");
+    expect(labelId).toBeTruthy();
+    expect(within(heading).getByText("Hello")).toHaveAttribute("id", labelId);
+  });
 
   it("does not use aria-labelledby when no action elements are present", () => {
     render(
@@ -612,15 +615,15 @@ describe("StreamlitMarkdown", () => {
             Hello
           </HeadingWithActionElements>
         </IsDialogContext.Provider>
-      </IsSidebarContext.Provider>
-    )
+      </IsSidebarContext.Provider>,
+    );
 
-    const heading = screen.getByRole("heading", { name: "Hello" })
-    expect(heading).toHaveAttribute("id", "my-anchor")
-    expect(heading).not.toHaveAttribute("aria-labelledby")
-  })
+    const heading = screen.getByRole("heading", { name: "Hello" });
+    expect(heading).toHaveAttribute("id", "my-anchor");
+    expect(heading).not.toHaveAttribute("aria-labelledby");
+  });
 
-  it("updates heading anchor when text changes across reruns (no explicit anchor)", async () => {
+  it("updates heading anchor when text changes across reruns (no explicit anchor)", () => {
     const { rerender } = render(
       <IsSidebarContext.Provider value={false}>
         <IsDialogContext.Provider value={false}>
@@ -628,11 +631,11 @@ describe("StreamlitMarkdown", () => {
             First Heading
           </HeadingWithActionElements>
         </IsDialogContext.Provider>
-      </IsSidebarContext.Provider>
-    )
+      </IsSidebarContext.Provider>,
+    );
 
-    const heading = screen.getByRole("heading")
-    expect(heading).toHaveAttribute("id", "first-heading")
+    const heading = screen.getByRole("heading");
+    expect(heading).toHaveAttribute("id", "first-heading");
 
     rerender(
       <IsSidebarContext.Provider value={false}>
@@ -641,23 +644,23 @@ describe("StreamlitMarkdown", () => {
             Second Heading
           </HeadingWithActionElements>
         </IsDialogContext.Provider>
-      </IsSidebarContext.Provider>
-    )
+      </IsSidebarContext.Provider>,
+    );
 
-    await waitFor(() => {
-      expect(screen.getByRole("heading")).toHaveAttribute(
-        "id",
-        "second-heading"
-      )
-    })
+    // useLayoutEffect commits the re-derived id before paint, so the assertion
+    // can be direct -- no waitFor needed.
+    expect(screen.getByRole("heading")).toHaveAttribute(
+      "id",
+      "second-heading",
+    );
     // The stale anchor must be gone, not merely joined by the new one.
     expect(screen.getByRole("heading")).not.toHaveAttribute(
       "id",
-      "first-heading"
-    )
-  })
+      "first-heading",
+    );
+  });
 
-  it("keeps an explicit anchor when heading text changes across reruns", async () => {
+  it("keeps an explicit anchor when heading text changes across reruns", () => {
     const { rerender } = render(
       <IsSidebarContext.Provider value={false}>
         <IsDialogContext.Provider value={false}>
@@ -665,10 +668,10 @@ describe("StreamlitMarkdown", () => {
             First Heading
           </HeadingWithActionElements>
         </IsDialogContext.Provider>
-      </IsSidebarContext.Provider>
-    )
+      </IsSidebarContext.Provider>,
+    );
 
-    expect(screen.getByRole("heading")).toHaveAttribute("id", "my-anchor")
+    expect(screen.getByRole("heading")).toHaveAttribute("id", "my-anchor");
 
     rerender(
       <IsSidebarContext.Provider value={false}>
@@ -677,29 +680,27 @@ describe("StreamlitMarkdown", () => {
             Second Heading
           </HeadingWithActionElements>
         </IsDialogContext.Provider>
-      </IsSidebarContext.Provider>
-    )
+      </IsSidebarContext.Provider>,
+    );
 
     // A developer-supplied anchor is never re-derived from the text.
-    await waitFor(() => {
-      expect(screen.getByRole("heading")).toHaveTextContent("Second Heading")
-    })
-    expect(screen.getByRole("heading")).toHaveAttribute("id", "my-anchor")
-  })
+    expect(screen.getByRole("heading")).toHaveTextContent("Second Heading");
+    expect(screen.getByRole("heading")).toHaveAttribute("id", "my-anchor");
+  });
 
   it("propagates header attributes to custom header", async () => {
-    const source = '<h1 data-test="lol">alsdkjhflaf</h1>'
-    render(<StreamlitMarkdown source={source} allowHTML />)
-    const h1 = await screen.findByRole("heading")
-    expect(h1).toHaveAttribute("data-test", "lol")
-  })
+    const source = '<h1 data-test="lol">alsdkjhflaf</h1>';
+    render(<StreamlitMarkdown source={source} allowHTML />);
+    const h1 = await screen.findByRole("heading");
+    expect(h1).toHaveAttribute("data-test", "lol");
+  });
 
   it("displays captions correctly", () => {
-    const source = "hello this is a caption"
-    render(<StreamlitMarkdown allowHTML={false} source={source} isCaption />)
-    const caption = screen.getByTestId("stCaptionContainer")
-    expect(caption).toHaveTextContent("hello this is a caption")
-  })
+    const source = "hello this is a caption";
+    render(<StreamlitMarkdown allowHTML={false} source={source} isCaption />);
+    const caption = screen.getByTestId("stCaptionContainer");
+    expect(caption).toHaveTextContent("hello this is a caption");
+  });
 
   // Valid Markdown - italics, bold, strikethrough, code, links, emojis, shortcodes
   const validCases = [
@@ -715,51 +716,51 @@ describe("StreamlitMarkdown", () => {
     { input: "🐶", tag: "p", expected: "🐶" },
     { input: ":joy:", tag: "p", expected: "😂" },
     { input: ":material/search:", tag: "span", expected: "search" },
-  ]
+  ];
 
   it.each(validCases)(
     "renders valid markdown when isLabel is true - $tag",
     async ({ input, tag, expected }) => {
-      render(<StreamlitMarkdown source={input} allowHTML={false} isLabel />)
+      render(<StreamlitMarkdown source={input} allowHTML={false} isLabel />);
       // Use findByText for emoji shortcodes since remark-emoji is lazy-loaded
       const markdownText =
         input === ":joy:"
           ? await screen.findByText(expected)
-          : screen.getByText(expected)
-      expect(markdownText).toBeInTheDocument()
+          : screen.getByText(expected);
+      expect(markdownText).toBeInTheDocument();
 
-      const expectedTag = markdownText.nodeName.toLowerCase()
-      expect(expectedTag).toEqual(tag)
+      const expectedTag = markdownText.nodeName.toLowerCase();
+      expect(expectedTag).toEqual(tag);
 
       // Removes rendered StreamlitMarkdown component before next case run
-      cleanup()
-    }
-  )
+      cleanup();
+    },
+  );
 
   it("renders streamlit logo in markdown when isLabel is true", () => {
     render(
-      <StreamlitMarkdown source={":streamlit:"} allowHTML={false} isLabel />
-    )
-    const image = screen.getByRole("img")
-    expect(image).toHaveAttribute("alt", "Streamlit logo")
-  })
+      <StreamlitMarkdown source={":streamlit:"} allowHTML={false} isLabel />,
+    );
+    const image = screen.getByRole("img");
+    expect(image).toHaveAttribute("alt", "Streamlit logo");
+  });
 
   it("renders streamlit logo with allowHTML=true", async () => {
-    render(<StreamlitMarkdown source={":streamlit:"} allowHTML={true} />)
-    const image = await screen.findByRole("img")
-    expect(image).toHaveAttribute("alt", "Streamlit logo")
-    expect(image).toHaveStyle("display: inline-block")
-    expect(image).toHaveStyle("user-select: none")
-  })
+    render(<StreamlitMarkdown source={":streamlit:"} allowHTML={true} />);
+    const image = await screen.findByRole("img");
+    expect(image).toHaveAttribute("alt", "Streamlit logo");
+    expect(image).toHaveStyle("display: inline-block");
+    expect(image).toHaveStyle("user-select: none");
+  });
 
   it("renders material icons with allowHTML=true", async () => {
-    const source = `:material/search: Icon`
-    render(<StreamlitMarkdown source={source} allowHTML={true} />)
-    const markdown = await screen.findByText("search")
-    const tagName = markdown.nodeName.toLowerCase()
-    expect(tagName).toBe("span")
-    expect(markdown).toHaveStyle("font-family: Material Symbols Rounded")
-  })
+    const source = `:material/search: Icon`;
+    render(<StreamlitMarkdown source={source} allowHTML={true} />);
+    const markdown = await screen.findByText("search");
+    const tagName = markdown.nodeName.toLowerCase();
+    expect(tagName).toBe("span");
+    expect(markdown).toHaveStyle("font-family: Material Symbols Rounded");
+  });
 
   // Typographical symbol replacements
   const symbolReplacementCases = [
@@ -776,35 +777,35 @@ describe("StreamlitMarkdown", () => {
       expected: "Link ->",
     },
     { input: "`Code ->`", tag: "code", expected: "Code ->" },
-  ]
+  ];
 
   it.each(symbolReplacementCases)(
     "replaces symbols with nicer typographical symbols - $input",
     ({ input, tag, expected }) => {
-      render(<StreamlitMarkdown source={input} allowHTML={false} isLabel />)
-      const markdownText = screen.getByText(expected)
-      expect(markdownText).toBeInTheDocument()
+      render(<StreamlitMarkdown source={input} allowHTML={false} isLabel />);
+      const markdownText = screen.getByText(expected);
+      expect(markdownText).toBeInTheDocument();
 
-      const expectedTag = markdownText.nodeName.toLowerCase()
-      expect(expectedTag).toEqual(tag)
+      const expectedTag = markdownText.nodeName.toLowerCase();
+      expect(expectedTag).toEqual(tag);
 
       // Removes rendered StreamlitMarkdown component before next case run
-      cleanup()
-    }
-  )
+      cleanup();
+    },
+  );
 
   // Invalid Markdown - images, table elements, headings, unordered/ordered lists, task lists, horizontal rules, & blockquotes
   const table = `| Syntax | Description |
   | ----------- | ----------- |
   | Header      | Title       |
-  | Paragraph   | Text        |`
-  const tableText = "Syntax Description Header Title Paragraph Text"
+  | Paragraph   | Text        |`;
+  const tableText = "Syntax Description Header Title Paragraph Text";
   const horizontalRule = `
 
   ---
 
   Horizontal rule
-  `
+  `;
 
   const invalidCases = [
     { input: table, tag: "table", expected: tableText },
@@ -832,37 +833,37 @@ describe("StreamlitMarkdown", () => {
     },
     { input: horizontalRule, tag: "hr", expected: "Horizontal rule" },
     { input: "> Blockquote", tag: "blockquote", expected: "> Blockquote" },
-  ]
+  ];
 
   it.each(invalidCases)(
     "does NOT render invalid markdown when isLabel is true - $tag",
     ({ input, tag, expected }) => {
-      render(<StreamlitMarkdown source={input} allowHTML={false} isLabel />)
-      const markdownText = screen.getByText(expected)
-      expect(markdownText).toBeInTheDocument()
+      render(<StreamlitMarkdown source={input} allowHTML={false} isLabel />);
+      const markdownText = screen.getByText(expected);
+      expect(markdownText).toBeInTheDocument();
 
-      const expectedTag = markdownText.nodeName.toLowerCase()
-      expect(expectedTag).not.toEqual(tag)
+      const expectedTag = markdownText.nodeName.toLowerCase();
+      expect(expectedTag).not.toEqual(tag);
 
       // Removes rendered StreamlitMarkdown component before next case run
-      cleanup()
-    }
-  )
+      cleanup();
+    },
+  );
 
   it("doesn't render links when disableLinks is true", () => {
     // Valid markdown further restricted with buttons to eliminate links
-    const source = "[Link text](www.example.com)"
+    const source = "[Link text](www.example.com)";
     render(
       <StreamlitMarkdown
         source={source}
         allowHTML={false}
         isLabel
         disableLinks
-      />
-    )
-    const tag = screen.getByText("Link text")
-    expect(tag instanceof HTMLAnchorElement).toBe(false)
-  })
+      />,
+    );
+    const tag = screen.getByText("Link text");
+    expect(tag instanceof HTMLAnchorElement).toBe(false);
+  });
 
   // Test for markdown syntax escaping in labels (https://github.com/streamlit/streamlit/issues/7359)
   // These characters/patterns would normally create markdown elements that get stripped,
@@ -900,22 +901,22 @@ describe("StreamlitMarkdown", () => {
     { input: "#", expected: "#", description: "single hash" },
     { input: "##", expected: "##", description: "double hash" },
     { input: "# text", expected: "# text", description: "heading with text" },
-  ]
+  ];
 
   it.each(markdownEscapingCases)(
     "preserves markdown syntax in labels - $description",
     ({ input, expected }) => {
-      render(<StreamlitMarkdown source={input} allowHTML={false} isLabel />)
-      const markdownText = screen.getByText(expected)
-      expect(markdownText).toBeInTheDocument()
+      render(<StreamlitMarkdown source={input} allowHTML={false} isLabel />);
+      const markdownText = screen.getByText(expected);
+      expect(markdownText).toBeInTheDocument();
 
       // Should be rendered as plain paragraph text, not special elements
-      const tagName = markdownText.nodeName.toLowerCase()
-      expect(tagName).toBe("p")
+      const tagName = markdownText.nodeName.toLowerCase();
+      expect(tagName).toBe("p");
 
-      cleanup()
-    }
-  )
+      cleanup();
+    },
+  );
 
   // Patterns that should NOT be escaped (no space after marker)
   const nonEscapingCases = [
@@ -940,65 +941,70 @@ describe("StreamlitMarkdown", () => {
       expected: "- Already escaped",
       description: "pre-escaped unordered list",
     },
-  ]
+  ];
 
   it.each(nonEscapingCases)(
     "does not escape non-markdown patterns in labels - $description",
     ({ input, expected }) => {
-      render(<StreamlitMarkdown source={input} allowHTML={false} isLabel />)
-      const markdownText = screen.getByText(expected)
-      expect(markdownText).toBeInTheDocument()
-      cleanup()
-    }
-  )
+      render(<StreamlitMarkdown source={input} allowHTML={false} isLabel />);
+      const markdownText = screen.getByText(expected);
+      expect(markdownText).toBeInTheDocument();
+      cleanup();
+    },
+  );
 
   it("renders emphasis markdown in labels", () => {
     // *italic label* should render as emphasized text, not be escaped
     render(
-      <StreamlitMarkdown source="*italic label*" allowHTML={false} isLabel />
-    )
-    const emphasisText = screen.getByText("italic label")
-    expect(emphasisText).toBeInTheDocument()
-    expect(emphasisText.tagName.toLowerCase()).toBe("em")
-    cleanup()
-  })
+      <StreamlitMarkdown source="*italic label*" allowHTML={false} isLabel />,
+    );
+    const emphasisText = screen.getByText("italic label");
+    expect(emphasisText).toBeInTheDocument();
+    expect(emphasisText.tagName.toLowerCase()).toBe("em");
+    cleanup();
+  });
 
   it("renders smaller text sizing when isLabel is true", () => {
-    const source = "Here is some label text"
-    render(<StreamlitMarkdown source={source} allowHTML={false} isLabel />)
+    const source = "Here is some label text";
+    render(<StreamlitMarkdown source={source} allowHTML={false} isLabel />);
 
-    const textTag = screen.getByText("Here is some label text")
-    expect(textTag).toBeInTheDocument()
+    const textTag = screen.getByText("Here is some label text");
+    expect(textTag).toBeInTheDocument();
 
     // All widget labels use the smaller font size for the markdown container
-    const markdownContainer = screen.getByTestId("stMarkdownContainer")
-    expect(markdownContainer).toHaveStyle("font-size: 0.875rem")
-  })
+    const markdownContainer = screen.getByTestId("stMarkdownContainer");
+    expect(markdownContainer).toHaveStyle("font-size: 0.875rem");
+  });
 
   it("renders smaller text sizing when isToast is true", () => {
-    const source = "Here is some toast text"
-    render(<StreamlitMarkdown source={source} allowHTML={false} isToast />)
+    const source = "Here is some toast text";
+    render(<StreamlitMarkdown source={source} allowHTML={false} isToast />);
 
-    const textTag = screen.getByText("Here is some toast text")
-    expect(textTag).toBeInTheDocument()
+    const textTag = screen.getByText("Here is some toast text");
+    expect(textTag).toBeInTheDocument();
 
     // Use the smaller font size for the markdown container
-    const markdownContainer = screen.getByTestId("stMarkdownContainer")
-    expect(markdownContainer).toHaveStyle("font-size: 0.875rem")
-  })
+    const markdownContainer = screen.getByTestId("stMarkdownContainer");
+    expect(markdownContainer).toHaveStyle("font-size: 0.875rem");
+  });
 
   it("renders bold label text when boldLabel is true", () => {
-    const source = "Here is some checkbox label text"
+    const source = "Here is some checkbox label text";
     render(
-      <StreamlitMarkdown source={source} allowHTML={false} isLabel boldLabel />
-    )
+      <StreamlitMarkdown
+        source={source}
+        allowHTML={false}
+        isLabel
+        boldLabel
+      />,
+    );
 
-    const textTag = screen.getByText("Here is some checkbox label text")
-    expect(textTag).toHaveStyle("font-weight: 600")
-  })
+    const textTag = screen.getByText("Here is some checkbox label text");
+    expect(textTag).toHaveStyle("font-weight: 600");
+  });
 
   it("colours text properly", () => {
-    const grayTextColor = transparentize(colors.gray85, 0.4)
+    const grayTextColor = transparentize(colors.gray85, 0.4);
 
     const colorMapping = new Map([
       ["red", colors.red90],
@@ -1010,315 +1016,317 @@ describe("StreamlitMarkdown", () => {
       ["gray", grayTextColor],
       ["grey", grayTextColor],
       ["rainbow", "rgba(0, 0, 0, 0)"],
-    ])
+    ]);
 
     colorMapping.forEach(function (style, color) {
-      const source = `:${color}[text]`
-      render(<StreamlitMarkdown source={source} allowHTML={false} />)
-      const markdown = screen.getByText("text")
-      const tagName = markdown.nodeName.toLowerCase()
-      expect(tagName).toBe("span")
-      expect(markdown).toHaveStyle(`color: ${style}`)
-      expect(markdown).toHaveClass("stMarkdownColoredText")
+      const source = `:${color}[text]`;
+      render(<StreamlitMarkdown source={source} allowHTML={false} />);
+      const markdown = screen.getByText("text");
+      const tagName = markdown.nodeName.toLowerCase();
+      expect(tagName).toBe("span");
+      expect(markdown).toHaveStyle(`color: ${style}`);
+      expect(markdown).toHaveClass("stMarkdownColoredText");
 
       // Removes rendered StreamlitMarkdown component before next case run
-      cleanup()
-    })
-  })
+      cleanup();
+    });
+  });
 
   it("properly adds custom material icon", () => {
-    const source = `:material/search: Icon`
-    render(<StreamlitMarkdown source={source} allowHTML={false} />)
-    const markdown = screen.getByText("search")
-    const tagName = markdown.nodeName.toLowerCase()
-    expect(tagName).toBe("span")
-    expect(markdown).toHaveStyle(`font-family: Material Symbols Rounded`)
-    expect(markdown).toHaveStyle(`user-select: none`)
-    expect(markdown).toHaveStyle(`vertical-align: bottom`)
-    expect(markdown).toHaveAttribute("translate", "no")
-  })
+    const source = `:material/search: Icon`;
+    render(<StreamlitMarkdown source={source} allowHTML={false} />);
+    const markdown = screen.getByText("search");
+    const tagName = markdown.nodeName.toLowerCase();
+    expect(tagName).toBe("span");
+    expect(markdown).toHaveStyle(`font-family: Material Symbols Rounded`);
+    expect(markdown).toHaveStyle(`user-select: none`);
+    expect(markdown).toHaveStyle(`vertical-align: bottom`);
+    expect(markdown).toHaveAttribute("translate", "no");
+  });
 
   it("does not remove unknown directive", () => {
-    const source = `test :foo test:test :`
-    render(<StreamlitMarkdown source={source} allowHTML={false} />)
-    const markdown = screen.getByText("test :foo test:test :")
-    expect(markdown).toBeInTheDocument()
-  })
+    const source = `test :foo test:test :`;
+    render(<StreamlitMarkdown source={source} allowHTML={false} />);
+    const markdown = screen.getByText("test :foo test:test :");
+    expect(markdown).toBeInTheDocument();
+  });
 
   it("converts unsupported text directives to plain text", () => {
     // Text directives use the syntax :name[content]
     // Unsupported ones should render as :name (prefix only, content lost)
-    const source = `test :unknown[content] end`
-    render(<StreamlitMarkdown source={source} allowHTML={false} />)
-    const markdown = screen.getByText("test :unknown end")
-    expect(markdown).toBeVisible()
-  })
+    const source = `test :unknown[content] end`;
+    render(<StreamlitMarkdown source={source} allowHTML={false} />);
+    const markdown = screen.getByText("test :unknown end");
+    expect(markdown).toBeVisible();
+  });
 
   it("properly adds background colors", () => {
     backgroundColorMapping.forEach(function (style, color) {
-      const source = `:${color}-background[text]`
-      render(<StreamlitMarkdown source={source} allowHTML={false} />)
-      const markdown = screen.getByText("text")
-      const tagName = markdown.nodeName.toLowerCase()
-      expect(tagName).toBe("span")
-      expect(markdown).toHaveStyle(`background-color: ${style}`)
+      const source = `:${color}-background[text]`;
+      render(<StreamlitMarkdown source={source} allowHTML={false} />);
+      const markdown = screen.getByText("text");
+      const tagName = markdown.nodeName.toLowerCase();
+      expect(tagName).toBe("span");
+      expect(markdown).toHaveStyle(`background-color: ${style}`);
 
       // Removes rendered StreamlitMarkdown component before next case run
-      cleanup()
-    })
-  })
+      cleanup();
+    });
+  });
 
   it("properly adds rainbow background color", () => {
     const { redbg, orangebg, yellowbg, greenbg, bluebg, violetbg, purplebg } =
-      bgColors
-    const rainbowGradient = `linear-gradient(to right, ${redbg}, ${orangebg}, ${yellowbg}, ${greenbg}, ${bluebg}, ${violetbg}, ${purplebg})`
+      bgColors;
+    const rainbowGradient = `linear-gradient(to right, ${redbg}, ${orangebg}, ${yellowbg}, ${greenbg}, ${bluebg}, ${violetbg}, ${purplebg})`;
 
-    const source = `:rainbow-background[text]`
-    render(<StreamlitMarkdown source={source} allowHTML={false} />)
-    const markdown = screen.getByText("text")
-    const tagName = markdown.nodeName.toLowerCase()
-    expect(tagName).toBe("span")
-    expect(markdown).toHaveStyle(`background: ${rainbowGradient}`)
-  })
+    const source = `:rainbow-background[text]`;
+    render(<StreamlitMarkdown source={source} allowHTML={false} />);
+    const markdown = screen.getByText("text");
+    const tagName = markdown.nodeName.toLowerCase();
+    expect(tagName).toBe("span");
+    expect(markdown).toHaveStyle(`background: ${rainbowGradient}`);
+  });
 
   it("renders small text properly", () => {
-    const source = `:small[text]`
-    render(<StreamlitMarkdown source={source} allowHTML={false} />)
-    const markdown = screen.getByText("text")
-    const tagName = markdown.nodeName.toLowerCase()
-    expect(tagName).toBe("span")
+    const source = `:small[text]`;
+    render(<StreamlitMarkdown source={source} allowHTML={false} />);
+    const markdown = screen.getByText("text");
+    const tagName = markdown.nodeName.toLowerCase();
+    expect(tagName).toBe("span");
     expect(markdown).toHaveStyle(
-      `font-size: ${mockTheme.emotion.fontSizes.sm}`
-    )
-  })
+      `font-size: ${mockTheme.emotion.fontSizes.sm}`,
+    );
+  });
 
   it("renders shimmer text with correct class", () => {
     render(
-      <StreamlitMarkdown source=":shimmer[Loading...]" allowHTML={false} />
-    )
-    const element = screen.getByText("Loading...")
-    expect(element.tagName.toLowerCase()).toBe("span")
-    expect(element).toHaveClass("stMarkdownShimmer")
-  })
+      <StreamlitMarkdown source=":shimmer[Loading...]" allowHTML={false} />,
+    );
+    const element = screen.getByText("Loading...");
+    expect(element.tagName.toLowerCase()).toBe("span");
+    expect(element).toHaveClass("stMarkdownShimmer");
+  });
 
   it("does not apply shimmer class to regular text", () => {
     render(
       <StreamlitMarkdown
         source="Regular text without shimmer"
         allowHTML={false}
-      />
-    )
-    const element = screen.getByText("Regular text without shimmer")
-    expect(element).not.toHaveClass("stMarkdownShimmer")
-  })
+      />,
+    );
+    const element = screen.getByText("Regular text without shimmer");
+    expect(element).not.toHaveClass("stMarkdownShimmer");
+  });
 
   it("renders shimmer nested inside color directive with correct DOM structure", () => {
     render(
       <StreamlitMarkdown
         source=":red[:shimmer[Loading...]]"
         allowHTML={false}
-      />
-    )
-    const shimmerElement = screen.getByText("Loading...")
-    expect(shimmerElement).toHaveClass("stMarkdownShimmer")
+      />,
+    );
+    const shimmerElement = screen.getByText("Loading...");
+    expect(shimmerElement).toHaveClass("stMarkdownShimmer");
     // Verify the parent span has the color directive class (shimmer uses fadedText60,
     // but the outer :red[] span still has its color class applied)
-    const parentSpan = shimmerElement.parentElement
-    expect(parentSpan).not.toBeNull()
-    expect(parentSpan).toHaveClass("stMarkdownColoredText")
+    const parentSpan = shimmerElement.parentElement;
+    expect(parentSpan).not.toBeNull();
+    expect(parentSpan).toHaveClass("stMarkdownColoredText");
     // The color style should be applied (the exact value comes from the theme)
-    expect(parentSpan).toHaveAttribute("style")
-    expect(parentSpan?.getAttribute("style")).toContain("color:")
-  })
+    expect(parentSpan).toHaveAttribute("style");
+    expect(parentSpan?.getAttribute("style")).toContain("color:");
+  });
 
   it("applies truncate styles when truncate is true", () => {
-    const source = "This is some text that should be truncated"
-    render(<StreamlitMarkdown source={source} allowHTML={false} truncate />)
-    const container = screen.getByTestId("stMarkdownContainer")
-    expect(container).toHaveStyle("overflow: hidden")
-    expect(container).toHaveStyle("white-space: nowrap")
-    expect(container).toHaveStyle("text-overflow: ellipsis")
-  })
+    const source = "This is some text that should be truncated";
+    render(<StreamlitMarkdown source={source} allowHTML={false} truncate />);
+    const container = screen.getByTestId("stMarkdownContainer");
+    expect(container).toHaveStyle("overflow: hidden");
+    expect(container).toHaveStyle("white-space: nowrap");
+    expect(container).toHaveStyle("text-overflow: ellipsis");
+  });
 
   it("does not apply truncate styles when truncate is false", () => {
-    const source = "This is some text that should not be truncated"
-    render(<StreamlitMarkdown source={source} allowHTML={false} />)
-    const container = screen.getByTestId("stMarkdownContainer")
-    expect(container).not.toHaveStyle("white-space: nowrap")
-  })
+    const source = "This is some text that should not be truncated";
+    render(<StreamlitMarkdown source={source} allowHTML={false} />);
+    const container = screen.getByTestId("stMarkdownContainer");
+    expect(container).not.toHaveStyle("white-space: nowrap");
+  });
 
   // Custom color directive tests
   describe("custom color directive", () => {
     it("applies custom foreground color with hex value", () => {
-      const source = `:color[custom text]{foreground="#FF5733"}`
-      render(<StreamlitMarkdown source={source} allowHTML={false} />)
-      const markdown = screen.getByText("custom text")
-      expect(markdown.tagName.toLowerCase()).toBe("span")
-      expect(markdown).toHaveStyle("color: #FF5733")
-      expect(markdown).toHaveClass("stMarkdownColoredText")
-    })
+      const source = `:color[custom text]{foreground="#FF5733"}`;
+      render(<StreamlitMarkdown source={source} allowHTML={false} />);
+      const markdown = screen.getByText("custom text");
+      expect(markdown.tagName.toLowerCase()).toBe("span");
+      expect(markdown).toHaveStyle("color: #FF5733");
+      expect(markdown).toHaveClass("stMarkdownColoredText");
+    });
 
     it("applies custom background color with hex value", () => {
-      const source = `:color[custom text]{background="#FF5733"}`
-      render(<StreamlitMarkdown source={source} allowHTML={false} />)
-      const markdown = screen.getByText("custom text")
-      expect(markdown.tagName.toLowerCase()).toBe("span")
-      expect(markdown).toHaveStyle("background-color: #FF5733")
-      expect(markdown).toHaveClass("stMarkdownColoredBackground")
-    })
+      const source = `:color[custom text]{background="#FF5733"}`;
+      render(<StreamlitMarkdown source={source} allowHTML={false} />);
+      const markdown = screen.getByText("custom text");
+      expect(markdown.tagName.toLowerCase()).toBe("span");
+      expect(markdown).toHaveStyle("background-color: #FF5733");
+      expect(markdown).toHaveClass("stMarkdownColoredBackground");
+    });
 
     it("applies both foreground and background colors", () => {
       // Note: directive attributes are space-separated, not comma-separated
-      const source = `:color[text]{foreground="#FFFFFF" background="#000000"}`
-      render(<StreamlitMarkdown source={source} allowHTML={false} />)
-      const markdown = screen.getByText("text")
-      expect(markdown.tagName.toLowerCase()).toBe("span")
-      expect(markdown).toHaveStyle("color: #FFFFFF")
-      expect(markdown).toHaveStyle("background-color: #000000")
+      const source = `:color[text]{foreground="#FFFFFF" background="#000000"}`;
+      render(<StreamlitMarkdown source={source} allowHTML={false} />);
+      const markdown = screen.getByText("text");
+      expect(markdown.tagName.toLowerCase()).toBe("span");
+      expect(markdown).toHaveStyle("color: #FFFFFF");
+      expect(markdown).toHaveStyle("background-color: #000000");
       // Should use background class when both are present for proper styling
-      expect(markdown).toHaveClass("stMarkdownColoredBackground")
-    })
+      expect(markdown).toHaveClass("stMarkdownColoredBackground");
+    });
 
     it("applies custom color with 3-digit hex", () => {
-      const source = `:color[text]{foreground="#F00"}`
-      render(<StreamlitMarkdown source={source} allowHTML={false} />)
-      const markdown = screen.getByText("text")
-      expect(markdown).toHaveStyle("color: #F00")
-    })
+      const source = `:color[text]{foreground="#F00"}`;
+      render(<StreamlitMarkdown source={source} allowHTML={false} />);
+      const markdown = screen.getByText("text");
+      expect(markdown).toHaveStyle("color: #F00");
+    });
 
     it("applies custom color with named color", () => {
-      const source = `:color[text]{foreground="red"}`
-      render(<StreamlitMarkdown source={source} allowHTML={false} />)
-      const markdown = screen.getByText("text")
+      const source = `:color[text]{foreground="red"}`;
+      render(<StreamlitMarkdown source={source} allowHTML={false} />);
+      const markdown = screen.getByText("text");
       // Named colors are normalized by the browser to rgb() format
-      expect(markdown).toHaveStyle("color: rgb(255, 0, 0)")
-    })
+      expect(markdown).toHaveStyle("color: rgb(255, 0, 0)");
+    });
 
     it("renders content as plain text when color values are invalid", () => {
-      const source = `:color[text]{foreground="notacolor"}`
-      render(<StreamlitMarkdown source={source} allowHTML={false} />)
+      const source = `:color[text]{foreground="notacolor"}`;
+      render(<StreamlitMarkdown source={source} allowHTML={false} />);
       // Invalid colors should still render the content as plain text
-      const markdown = screen.getByText("text")
-      expect(markdown.tagName.toLowerCase()).toBe("span")
+      const markdown = screen.getByText("text");
+      expect(markdown.tagName.toLowerCase()).toBe("span");
       // Should not have any style attribute when color is invalid
-      expect(markdown).not.toHaveAttribute("style")
-    })
+      expect(markdown).not.toHaveAttribute("style");
+    });
 
     it("ignores potential XSS in color values and renders content safely", () => {
-      const source = `:color[text]{foreground="javascript:alert(1)"}`
-      render(<StreamlitMarkdown source={source} allowHTML={false} />)
+      const source = `:color[text]{foreground="javascript:alert(1)"}`;
+      render(<StreamlitMarkdown source={source} allowHTML={false} />);
       // Invalid/dangerous colors should still render the content as plain text
-      const markdown = screen.getByText("text")
-      expect(markdown.tagName.toLowerCase()).toBe("span")
+      const markdown = screen.getByText("text");
+      expect(markdown.tagName.toLowerCase()).toBe("span");
       // Should not have the dangerous value in any attribute
-      expect(markdown).not.toHaveAttribute("style")
-    })
+      expect(markdown).not.toHaveAttribute("style");
+    });
 
     it("applies only valid colors when mixed with invalid colors", () => {
       // Test partial validity: foreground is valid, background is invalid
-      const source = `:color[text]{foreground="red" background="notacolor"}`
-      render(<StreamlitMarkdown source={source} allowHTML={false} />)
-      const markdown = screen.getByText("text")
-      expect(markdown.tagName.toLowerCase()).toBe("span")
+      const source = `:color[text]{foreground="red" background="notacolor"}`;
+      render(<StreamlitMarkdown source={source} allowHTML={false} />);
+      const markdown = screen.getByText("text");
+      expect(markdown.tagName.toLowerCase()).toBe("span");
       // Only the valid foreground color should be applied
-      expect(markdown).toHaveStyle("color: rgb(255, 0, 0)")
+      expect(markdown).toHaveStyle("color: rgb(255, 0, 0)");
       // Background should not be applied since it's invalid
-      expect(markdown).not.toHaveStyle("background-color: notacolor")
+      expect(markdown).not.toHaveStyle("background-color: notacolor");
       // Should use text class since no valid background
-      expect(markdown).toHaveClass("stMarkdownColoredText")
-    })
+      expect(markdown).toHaveClass("stMarkdownColoredText");
+    });
 
     it("renders as plain span when used without attributes", () => {
-      const source = `:color[text]`
-      render(<StreamlitMarkdown source={source} allowHTML={false} />)
-      const markdown = screen.getByText("text")
-      expect(markdown.tagName.toLowerCase()).toBe("span")
+      const source = `:color[text]`;
+      render(<StreamlitMarkdown source={source} allowHTML={false} />);
+      const markdown = screen.getByText("text");
+      expect(markdown.tagName.toLowerCase()).toBe("span");
       // Should not have any style when no attributes are provided
-      expect(markdown).not.toHaveAttribute("style")
+      expect(markdown).not.toHaveAttribute("style");
       // Should not have the colored text class
-      expect(markdown).not.toHaveClass("stMarkdownColoredText")
-      expect(markdown).not.toHaveClass("stMarkdownColoredBackground")
-    })
-  })
-})
+      expect(markdown).not.toHaveClass("stMarkdownColoredText");
+      expect(markdown).not.toHaveClass("stMarkdownColoredBackground");
+    });
+  });
+});
 
 const getCustomCodeTagProps = (
-  props: Partial<CustomCodeTagProps> = {}
+  props: Partial<CustomCodeTagProps> = {},
 ): CustomCodeTagProps => ({
   children: `import streamlit as st
 
 st.write("Hello")
 `,
   ...props,
-})
+});
 
 describe("CustomCodeTag Element", () => {
   beforeAll(async () => {
-    await import("~lib/components/elements/CodeBlock/StreamlitSyntaxHighlighter")
-  }, 30_000)
+    await import("~lib/components/elements/CodeBlock/StreamlitSyntaxHighlighter");
+  }, 30_000);
 
   it("should render without crashing", async () => {
-    const props = getCustomCodeTagProps()
-    render(<CustomCodeTag {...props} />)
+    const props = getCustomCodeTagProps();
+    render(<CustomCodeTag {...props} />);
 
-    const stCode = await screen.findByTestId("stCode")
-    expect(stCode).toBeVisible()
-  })
+    const stCode = await screen.findByTestId("stCode");
+    expect(stCode).toBeVisible();
+  });
 
   it("should render as plaintext", async () => {
-    const props = getCustomCodeTagProps({ className: "language-plaintext" })
-    render(<CustomCodeTag {...props} />)
+    const props = getCustomCodeTagProps({ className: "language-plaintext" });
+    render(<CustomCodeTag {...props} />);
 
-    const stCode = await screen.findByTestId("stCode")
-    expect(stCode.innerHTML.indexOf(`class="language-plaintext"`)).not.toBe(-1)
-  })
+    const stCode = await screen.findByTestId("stCode");
+    expect(stCode.innerHTML.indexOf(`class="language-plaintext"`)).not.toBe(
+      -1,
+    );
+  });
 
   it("should render copy button when code block has content", async () => {
     const props = getCustomCodeTagProps({
       children: "i am not empty",
-    })
-    render(<CustomCodeTag {...props} />)
-    await screen.findByTestId("stCode")
+    });
+    render(<CustomCodeTag {...props} />);
+    await screen.findByTestId("stCode");
     const copyButton = screen.getByLabelText(/copy to clipboard/i, {
       selector: "button",
-    })
+    });
 
-    expect(copyButton).toBeEnabled()
+    expect(copyButton).toBeEnabled();
     expect(
-      screen.queryByRole("button", { name: /copy to clipboard/i })
-    ).not.toBeInTheDocument()
-  })
+      screen.queryByRole("button", { name: /copy to clipboard/i }),
+    ).not.toBeInTheDocument();
+  });
 
   it("should not render copy button when code block is empty", async () => {
     const props = getCustomCodeTagProps({
       children: "",
-    })
-    render(<CustomCodeTag {...props} />)
+    });
+    render(<CustomCodeTag {...props} />);
 
     // Wait for the component to load
-    await screen.findByTestId("stCode")
+    await screen.findByTestId("stCode");
 
     // queryBy returns null vs. error
-    const copyButton = screen.queryByRole("button")
+    const copyButton = screen.queryByRole("button");
 
-    expect(copyButton).toBeNull()
-  })
+    expect(copyButton).toBeNull();
+  });
 
   it("should render inline", () => {
-    const props = getCustomCodeTagProps({ inline: true })
-    const { baseElement } = render(<CustomCodeTag {...props} />)
+    const props = getCustomCodeTagProps({ inline: true });
+    const { baseElement } = render(<CustomCodeTag {...props} />);
     const codeWithoutClass = baseElement.innerHTML.replace(
       /class="(.*)"/,
-      'class="foo"'
-    )
+      'class="foo"',
+    );
 
     expect(codeWithoutClass).toBe(
       '<div><code class="foo">' +
         "import streamlit as st\n\n" +
         'st.write("Hello")\n' +
-        "</code></div>"
-    )
-  })
+        "</code></div>",
+    );
+  });
 
   it.each([
     [null, ""],
@@ -1326,23 +1334,23 @@ describe("CustomCodeTag Element", () => {
     ["null", "null"],
     ["undefined", "undefined"],
   ])("renders children '%s' as '%s'", (children, expected) => {
-    const props = getCustomCodeTagProps({ children })
-    render(<CustomCodeTag {...props} />)
-    expect(screen.getByTestId("stCode")).toHaveTextContent(expected)
-  })
-})
+    const props = getCustomCodeTagProps({ children });
+    render(<CustomCodeTag {...props} />);
+    expect(screen.getByTestId("stCode")).toHaveTextContent(expected);
+  });
+});
 
 describe("mermaid code blocks", () => {
-  const mermaidSource = "```mermaid\ngraph TD\n  A-->B\n```"
+  const mermaidSource = "```mermaid\ngraph TD\n  A-->B\n```";
 
   it("renders a mermaid code block as a diagram when not streaming", async () => {
-    render(<StreamlitMarkdown source={mermaidSource} allowHTML={false} />)
+    render(<StreamlitMarkdown source={mermaidSource} allowHTML={false} />);
 
     // The lazy-loaded MermaidChart renders with the stMermaidChart test id.
-    expect(await screen.findByTestId("stMermaidChart")).toBeVisible()
+    expect(await screen.findByTestId("stMermaidChart")).toBeVisible();
     // It must not fall back to a syntax-highlighted code block.
-    expect(screen.queryByTestId("stCode")).not.toBeInTheDocument()
-  })
+    expect(screen.queryByTestId("stCode")).not.toBeInTheDocument();
+  });
 
   it("renders a mermaid code block as syntax-highlighted code while streaming", async () => {
     render(
@@ -1350,30 +1358,30 @@ describe("mermaid code blocks", () => {
         source={mermaidSource}
         allowHTML={false}
         unterminatedParsing={true}
-      />
-    )
+      />,
+    );
 
     // While streaming, the (possibly partial) mermaid block is shown as code
     // to avoid flickering and error states from incomplete diagram source.
-    expect(await screen.findByTestId("stCode")).toBeVisible()
-    expect(screen.queryByTestId("stMermaidChart")).not.toBeInTheDocument()
-  })
-})
+    expect(await screen.findByTestId("stCode")).toBeVisible();
+    expect(screen.queryByTestId("stMermaidChart")).not.toBeInTheDocument();
+  });
+});
 
 describe("CustomPreTag", () => {
   it("should render without crashing", () => {
-    const props = getCustomCodeTagProps()
-    render(<CustomPreTag {...props} />)
+    const props = getCustomCodeTagProps();
+    render(<CustomPreTag {...props} />);
 
-    const preTag = screen.getByTestId("stMarkdownPre")
-    const tagName = preTag.nodeName.toLowerCase()
+    const preTag = screen.getByTestId("stMarkdownPre");
+    const tagName = preTag.nodeName.toLowerCase();
 
-    expect(preTag).toBeInTheDocument()
-    expect(tagName).toBe("div")
+    expect(preTag).toBeInTheDocument();
+    expect(tagName).toBe("div");
     expect(preTag).toHaveTextContent(
-      'import streamlit as st st.write("Hello")'
-    )
-  })
+      'import streamlit as st st.write("Hello")',
+    );
+  });
 
   describe("remend integration (streaming markdown)", () => {
     it.each([
@@ -1389,13 +1397,13 @@ describe("CustomPreTag", () => {
             source={`This is ${source}`}
             allowHTML={false}
             unterminatedParsing={true}
-          />
-        )
-        const element = screen.getByText(expectedText)
-        expect(element).toBeVisible()
-        expect(element.tagName).toBe(expectedTag)
-      }
-    )
+          />,
+        );
+        const element = screen.getByText(expectedText);
+        expect(element).toBeVisible();
+        expect(element.tagName).toBe(expectedTag);
+      },
+    );
 
     it.each([
       [
@@ -1412,14 +1420,14 @@ describe("CustomPreTag", () => {
       ],
       ["unterminatedParsing not set", { isLabel: false, allowHTML: false }],
     ])("does NOT apply remend when %s", async (_, props) => {
-      const source = "Content with **incomplete bold"
-      render(<StreamlitMarkdown source={source} {...props} />)
+      const source = "Content with **incomplete bold";
+      render(<StreamlitMarkdown source={source} {...props} />);
       // Wait for content to render (allowHTML=true triggers async plugin load)
-      const textElement = await screen.findByText(source, { exact: false })
-      expect(textElement).toBeVisible()
-      const container = screen.getByTestId("stMarkdownContainer")
-      expect(container.querySelector("strong")).toBeNull()
-    })
+      const textElement = await screen.findByText(source, { exact: false });
+      expect(textElement).toBeVisible();
+      const container = screen.getByTestId("stMarkdownContainer");
+      expect(container.querySelector("strong")).toBeNull();
+    });
 
     describe("directive completion during streaming", () => {
       it.each([
@@ -1438,17 +1446,17 @@ describe("CustomPreTag", () => {
               source={`This is ${source}`}
               allowHTML={false}
               unterminatedParsing={true}
-            />
-          )
+            />,
+          );
 
-          expect(screen.getByText(expectedText)).toBeVisible()
+          expect(screen.getByText(expectedText)).toBeVisible();
 
-          const container = screen.getByTestId("stMarkdownContainer")
+          const container = screen.getByTestId("stMarkdownContainer");
           expect(container.textContent).not.toContain(
-            "streamdown:incomplete-link"
-          )
-        }
-      )
+            "streamdown:incomplete-link",
+          );
+        },
+      );
 
       it("completes nested incomplete directives", () => {
         render(
@@ -1456,15 +1464,15 @@ describe("CustomPreTag", () => {
             source=":red-background[:rainbow[nested text"
             allowHTML={false}
             unterminatedParsing={true}
-          />
-        )
+          />,
+        );
 
-        const container = screen.getByTestId("stMarkdownContainer")
-        expect(container.textContent).toContain("nested text")
+        const container = screen.getByTestId("stMarkdownContainer");
+        expect(container.textContent).toContain("nested text");
         expect(container.textContent).not.toContain(
-          "streamdown:incomplete-link"
-        )
-      })
+          "streamdown:incomplete-link",
+        );
+      });
 
       it("does not close non-directive brackets in markdown links", () => {
         // This tests the fix for the issue where `:red[text] and [link`
@@ -1475,19 +1483,19 @@ describe("CustomPreTag", () => {
             source=":red[red text] and [incomplete link"
             allowHTML={false}
             unterminatedParsing={true}
-          />
-        )
+          />,
+        );
 
-        const container = screen.getByTestId("stMarkdownContainer")
-        expect(container.textContent).toContain("red text")
+        const container = screen.getByTestId("stMarkdownContainer");
+        expect(container.textContent).toContain("red text");
         // The important thing is that no streamdown artifact appears and no extra ]
         // is appended that would break the rendering
         expect(container.textContent).not.toContain(
-          "streamdown:incomplete-link"
-        )
+          "streamdown:incomplete-link",
+        );
         // Should not have extra closing brackets added for non-directive [
-        expect(container.textContent).not.toContain("link]")
-      })
+        expect(container.textContent).not.toContain("link]");
+      });
 
       it("handles nested brackets inside directives", () => {
         // This tests the fix for `:red[text [link` where a non-directive `[`
@@ -1498,26 +1506,26 @@ describe("CustomPreTag", () => {
             source=":red[text [link"
             allowHTML={false}
             unterminatedParsing={true}
-          />
-        )
+          />,
+        );
 
-        const container = screen.getByTestId("stMarkdownContainer")
+        const container = screen.getByTestId("stMarkdownContainer");
         // The text should be rendered without the artifact
-        expect(container.textContent).toContain("text [link")
+        expect(container.textContent).toContain("text [link");
         expect(container.textContent).not.toContain(
-          "streamdown:incomplete-link"
-        )
-      })
-    })
-  })
-})
+          "streamdown:incomplete-link",
+        );
+      });
+    });
+  });
+});
 
 describe("CustomMediaTag", () => {
-  const mockNode = { tagName: "img" } as Element
+  const mockNode = { tagName: "img" } as Element;
   const mockProps = {
     src: "test-image.jpg",
     alt: "Test image",
-  }
+  };
 
   it.each([
     { resourceCrossOriginMode: "anonymous" },
@@ -1530,25 +1538,25 @@ describe("CustomMediaTag", () => {
         libConfigContext: {
           resourceCrossOriginMode,
         },
-      })
+      });
 
-      const imgElement = screen.getByRole("img")
+      const imgElement = screen.getByRole("img");
 
-      expect(imgElement).not.toHaveAttribute("crossOrigin")
-      expect(imgElement).toHaveAttribute("src", "test-image.jpg")
-      expect(imgElement).toHaveAttribute("alt", "Test image")
-    }
-  )
+      expect(imgElement).not.toHaveAttribute("crossOrigin");
+      expect(imgElement).toHaveAttribute("src", "test-image.jpg");
+      expect(imgElement).toHaveAttribute("alt", "Test image");
+    },
+  );
 
   describe("with BACKEND_BASE_URL set", () => {
     beforeEach(() => {
       globalThis.__mockStreamlitConfig.BACKEND_BASE_URL =
-        "https://backend.example.com:8080/app"
-    })
+        "https://backend.example.com:8080/app";
+    });
 
     afterEach(() => {
-      globalThis.__mockStreamlitConfig = {}
-    })
+      globalThis.__mockStreamlitConfig = {};
+    });
 
     it.each([
       {
@@ -1588,8 +1596,8 @@ describe("CustomMediaTag", () => {
     ])(
       "should render $tagName element with crossOrigin='$expected' when $scenario",
       ({ tagName, expected, resourceCrossOriginMode, src, extraProps }) => {
-        const node = { tagName } as Element
-        const props = { src, ...extraProps }
+        const node = { tagName } as Element;
+        const props = { src, ...extraProps };
 
         const { container } = renderWithContexts(
           <CustomMediaTag node={node} {...props} />,
@@ -1597,19 +1605,19 @@ describe("CustomMediaTag", () => {
             libConfigContext: {
               resourceCrossOriginMode,
             },
-          }
-        )
+          },
+        );
 
         const element =
           tagName === "img"
             ? screen.getByRole("img")
-            : container.querySelector(tagName)
+            : container.querySelector(tagName);
 
-        expect(element).toBeTruthy()
-        expect(element).toHaveAttribute("crossOrigin", expected)
-        expect(element).toHaveAttribute("src", src)
-      }
-    )
+        expect(element).toBeTruthy();
+        expect(element).toHaveAttribute("crossOrigin", expected);
+        expect(element).toHaveAttribute("src", src);
+      },
+    );
 
     it.each([
       {
@@ -1653,8 +1661,8 @@ describe("CustomMediaTag", () => {
     ])(
       "should render $tagName element without crossOrigin when $scenario",
       ({ tagName, resourceCrossOriginMode, src, extraProps }) => {
-        const node = { tagName } as Element
-        const props = { src, ...extraProps }
+        const node = { tagName } as Element;
+        const props = { src, ...extraProps };
 
         const { container } = renderWithContexts(
           <CustomMediaTag node={node} {...props} />,
@@ -1662,18 +1670,18 @@ describe("CustomMediaTag", () => {
             libConfigContext: {
               resourceCrossOriginMode,
             },
-          }
-        )
+          },
+        );
 
         const element =
           tagName === "img"
             ? screen.getByRole("img")
-            : container.querySelector(tagName)
+            : container.querySelector(tagName);
 
-        expect(element).toBeTruthy()
-        expect(element).not.toHaveAttribute("crossOrigin")
-        expect(element).toHaveAttribute("src", src)
-      }
-    )
-  })
-})
+        expect(element).toBeTruthy();
+        expect(element).not.toHaveAttribute("crossOrigin");
+        expect(element).toHaveAttribute("src", src);
+      },
+    );
+  });
+});

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -26,8 +26,8 @@ import {
   Suspense,
   useCallback,
   useContext,
-  useEffect,
   useId,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -342,9 +342,12 @@ export const HeadingWithActionElements: FC<HeadingWithActionElementsProps> = ({
   const [elementId, setElementId] = useState(propsAnchor)
   const nodeRef = useRef<HTMLElement | null>(null)
 
-  // Derive the anchor from the node and scroll to it if it matches the URL hash.
-  // Shared by the mount-time ref callback and the rerun effect below so the two
-  // paths cannot drift apart.
+  /**
+   * Set the heading id from `propsAnchor` or the node's textContent, then scroll
+   * the node into view if that id matches the current URL hash. Shared by the
+   * mount-time ref callback and the rerun effect below so the two paths cannot
+   * drift apart.
+   */
   const applyAnchor = useCallback(
     (node: HTMLElement) => {
       const anchor = propsAnchor || createAnchorFromText(node.textContent)
@@ -373,7 +376,10 @@ export const HeadingWithActionElements: FC<HeadingWithActionElementsProps> = ({
   // content changes, React reuses the DOM node and the callback never re-fires.
   // Skipped when propsAnchor is set, since an explicit anchor never depends on
   // the text.
-  useEffect(() => {
+  //
+  // useLayoutEffect (not useEffect) so the re-derived id is committed before
+  // paint; otherwise a frame can render with the previous hash link.
+  useLayoutEffect(() => {
     const node = nodeRef.current
     if (!node || propsAnchor) {
       return

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -31,43 +31,43 @@ import {
   useMemo,
   useRef,
   useState,
-} from "react"
+} from "react";
 
-import slugify from "@sindresorhus/slugify"
-import { parseToRgba } from "color2k"
-import { type Element, type Root as HastRoot } from "hast"
-import { omit, once } from "lodash-es"
-import type { Root as MdastRoot, Text } from "mdast"
-import { findAndReplace } from "mdast-util-find-and-replace"
-import { Link2 as LinkIcon } from "react-feather"
+import slugify from "@sindresorhus/slugify";
+import { parseToRgba } from "color2k";
+import { type Element, type Root as HastRoot } from "hast";
+import { omit, once } from "lodash-es";
+import type { Root as MdastRoot, Text } from "mdast";
+import { findAndReplace } from "mdast-util-find-and-replace";
+import { Link2 as LinkIcon } from "react-feather";
 import ReactMarkdown, {
   Components,
   Options as ReactMarkdownProps,
-} from "react-markdown"
-import remarkDirective from "remark-directive"
-import remarkGfm from "remark-gfm"
-import remarkMathPlugin from "remark-math"
-import remend, { type RemendHandler } from "remend"
-import { PluggableList } from "unified"
-import { visit } from "unist-util-visit"
-import xxhash from "xxhashjs"
+} from "react-markdown";
+import remarkDirective from "remark-directive";
+import remarkGfm from "remark-gfm";
+import remarkMathPlugin from "remark-math";
+import remend, { type RemendHandler } from "remend";
+import { PluggableList } from "unified";
+import { visit } from "unist-util-visit";
+import xxhash from "xxhashjs";
 
-import streamlitLogo from "~lib/assets/img/streamlit-logo/streamlit-mark-color.svg"
-import IsDialogContext from "~lib/components/core/IsDialogContext"
-import IsSidebarContext from "~lib/components/core/IsSidebarContext"
-import { StyledInlineCode } from "~lib/components/elements/CodeBlock/styled-components"
-import { SquareSkeleton } from "~lib/components/elements/Skeleton/styled-components"
-import ErrorBoundary from "~lib/components/shared/ErrorBoundary/ErrorBoundary"
-import { InlineTooltipIcon } from "~lib/components/shared/TooltipIcon/TooltipIcon"
-import { useCrossOriginAttribute } from "~lib/hooks/useCrossOriginAttribute"
-import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
+import streamlitLogo from "~lib/assets/img/streamlit-logo/streamlit-mark-color.svg";
+import IsDialogContext from "~lib/components/core/IsDialogContext";
+import IsSidebarContext from "~lib/components/core/IsSidebarContext";
+import { StyledInlineCode } from "~lib/components/elements/CodeBlock/styled-components";
+import { SquareSkeleton } from "~lib/components/elements/Skeleton/styled-components";
+import ErrorBoundary from "~lib/components/shared/ErrorBoundary/ErrorBoundary";
+import { InlineTooltipIcon } from "~lib/components/shared/TooltipIcon/TooltipIcon";
+import { useCrossOriginAttribute } from "~lib/hooks/useCrossOriginAttribute";
+import { useEmotionTheme } from "~lib/hooks/useEmotionTheme";
 import {
   getMarkdownTextColors,
   getThemeBackgroundColors,
-} from "~lib/theme/getColors"
-import type { EmotionTheme } from "~lib/theme/types"
-import { convertRemToPx } from "~lib/theme/utils"
-import { BLOCKED_LINK_URI, isDangerousLinkUri } from "~lib/util/UriUtil"
+} from "~lib/theme/getColors";
+import type { EmotionTheme } from "~lib/theme/types";
+import { convertRemToPx } from "~lib/theme/utils";
+import { BLOCKED_LINK_URI, isDangerousLinkUri } from "~lib/util/UriUtil";
 
 import {
   StyledHeadingActionElements,
@@ -76,7 +76,7 @@ import {
   StyledLinkIcon,
   StyledPreWrapper,
   StyledStreamlitMarkdown,
-} from "./styled-components"
+} from "./styled-components";
 import {
   type EmojiPlugin,
   isLoadedPlugin,
@@ -90,15 +90,18 @@ import {
   useLazyPlugin,
   wrapRehypePlugin,
   wrapRemarkPlugin,
-} from "./utils"
+} from "./utils";
 
 const StreamlitSyntaxHighlighter = lazy(
-  () => import("~lib/components/elements/CodeBlock/StreamlitSyntaxHighlighter")
-)
+  () =>
+    import("~lib/components/elements/CodeBlock/StreamlitSyntaxHighlighter"),
+);
 
 const MermaidChart = lazy(() =>
-  import("./MermaidChart").then(module => ({ default: module.MermaidChart }))
-)
+  import("./MermaidChart").then((module) => ({
+    default: module.MermaidChart,
+  })),
+);
 
 /**
  * Heuristic to determine if the markdown source contains emoji shortcodes that require remark-emoji.
@@ -110,7 +113,7 @@ const MermaidChart = lazy(() =>
  * @returns true if emoji shortcodes are detected, false otherwise
  */
 export function containsEmojiShortcodes(source: string): boolean {
-  return /:(?!material\/|streamlit:)[\w+-][\w_+-]*:/.test(source)
+  return /:(?!material\/|streamlit:)[\w+-][\w_+-]*:/.test(source);
 }
 
 /**
@@ -125,7 +128,7 @@ export function containsEmojiShortcodes(source: string): boolean {
 export function containsMathSyntax(source: string): boolean {
   // Detect display math: $$...$$ or inline math: $...$
   // Inline math requires non-whitespace after opening $ and before closing $
-  return /\$\$[\s\S]+?\$\$|\$(?!\s)[^$\n]+?(?<!\s)\$/.test(source)
+  return /\$\$[\s\S]+?\$\$|\$(?!\s)[^$\n]+?(?<!\s)\$/.test(source);
 }
 
 export enum Tags {
@@ -138,63 +141,63 @@ export interface Props {
   /**
    * The Markdown formatted text to render.
    */
-  source: string
+  source: string;
 
   /**
    * True if HTML is allowed in the source string. If this is false,
    * any HTML will be escaped in the output.
    */
-  allowHTML: boolean
-  style?: CSSProperties
-  isCaption?: boolean
+  allowHTML: boolean;
+  style?: CSSProperties;
+  isCaption?: boolean;
 
   /**
    * Indicates widget labels & restricts allowed elements
    */
-  isLabel?: boolean
+  isLabel?: boolean;
 
   /**
    * Make the label bold
    */
-  boldLabel?: boolean
+  boldLabel?: boolean;
 
   /**
    * Does not allow links
    */
-  disableLinks?: boolean
+  disableLinks?: boolean;
 
   /**
    * Toast has smaller font sizing & special CSS
    */
-  isToast?: boolean
+  isToast?: boolean;
 
   /**
    * Inherit font family, size, and weight from parent
    */
-  inheritFont?: boolean
+  inheritFont?: boolean;
 
   /**
    * Optional help text for inline help tooltips.
    * When present, :help[] markers in the source will use this text.
    */
-  helpText?: string
+  helpText?: string;
 
   /**
    * Truncate text with ellipsis when it overflows the container.
    * Useful for single-line text that should not wrap, such as metric labels.
    */
-  truncate?: boolean
+  truncate?: boolean;
 
   /**
    * Enables unterminated markdown completion (via remend) during streaming.
    */
-  unterminatedParsing?: boolean
+  unterminatedParsing?: boolean;
 
   /**
    * When true, headers (h1-h6) keep their `id` for deep linking but the
    * visible anchor link icon is not rendered.
    */
-  hideAnchors?: boolean
+  hideAnchors?: boolean;
 }
 
 /**
@@ -203,13 +206,13 @@ export interface Props {
  * @see https://github.com/syntax-tree/mdast-util-to-hast#fields-on-nodes
  */
 interface MdastTextWithHastData {
-  type: "text"
-  value: string
+  type: "text";
+  value: string;
   data: {
-    hName: string
-    hProperties: Record<string, string>
-    hChildren?: Array<{ type: string; value: string }>
-  }
+    hName: string;
+    hProperties: Record<string, string>;
+    hChildren?: Array<{ type: string; value: string }>;
+  };
 }
 
 /**
@@ -221,16 +224,16 @@ function rehypeSetCodeInlineProperty() {
   return (tree: HastRoot) => {
     visit(tree, "element", (node: Element, _index, parent) => {
       if (node.tagName !== "code") {
-        return
+        return;
       }
 
       if (parent?.type === "element" && parent.tagName === "pre") {
-        node.properties = { ...node.properties, inline: false }
+        node.properties = { ...node.properties, inline: false };
       } else {
-        node.properties = { ...node.properties, inline: true }
+        node.properties = { ...node.properties, inline: true };
       }
-    })
-  }
+    });
+  };
 }
 
 /**
@@ -249,21 +252,21 @@ function rehypeSetCodeInlineProperty() {
  */
 export function createAnchorFromText(text: string | null): string {
   if (!text) {
-    return ""
+    return "";
   }
 
   /**
    * @see https://www.npmjs.com/package/@sindresorhus/slugify
    * @see https://www.npmjs.com/package/@sindresorhus/transliterate
    */
-  const newAnchor = slugify(text)
+  const newAnchor = slugify(text);
 
   if (newAnchor.length > 0) {
-    return newAnchor
+    return newAnchor;
   }
 
   // If slugify is not able to create a slug, fallback to hash
-  return xxhash.h32(text, 0xabcd).toString(16)
+  return xxhash.h32(text, 0xabcd).toString(16);
 }
 
 /**
@@ -279,18 +282,18 @@ export function createAnchorFromText(text: string | null): string {
  * current page in a new tab.
  */
 function transformLinkUri(href: string): string {
-  return isDangerousLinkUri(href) ? BLOCKED_LINK_URI : href
+  return isDangerousLinkUri(href) ? BLOCKED_LINK_URI : href;
 }
 
 // wrapping in `once` ensures we only scroll once
 const scrollNodeIntoView = once((node: HTMLElement): void => {
-  node.scrollIntoView(true)
-})
+  node.scrollIntoView(true);
+});
 
 interface HeadingActionElements {
-  elementId?: string
-  help?: string
-  hideAnchor?: boolean
+  elementId?: string;
+  help?: string;
+  hideAnchor?: boolean;
 }
 
 const HeaderActionElements: FC<HeadingActionElements> = ({
@@ -298,9 +301,9 @@ const HeaderActionElements: FC<HeadingActionElements> = ({
   help,
   hideAnchor,
 }) => {
-  const theme = useEmotionTheme()
+  const theme = useEmotionTheme();
   if (!help && hideAnchor) {
-    return <></>
+    return <></>;
   }
 
   return (
@@ -317,16 +320,16 @@ const HeaderActionElements: FC<HeadingActionElements> = ({
         </StyledLinkIcon>
       )}
     </StyledHeadingActionElements>
-  )
-}
+  );
+};
 
 interface HeadingWithActionElementsProps {
-  tag: string
-  anchor?: string
-  hideAnchor?: boolean
-  children: ReactNode[] | ReactNode
-  tagProps?: HTMLProps<HTMLHeadingElement>
-  help?: string
+  tag: string;
+  anchor?: string;
+  hideAnchor?: boolean;
+  children: ReactNode[] | ReactNode;
+  tagProps?: HTMLProps<HTMLHeadingElement>;
+  help?: string;
 }
 
 export const HeadingWithActionElements: FC<HeadingWithActionElementsProps> = ({
@@ -337,10 +340,10 @@ export const HeadingWithActionElements: FC<HeadingWithActionElementsProps> = ({
   children,
   tagProps,
 }) => {
-  const isInSidebar = useContext(IsSidebarContext)
-  const isInDialog = useContext(IsDialogContext)
-  const [elementId, setElementId] = useState(propsAnchor)
-  const nodeRef = useRef<HTMLElement | null>(null)
+  const isInSidebar = useContext(IsSidebarContext);
+  const isInDialog = useContext(IsDialogContext);
+  const [elementId, setElementId] = useState(propsAnchor);
+  const nodeRef = useRef<HTMLElement | null>(null);
 
   /**
    * Set the heading id from `propsAnchor` or the node's textContent, then scroll
@@ -349,27 +352,27 @@ export const HeadingWithActionElements: FC<HeadingWithActionElementsProps> = ({
    * drift apart.
    */
   const applyAnchor = useCallback(
-    (node: HTMLElement) => {
-      const anchor = propsAnchor || createAnchorFromText(node.textContent)
-      setElementId(anchor)
-      const windowHash = window.location.hash.slice(1)
+    (node: HTMLElement): void => {
+      const anchor = propsAnchor || createAnchorFromText(node.textContent);
+      setElementId(anchor);
+      const windowHash = window.location.hash.slice(1);
       if (windowHash && windowHash === anchor) {
-        scrollNodeIntoView(node)
+        scrollNodeIntoView(node);
       }
     },
-    [propsAnchor]
-  )
+    [propsAnchor],
+  );
 
   const ref = useCallback(
     (node: HTMLElement | null) => {
-      nodeRef.current = node
+      nodeRef.current = node;
       if (node === null) {
-        return
+        return;
       }
-      applyAnchor(node)
+      applyAnchor(node);
     },
-    [applyAnchor]
-  )
+    [applyAnchor],
+  );
 
   // Re-derive the anchor when heading text changes across reruns. The ref
   // callback only fires on mount or when propsAnchor changes; when only the text
@@ -380,21 +383,21 @@ export const HeadingWithActionElements: FC<HeadingWithActionElementsProps> = ({
   // useLayoutEffect (not useEffect) so the re-derived id is committed before
   // paint; otherwise a frame can render with the previous hash link.
   useLayoutEffect(() => {
-    const node = nodeRef.current
+    const node = nodeRef.current;
     if (!node || propsAnchor) {
-      return
+      return;
     }
-    applyAnchor(node)
-  }, [children, propsAnchor, applyAnchor])
+    applyAnchor(node);
+  }, [children, propsAnchor, applyAnchor]);
 
-  const isInSidebarOrDialog = isInSidebar || isInDialog
+  const isInSidebarOrDialog = isInSidebar || isInDialog;
   const actionElements = (
     <HeaderActionElements
       elementId={elementId}
       help={help}
       hideAnchor={hideAnchor || isInSidebarOrDialog}
     />
-  )
+  );
 
   // Accessibility:
   // Headings can contain action elements (help tooltip icon, anchor link icon).
@@ -411,21 +414,21 @@ export const HeadingWithActionElements: FC<HeadingWithActionElementsProps> = ({
   // - help: tooltip icon can be present even in sidebar/dialog (where we don't
   //   set a heading id/anchor)
   // - anchor icon: only present when we have an elementId and it's not hidden
-  const rawHeadingTextId = useId()
+  const rawHeadingTextId = useId();
   const headingTextId =
     help || (elementId && !hideAnchor && !isInSidebarOrDialog)
       ? rawHeadingTextId
-      : undefined
+      : undefined;
 
-  const idAttribute = elementId ? { id: elementId } : {}
+  const idAttribute = elementId ? { id: elementId } : {};
   const ariaLabelledbyAttribute = headingTextId
     ? { "aria-labelledby": headingTextId }
-    : {}
+    : {};
   const mergedAttributes = {
     ...(isInSidebarOrDialog ? {} : { ref, ...idAttribute }),
     ...ariaLabelledbyAttribute,
-  }
-  const Tag = tag
+  };
+  const Tag = tag;
   // We nest the action-elements (tooltip, link-icon) into the header element (e.g. h1),
   // so that it appears inline. For context: we also tried setting the h's display attribute to 'inline', but
   // then we would need to add padding to the outer container and fiddle with the vertical alignment.
@@ -434,46 +437,46 @@ export const HeadingWithActionElements: FC<HeadingWithActionElementsProps> = ({
       {headingTextId ? <span id={headingTextId}>{children}</span> : children}
       {actionElements}
     </Tag>
-  )
+  );
 
   // we don't want to apply styling, so return the "raw" header
   if (isInSidebarOrDialog) {
-    return headerElementWithActions
+    return headerElementWithActions;
   }
 
   return (
     <StyledHeadingWithActionElements data-testid="stHeadingWithActionElements">
       {headerElementWithActions}
     </StyledHeadingWithActionElements>
-  )
-}
+  );
+};
 
 type HeadingProps = JSX.IntrinsicElements["h1"] &
   ReactMarkdownProps & {
-    level: number
-    "data-anchor"?: string
-    node: Element
-  }
+    level: number;
+    "data-anchor"?: string;
+    node: Element;
+  };
 
 /**
  * Context to indicate if markdown is being streamed (unterminatedParsing mode).
  * When true, mermaid code blocks render as syntax-highlighted code instead of diagrams.
  * This prevents flickering and error states from partial/incomplete diagram source.
  */
-const StreamingContext = createContext<boolean>(false)
-StreamingContext.displayName = "StreamingContext"
+const StreamingContext = createContext<boolean>(false);
+StreamingContext.displayName = "StreamingContext";
 
 /**
  * Context that controls whether anchor link icons render next to markdown
  * headings. Heading `id` attributes are still set when this is true, so URL
  * fragment deep links keep working.
  */
-const HideAnchorsContext = createContext<boolean>(false)
-HideAnchorsContext.displayName = "HideAnchorsContext"
+const HideAnchorsContext = createContext<boolean>(false);
+HideAnchorsContext.displayName = "HideAnchorsContext";
 
 const CustomHeading: FC<HeadingProps> = ({ node, children, ...rest }) => {
-  const anchor = rest["data-anchor"]
-  const hideAnchor = useContext(HideAnchorsContext)
+  const anchor = rest["data-anchor"];
+  const hideAnchor = useContext(HideAnchorsContext);
   return (
     <HeadingWithActionElements
       tag={node.tagName}
@@ -483,52 +486,52 @@ const CustomHeading: FC<HeadingProps> = ({ node, children, ...rest }) => {
     >
       {children}
     </HeadingWithActionElements>
-  )
-}
+  );
+};
 interface RenderedMarkdownProps {
   /**
    * The Markdown formatted text to render.
    */
-  source: string
+  source: string;
 
   /**
    * True if HTML is allowed in the source string. If this is false,
    * any HTML will be escaped in the output.
    */
-  allowHTML: boolean
+  allowHTML: boolean;
 
-  overrideComponents?: Components
+  overrideComponents?: Components;
 
   /**
    * Indicates widget labels & restricts allowed elements
    */
-  isLabel?: boolean
+  isLabel?: boolean;
 
   /**
    * Does not allow links
    */
-  disableLinks?: boolean
+  disableLinks?: boolean;
 
   /**
    * Optional help text for inline help tooltips.
    * When present, :help[] markers in the source will use this text.
    */
-  helpText?: string
+  helpText?: string;
 
   /**
    * Enables unterminated markdown completion (via remend) during streaming.
    */
-  unterminatedParsing?: boolean
+  unterminatedParsing?: boolean;
 
   /**
    * When true, headers (h1-h6) keep their `id` for deep linking but the
    * visible anchor link icon is not rendered.
    */
-  hideAnchors?: boolean
+  hideAnchors?: boolean;
 }
 
 export type CustomCodeTagProps = JSX.IntrinsicElements["code"] &
-  ReactMarkdownProps & { inline?: boolean }
+  ReactMarkdownProps & { inline?: boolean };
 
 /**
  * Renders code tag with highlighting based on requested language.
@@ -540,14 +543,14 @@ export const CustomCodeTag: FC<CustomCodeTagProps> = ({
   children,
   ...props
 }) => {
-  const match = /language-(\w+)/.exec(className || "")
-  const isStreaming = useContext(StreamingContext)
+  const match = /language-(\w+)/.exec(className || "");
+  const isStreaming = useContext(StreamingContext);
 
   const codeText = String(children ?? "")
     .replace(/^\n/, "")
-    .replace(/\n$/, "")
+    .replace(/\n$/, "");
 
-  const language = match?.[1] || ""
+  const language = match?.[1] || "";
 
   // Handle mermaid code blocks: render as a diagram unless streaming
   // (see StreamingContext for rationale).
@@ -562,7 +565,7 @@ export const CustomCodeTag: FC<CustomCodeTagProps> = ({
           <MermaidChart source={codeText} />
         </Suspense>
       </ErrorBoundary>
-    )
+    );
   }
 
   return !inline ? (
@@ -584,8 +587,8 @@ export const CustomCodeTag: FC<CustomCodeTagProps> = ({
     <StyledInlineCode className={className} {...omit(props, "node")}>
       {children}
     </StyledInlineCode>
-  )
-}
+  );
+};
 
 /**
  * Renders pre tag with added margin.
@@ -593,28 +596,28 @@ export const CustomCodeTag: FC<CustomCodeTagProps> = ({
 export const CustomPreTag: FC<ReactMarkdownProps> = ({ children }) => {
   return (
     <StyledPreWrapper data-testid="stMarkdownPre">{children}</StyledPreWrapper>
-  )
-}
+  );
+};
 
 export const CustomMediaTag: FC<
   JSX.IntrinsicElements["img" | "video" | "audio"] &
     ReactMarkdownProps & { node: Element }
 > = ({ node, ...props }) => {
-  const crossOrigin = useCrossOriginAttribute(props.src)
-  const Tag = node.tagName
+  const crossOrigin = useCrossOriginAttribute(props.src);
+  const Tag = node.tagName;
 
   const attributes = {
     ...props,
     crossOrigin,
-  }
-  return <Tag {...attributes} />
-}
+  };
+  return <Tag {...attributes} />;
+};
 
-const HelpTextContext = createContext<string | undefined>(undefined)
-HelpTextContext.displayName = "HelpTextContext"
+const HelpTextContext = createContext<string | undefined>(undefined);
+HelpTextContext.displayName = "HelpTextContext";
 
 interface CustomHelpIconProps {
-  children?: string
+  children?: string;
 }
 
 /**
@@ -633,16 +636,16 @@ interface CustomHelpIconProps {
  */
 const CustomHelpIcon: FC<CustomHelpIconProps> = ({ children }) => {
   // Prefer context (from help parameter) over children (from directive label)
-  const contextHelpText = useContext(HelpTextContext)
+  const contextHelpText = useContext(HelpTextContext);
   const tooltipContent =
-    contextHelpText || (typeof children === "string" ? children : "")
+    contextHelpText || (typeof children === "string" ? children : "");
 
   return (
     <StyledHelpIconWrapper>
       <InlineTooltipIcon content={tooltipContent} />
     </StyledHelpIconWrapper>
-  )
-}
+  );
+};
 
 // These are common renderers that don't depend on props or context
 const BASE_RENDERERS = {
@@ -658,7 +661,7 @@ const BASE_RENDERERS = {
   video: CustomMediaTag,
   audio: CustomMediaTag,
   "streamlit-help-icon": CustomHelpIcon,
-}
+};
 
 /**
  * Create a color mapping based on the theme.
@@ -666,7 +669,7 @@ const BASE_RENDERERS = {
  */
 function createColorMapping(theme: EmotionTheme): Map<string, string> {
   const { red, orange, yellow, green, blue, violet, purple, gray, primary } =
-    getMarkdownTextColors(theme)
+    getMarkdownTextColors(theme);
   const {
     redbg,
     orangebg,
@@ -677,7 +680,7 @@ function createColorMapping(theme: EmotionTheme): Map<string, string> {
     purplebg,
     graybg,
     primarybg,
-  }: Record<string, string> = getThemeBackgroundColors(theme)
+  }: Record<string, string> = getThemeBackgroundColors(theme);
 
   return new Map(
     Object.entries({
@@ -705,8 +708,8 @@ function createColorMapping(theme: EmotionTheme): Map<string, string> {
       // Gradient from red, orange, yellow, green, blue, violet, purple
       "rainbow-background": `background: linear-gradient(to right,
         ${redbg}, ${orangebg}, ${yellowbg}, ${greenbg}, ${bluebg}, ${violetbg}, ${purplebg});`,
-    })
-  )
+    }),
+  );
 }
 
 /**
@@ -715,20 +718,20 @@ function createColorMapping(theme: EmotionTheme): Map<string, string> {
 function createRemarkHelpIcon() {
   return () => (tree: MdastRoot) => {
     visit(tree, "textDirective", (node, _index, _parent) => {
-      const nodeName = String(node.name)
+      const nodeName = String(node.name);
 
       // Handle help icon directive (:help[tooltip content])
       if (nodeName === "help") {
-        const data = node.data || (node.data = {})
-        data.hName = "streamlit-help-icon"
-        data.hProperties = data.hProperties || {}
+        const data = node.data || (node.data = {});
+        data.hName = "streamlit-help-icon";
+        data.hProperties = data.hProperties || {};
         // Pass the children through so CustomHelpIcon can extract the content
-        return
+        return;
       }
-    })
+    });
 
-    return tree
-  }
+    return tree;
+  };
 }
 
 /**
@@ -740,12 +743,12 @@ function createRemarkHelpIcon() {
  * @returns true if the color is valid, false otherwise
  */
 export function isValidCssColor(color: string): boolean {
-  if (!color) return false
+  if (!color) return false;
   try {
-    parseToRgba(color)
-    return true
+    parseToRgba(color);
+    return true;
   } catch {
-    return false
+    return false;
   }
 }
 
@@ -754,69 +757,69 @@ export function isValidCssColor(color: string): boolean {
  */
 function createRemarkColoringAndSmall(
   theme: EmotionTheme,
-  colorMapping: Map<string, string>
+  colorMapping: Map<string, string>,
 ) {
   return () => (tree: MdastRoot) => {
     visit(tree, "textDirective", (node, _index, _parent) => {
-      const nodeName = String(node.name)
+      const nodeName = String(node.name);
 
       // Handle shimmer text directive (:shimmer[])
       if (nodeName === "shimmer") {
-        const data = node.data || (node.data = {})
-        data.hName = "span"
-        data.hProperties = data.hProperties || {}
-        data.hProperties.className = "stMarkdownShimmer"
-        return
+        const data = node.data || (node.data = {});
+        data.hName = "span";
+        data.hProperties = data.hProperties || {};
+        data.hProperties.className = "stMarkdownShimmer";
+        return;
       }
 
       // Handle small text directive (:small[])
       if (nodeName === "small") {
-        const data = node.data || (node.data = {})
-        data.hName = "span"
-        data.hProperties = data.hProperties || {}
-        data.hProperties.style = `font-size: ${theme.fontSizes.sm};`
-        return
+        const data = node.data || (node.data = {});
+        data.hName = "span";
+        data.hProperties = data.hProperties || {};
+        data.hProperties.style = `font-size: ${theme.fontSizes.sm};`;
+        return;
       }
 
       // Handle custom color directive (:color[text]{foreground="...", background="..."})
       if (nodeName === "color" && node.attributes) {
-        const { foreground, background } = node.attributes
-        const validForeground = foreground && isValidCssColor(foreground)
-        const validBackground = background && isValidCssColor(background)
+        const { foreground, background } = node.attributes;
+        const validForeground = foreground && isValidCssColor(foreground);
+        const validBackground = background && isValidCssColor(background);
 
-        const data = node.data || (node.data = {})
-        data.hName = "span"
-        data.hProperties = data.hProperties || {}
+        const data = node.data || (node.data = {});
+        data.hName = "span";
+        data.hProperties = data.hProperties || {};
 
         if (validForeground || validBackground) {
-          const styles: string[] = []
+          const styles: string[] = [];
 
           if (validForeground) {
-            styles.push(`color: ${foreground}`)
+            styles.push(`color: ${foreground}`);
           }
 
           if (validBackground) {
-            styles.push(`background-color: ${background}`)
+            styles.push(`background-color: ${background}`);
           }
 
           // Use background class when background is set (has more styling: padding, border-radius)
           const className = validBackground
             ? "stMarkdownColoredBackground"
-            : "stMarkdownColoredText"
+            : "stMarkdownColoredText";
 
-          data.hProperties.style = styles.join("; ")
-          data.hProperties.className = className
+          data.hProperties.style = styles.join("; ");
+          data.hProperties.className = className;
         }
         // When both colors are invalid, render as plain span (no style)
         // to preserve the content text rather than falling through to
         // unsupported directive cleanup which would lose the content
-        return
+        return;
       }
 
       // Handle badge directives (:color-badge[])
-      const badgeMatch = nodeName.match(/^(.+)-badge$/)
+      const badgeMatch = nodeName.match(/^(.+)-badge$/);
       if (badgeMatch && colorMapping.has(badgeMatch[1])) {
-        const color = badgeMatch[1]
+        const color = badgeMatch[1];
 
         // rainbow-badge is not supported because the rainbow text effect uses
         // background-clip: text with a transparent color, which conflicts with
@@ -826,44 +829,44 @@ function createRemarkColoringAndSmall(
         // We can support that in the future if we want to, but I think a
         // rainbow-colored badge shouldn't be a common use case anyway.
         if (color === "rainbow") {
-          return
+          return;
         }
 
-        const textColor = colorMapping.get(color)
-        const bgColor = colorMapping.get(`${color}-background`)
+        const textColor = colorMapping.get(color);
+        const bgColor = colorMapping.get(`${color}-background`);
 
         if (textColor && bgColor) {
-          const data = node.data || (node.data = {})
-          data.hName = "span"
-          data.hProperties = data.hProperties || {}
-          data.hProperties.className = "stMarkdownBadge"
-          data.hProperties.style = `${bgColor}; ${textColor}; font-size: ${theme.fontSizes.sm};`
-          return
+          const data = node.data || (node.data = {});
+          data.hName = "span";
+          data.hProperties = data.hProperties || {};
+          data.hProperties.className = "stMarkdownBadge";
+          data.hProperties.style = `${bgColor}; ${textColor}; font-size: ${theme.fontSizes.sm};`;
+          return;
         }
       }
 
       // Handle color directives (:color[] or :color-background[])
       if (colorMapping.has(nodeName)) {
-        const data = node.data || (node.data = {})
-        const style = colorMapping.get(nodeName)
-        data.hName = "span"
-        data.hProperties = data.hProperties || {}
-        data.hProperties.style = style
+        const data = node.data || (node.data = {});
+        const style = colorMapping.get(nodeName);
+        data.hName = "span";
+        data.hProperties = data.hProperties || {};
+        data.hProperties.style = style;
         // Add class name specific to colored text used for button hover selector
         // to override text color
-        data.hProperties.className = "stMarkdownColoredText"
+        data.hProperties.className = "stMarkdownColoredText";
         // Add class for background color for custom styling
         if (
           style &&
           (/background-color:/.test(style) || /background:/.test(style))
         ) {
-          data.hProperties.className = "stMarkdownColoredBackground"
+          data.hProperties.className = "stMarkdownColoredBackground";
         }
-        return
+        return;
       }
-    })
-    return tree
-  }
+    });
+    return tree;
+  };
 }
 
 /**
@@ -872,7 +875,7 @@ function createRemarkColoringAndSmall(
  * to plain text, ensuring they are rendered rather than ignored.
  */
 function createRemarkUnsupportedDirectivesCleanup(): () => (
-  tree: MdastRoot
+  tree: MdastRoot,
 ) => MdastRoot {
   return () => (tree: MdastRoot) => {
     visit(tree, "textDirective", (node, index, parent) => {
@@ -884,12 +887,12 @@ function createRemarkUnsupportedDirectivesCleanup(): () => (
         const textNode: Text = {
           type: "text",
           value: `:${node.name}`,
-        }
-        parent.children[index] = textNode
+        };
+        parent.children[index] = textNode;
       }
-    })
-    return tree
-  }
+    });
+    return tree;
+  };
 }
 
 /**
@@ -899,7 +902,7 @@ function createRemarkMaterialIcons(theme: EmotionTheme) {
   return () => (tree: MdastRoot) => {
     function replace(
       fullMatch: string,
-      iconName: string
+      iconName: string,
     ): MdastTextWithHastData {
       return {
         type: "text",
@@ -927,7 +930,7 @@ function createRemarkMaterialIcons(theme: EmotionTheme) {
           },
           hChildren: [{ type: "text", value: iconName }],
         },
-      }
+      };
     }
     // We replace all `:material/` occurrences with `:material_` to avoid
     // conflicts with the directive plugin.
@@ -939,9 +942,9 @@ function createRemarkMaterialIcons(theme: EmotionTheme) {
         /:material_(\w+):/g,
         replace as (fullMatch: string, iconName: string) => Text,
       ],
-    ])
-    return tree
-  }
+    ]);
+    return tree;
+  };
 }
 
 /**
@@ -965,11 +968,11 @@ function createRemarkStreamlitLogo() {
             style: `display: inline-block; user-select: none; height: 0.75em; vertical-align: baseline; margin-bottom: -0.05ex;`,
           },
         },
-      }
+      };
     }
-    findAndReplace(tree, [[/:streamlit:/g, replaceStreamlit as () => Text]])
-    return tree
-  }
+    findAndReplace(tree, [[/:streamlit:/g, replaceStreamlit as () => Text]]);
+    return tree;
+  };
 }
 
 /**
@@ -985,7 +988,7 @@ function createRemarkTypographicalSymbols() {
         // Don't replace symbols in links.
         // Note that remark extensions are not applied in code blocks and latex
         // formulas, so we don't need to worry about them here.
-        return
+        return;
       }
 
       if (node.type === "text" && node.value) {
@@ -999,21 +1002,21 @@ function createRemarkTypographicalSymbols() {
           [/(^|\s)>=(\s|$)/g, "$1≥$2"],
           [/(^|\s)<=(\s|$)/g, "$1≤$2"],
           [/(^|\s)~=(\s|$)/g, "$1≈$2"],
-        ]
+        ];
 
-        let newValue = node.value
+        let newValue = node.value;
         for (const [pattern, replacement] of replacements) {
-          newValue = newValue.replace(pattern, replacement as string)
+          newValue = newValue.replace(pattern, replacement as string);
         }
 
         if (newValue !== node.value) {
-          node.value = newValue
+          node.value = newValue;
         }
       }
-    })
+    });
 
-    return tree
-  }
+    return tree;
+  };
 }
 
 /**
@@ -1028,53 +1031,53 @@ const directiveCompletionHandler: RemendHandler = {
   priority: 10,
   handle: (text: string): string => {
     // Match directive patterns like :red[, :small[, :red-background[
-    const directivePattern = /:[a-z][a-z0-9-]*\[/
-    const firstMatch = directivePattern.exec(text)
+    const directivePattern = /:[a-z][a-z0-9-]*\[/;
+    const firstMatch = directivePattern.exec(text);
     if (!firstMatch) {
-      return text
+      return text;
     }
 
     // Track directive openings (:<name>[), nested brackets, and close with ']'.
     // We track all '[' inside directives to handle cases like `:red[text [link]`
     // where nested brackets need proper balancing.
-    let depth = 1
-    let i = firstMatch.index + firstMatch[0].length
+    let depth = 1;
+    let i = firstMatch.index + firstMatch[0].length;
 
     while (i < text.length) {
-      const char = text[i]
+      const char = text[i];
 
       if (char === "[" && depth > 0) {
-        depth += 1
-        i += 1
-        continue
+        depth += 1;
+        i += 1;
+        continue;
       }
 
       if (char === "]" && depth > 0) {
-        depth -= 1
-        i += 1
-        continue
+        depth -= 1;
+        i += 1;
+        continue;
       }
 
       if (char === ":") {
         // Attempt to match another directive starting at this position.
-        const remainingText = text.slice(i)
-        const nextMatch = directivePattern.exec(remainingText)
+        const remainingText = text.slice(i);
+        const nextMatch = directivePattern.exec(remainingText);
         if (nextMatch?.index === 0) {
-          depth += 1
-          i += nextMatch[0].length
-          continue
+          depth += 1;
+          i += nextMatch[0].length;
+          continue;
         }
       }
 
-      i += 1
+      i += 1;
     }
 
-    return depth > 0 ? text + "]".repeat(depth) : text
+    return depth > 0 ? text + "]".repeat(depth) : text;
   },
-}
+};
 
 // Options for remend to use the directive completion handler
-const REMEND_OPTIONS = { handlers: [directiveCompletionHandler] }
+const REMEND_OPTIONS = { handlers: [directiveCompletionHandler] };
 
 // Standard remark plugins that don't depend on theme or props
 // Note: remarkEmoji is lazy-loaded and added conditionally when emoji shortcodes are detected
@@ -1085,7 +1088,7 @@ const BASE_REMARK_PLUGINS = [
   createRemarkHelpIcon(),
   createRemarkStreamlitLogo(),
   createRemarkTypographicalSymbols(),
-]
+];
 
 // Sets disallowed markdown for widget labels
 const LABEL_DISALLOWED_ELEMENTS = [
@@ -1109,31 +1112,31 @@ const LABEL_DISALLOWED_ELEMENTS = [
   "input",
   "hr",
   "blockquote",
-]
+];
 
 // Add link disallowing to the base disallowed elements
-const LINKS_DISALLOWED_ELEMENTS = [...LABEL_DISALLOWED_ELEMENTS, "a"]
+const LINKS_DISALLOWED_ELEMENTS = [...LABEL_DISALLOWED_ELEMENTS, "a"];
 
 interface LinkProps {
-  node?: Element
-  children?: ReactNode
-  href?: string
-  title?: string
-  target?: string
-  rel?: string
+  node?: Element;
+  children?: ReactNode;
+  href?: string;
+  title?: string;
+  target?: string;
+  rel?: string;
 }
 
 // Using target="_blank" without rel="noopener noreferrer" is a security risk:
 // see https://mathiasbynens.github.io/rel-noopener
 export function LinkWithTargetBlank(props: LinkProps): ReactElement {
   // if it's a #hash link, don't open in new tab
-  const { href } = props
+  const { href } = props;
   if (href?.startsWith("#")) {
-    const { children, ...rest } = props
-    return <a {...omit(rest, "node")}>{children}</a>
+    const { children, ...rest } = props;
+    return <a {...omit(rest, "node")}>{children}</a>;
   }
 
-  const { title, children, target, rel, ...rest } = props
+  const { title, children, target, rel, ...rest } = props;
   return (
     <a
       href={href}
@@ -1144,7 +1147,7 @@ export function LinkWithTargetBlank(props: LinkProps): ReactElement {
     >
       {children}
     </a>
-  )
+  );
 }
 
 export const RenderedMarkdown = memo(function RenderedMarkdown({
@@ -1157,10 +1160,10 @@ export const RenderedMarkdown = memo(function RenderedMarkdown({
   unterminatedParsing,
   hideAnchors,
 }: Readonly<RenderedMarkdownProps>): ReactElement {
-  const theme = useEmotionTheme()
+  const theme = useEmotionTheme();
 
-  const needsKatex = useMemo(() => containsMathSyntax(source), [source])
-  const needsEmoji = useMemo(() => containsEmojiShortcodes(source), [source])
+  const needsKatex = useMemo(() => containsMathSyntax(source), [source]);
+  const needsEmoji = useMemo(() => containsEmojiShortcodes(source), [source]);
 
   // Lazy load plugins only when needed
   const katexPlugin = useLazyPlugin<KatexPlugin>({
@@ -1169,23 +1172,23 @@ export const RenderedMarkdown = memo(function RenderedMarkdown({
     load: loadKatexPlugin,
     pluginName: "rehype-katex",
     onBeforeLoad: loadKatexStyles,
-  })
+  });
 
   const rawPlugin = useLazyPlugin<RawPlugin>({
     key: "raw",
     needed: allowHTML,
     load: loadRehypeRaw,
     pluginName: "rehype-raw",
-  })
+  });
 
   const emojiPlugin = useLazyPlugin<EmojiPlugin>({
     key: "emoji",
     needed: needsEmoji,
     load: loadRemarkEmoji,
     pluginName: "remark-emoji",
-  })
+  });
 
-  const colorMapping = useMemo(() => createColorMapping(theme), [theme])
+  const colorMapping = useMemo(() => createColorMapping(theme), [theme]);
 
   // Wrap plugins once when they load, not on every render or when other deps change
   const wrappedKatexPlugin = useMemo(
@@ -1193,16 +1196,16 @@ export const RenderedMarkdown = memo(function RenderedMarkdown({
       isLoadedPlugin(katexPlugin)
         ? wrapRehypePlugin(katexPlugin, "rehype-katex")
         : null,
-    [katexPlugin]
-  )
+    [katexPlugin],
+  );
 
   const wrappedRawPlugin = useMemo(
     () =>
       isLoadedPlugin(rawPlugin)
         ? wrapRehypePlugin(rawPlugin, "rehype-raw")
         : null,
-    [rawPlugin]
-  )
+    [rawPlugin],
+  );
 
   const wrappedEmojiPlugin = useMemo(
     () =>
@@ -1210,43 +1213,43 @@ export const RenderedMarkdown = memo(function RenderedMarkdown({
         ? // Cast needed: unified's Plugin type is more complex than our RemarkPluginFactory wrapper
           wrapRemarkPlugin(emojiPlugin as RemarkPluginFactory, "remark-emoji")
         : null,
-    [emojiPlugin]
-  )
+    [emojiPlugin],
+  );
 
   const remarkPlugins = useMemo<PluggableList>(() => {
     const plugins: PluggableList = [
       ...BASE_REMARK_PLUGINS,
       createRemarkColoringAndSmall(theme, colorMapping),
       createRemarkMaterialIcons(theme),
-    ]
+    ];
 
     if (needsEmoji && wrappedEmojiPlugin) {
-      plugins.push(wrappedEmojiPlugin)
+      plugins.push(wrappedEmojiPlugin);
     }
 
     // This plugin must run last to clean up any unsupported directives
-    plugins.push(createRemarkUnsupportedDirectivesCleanup())
+    plugins.push(createRemarkUnsupportedDirectivesCleanup());
 
-    return plugins
-  }, [theme, colorMapping, needsEmoji, wrappedEmojiPlugin])
+    return plugins;
+  }, [theme, colorMapping, needsEmoji, wrappedEmojiPlugin]);
 
   const rehypePlugins = useMemo<PluggableList>(() => {
-    const plugins: PluggableList = []
+    const plugins: PluggableList = [];
 
     if (needsKatex && wrappedKatexPlugin) {
-      plugins.push(wrappedKatexPlugin)
+      plugins.push(wrappedKatexPlugin);
     }
 
     if (allowHTML && wrappedRawPlugin) {
-      plugins.push(wrappedRawPlugin)
+      plugins.push(wrappedRawPlugin);
     }
 
     // This plugin must run last to ensure the inline property is set correctly
     // and not overwritten by other plugins like rehypeRaw
-    plugins.push(rehypeSetCodeInlineProperty)
+    plugins.push(rehypeSetCodeInlineProperty);
 
-    return plugins
-  }, [allowHTML, needsKatex, wrappedKatexPlugin, wrappedRawPlugin])
+    return plugins;
+  }, [allowHTML, needsKatex, wrappedKatexPlugin, wrappedRawPlugin]);
 
   const renderers = useMemo(
     () =>
@@ -1255,13 +1258,13 @@ export const RenderedMarkdown = memo(function RenderedMarkdown({
         a: LinkWithTargetBlank,
         ...overrideComponents,
       }) as Components,
-    [overrideComponents]
-  )
+    [overrideComponents],
+  );
 
   const processedSource = useMemo(() => {
     // Replace :material/ with :material_ to avoid conflicts with the directive plugin.
     // The material icon regex in createMaterialIconPlugin uses :material_ to match.
-    let processed = source.replaceAll(":material/", ":material_")
+    let processed = source.replaceAll(":material/", ":material_");
 
     if (isLabel) {
       // Escape markdown syntax that would be stripped in labels, leaving empty content.
@@ -1274,40 +1277,42 @@ export const RenderedMarkdown = memo(function RenderedMarkdown({
       // Note: > doesn't need lookahead (always a blockquote), others need (?=\s|$)
       processed = processed.replace(
         /^(\s*)((?:[+\-*]|#+)(?=\s|$)|>)/gm,
-        "$1\\$2"
-      )
+        "$1\\$2",
+      );
       // Ordered lists (1., 2., etc.): escape only the punctuation, not the digits
-      processed = processed.replace(/^(\s*)(\d+)([.)])(?=\s|$)/gm, "$1$2\\$3")
+      processed = processed.replace(/^(\s*)(\d+)([.)])(?=\s|$)/gm, "$1$2\\$3");
     }
 
     // Complete incomplete markdown syntax (e.g., unclosed **bold) during streaming.
     // Only apply when unterminatedParsing is enabled (during streaming).
     // Skip for labels (short, complete strings) and HTML content (may interfere).
     if (unterminatedParsing && !isLabel && !allowHTML) {
-      processed = remend(processed, REMEND_OPTIONS)
+      processed = remend(processed, REMEND_OPTIONS);
     }
 
-    return processed
-  }, [source, isLabel, allowHTML, unterminatedParsing])
+    return processed;
+  }, [source, isLabel, allowHTML, unterminatedParsing]);
 
   const disallowed = useMemo(() => {
-    if (!isLabel) return []
-    return disableLinks ? LINKS_DISALLOWED_ELEMENTS : LABEL_DISALLOWED_ELEMENTS
-  }, [isLabel, disableLinks])
+    if (!isLabel) return [];
+    return disableLinks
+      ? LINKS_DISALLOWED_ELEMENTS
+      : LABEL_DISALLOWED_ELEMENTS;
+  }, [isLabel, disableLinks]);
 
   // Show skeleton while required plugins are still loading
   // A plugin is "loading" if it's needed but state is still null (not loaded, not failed)
   const isLoadingPlugins =
     (needsKatex && katexPlugin === null) ||
     (allowHTML && rawPlugin === null) ||
-    (needsEmoji && emojiPlugin === null)
+    (needsEmoji && emojiPlugin === null);
 
   if (isLoadingPlugins) {
     return (
       <ErrorBoundary>
         <SquareSkeleton data-testid="stSkeleton" aria-hidden="true" />
       </ErrorBoundary>
-    )
+    );
   }
 
   return (
@@ -1330,8 +1335,8 @@ export const RenderedMarkdown = memo(function RenderedMarkdown({
         </HideAnchorsContext.Provider>
       </HelpTextContext.Provider>
     </StreamingContext.Provider>
-  )
-})
+  );
+});
 
 /**
  * Wraps the <ReactMarkdown> component to include our standard
@@ -1352,7 +1357,7 @@ const StreamlitMarkdown: FC<Props> = ({
   unterminatedParsing,
   hideAnchors,
 }) => {
-  const isInDialog = useContext(IsDialogContext)
+  const isInDialog = useContext(IsDialogContext);
 
   return (
     <StyledStreamlitMarkdown
@@ -1376,7 +1381,7 @@ const StreamlitMarkdown: FC<Props> = ({
         hideAnchors={hideAnchors}
       />
     </StyledStreamlitMarkdown>
-  )
-}
+  );
+};
 
-export default memo(StreamlitMarkdown)
+export default memo(StreamlitMarkdown);

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -26,8 +26,10 @@ import {
   Suspense,
   useCallback,
   useContext,
+  useEffect,
   useId,
   useMemo,
+  useRef,
   useState,
 } from "react"
 
@@ -338,9 +340,11 @@ export const HeadingWithActionElements: FC<HeadingWithActionElementsProps> = ({
   const isInSidebar = useContext(IsSidebarContext)
   const isInDialog = useContext(IsDialogContext)
   const [elementId, setElementId] = useState(propsAnchor)
+  const nodeRef = useRef<HTMLElement | null>(null)
 
   const ref = useCallback(
     (node: HTMLElement | null) => {
+      nodeRef.current = node
       if (node === null) {
         return
       }
@@ -354,6 +358,22 @@ export const HeadingWithActionElements: FC<HeadingWithActionElementsProps> = ({
     },
     [propsAnchor]
   )
+
+  // Re-derive anchor when heading text changes across reruns. The ref callback
+  // only fires on mount or when propsAnchor changes; when only the text content
+  // changes, React reuses the DOM node and the callback never re-fires.
+  useEffect(() => {
+    const node = nodeRef.current
+    if (!node || propsAnchor) {
+      return
+    }
+    const anchor = createAnchorFromText(node.textContent)
+    setElementId(anchor)
+    const windowHash = window.location.hash.slice(1)
+    if (windowHash && windowHash === anchor) {
+      scrollNodeIntoView(node)
+    }
+  }, [children, propsAnchor])
 
   const isInSidebarOrDialog = isInSidebar || isInDialog
   const actionElements = (

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -31,43 +31,43 @@ import {
   useMemo,
   useRef,
   useState,
-} from "react";
+} from "react"
 
-import slugify from "@sindresorhus/slugify";
-import { parseToRgba } from "color2k";
-import { type Element, type Root as HastRoot } from "hast";
-import { omit, once } from "lodash-es";
-import type { Root as MdastRoot, Text } from "mdast";
-import { findAndReplace } from "mdast-util-find-and-replace";
-import { Link2 as LinkIcon } from "react-feather";
+import slugify from "@sindresorhus/slugify"
+import { parseToRgba } from "color2k"
+import { type Element, type Root as HastRoot } from "hast"
+import { omit, once } from "lodash-es"
+import type { Root as MdastRoot, Text } from "mdast"
+import { findAndReplace } from "mdast-util-find-and-replace"
+import { Link2 as LinkIcon } from "react-feather"
 import ReactMarkdown, {
   Components,
   Options as ReactMarkdownProps,
-} from "react-markdown";
-import remarkDirective from "remark-directive";
-import remarkGfm from "remark-gfm";
-import remarkMathPlugin from "remark-math";
-import remend, { type RemendHandler } from "remend";
-import { PluggableList } from "unified";
-import { visit } from "unist-util-visit";
-import xxhash from "xxhashjs";
+} from "react-markdown"
+import remarkDirective from "remark-directive"
+import remarkGfm from "remark-gfm"
+import remarkMathPlugin from "remark-math"
+import remend, { type RemendHandler } from "remend"
+import { PluggableList } from "unified"
+import { visit } from "unist-util-visit"
+import xxhash from "xxhashjs"
 
-import streamlitLogo from "~lib/assets/img/streamlit-logo/streamlit-mark-color.svg";
-import IsDialogContext from "~lib/components/core/IsDialogContext";
-import IsSidebarContext from "~lib/components/core/IsSidebarContext";
-import { StyledInlineCode } from "~lib/components/elements/CodeBlock/styled-components";
-import { SquareSkeleton } from "~lib/components/elements/Skeleton/styled-components";
-import ErrorBoundary from "~lib/components/shared/ErrorBoundary/ErrorBoundary";
-import { InlineTooltipIcon } from "~lib/components/shared/TooltipIcon/TooltipIcon";
-import { useCrossOriginAttribute } from "~lib/hooks/useCrossOriginAttribute";
-import { useEmotionTheme } from "~lib/hooks/useEmotionTheme";
+import streamlitLogo from "~lib/assets/img/streamlit-logo/streamlit-mark-color.svg"
+import IsDialogContext from "~lib/components/core/IsDialogContext"
+import IsSidebarContext from "~lib/components/core/IsSidebarContext"
+import { StyledInlineCode } from "~lib/components/elements/CodeBlock/styled-components"
+import { SquareSkeleton } from "~lib/components/elements/Skeleton/styled-components"
+import ErrorBoundary from "~lib/components/shared/ErrorBoundary/ErrorBoundary"
+import { InlineTooltipIcon } from "~lib/components/shared/TooltipIcon/TooltipIcon"
+import { useCrossOriginAttribute } from "~lib/hooks/useCrossOriginAttribute"
+import { useEmotionTheme } from "~lib/hooks/useEmotionTheme"
 import {
   getMarkdownTextColors,
   getThemeBackgroundColors,
-} from "~lib/theme/getColors";
-import type { EmotionTheme } from "~lib/theme/types";
-import { convertRemToPx } from "~lib/theme/utils";
-import { BLOCKED_LINK_URI, isDangerousLinkUri } from "~lib/util/UriUtil";
+} from "~lib/theme/getColors"
+import type { EmotionTheme } from "~lib/theme/types"
+import { convertRemToPx } from "~lib/theme/utils"
+import { BLOCKED_LINK_URI, isDangerousLinkUri } from "~lib/util/UriUtil"
 
 import {
   StyledHeadingActionElements,
@@ -76,7 +76,7 @@ import {
   StyledLinkIcon,
   StyledPreWrapper,
   StyledStreamlitMarkdown,
-} from "./styled-components";
+} from "./styled-components"
 import {
   type EmojiPlugin,
   isLoadedPlugin,
@@ -90,18 +90,17 @@ import {
   useLazyPlugin,
   wrapRehypePlugin,
   wrapRemarkPlugin,
-} from "./utils";
+} from "./utils"
 
 const StreamlitSyntaxHighlighter = lazy(
-  () =>
-    import("~lib/components/elements/CodeBlock/StreamlitSyntaxHighlighter"),
-);
+  () => import("~lib/components/elements/CodeBlock/StreamlitSyntaxHighlighter")
+)
 
 const MermaidChart = lazy(() =>
-  import("./MermaidChart").then((module) => ({
+  import("./MermaidChart").then(module => ({
     default: module.MermaidChart,
-  })),
-);
+  }))
+)
 
 /**
  * Heuristic to determine if the markdown source contains emoji shortcodes that require remark-emoji.
@@ -113,7 +112,7 @@ const MermaidChart = lazy(() =>
  * @returns true if emoji shortcodes are detected, false otherwise
  */
 export function containsEmojiShortcodes(source: string): boolean {
-  return /:(?!material\/|streamlit:)[\w+-][\w_+-]*:/.test(source);
+  return /:(?!material\/|streamlit:)[\w+-][\w_+-]*:/.test(source)
 }
 
 /**
@@ -128,7 +127,7 @@ export function containsEmojiShortcodes(source: string): boolean {
 export function containsMathSyntax(source: string): boolean {
   // Detect display math: $$...$$ or inline math: $...$
   // Inline math requires non-whitespace after opening $ and before closing $
-  return /\$\$[\s\S]+?\$\$|\$(?!\s)[^$\n]+?(?<!\s)\$/.test(source);
+  return /\$\$[\s\S]+?\$\$|\$(?!\s)[^$\n]+?(?<!\s)\$/.test(source)
 }
 
 export enum Tags {
@@ -141,63 +140,63 @@ export interface Props {
   /**
    * The Markdown formatted text to render.
    */
-  source: string;
+  source: string
 
   /**
    * True if HTML is allowed in the source string. If this is false,
    * any HTML will be escaped in the output.
    */
-  allowHTML: boolean;
-  style?: CSSProperties;
-  isCaption?: boolean;
+  allowHTML: boolean
+  style?: CSSProperties
+  isCaption?: boolean
 
   /**
    * Indicates widget labels & restricts allowed elements
    */
-  isLabel?: boolean;
+  isLabel?: boolean
 
   /**
    * Make the label bold
    */
-  boldLabel?: boolean;
+  boldLabel?: boolean
 
   /**
    * Does not allow links
    */
-  disableLinks?: boolean;
+  disableLinks?: boolean
 
   /**
    * Toast has smaller font sizing & special CSS
    */
-  isToast?: boolean;
+  isToast?: boolean
 
   /**
    * Inherit font family, size, and weight from parent
    */
-  inheritFont?: boolean;
+  inheritFont?: boolean
 
   /**
    * Optional help text for inline help tooltips.
    * When present, :help[] markers in the source will use this text.
    */
-  helpText?: string;
+  helpText?: string
 
   /**
    * Truncate text with ellipsis when it overflows the container.
    * Useful for single-line text that should not wrap, such as metric labels.
    */
-  truncate?: boolean;
+  truncate?: boolean
 
   /**
    * Enables unterminated markdown completion (via remend) during streaming.
    */
-  unterminatedParsing?: boolean;
+  unterminatedParsing?: boolean
 
   /**
    * When true, headers (h1-h6) keep their `id` for deep linking but the
    * visible anchor link icon is not rendered.
    */
-  hideAnchors?: boolean;
+  hideAnchors?: boolean
 }
 
 /**
@@ -206,13 +205,13 @@ export interface Props {
  * @see https://github.com/syntax-tree/mdast-util-to-hast#fields-on-nodes
  */
 interface MdastTextWithHastData {
-  type: "text";
-  value: string;
+  type: "text"
+  value: string
   data: {
-    hName: string;
-    hProperties: Record<string, string>;
-    hChildren?: Array<{ type: string; value: string }>;
-  };
+    hName: string
+    hProperties: Record<string, string>
+    hChildren?: Array<{ type: string; value: string }>
+  }
 }
 
 /**
@@ -224,16 +223,16 @@ function rehypeSetCodeInlineProperty() {
   return (tree: HastRoot) => {
     visit(tree, "element", (node: Element, _index, parent) => {
       if (node.tagName !== "code") {
-        return;
+        return
       }
 
       if (parent?.type === "element" && parent.tagName === "pre") {
-        node.properties = { ...node.properties, inline: false };
+        node.properties = { ...node.properties, inline: false }
       } else {
-        node.properties = { ...node.properties, inline: true };
+        node.properties = { ...node.properties, inline: true }
       }
-    });
-  };
+    })
+  }
 }
 
 /**
@@ -252,21 +251,21 @@ function rehypeSetCodeInlineProperty() {
  */
 export function createAnchorFromText(text: string | null): string {
   if (!text) {
-    return "";
+    return ""
   }
 
   /**
    * @see https://www.npmjs.com/package/@sindresorhus/slugify
    * @see https://www.npmjs.com/package/@sindresorhus/transliterate
    */
-  const newAnchor = slugify(text);
+  const newAnchor = slugify(text)
 
   if (newAnchor.length > 0) {
-    return newAnchor;
+    return newAnchor
   }
 
   // If slugify is not able to create a slug, fallback to hash
-  return xxhash.h32(text, 0xabcd).toString(16);
+  return xxhash.h32(text, 0xabcd).toString(16)
 }
 
 /**
@@ -282,18 +281,18 @@ export function createAnchorFromText(text: string | null): string {
  * current page in a new tab.
  */
 function transformLinkUri(href: string): string {
-  return isDangerousLinkUri(href) ? BLOCKED_LINK_URI : href;
+  return isDangerousLinkUri(href) ? BLOCKED_LINK_URI : href
 }
 
 // wrapping in `once` ensures we only scroll once
 const scrollNodeIntoView = once((node: HTMLElement): void => {
-  node.scrollIntoView(true);
-});
+  node.scrollIntoView(true)
+})
 
 interface HeadingActionElements {
-  elementId?: string;
-  help?: string;
-  hideAnchor?: boolean;
+  elementId?: string
+  help?: string
+  hideAnchor?: boolean
 }
 
 const HeaderActionElements: FC<HeadingActionElements> = ({
@@ -301,9 +300,9 @@ const HeaderActionElements: FC<HeadingActionElements> = ({
   help,
   hideAnchor,
 }) => {
-  const theme = useEmotionTheme();
+  const theme = useEmotionTheme()
   if (!help && hideAnchor) {
-    return <></>;
+    return <></>
   }
 
   return (
@@ -320,16 +319,16 @@ const HeaderActionElements: FC<HeadingActionElements> = ({
         </StyledLinkIcon>
       )}
     </StyledHeadingActionElements>
-  );
-};
+  )
+}
 
 interface HeadingWithActionElementsProps {
-  tag: string;
-  anchor?: string;
-  hideAnchor?: boolean;
-  children: ReactNode[] | ReactNode;
-  tagProps?: HTMLProps<HTMLHeadingElement>;
-  help?: string;
+  tag: string
+  anchor?: string
+  hideAnchor?: boolean
+  children: ReactNode[] | ReactNode
+  tagProps?: HTMLProps<HTMLHeadingElement>
+  help?: string
 }
 
 export const HeadingWithActionElements: FC<HeadingWithActionElementsProps> = ({
@@ -340,10 +339,10 @@ export const HeadingWithActionElements: FC<HeadingWithActionElementsProps> = ({
   children,
   tagProps,
 }) => {
-  const isInSidebar = useContext(IsSidebarContext);
-  const isInDialog = useContext(IsDialogContext);
-  const [elementId, setElementId] = useState(propsAnchor);
-  const nodeRef = useRef<HTMLElement | null>(null);
+  const isInSidebar = useContext(IsSidebarContext)
+  const isInDialog = useContext(IsDialogContext)
+  const [elementId, setElementId] = useState(propsAnchor)
+  const nodeRef = useRef<HTMLElement | null>(null)
 
   /**
    * Set the heading id from `propsAnchor` or the node's textContent, then scroll
@@ -353,26 +352,26 @@ export const HeadingWithActionElements: FC<HeadingWithActionElementsProps> = ({
    */
   const applyAnchor = useCallback(
     (node: HTMLElement): void => {
-      const anchor = propsAnchor || createAnchorFromText(node.textContent);
-      setElementId(anchor);
-      const windowHash = window.location.hash.slice(1);
+      const anchor = propsAnchor || createAnchorFromText(node.textContent)
+      setElementId(anchor)
+      const windowHash = window.location.hash.slice(1)
       if (windowHash && windowHash === anchor) {
-        scrollNodeIntoView(node);
+        scrollNodeIntoView(node)
       }
     },
-    [propsAnchor],
-  );
+    [propsAnchor]
+  )
 
   const ref = useCallback(
     (node: HTMLElement | null) => {
-      nodeRef.current = node;
+      nodeRef.current = node
       if (node === null) {
-        return;
+        return
       }
-      applyAnchor(node);
+      applyAnchor(node)
     },
-    [applyAnchor],
-  );
+    [applyAnchor]
+  )
 
   // Re-derive the anchor when heading text changes across reruns. The ref
   // callback only fires on mount or when propsAnchor changes; when only the text
@@ -383,21 +382,21 @@ export const HeadingWithActionElements: FC<HeadingWithActionElementsProps> = ({
   // useLayoutEffect (not useEffect) so the re-derived id is committed before
   // paint; otherwise a frame can render with the previous hash link.
   useLayoutEffect(() => {
-    const node = nodeRef.current;
+    const node = nodeRef.current
     if (!node || propsAnchor) {
-      return;
+      return
     }
-    applyAnchor(node);
-  }, [children, propsAnchor, applyAnchor]);
+    applyAnchor(node)
+  }, [children, propsAnchor, applyAnchor])
 
-  const isInSidebarOrDialog = isInSidebar || isInDialog;
+  const isInSidebarOrDialog = isInSidebar || isInDialog
   const actionElements = (
     <HeaderActionElements
       elementId={elementId}
       help={help}
       hideAnchor={hideAnchor || isInSidebarOrDialog}
     />
-  );
+  )
 
   // Accessibility:
   // Headings can contain action elements (help tooltip icon, anchor link icon).
@@ -414,21 +413,21 @@ export const HeadingWithActionElements: FC<HeadingWithActionElementsProps> = ({
   // - help: tooltip icon can be present even in sidebar/dialog (where we don't
   //   set a heading id/anchor)
   // - anchor icon: only present when we have an elementId and it's not hidden
-  const rawHeadingTextId = useId();
+  const rawHeadingTextId = useId()
   const headingTextId =
     help || (elementId && !hideAnchor && !isInSidebarOrDialog)
       ? rawHeadingTextId
-      : undefined;
+      : undefined
 
-  const idAttribute = elementId ? { id: elementId } : {};
+  const idAttribute = elementId ? { id: elementId } : {}
   const ariaLabelledbyAttribute = headingTextId
     ? { "aria-labelledby": headingTextId }
-    : {};
+    : {}
   const mergedAttributes = {
     ...(isInSidebarOrDialog ? {} : { ref, ...idAttribute }),
     ...ariaLabelledbyAttribute,
-  };
-  const Tag = tag;
+  }
+  const Tag = tag
   // We nest the action-elements (tooltip, link-icon) into the header element (e.g. h1),
   // so that it appears inline. For context: we also tried setting the h's display attribute to 'inline', but
   // then we would need to add padding to the outer container and fiddle with the vertical alignment.
@@ -437,46 +436,46 @@ export const HeadingWithActionElements: FC<HeadingWithActionElementsProps> = ({
       {headingTextId ? <span id={headingTextId}>{children}</span> : children}
       {actionElements}
     </Tag>
-  );
+  )
 
   // we don't want to apply styling, so return the "raw" header
   if (isInSidebarOrDialog) {
-    return headerElementWithActions;
+    return headerElementWithActions
   }
 
   return (
     <StyledHeadingWithActionElements data-testid="stHeadingWithActionElements">
       {headerElementWithActions}
     </StyledHeadingWithActionElements>
-  );
-};
+  )
+}
 
 type HeadingProps = JSX.IntrinsicElements["h1"] &
   ReactMarkdownProps & {
-    level: number;
-    "data-anchor"?: string;
-    node: Element;
-  };
+    level: number
+    "data-anchor"?: string
+    node: Element
+  }
 
 /**
  * Context to indicate if markdown is being streamed (unterminatedParsing mode).
  * When true, mermaid code blocks render as syntax-highlighted code instead of diagrams.
  * This prevents flickering and error states from partial/incomplete diagram source.
  */
-const StreamingContext = createContext<boolean>(false);
-StreamingContext.displayName = "StreamingContext";
+const StreamingContext = createContext<boolean>(false)
+StreamingContext.displayName = "StreamingContext"
 
 /**
  * Context that controls whether anchor link icons render next to markdown
  * headings. Heading `id` attributes are still set when this is true, so URL
  * fragment deep links keep working.
  */
-const HideAnchorsContext = createContext<boolean>(false);
-HideAnchorsContext.displayName = "HideAnchorsContext";
+const HideAnchorsContext = createContext<boolean>(false)
+HideAnchorsContext.displayName = "HideAnchorsContext"
 
 const CustomHeading: FC<HeadingProps> = ({ node, children, ...rest }) => {
-  const anchor = rest["data-anchor"];
-  const hideAnchor = useContext(HideAnchorsContext);
+  const anchor = rest["data-anchor"]
+  const hideAnchor = useContext(HideAnchorsContext)
   return (
     <HeadingWithActionElements
       tag={node.tagName}
@@ -486,52 +485,52 @@ const CustomHeading: FC<HeadingProps> = ({ node, children, ...rest }) => {
     >
       {children}
     </HeadingWithActionElements>
-  );
-};
+  )
+}
 interface RenderedMarkdownProps {
   /**
    * The Markdown formatted text to render.
    */
-  source: string;
+  source: string
 
   /**
    * True if HTML is allowed in the source string. If this is false,
    * any HTML will be escaped in the output.
    */
-  allowHTML: boolean;
+  allowHTML: boolean
 
-  overrideComponents?: Components;
+  overrideComponents?: Components
 
   /**
    * Indicates widget labels & restricts allowed elements
    */
-  isLabel?: boolean;
+  isLabel?: boolean
 
   /**
    * Does not allow links
    */
-  disableLinks?: boolean;
+  disableLinks?: boolean
 
   /**
    * Optional help text for inline help tooltips.
    * When present, :help[] markers in the source will use this text.
    */
-  helpText?: string;
+  helpText?: string
 
   /**
    * Enables unterminated markdown completion (via remend) during streaming.
    */
-  unterminatedParsing?: boolean;
+  unterminatedParsing?: boolean
 
   /**
    * When true, headers (h1-h6) keep their `id` for deep linking but the
    * visible anchor link icon is not rendered.
    */
-  hideAnchors?: boolean;
+  hideAnchors?: boolean
 }
 
 export type CustomCodeTagProps = JSX.IntrinsicElements["code"] &
-  ReactMarkdownProps & { inline?: boolean };
+  ReactMarkdownProps & { inline?: boolean }
 
 /**
  * Renders code tag with highlighting based on requested language.
@@ -543,14 +542,14 @@ export const CustomCodeTag: FC<CustomCodeTagProps> = ({
   children,
   ...props
 }) => {
-  const match = /language-(\w+)/.exec(className || "");
-  const isStreaming = useContext(StreamingContext);
+  const match = /language-(\w+)/.exec(className || "")
+  const isStreaming = useContext(StreamingContext)
 
   const codeText = String(children ?? "")
     .replace(/^\n/, "")
-    .replace(/\n$/, "");
+    .replace(/\n$/, "")
 
-  const language = match?.[1] || "";
+  const language = match?.[1] || ""
 
   // Handle mermaid code blocks: render as a diagram unless streaming
   // (see StreamingContext for rationale).
@@ -565,7 +564,7 @@ export const CustomCodeTag: FC<CustomCodeTagProps> = ({
           <MermaidChart source={codeText} />
         </Suspense>
       </ErrorBoundary>
-    );
+    )
   }
 
   return !inline ? (
@@ -587,8 +586,8 @@ export const CustomCodeTag: FC<CustomCodeTagProps> = ({
     <StyledInlineCode className={className} {...omit(props, "node")}>
       {children}
     </StyledInlineCode>
-  );
-};
+  )
+}
 
 /**
  * Renders pre tag with added margin.
@@ -596,28 +595,28 @@ export const CustomCodeTag: FC<CustomCodeTagProps> = ({
 export const CustomPreTag: FC<ReactMarkdownProps> = ({ children }) => {
   return (
     <StyledPreWrapper data-testid="stMarkdownPre">{children}</StyledPreWrapper>
-  );
-};
+  )
+}
 
 export const CustomMediaTag: FC<
   JSX.IntrinsicElements["img" | "video" | "audio"] &
     ReactMarkdownProps & { node: Element }
 > = ({ node, ...props }) => {
-  const crossOrigin = useCrossOriginAttribute(props.src);
-  const Tag = node.tagName;
+  const crossOrigin = useCrossOriginAttribute(props.src)
+  const Tag = node.tagName
 
   const attributes = {
     ...props,
     crossOrigin,
-  };
-  return <Tag {...attributes} />;
-};
+  }
+  return <Tag {...attributes} />
+}
 
-const HelpTextContext = createContext<string | undefined>(undefined);
-HelpTextContext.displayName = "HelpTextContext";
+const HelpTextContext = createContext<string | undefined>(undefined)
+HelpTextContext.displayName = "HelpTextContext"
 
 interface CustomHelpIconProps {
-  children?: string;
+  children?: string
 }
 
 /**
@@ -636,16 +635,16 @@ interface CustomHelpIconProps {
  */
 const CustomHelpIcon: FC<CustomHelpIconProps> = ({ children }) => {
   // Prefer context (from help parameter) over children (from directive label)
-  const contextHelpText = useContext(HelpTextContext);
+  const contextHelpText = useContext(HelpTextContext)
   const tooltipContent =
-    contextHelpText || (typeof children === "string" ? children : "");
+    contextHelpText || (typeof children === "string" ? children : "")
 
   return (
     <StyledHelpIconWrapper>
       <InlineTooltipIcon content={tooltipContent} />
     </StyledHelpIconWrapper>
-  );
-};
+  )
+}
 
 // These are common renderers that don't depend on props or context
 const BASE_RENDERERS = {
@@ -661,7 +660,7 @@ const BASE_RENDERERS = {
   video: CustomMediaTag,
   audio: CustomMediaTag,
   "streamlit-help-icon": CustomHelpIcon,
-};
+}
 
 /**
  * Create a color mapping based on the theme.
@@ -669,7 +668,7 @@ const BASE_RENDERERS = {
  */
 function createColorMapping(theme: EmotionTheme): Map<string, string> {
   const { red, orange, yellow, green, blue, violet, purple, gray, primary } =
-    getMarkdownTextColors(theme);
+    getMarkdownTextColors(theme)
   const {
     redbg,
     orangebg,
@@ -680,7 +679,7 @@ function createColorMapping(theme: EmotionTheme): Map<string, string> {
     purplebg,
     graybg,
     primarybg,
-  }: Record<string, string> = getThemeBackgroundColors(theme);
+  }: Record<string, string> = getThemeBackgroundColors(theme)
 
   return new Map(
     Object.entries({
@@ -708,8 +707,8 @@ function createColorMapping(theme: EmotionTheme): Map<string, string> {
       // Gradient from red, orange, yellow, green, blue, violet, purple
       "rainbow-background": `background: linear-gradient(to right,
         ${redbg}, ${orangebg}, ${yellowbg}, ${greenbg}, ${bluebg}, ${violetbg}, ${purplebg});`,
-    }),
-  );
+    })
+  )
 }
 
 /**
@@ -718,20 +717,20 @@ function createColorMapping(theme: EmotionTheme): Map<string, string> {
 function createRemarkHelpIcon() {
   return () => (tree: MdastRoot) => {
     visit(tree, "textDirective", (node, _index, _parent) => {
-      const nodeName = String(node.name);
+      const nodeName = String(node.name)
 
       // Handle help icon directive (:help[tooltip content])
       if (nodeName === "help") {
-        const data = node.data || (node.data = {});
-        data.hName = "streamlit-help-icon";
-        data.hProperties = data.hProperties || {};
+        const data = node.data || (node.data = {})
+        data.hName = "streamlit-help-icon"
+        data.hProperties = data.hProperties || {}
         // Pass the children through so CustomHelpIcon can extract the content
-        return;
+        return
       }
-    });
+    })
 
-    return tree;
-  };
+    return tree
+  }
 }
 
 /**
@@ -743,12 +742,12 @@ function createRemarkHelpIcon() {
  * @returns true if the color is valid, false otherwise
  */
 export function isValidCssColor(color: string): boolean {
-  if (!color) return false;
+  if (!color) return false
   try {
-    parseToRgba(color);
-    return true;
+    parseToRgba(color)
+    return true
   } catch {
-    return false;
+    return false
   }
 }
 
@@ -757,69 +756,69 @@ export function isValidCssColor(color: string): boolean {
  */
 function createRemarkColoringAndSmall(
   theme: EmotionTheme,
-  colorMapping: Map<string, string>,
+  colorMapping: Map<string, string>
 ) {
   return () => (tree: MdastRoot) => {
     visit(tree, "textDirective", (node, _index, _parent) => {
-      const nodeName = String(node.name);
+      const nodeName = String(node.name)
 
       // Handle shimmer text directive (:shimmer[])
       if (nodeName === "shimmer") {
-        const data = node.data || (node.data = {});
-        data.hName = "span";
-        data.hProperties = data.hProperties || {};
-        data.hProperties.className = "stMarkdownShimmer";
-        return;
+        const data = node.data || (node.data = {})
+        data.hName = "span"
+        data.hProperties = data.hProperties || {}
+        data.hProperties.className = "stMarkdownShimmer"
+        return
       }
 
       // Handle small text directive (:small[])
       if (nodeName === "small") {
-        const data = node.data || (node.data = {});
-        data.hName = "span";
-        data.hProperties = data.hProperties || {};
-        data.hProperties.style = `font-size: ${theme.fontSizes.sm};`;
-        return;
+        const data = node.data || (node.data = {})
+        data.hName = "span"
+        data.hProperties = data.hProperties || {}
+        data.hProperties.style = `font-size: ${theme.fontSizes.sm};`
+        return
       }
 
       // Handle custom color directive (:color[text]{foreground="...", background="..."})
       if (nodeName === "color" && node.attributes) {
-        const { foreground, background } = node.attributes;
-        const validForeground = foreground && isValidCssColor(foreground);
-        const validBackground = background && isValidCssColor(background);
+        const { foreground, background } = node.attributes
+        const validForeground = foreground && isValidCssColor(foreground)
+        const validBackground = background && isValidCssColor(background)
 
-        const data = node.data || (node.data = {});
-        data.hName = "span";
-        data.hProperties = data.hProperties || {};
+        const data = node.data || (node.data = {})
+        data.hName = "span"
+        data.hProperties = data.hProperties || {}
 
         if (validForeground || validBackground) {
-          const styles: string[] = [];
+          const styles: string[] = []
 
           if (validForeground) {
-            styles.push(`color: ${foreground}`);
+            styles.push(`color: ${foreground}`)
           }
 
           if (validBackground) {
-            styles.push(`background-color: ${background}`);
+            styles.push(`background-color: ${background}`)
           }
 
           // Use background class when background is set (has more styling: padding, border-radius)
           const className = validBackground
             ? "stMarkdownColoredBackground"
-            : "stMarkdownColoredText";
+            : "stMarkdownColoredText"
 
-          data.hProperties.style = styles.join("; ");
-          data.hProperties.className = className;
+          data.hProperties.style = styles.join("; ")
+          data.hProperties.className = className
         }
         // When both colors are invalid, render as plain span (no style)
         // to preserve the content text rather than falling through to
         // unsupported directive cleanup which would lose the content
-        return;
+        return
       }
 
       // Handle badge directives (:color-badge[])
-      const badgeMatch = nodeName.match(/^(.+)-badge$/);
+      const badgeMatch = nodeName.match(/^(.+)-badge$/)
       if (badgeMatch && colorMapping.has(badgeMatch[1])) {
-        const color = badgeMatch[1];
+        const color = badgeMatch[1]
 
         // rainbow-badge is not supported because the rainbow text effect uses
         // background-clip: text with a transparent color, which conflicts with
@@ -829,44 +828,44 @@ function createRemarkColoringAndSmall(
         // We can support that in the future if we want to, but I think a
         // rainbow-colored badge shouldn't be a common use case anyway.
         if (color === "rainbow") {
-          return;
+          return
         }
 
-        const textColor = colorMapping.get(color);
-        const bgColor = colorMapping.get(`${color}-background`);
+        const textColor = colorMapping.get(color)
+        const bgColor = colorMapping.get(`${color}-background`)
 
         if (textColor && bgColor) {
-          const data = node.data || (node.data = {});
-          data.hName = "span";
-          data.hProperties = data.hProperties || {};
-          data.hProperties.className = "stMarkdownBadge";
-          data.hProperties.style = `${bgColor}; ${textColor}; font-size: ${theme.fontSizes.sm};`;
-          return;
+          const data = node.data || (node.data = {})
+          data.hName = "span"
+          data.hProperties = data.hProperties || {}
+          data.hProperties.className = "stMarkdownBadge"
+          data.hProperties.style = `${bgColor}; ${textColor}; font-size: ${theme.fontSizes.sm};`
+          return
         }
       }
 
       // Handle color directives (:color[] or :color-background[])
       if (colorMapping.has(nodeName)) {
-        const data = node.data || (node.data = {});
-        const style = colorMapping.get(nodeName);
-        data.hName = "span";
-        data.hProperties = data.hProperties || {};
-        data.hProperties.style = style;
+        const data = node.data || (node.data = {})
+        const style = colorMapping.get(nodeName)
+        data.hName = "span"
+        data.hProperties = data.hProperties || {}
+        data.hProperties.style = style
         // Add class name specific to colored text used for button hover selector
         // to override text color
-        data.hProperties.className = "stMarkdownColoredText";
+        data.hProperties.className = "stMarkdownColoredText"
         // Add class for background color for custom styling
         if (
           style &&
           (/background-color:/.test(style) || /background:/.test(style))
         ) {
-          data.hProperties.className = "stMarkdownColoredBackground";
+          data.hProperties.className = "stMarkdownColoredBackground"
         }
-        return;
+        return
       }
-    });
-    return tree;
-  };
+    })
+    return tree
+  }
 }
 
 /**
@@ -875,7 +874,7 @@ function createRemarkColoringAndSmall(
  * to plain text, ensuring they are rendered rather than ignored.
  */
 function createRemarkUnsupportedDirectivesCleanup(): () => (
-  tree: MdastRoot,
+  tree: MdastRoot
 ) => MdastRoot {
   return () => (tree: MdastRoot) => {
     visit(tree, "textDirective", (node, index, parent) => {
@@ -887,12 +886,12 @@ function createRemarkUnsupportedDirectivesCleanup(): () => (
         const textNode: Text = {
           type: "text",
           value: `:${node.name}`,
-        };
-        parent.children[index] = textNode;
+        }
+        parent.children[index] = textNode
       }
-    });
-    return tree;
-  };
+    })
+    return tree
+  }
 }
 
 /**
@@ -902,7 +901,7 @@ function createRemarkMaterialIcons(theme: EmotionTheme) {
   return () => (tree: MdastRoot) => {
     function replace(
       fullMatch: string,
-      iconName: string,
+      iconName: string
     ): MdastTextWithHastData {
       return {
         type: "text",
@@ -930,7 +929,7 @@ function createRemarkMaterialIcons(theme: EmotionTheme) {
           },
           hChildren: [{ type: "text", value: iconName }],
         },
-      };
+      }
     }
     // We replace all `:material/` occurrences with `:material_` to avoid
     // conflicts with the directive plugin.
@@ -942,9 +941,9 @@ function createRemarkMaterialIcons(theme: EmotionTheme) {
         /:material_(\w+):/g,
         replace as (fullMatch: string, iconName: string) => Text,
       ],
-    ]);
-    return tree;
-  };
+    ])
+    return tree
+  }
 }
 
 /**
@@ -968,11 +967,11 @@ function createRemarkStreamlitLogo() {
             style: `display: inline-block; user-select: none; height: 0.75em; vertical-align: baseline; margin-bottom: -0.05ex;`,
           },
         },
-      };
+      }
     }
-    findAndReplace(tree, [[/:streamlit:/g, replaceStreamlit as () => Text]]);
-    return tree;
-  };
+    findAndReplace(tree, [[/:streamlit:/g, replaceStreamlit as () => Text]])
+    return tree
+  }
 }
 
 /**
@@ -988,7 +987,7 @@ function createRemarkTypographicalSymbols() {
         // Don't replace symbols in links.
         // Note that remark extensions are not applied in code blocks and latex
         // formulas, so we don't need to worry about them here.
-        return;
+        return
       }
 
       if (node.type === "text" && node.value) {
@@ -1002,21 +1001,21 @@ function createRemarkTypographicalSymbols() {
           [/(^|\s)>=(\s|$)/g, "$1≥$2"],
           [/(^|\s)<=(\s|$)/g, "$1≤$2"],
           [/(^|\s)~=(\s|$)/g, "$1≈$2"],
-        ];
+        ]
 
-        let newValue = node.value;
+        let newValue = node.value
         for (const [pattern, replacement] of replacements) {
-          newValue = newValue.replace(pattern, replacement as string);
+          newValue = newValue.replace(pattern, replacement as string)
         }
 
         if (newValue !== node.value) {
-          node.value = newValue;
+          node.value = newValue
         }
       }
-    });
+    })
 
-    return tree;
-  };
+    return tree
+  }
 }
 
 /**
@@ -1031,53 +1030,53 @@ const directiveCompletionHandler: RemendHandler = {
   priority: 10,
   handle: (text: string): string => {
     // Match directive patterns like :red[, :small[, :red-background[
-    const directivePattern = /:[a-z][a-z0-9-]*\[/;
-    const firstMatch = directivePattern.exec(text);
+    const directivePattern = /:[a-z][a-z0-9-]*\[/
+    const firstMatch = directivePattern.exec(text)
     if (!firstMatch) {
-      return text;
+      return text
     }
 
     // Track directive openings (:<name>[), nested brackets, and close with ']'.
     // We track all '[' inside directives to handle cases like `:red[text [link]`
     // where nested brackets need proper balancing.
-    let depth = 1;
-    let i = firstMatch.index + firstMatch[0].length;
+    let depth = 1
+    let i = firstMatch.index + firstMatch[0].length
 
     while (i < text.length) {
-      const char = text[i];
+      const char = text[i]
 
       if (char === "[" && depth > 0) {
-        depth += 1;
-        i += 1;
-        continue;
+        depth += 1
+        i += 1
+        continue
       }
 
       if (char === "]" && depth > 0) {
-        depth -= 1;
-        i += 1;
-        continue;
+        depth -= 1
+        i += 1
+        continue
       }
 
       if (char === ":") {
         // Attempt to match another directive starting at this position.
-        const remainingText = text.slice(i);
-        const nextMatch = directivePattern.exec(remainingText);
+        const remainingText = text.slice(i)
+        const nextMatch = directivePattern.exec(remainingText)
         if (nextMatch?.index === 0) {
-          depth += 1;
-          i += nextMatch[0].length;
-          continue;
+          depth += 1
+          i += nextMatch[0].length
+          continue
         }
       }
 
-      i += 1;
+      i += 1
     }
 
-    return depth > 0 ? text + "]".repeat(depth) : text;
+    return depth > 0 ? text + "]".repeat(depth) : text
   },
-};
+}
 
 // Options for remend to use the directive completion handler
-const REMEND_OPTIONS = { handlers: [directiveCompletionHandler] };
+const REMEND_OPTIONS = { handlers: [directiveCompletionHandler] }
 
 // Standard remark plugins that don't depend on theme or props
 // Note: remarkEmoji is lazy-loaded and added conditionally when emoji shortcodes are detected
@@ -1088,7 +1087,7 @@ const BASE_REMARK_PLUGINS = [
   createRemarkHelpIcon(),
   createRemarkStreamlitLogo(),
   createRemarkTypographicalSymbols(),
-];
+]
 
 // Sets disallowed markdown for widget labels
 const LABEL_DISALLOWED_ELEMENTS = [
@@ -1112,31 +1111,31 @@ const LABEL_DISALLOWED_ELEMENTS = [
   "input",
   "hr",
   "blockquote",
-];
+]
 
 // Add link disallowing to the base disallowed elements
-const LINKS_DISALLOWED_ELEMENTS = [...LABEL_DISALLOWED_ELEMENTS, "a"];
+const LINKS_DISALLOWED_ELEMENTS = [...LABEL_DISALLOWED_ELEMENTS, "a"]
 
 interface LinkProps {
-  node?: Element;
-  children?: ReactNode;
-  href?: string;
-  title?: string;
-  target?: string;
-  rel?: string;
+  node?: Element
+  children?: ReactNode
+  href?: string
+  title?: string
+  target?: string
+  rel?: string
 }
 
 // Using target="_blank" without rel="noopener noreferrer" is a security risk:
 // see https://mathiasbynens.github.io/rel-noopener
 export function LinkWithTargetBlank(props: LinkProps): ReactElement {
   // if it's a #hash link, don't open in new tab
-  const { href } = props;
+  const { href } = props
   if (href?.startsWith("#")) {
-    const { children, ...rest } = props;
-    return <a {...omit(rest, "node")}>{children}</a>;
+    const { children, ...rest } = props
+    return <a {...omit(rest, "node")}>{children}</a>
   }
 
-  const { title, children, target, rel, ...rest } = props;
+  const { title, children, target, rel, ...rest } = props
   return (
     <a
       href={href}
@@ -1147,7 +1146,7 @@ export function LinkWithTargetBlank(props: LinkProps): ReactElement {
     >
       {children}
     </a>
-  );
+  )
 }
 
 export const RenderedMarkdown = memo(function RenderedMarkdown({
@@ -1160,10 +1159,10 @@ export const RenderedMarkdown = memo(function RenderedMarkdown({
   unterminatedParsing,
   hideAnchors,
 }: Readonly<RenderedMarkdownProps>): ReactElement {
-  const theme = useEmotionTheme();
+  const theme = useEmotionTheme()
 
-  const needsKatex = useMemo(() => containsMathSyntax(source), [source]);
-  const needsEmoji = useMemo(() => containsEmojiShortcodes(source), [source]);
+  const needsKatex = useMemo(() => containsMathSyntax(source), [source])
+  const needsEmoji = useMemo(() => containsEmojiShortcodes(source), [source])
 
   // Lazy load plugins only when needed
   const katexPlugin = useLazyPlugin<KatexPlugin>({
@@ -1172,23 +1171,23 @@ export const RenderedMarkdown = memo(function RenderedMarkdown({
     load: loadKatexPlugin,
     pluginName: "rehype-katex",
     onBeforeLoad: loadKatexStyles,
-  });
+  })
 
   const rawPlugin = useLazyPlugin<RawPlugin>({
     key: "raw",
     needed: allowHTML,
     load: loadRehypeRaw,
     pluginName: "rehype-raw",
-  });
+  })
 
   const emojiPlugin = useLazyPlugin<EmojiPlugin>({
     key: "emoji",
     needed: needsEmoji,
     load: loadRemarkEmoji,
     pluginName: "remark-emoji",
-  });
+  })
 
-  const colorMapping = useMemo(() => createColorMapping(theme), [theme]);
+  const colorMapping = useMemo(() => createColorMapping(theme), [theme])
 
   // Wrap plugins once when they load, not on every render or when other deps change
   const wrappedKatexPlugin = useMemo(
@@ -1196,16 +1195,16 @@ export const RenderedMarkdown = memo(function RenderedMarkdown({
       isLoadedPlugin(katexPlugin)
         ? wrapRehypePlugin(katexPlugin, "rehype-katex")
         : null,
-    [katexPlugin],
-  );
+    [katexPlugin]
+  )
 
   const wrappedRawPlugin = useMemo(
     () =>
       isLoadedPlugin(rawPlugin)
         ? wrapRehypePlugin(rawPlugin, "rehype-raw")
         : null,
-    [rawPlugin],
-  );
+    [rawPlugin]
+  )
 
   const wrappedEmojiPlugin = useMemo(
     () =>
@@ -1213,43 +1212,43 @@ export const RenderedMarkdown = memo(function RenderedMarkdown({
         ? // Cast needed: unified's Plugin type is more complex than our RemarkPluginFactory wrapper
           wrapRemarkPlugin(emojiPlugin as RemarkPluginFactory, "remark-emoji")
         : null,
-    [emojiPlugin],
-  );
+    [emojiPlugin]
+  )
 
   const remarkPlugins = useMemo<PluggableList>(() => {
     const plugins: PluggableList = [
       ...BASE_REMARK_PLUGINS,
       createRemarkColoringAndSmall(theme, colorMapping),
       createRemarkMaterialIcons(theme),
-    ];
+    ]
 
     if (needsEmoji && wrappedEmojiPlugin) {
-      plugins.push(wrappedEmojiPlugin);
+      plugins.push(wrappedEmojiPlugin)
     }
 
     // This plugin must run last to clean up any unsupported directives
-    plugins.push(createRemarkUnsupportedDirectivesCleanup());
+    plugins.push(createRemarkUnsupportedDirectivesCleanup())
 
-    return plugins;
-  }, [theme, colorMapping, needsEmoji, wrappedEmojiPlugin]);
+    return plugins
+  }, [theme, colorMapping, needsEmoji, wrappedEmojiPlugin])
 
   const rehypePlugins = useMemo<PluggableList>(() => {
-    const plugins: PluggableList = [];
+    const plugins: PluggableList = []
 
     if (needsKatex && wrappedKatexPlugin) {
-      plugins.push(wrappedKatexPlugin);
+      plugins.push(wrappedKatexPlugin)
     }
 
     if (allowHTML && wrappedRawPlugin) {
-      plugins.push(wrappedRawPlugin);
+      plugins.push(wrappedRawPlugin)
     }
 
     // This plugin must run last to ensure the inline property is set correctly
     // and not overwritten by other plugins like rehypeRaw
-    plugins.push(rehypeSetCodeInlineProperty);
+    plugins.push(rehypeSetCodeInlineProperty)
 
-    return plugins;
-  }, [allowHTML, needsKatex, wrappedKatexPlugin, wrappedRawPlugin]);
+    return plugins
+  }, [allowHTML, needsKatex, wrappedKatexPlugin, wrappedRawPlugin])
 
   const renderers = useMemo(
     () =>
@@ -1258,13 +1257,13 @@ export const RenderedMarkdown = memo(function RenderedMarkdown({
         a: LinkWithTargetBlank,
         ...overrideComponents,
       }) as Components,
-    [overrideComponents],
-  );
+    [overrideComponents]
+  )
 
   const processedSource = useMemo(() => {
     // Replace :material/ with :material_ to avoid conflicts with the directive plugin.
     // The material icon regex in createMaterialIconPlugin uses :material_ to match.
-    let processed = source.replaceAll(":material/", ":material_");
+    let processed = source.replaceAll(":material/", ":material_")
 
     if (isLabel) {
       // Escape markdown syntax that would be stripped in labels, leaving empty content.
@@ -1277,42 +1276,40 @@ export const RenderedMarkdown = memo(function RenderedMarkdown({
       // Note: > doesn't need lookahead (always a blockquote), others need (?=\s|$)
       processed = processed.replace(
         /^(\s*)((?:[+\-*]|#+)(?=\s|$)|>)/gm,
-        "$1\\$2",
-      );
+        "$1\\$2"
+      )
       // Ordered lists (1., 2., etc.): escape only the punctuation, not the digits
-      processed = processed.replace(/^(\s*)(\d+)([.)])(?=\s|$)/gm, "$1$2\\$3");
+      processed = processed.replace(/^(\s*)(\d+)([.)])(?=\s|$)/gm, "$1$2\\$3")
     }
 
     // Complete incomplete markdown syntax (e.g., unclosed **bold) during streaming.
     // Only apply when unterminatedParsing is enabled (during streaming).
     // Skip for labels (short, complete strings) and HTML content (may interfere).
     if (unterminatedParsing && !isLabel && !allowHTML) {
-      processed = remend(processed, REMEND_OPTIONS);
+      processed = remend(processed, REMEND_OPTIONS)
     }
 
-    return processed;
-  }, [source, isLabel, allowHTML, unterminatedParsing]);
+    return processed
+  }, [source, isLabel, allowHTML, unterminatedParsing])
 
   const disallowed = useMemo(() => {
-    if (!isLabel) return [];
-    return disableLinks
-      ? LINKS_DISALLOWED_ELEMENTS
-      : LABEL_DISALLOWED_ELEMENTS;
-  }, [isLabel, disableLinks]);
+    if (!isLabel) return []
+    return disableLinks ? LINKS_DISALLOWED_ELEMENTS : LABEL_DISALLOWED_ELEMENTS
+  }, [isLabel, disableLinks])
 
   // Show skeleton while required plugins are still loading
   // A plugin is "loading" if it's needed but state is still null (not loaded, not failed)
   const isLoadingPlugins =
     (needsKatex && katexPlugin === null) ||
     (allowHTML && rawPlugin === null) ||
-    (needsEmoji && emojiPlugin === null);
+    (needsEmoji && emojiPlugin === null)
 
   if (isLoadingPlugins) {
     return (
       <ErrorBoundary>
         <SquareSkeleton data-testid="stSkeleton" aria-hidden="true" />
       </ErrorBoundary>
-    );
+    )
   }
 
   return (
@@ -1335,8 +1332,8 @@ export const RenderedMarkdown = memo(function RenderedMarkdown({
         </HideAnchorsContext.Provider>
       </HelpTextContext.Provider>
     </StreamingContext.Provider>
-  );
-});
+  )
+})
 
 /**
  * Wraps the <ReactMarkdown> component to include our standard
@@ -1357,7 +1354,7 @@ const StreamlitMarkdown: FC<Props> = ({
   unterminatedParsing,
   hideAnchors,
 }) => {
-  const isInDialog = useContext(IsDialogContext);
+  const isInDialog = useContext(IsDialogContext)
 
   return (
     <StyledStreamlitMarkdown
@@ -1381,7 +1378,7 @@ const StreamlitMarkdown: FC<Props> = ({
         hideAnchors={hideAnchors}
       />
     </StyledStreamlitMarkdown>
-  );
-};
+  )
+}
 
-export default memo(StreamlitMarkdown);
+export default memo(StreamlitMarkdown)

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -342,13 +342,11 @@ export const HeadingWithActionElements: FC<HeadingWithActionElementsProps> = ({
   const [elementId, setElementId] = useState(propsAnchor)
   const nodeRef = useRef<HTMLElement | null>(null)
 
-  const ref = useCallback(
-    (node: HTMLElement | null) => {
-      nodeRef.current = node
-      if (node === null) {
-        return
-      }
-
+  // Derive the anchor from the node and scroll to it if it matches the URL hash.
+  // Shared by the mount-time ref callback and the rerun effect below so the two
+  // paths cannot drift apart.
+  const applyAnchor = useCallback(
+    (node: HTMLElement) => {
       const anchor = propsAnchor || createAnchorFromText(node.textContent)
       setElementId(anchor)
       const windowHash = window.location.hash.slice(1)
@@ -359,21 +357,29 @@ export const HeadingWithActionElements: FC<HeadingWithActionElementsProps> = ({
     [propsAnchor]
   )
 
-  // Re-derive anchor when heading text changes across reruns. The ref callback
-  // only fires on mount or when propsAnchor changes; when only the text content
-  // changes, React reuses the DOM node and the callback never re-fires.
+  const ref = useCallback(
+    (node: HTMLElement | null) => {
+      nodeRef.current = node
+      if (node === null) {
+        return
+      }
+      applyAnchor(node)
+    },
+    [applyAnchor]
+  )
+
+  // Re-derive the anchor when heading text changes across reruns. The ref
+  // callback only fires on mount or when propsAnchor changes; when only the text
+  // content changes, React reuses the DOM node and the callback never re-fires.
+  // Skipped when propsAnchor is set, since an explicit anchor never depends on
+  // the text.
   useEffect(() => {
     const node = nodeRef.current
     if (!node || propsAnchor) {
       return
     }
-    const anchor = createAnchorFromText(node.textContent)
-    setElementId(anchor)
-    const windowHash = window.location.hash.slice(1)
-    if (windowHash && windowHash === anchor) {
-      scrollNodeIntoView(node)
-    }
-  }, [children, propsAnchor])
+    applyAnchor(node)
+  }, [children, propsAnchor, applyAnchor])
 
   const isInSidebarOrDialog = isInSidebar || isInDialog
   const actionElements = (


### PR DESCRIPTION
## Describe your changes

Heading anchors did not update when the heading text changed across a rerun.

**Root cause.** In `HeadingWithActionElements` (`frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx`), `elementId` was seeded via `useState(propsAnchor)` and only recomputed inside a `ref` callback whose `useCallback` deps were `[propsAnchor]`. On a rerun where only the heading *text* changes and `propsAnchor` is `undefined`, React reuses the same DOM node **and** the callback identity is unchanged, so the ref never re-fires. `elementId` therefore kept the anchor derived on first render.

**The fix.** Store the node in a `nodeRef` and add a `useEffect` keyed on `[children, propsAnchor]` that re-derives the anchor from the current `node.textContent` when the text changes. This closes the gap the mount-only ref callback left open.

### Behavior explicitly preserved

- **Explicit `propsAnchor`** — the effect returns early when `propsAnchor` is set, so a developer-supplied anchor is never overwritten.
- **Hash scroll-into-view** — the effect re-applies the existing `window.location.hash === anchor` → `scrollNodeIntoView(node)` side effect, so deep-linking still works when the anchor changes.
- **Sidebar / dialog suppression** — untouched (`isInSidebar` / `isInDialog` still gate anchor rendering).
- **`hideAnchor`** — untouched.
- **`aria-labelledby`** — untouched; existing tests for it still pass.

## GitHub Issue Link

Closes https://github.com/streamlit/streamlit/issues/8793

## Testing Plan

**Frontend unit test** — `StreamlitMarkdown.test.tsx`: "updates heading anchor when text changes across reruns (no explicit anchor)". Renders a heading, reruns with different text, and asserts the anchor id tracks the new text.

Regression-proving evidence, obtained by reverting **only** `StreamlitMarkdown.tsx` and keeping the test:

- **Without the fix** — the new test FAILS (times out at 5008ms waiting for the anchor to update), while all 7 pre-existing anchor/aria tests still pass.
- **With the fix** — the whole file passes (`Test Files 1 passed`), including the pre-existing sidebar/dialog/`aria-labelledby` cases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI fix in markdown heading components with regression tests; no auth, data, or API changes.
> 
> **Overview**
> Fixes **#8793**: auto-generated heading anchors (`id` and “link to heading” `href`) stayed on the first slug when rerun changed only the heading text, because anchor state was set once from a mount-only ref callback.
> 
> **`HeadingWithActionElements`** now keeps the heading DOM in a ref, centralizes slug/hash scroll logic in **`applyAnchor`**, and runs **`useLayoutEffect`** when **`children`** changes to re-slug from `textContent` (skipped when an explicit **`anchor`** prop is set). Layout effect keeps the updated id in sync before paint so hash links don’t flash the old target.
> 
> Adds unit tests for text-only reruns (id, link href, no stale id) and for stable explicit anchors when text changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b09efb43876877ca6f84405180f439b8ff6f0278. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->