### PR TITLE
[fix] Preserve inline datasets for charts built via alt.Chart.from_json (#6269)

### DIFF
--- a/lib/streamlit/elements/vega_charts.py
+++ b/lib/streamlit/elements/vega_charts.py
@@ -438,8 +438,21 @@ def _convert_altair_to_vega_lite_spec(
             with data_transformer:  # ty: ignore[invalid-context-manager]
                 chart_dict = altair_chart.to_dict()
 
-    # Put datasets back into the chart dict:
-    chart_dict["datasets"] = datasets
+    # Put datasets back into the chart dict.
+    #
+    # Charts built with alt.Chart.from_json already carry their data as inline
+    # datasets keyed by name, with the spec referencing them via
+    # {"data": {"name": ...}}. Our transformer never sees a dataframe for those,
+    # so `datasets` is empty -- replacing outright would discard the chart's own
+    # data and render an empty chart. Merge instead, letting the Arrow-serialized
+    # datasets win on key collisions. See
+    # https://github.com/streamlit/streamlit/issues/6269.
+    existing_datasets = chart_dict.get("datasets")
+    chart_dict["datasets"] = (
+        {**existing_datasets, **datasets}
+        if isinstance(existing_datasets, dict)
+        else datasets
+    )
     return chart_dict
 
 

--- a/lib/streamlit/elements/vega_charts.py
+++ b/lib/streamlit/elements/vega_charts.py
@@ -438,15 +438,14 @@ def _convert_altair_to_vega_lite_spec(
             with data_transformer:  # ty: ignore[invalid-context-manager]
                 chart_dict = altair_chart.to_dict()
 
-    # Put datasets back into the chart dict.
+    # Merge the Arrow-serialized datasets we collected with any datasets the chart
+    # already carries, letting ours win on key collisions.
     #
-    # Charts built with alt.Chart.from_json already carry their data as inline
-    # datasets keyed by name, with the spec referencing them via
-    # {"data": {"name": ...}}. Our transformer never sees a dataframe for those,
-    # so `datasets` is empty -- replacing outright would discard the chart's own
-    # data and render an empty chart. Merge instead, letting the Arrow-serialized
-    # datasets win on key collisions. See
-    # https://github.com/streamlit/streamlit/issues/6269.
+    # Replacing outright would discard data: charts built with alt.Chart.from_json
+    # carry their data as inline datasets keyed by name, with the spec referencing
+    # them via {"data": {"name": ...}}. Our transformer never sees a dataframe for
+    # those, so `datasets` is empty and the chart would render with axes but no
+    # data. See https://github.com/streamlit/streamlit/issues/6269.
     existing_datasets = chart_dict.get("datasets")
     chart_dict["datasets"] = (
         {**existing_datasets, **datasets}

--- a/lib/streamlit/elements/vega_charts.py
+++ b/lib/streamlit/elements/vega_charts.py
@@ -441,7 +441,7 @@ def _convert_altair_to_vega_lite_spec(
     # Merge the Arrow-serialized datasets we collected with any datasets the chart
     # already carries, letting the Arrow-serialized datasets win on key collisions.
     #
-    # Replacing outright would discard data: charts built with alt.Chart.from_json
+    # Replacing outright would discard data — charts built with alt.Chart.from_json
     # carry their data as inline datasets keyed by name, with the spec referencing
     # them via {"data": {"name": ...}}. Our transformer never sees a dataframe for
     # those, so `datasets` is empty and the chart would render with axes but no

--- a/lib/streamlit/elements/vega_charts.py
+++ b/lib/streamlit/elements/vega_charts.py
@@ -439,7 +439,7 @@ def _convert_altair_to_vega_lite_spec(
                 chart_dict = altair_chart.to_dict()
 
     # Merge the Arrow-serialized datasets we collected with any datasets the chart
-    # already carries, letting ours win on key collisions.
+    # already carries, letting the Arrow-serialized datasets win on key collisions.
     #
     # Replacing outright would discard data: charts built with alt.Chart.from_json
     # carry their data as inline datasets keyed by name, with the spec referencing

--- a/lib/tests/streamlit/elements/vega_charts_test.py
+++ b/lib/tests/streamlit/elements/vega_charts_test.py
@@ -493,7 +493,7 @@ class AltairChartTest(DeltaGeneratorTestCase):
         # Verify the selection state is returned
         assert hasattr(event, "selection")
 
-    def test_chart_from_json_data_survives_roundtrip(self):
+    def test_chart_from_json_data_survives_roundtrip(self) -> None:
         """A from_json chart's data must be delivered, and delivered correctly.
 
         Charts rebuilt with ``alt.Chart.from_json`` carry their data as inline
@@ -518,7 +518,7 @@ class AltairChartTest(DeltaGeneratorTestCase):
             f"spec references dataset {data_name!r} but only {sent_names} were sent"
         )
 
-        # ...and the delivered data must be the original data, not just non-empty.
+        # The delivered data must match the original frame, not merely be non-empty.
         sent = proto.datasets[sent_names.index(data_name)]
         pd.testing.assert_frame_equal(
             convert_arrow_bytes_to_pandas_df(sent.data.data),
@@ -526,7 +526,7 @@ class AltairChartTest(DeltaGeneratorTestCase):
             check_dtype=False,
         )
 
-    def test_layered_chart_from_json_keeps_its_inline_datasets(self):
+    def test_layered_chart_from_json_keeps_its_inline_datasets(self) -> None:
         """Layered from_json charts must keep every named dataset the layers reference.
 
         A layered chart shares one named dataset across its layers, so the same
@@ -564,7 +564,7 @@ class AltairChartTest(DeltaGeneratorTestCase):
                 check_dtype=False,
             )
 
-    def test_regular_chart_datasets_still_arrow_serialized(self):
+    def test_regular_chart_datasets_still_arrow_serialized(self) -> None:
         """The normal (non-from_json) path must be unchanged by the merge.
 
         A chart built directly from a dataframe should still have its data routed

--- a/lib/tests/streamlit/elements/vega_charts_test.py
+++ b/lib/tests/streamlit/elements/vega_charts_test.py
@@ -530,7 +530,7 @@ class AltairChartTest(DeltaGeneratorTestCase):
         """Layered from_json charts must keep every named dataset the layers reference.
 
         A layered chart shares one named dataset across its layers, so the same
-        clobbering bug left every layer without data. See #6269.
+        overwrite left every layer without data. See #6269.
         """
         df = pd.DataFrame({"x": [0, 1, 2], "y": [0, 1, 2]})
         base = alt.Chart(df)
@@ -557,8 +557,11 @@ class AltairChartTest(DeltaGeneratorTestCase):
         missing = referenced - set(sent_names)
         assert not missing, f"spec references {missing} but only {sent_names} were sent"
         for name in referenced:
-            assert proto.datasets[sent_names.index(name)].data.data, (
-                f"referenced dataset {name!r} was sent empty"
+            sent = proto.datasets[sent_names.index(name)]
+            pd.testing.assert_frame_equal(
+                convert_arrow_bytes_to_pandas_df(sent.data.data),
+                df,
+                check_dtype=False,
             )
 
     def test_regular_chart_datasets_still_arrow_serialized(self):

--- a/lib/tests/streamlit/elements/vega_charts_test.py
+++ b/lib/tests/streamlit/elements/vega_charts_test.py
@@ -582,6 +582,13 @@ class AltairChartTest(DeltaGeneratorTestCase):
         assert "name" in spec["data"]
         assert len(proto.datasets) == 1
         assert proto.datasets[0].name == spec["data"]["name"]
+        # Decode it to confirm the payload really is Arrow bytes for this df, so
+        # this cannot pass on a merge that left raw JSON values in place.
+        pd.testing.assert_frame_equal(
+            convert_arrow_bytes_to_pandas_df(proto.datasets[0].data.data),
+            df,
+            check_dtype=False,
+        )
 
 
 class AltairChartWidthTest(DeltaGeneratorTestCase):

--- a/lib/tests/streamlit/elements/vega_charts_test.py
+++ b/lib/tests/streamlit/elements/vega_charts_test.py
@@ -540,6 +540,41 @@ class AltairChartTest(DeltaGeneratorTestCase):
             check_dtype=False,
         )
 
+    def test_layered_chart_from_json_keeps_its_inline_datasets(self):
+        """#6269 explicitly covers layered charts too.
+
+        A layered chart shares one named dataset across its layers, so the same
+        clobbering bug left every layer without data.
+        """
+        df = pd.DataFrame({"x": [0, 1, 2], "y": [0, 1, 2]})
+        base = alt.Chart(df)
+        layered = alt.layer(
+            base.mark_line().encode(x="x", y="y"),
+            base.mark_point().encode(x="x", y="y"),
+        )
+
+        st.altair_chart(alt.Chart.from_json(layered.to_json()))
+
+        proto = self.get_delta_from_queue().new_element.vega_lite_chart
+        spec = json.loads(proto.spec)
+        sent_names = [dataset.name for dataset in proto.datasets]
+
+        # Collect every dataset name referenced anywhere in the spec (top level
+        # plus each layer), and require all of them to have been delivered.
+        referenced = set()
+        for view in [spec, *spec.get("layer", [])]:
+            data_spec = view.get("data")
+            if isinstance(data_spec, dict) and "name" in data_spec:
+                referenced.add(data_spec["name"])
+
+        assert referenced, "layered spec referenced no named data at all"
+        missing = referenced - set(sent_names)
+        assert not missing, f"spec references {missing} but only {sent_names} were sent"
+        for name in referenced:
+            assert proto.datasets[sent_names.index(name)].data.data, (
+                f"referenced dataset {name!r} was sent empty"
+            )
+
     def test_regular_chart_datasets_still_arrow_serialized(self):
         """The normal (non-from_json) path must be unchanged by the merge.
 

--- a/lib/tests/streamlit/elements/vega_charts_test.py
+++ b/lib/tests/streamlit/elements/vega_charts_test.py
@@ -493,6 +493,72 @@ class AltairChartTest(DeltaGeneratorTestCase):
         # Verify the selection state is returned
         assert hasattr(event, "selection")
 
+    def test_chart_from_json_keeps_its_inline_datasets(self):
+        """Regression test for #6269.
+
+        A chart rebuilt with ``alt.Chart.from_json`` carries its data as inline
+        datasets referenced by name from the spec. Streamlit used to overwrite the
+        chart's ``datasets`` with only the Arrow-serialized ones it collected
+        itself, which is empty in this case, so the spec referenced a dataset that
+        was never sent and the chart rendered with axes but no data.
+        """
+        df = pd.DataFrame({"x": [0, 1, 2], "y": [0, 1, 2]})
+        chart = alt.Chart(df).mark_line().encode(x=alt.X("x"), y=alt.Y("y"))
+
+        roundtripped = alt.Chart.from_json(chart.to_json())
+        st.altair_chart(roundtripped)
+
+        proto = self.get_delta_from_queue().new_element.vega_lite_chart
+        spec = json.loads(proto.spec)
+
+        # The spec references its data by name, so that name must actually
+        # resolve to a dataset that was sent on the proto.
+        data_name = spec["data"]["name"]
+        sent_names = [dataset.name for dataset in proto.datasets]
+        assert data_name in sent_names, (
+            f"spec references dataset {data_name!r} but only {sent_names} were sent"
+        )
+        assert proto.datasets[sent_names.index(data_name)].data.data, (
+            "referenced dataset was sent empty"
+        )
+
+    def test_chart_from_json_data_survives_roundtrip(self):
+        """The values in a from_json chart's dataset must be preserved, not just present."""
+        df = pd.DataFrame({"x": [0, 1, 2], "y": [3, 4, 5]})
+        chart = alt.Chart(df).mark_line().encode(x=alt.X("x"), y=alt.Y("y"))
+
+        st.altair_chart(alt.Chart.from_json(chart.to_json()))
+
+        proto = self.get_delta_from_queue().new_element.vega_lite_chart
+        spec = json.loads(proto.spec)
+        sent_names = [dataset.name for dataset in proto.datasets]
+        sent = proto.datasets[sent_names.index(spec["data"]["name"])]
+
+        pd.testing.assert_frame_equal(
+            convert_arrow_bytes_to_pandas_df(sent.data.data),
+            df,
+            check_dtype=False,
+        )
+
+    def test_regular_chart_datasets_still_arrow_serialized(self):
+        """The normal (non-from_json) path must be unchanged by the merge.
+
+        A chart built directly from a dataframe should still have its data routed
+        through the Arrow dataset transformer rather than inlined into the spec.
+        """
+        df = pd.DataFrame({"x": [0, 1, 2], "y": [0, 1, 2]})
+        chart = alt.Chart(df).mark_line().encode(x=alt.X("x"), y=alt.Y("y"))
+
+        st.altair_chart(chart)
+
+        proto = self.get_delta_from_queue().new_element.vega_lite_chart
+        spec = json.loads(proto.spec)
+        # Data is still passed by reference, and the referenced dataset is
+        # delivered as an Arrow dataset on the proto (not inlined in the spec).
+        assert "name" in spec["data"]
+        assert len(proto.datasets) == 1
+        assert proto.datasets[0].name == spec["data"]["name"]
+
 
 class AltairChartWidthTest(DeltaGeneratorTestCase):
     """Test altair_chart width parameter functionality."""

--- a/lib/tests/streamlit/elements/vega_charts_test.py
+++ b/lib/tests/streamlit/elements/vega_charts_test.py
@@ -493,37 +493,15 @@ class AltairChartTest(DeltaGeneratorTestCase):
         # Verify the selection state is returned
         assert hasattr(event, "selection")
 
-    def test_chart_from_json_keeps_its_inline_datasets(self):
-        """Regression test for #6269.
+    def test_chart_from_json_data_survives_roundtrip(self):
+        """A from_json chart's data must be delivered, and delivered correctly.
 
-        A chart rebuilt with ``alt.Chart.from_json`` carries its data as inline
+        Charts rebuilt with ``alt.Chart.from_json`` carry their data as inline
         datasets referenced by name from the spec. Streamlit used to overwrite the
         chart's ``datasets`` with only the Arrow-serialized ones it collected
         itself, which is empty in this case, so the spec referenced a dataset that
-        was never sent and the chart rendered with axes but no data.
+        was never sent and the chart rendered with axes but no data. See #6269.
         """
-        df = pd.DataFrame({"x": [0, 1, 2], "y": [0, 1, 2]})
-        chart = alt.Chart(df).mark_line().encode(x=alt.X("x"), y=alt.Y("y"))
-
-        roundtripped = alt.Chart.from_json(chart.to_json())
-        st.altair_chart(roundtripped)
-
-        proto = self.get_delta_from_queue().new_element.vega_lite_chart
-        spec = json.loads(proto.spec)
-
-        # The spec references its data by name, so that name must actually
-        # resolve to a dataset that was sent on the proto.
-        data_name = spec["data"]["name"]
-        sent_names = [dataset.name for dataset in proto.datasets]
-        assert data_name in sent_names, (
-            f"spec references dataset {data_name!r} but only {sent_names} were sent"
-        )
-        assert proto.datasets[sent_names.index(data_name)].data.data, (
-            "referenced dataset was sent empty"
-        )
-
-    def test_chart_from_json_data_survives_roundtrip(self):
-        """The values in a from_json chart's dataset must be preserved, not just present."""
         df = pd.DataFrame({"x": [0, 1, 2], "y": [3, 4, 5]})
         chart = alt.Chart(df).mark_line().encode(x=alt.X("x"), y=alt.Y("y"))
 
@@ -531,9 +509,17 @@ class AltairChartTest(DeltaGeneratorTestCase):
 
         proto = self.get_delta_from_queue().new_element.vega_lite_chart
         spec = json.loads(proto.spec)
-        sent_names = [dataset.name for dataset in proto.datasets]
-        sent = proto.datasets[sent_names.index(spec["data"]["name"])]
 
+        # The spec references its data by name, so that name must resolve to a
+        # dataset that was actually sent on the proto.
+        data_name = spec["data"]["name"]
+        sent_names = [dataset.name for dataset in proto.datasets]
+        assert data_name in sent_names, (
+            f"spec references dataset {data_name!r} but only {sent_names} were sent"
+        )
+
+        # ...and the delivered data must be the original data, not just non-empty.
+        sent = proto.datasets[sent_names.index(data_name)]
         pd.testing.assert_frame_equal(
             convert_arrow_bytes_to_pandas_df(sent.data.data),
             df,
@@ -541,10 +527,10 @@ class AltairChartTest(DeltaGeneratorTestCase):
         )
 
     def test_layered_chart_from_json_keeps_its_inline_datasets(self):
-        """#6269 explicitly covers layered charts too.
+        """Layered from_json charts must keep every named dataset the layers reference.
 
         A layered chart shares one named dataset across its layers, so the same
-        clobbering bug left every layer without data.
+        clobbering bug left every layer without data. See #6269.
         """
         df = pd.DataFrame({"x": [0, 1, 2], "y": [0, 1, 2]})
         base = alt.Chart(df)


### PR DESCRIPTION
## Describe your changes

A chart rebuilt with `alt.Chart.from_json(...)` rendered with axes and labels but **no data**.

**Root cause.** `_convert_altair_to_vega_lite_spec` in `lib/streamlit/elements/vega_charts.py` registers a data transformer that replaces a chart's dataframe with a name reference and collects the Arrow-serialized data into a local `datasets` dict. After calling `to_dict()`, it then did:

```python
chart_dict["datasets"] = datasets
```

For a chart built from a dataframe this is fine. But a chart produced by `alt.Chart.from_json` already carries its data as **inline datasets keyed by name**, with the spec referencing them via `{"data": {"name": ...}}`. Altair's `to_dict()` emits those datasets correctly, and the transformer never sees a dataframe — so the locally collected `datasets` is **empty**, and the assignment above **overwrote the chart's own data with nothing**. The spec was then sent referencing a dataset that was never delivered, so the frontend had nothing to plot.

Measured on `develop` with the issue's repro:

```
chart.to_dict()      -> data: {"name": "data-75d3..."},
                        datasets: {"data-75d3...": [{"x":0,"y":0}, ...]}   # correct
after our conversion -> data: {"name": "data-75d3..."},
                        datasets: {}                                       # data lost
```

**The fix.** Merge instead of replace, letting the Arrow-serialized datasets win on key collisions:

```python
existing_datasets = chart_dict.get("datasets")
chart_dict["datasets"] = (
    {**existing_datasets, **datasets}
    if isinstance(existing_datasets, dict)
    else datasets
)
```

Downstream, `_marshall_chart_data` already handles both cases — it serializes any dataset that is not already `bytes` via `convert_anything_to_arrow_bytes` — so the recovered inline data is delivered on the proto through the existing path with no further changes. This is why the fix is confined to one expression.

Scope note: this only *adds back* datasets that were previously discarded. The normal dataframe path is unchanged (its keys still take precedence), and no public API changes.

## GitHub Issue Link

Closes https://github.com/streamlit/streamlit/issues/6269

## Testing Plan

Three unit tests in `lib/tests/streamlit/elements/vega_charts_test.py`:

- `test_chart_from_json_data_survives_roundtrip` — asserts the dataset named by `spec["data"]["name"]` was actually delivered on the proto (with an explicit "references X but only [...] were sent" message), then decodes the Arrow bytes and asserts the frame equals the original, so the data is *correct*, not merely present.
- `test_layered_chart_from_json_keeps_its_inline_datasets` — the issue explicitly calls out layered charts. Collects every named dataset referenced anywhere in the spec (top level plus each layer) and requires all of them to have been delivered non-empty. A layered `from_json` chart hoists one shared dataset to the top level, and that reference now resolves.
- `test_regular_chart_datasets_still_arrow_serialized` — guard test: a chart built directly from a dataframe still passes data by reference with exactly one Arrow dataset on the proto, proving the merge does not change the normal path.

Regression-proving evidence, obtained by restoring `develop`'s `vega_charts.py` and keeping the new tests:

- **Without the fix** — both regression tests fail, showing the data was never sent:
  `AssertionError: spec references dataset 'data-75d324fe121c7174d94c3631536c4dae' but only [] were sent`

  ```
  FAILED test_chart_from_json_data_survives_roundtrip
  FAILED test_layered_chart_from_json_keeps_its_inline_datasets
  2 failed, 1 passed
  ```
- **With the fix** — full `vega_charts_test.py` **308 passed, 80 subtests passed**.
- Adjacent chart suites (`built_in_chart_utils_test.py`, `plotly_chart_test.py`) — **114 passed, 10 subtests passed**.
- `make python-format`, `make python-lint` (`All checks passed!`), and `make python-types` clean.

The guard test passes both before and after, as expected — it protects the unchanged path rather than proving the bug.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single merge expression in Altair→Vega conversion with targeted tests; normal dataframe chart path behavior is explicitly preserved.
> 
> **Overview**
> Fixes **empty Altair charts** when the chart is rebuilt with `alt.Chart.from_json(...)`: axes and labels appeared but no series were drawn.
> 
> **Cause:** After `to_dict()`, conversion **replaced** `chart_dict["datasets"]` with only the Arrow datasets collected by the `to_arrow_dataset` transformer. For `from_json` charts, data lives in **inline named datasets** in the spec and the transformer never sees a dataframe, so that dict was **empty** and wiped the chart’s data.
> 
> **Change:** **Merge** existing `datasets` from the spec with the collected Arrow map (`{**existing, **datasets}`), so inline data is kept while dataframe-backed charts still prefer Arrow on key overlap. `_marshall_chart_data` already serializes non-bytes inline values to Arrow on the proto.
> 
> Adds regression tests for simple and layered `from_json` roundtrips and a guard that the normal dataframe → Arrow path is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f64d933ea037b9eb4b86c55ea50fc63e679a291c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->