### PR TITLE
[spec] Scoped and runtime theme overrides

### DIFF
--- a/specs/2026-08-02-scoped-runtime-themes/product-spec.md
+++ b/specs/2026-08-02-scoped-runtime-themes/product-spec.md
@@ -21,7 +21,7 @@ Streamlit themes are primarily deployment-level configuration. Users can define 
 logic. Common workarounds inject CSS against generated DOM selectors, which is global, brittle,
 and difficult to compose.
 
-The requests fall into two related scopes:
+The requests fall into several related use-case clusters:
 
 - [#10749](https://github.com/streamlit/streamlit/issues/10749) requests a stylable container
   so a theme value can affect only selected elements. A follow-up also asks for page-specific
@@ -200,8 +200,10 @@ Behavior:
 
 - The override applies to the container surface and all descendants, including columns, tabs,
   expanders, charts, and custom components created inside it.
-- The container paints its configured `background_color` and establishes its configured
-  `text_color`. Existing padding behavior is unchanged; use `border=True` for an inset card.
+- The container paints a surface only when the scope sets `background_color`, and applies a new
+  `text_color` only when the scope sets it. A primary-only override adds no opaque background, so
+  it preserves today's stacking behavior. Existing padding behavior is unchanged; use `border=True`
+  for an inset card.
 - Siblings and ancestors remain unchanged.
 - Portaled descendants such as select menus, tooltips, and popover bodies keep the scoped theme.
 - Light/dark sections follow the effective parent mode unless `base` forces a mode.
@@ -233,10 +235,13 @@ mode = st.segmented_control(
     label_visibility="collapsed",
 )
 
-st.set_page_config(
-    theme={**brand_theme, "base": mode}
-)
+st.set_page_config(theme={**brand_theme, "base": mode})
 ```
+
+Unlike most page settings, `theme` may be set after other commands have run, so the override can
+depend on widget values from the same run. On the first run of a new session the control returns
+its `default`, so the initial theme matches that default; persist the choice (for example in
+`st.session_state` or a user profile) to restore a returning user's selection.
 
 If the app should continue following the user's Streamlit/system theme selection, omit `base`:
 
@@ -261,6 +266,11 @@ The runtime override is:
   result deterministic when app state changes and removes omitted old tokens.
 - `theme={}` clears the runtime override and restores the configured/user-selected app theme.
 - If multiple calls provide `theme` in one run, the last mapping wins.
+
+This is a deliberate difference from `st.container`, where `theme=None` and `theme={}` both mean
+"no scoped override." On `st.set_page_config`, `None` preserves the current runtime override while
+`{}` clears it, because the page-level command is additive across reruns and navigation. The scope
+matrix below summarizes when to reach for each command.
 
 For page-specific themes, each page sets its mapping. A page that wants the normal app theme uses
 `theme={}` because page configuration otherwise inherits across navigation:

--- a/specs/2026-08-02-scoped-runtime-themes/product-spec.md
+++ b/specs/2026-08-02-scoped-runtime-themes/product-spec.md
@@ -1,0 +1,347 @@
+---
+author: lukasmasuch
+created: 2026-08-02
+---
+
+# Scoped and Runtime Theme Overrides
+
+## Summary
+
+Add a typed theme-override mapping to `st.container` and `st.set_page_config`.
+`st.container(theme=...)` changes semantic design tokens only for that container and its
+descendants, while `st.set_page_config(theme=...)` applies the same tokens to the current
+browser session at runtime. This supports targeted styling, per-page themes, and user-specific
+themes without exposing Streamlit's DOM or CSS implementation. Optional `light` and `dark`
+sections let one mapping follow the user's active theme mode.
+
+## Problem
+
+Streamlit themes are primarily deployment-level configuration. Users can define themes in
+`config.toml`, but they cannot safely apply an accent to one region or choose a theme from app
+logic. Common workarounds inject CSS against generated DOM selectors, which is global, brittle,
+and difficult to compose.
+
+The requests fall into two related scopes:
+
+- [#10749](https://github.com/streamlit/streamlit/issues/10749) requests a stylable container
+  so a theme value can affect only selected elements. A follow-up also asks for page-specific
+  themes.
+- [#14172](https://github.com/streamlit/streamlit/issues/14172) requests runtime, per-session
+  themes for account preferences and light/dark toggles.
+- [#8271](https://github.com/streamlit/streamlit/issues/8271) and
+  [#6649](https://github.com/streamlit/streamlit/issues/6649) ask more broadly for element
+  customization or a `styles` argument on every widget.
+- [#3656](https://github.com/streamlit/streamlit/issues/3656) shows a concrete need to visually
+  distinguish buttons without global CSS selectors.
+- [#6291](https://github.com/streamlit/streamlit/issues/6291) asks for reusable chart theming,
+  while [#9034](https://github.com/streamlit/streamlit/issues/9034) asks for raw utility classes.
+  The former fits semantic theme tokens; the latter remains intentionally out of scope.
+
+Static custom light/dark variants are covered separately by
+[#6813](https://github.com/streamlit/streamlit/issues/6813). Runtime theme awareness has a known
+timing limitation tracked in [#11920](https://github.com/streamlit/streamlit/issues/11920).
+
+The broad styling requests include unrelated layout and CSS use cases. This proposal addresses
+the subset that maps cleanly to Streamlit's semantic theme tokens. It does not promise arbitrary
+CSS, positioning, or element internals.
+
+## Goals
+
+- Make one element group use a different accent, surface, border, or chart palette.
+- Let app logic update the effective theme for the current session without a server restart.
+- Support page-specific themes in multipage apps.
+- Let scoped and runtime themes define light/dark variants that react to the active app mode.
+- Preserve Streamlit's design system and keep apps independent of internal CSS selectors.
+- Use one mapping format for local and page-wide overrides.
+
+## Proposal
+
+### Theme mapping
+
+Introduce public `ThemeConfig` and `ThemeVariantConfig` `TypedDict`s. Python keys use
+`snake_case`, consistent with Streamlit's Python API. Each visual key corresponds to an existing
+theme token.
+
+```python
+class ThemeVariantConfig(TypedDict, total=False):
+    primary_color: str
+    background_color: str
+    secondary_background_color: str
+    text_color: str
+    link_color: str
+    link_underline: bool
+    code_text_color: str
+    code_background_color: str
+    border_color: str
+    dataframe_border_color: str
+    dataframe_header_background_color: str
+    show_widget_border: bool
+    base_radius: str
+    button_radius: str
+    chart_categorical_colors: Sequence[str]
+    chart_sequential_colors: Sequence[str]
+    chart_diverging_colors: Sequence[str]
+
+
+class ThemeConfig(ThemeVariantConfig, total=False):
+    base: Literal["inherit", "light", "dark"]
+    light: ThemeVariantConfig
+    dark: ThemeVariantConfig
+```
+
+This is a deliberately audited subset of `config.toml` theming. Additional semantic tokens can
+be added later without changing either command signature.
+
+`base` behaves as follows:
+
+- Omitted or `"inherit"`: inherit from the effective parent theme.
+- `"light"` or `"dark"`: start from the app's corresponding configured light/dark variant,
+  falling back to Streamlit's preset when no configured variant exists, and then apply the
+  remaining overrides.
+
+Flat visual keys are shared between both modes. Optional `light` and `dark` mappings override the
+shared values only when their mode is active. Variant mappings cannot contain `base`, `light`, or
+`dark` recursively.
+
+```python
+brand_theme = {
+    "primary_color": "#7C3AED",  # Shared by both modes.
+    "button_radius": "full",
+    "light": {
+        "background_color": "#FAFAFF",
+        "secondary_background_color": "#F3F0FF",
+        "text_color": "#1F1733",
+    },
+    "dark": {
+        "background_color": "#171221",
+        "secondary_background_color": "#241B33",
+        "text_color": "#F7F2FF",
+    },
+}
+```
+
+When `base` is inherited, switching Streamlit's theme menu or the operating-system theme switches
+the active variant immediately in the browser. It does not require a Python rerun. If only one
+variant is provided, the other mode uses the shared values over its inherited base.
+
+Invalid keys and values raise a `StreamlitAPIException` with the invalid key/value and accepted
+alternatives. The validation rules for colors, radii, and chart palettes match their existing
+`config.toml` equivalents.
+
+### Scoped themes with `st.container`
+
+Add one keyword-only parameter:
+
+```python
+def st.container(
+    *,
+    # Existing parameters...
+    theme: ThemeConfig | None = None,
+) -> DeltaGenerator:
+    ...
+```
+
+The simplest use case remains a regular container around the target element:
+
+```python
+import streamlit as st
+
+with st.container(theme={"primary_color": "green"}):
+    st.button("Approve", type="primary")
+
+st.button("Unchanged", type="primary")
+```
+
+The returned container continues to support method calls:
+
+```python
+danger = st.container(theme={"primary_color": "#DC2626"})
+danger.button("Delete account", type="primary")
+```
+
+A richer card can override several semantic tokens:
+
+```python
+card_theme = {
+    "background_color": "#F0FDF4",
+    "secondary_background_color": "#DCFCE7",
+    "text_color": "#14532D",
+    "primary_color": "#16A34A",
+    "border_color": "#86EFAC",
+    "base_radius": "large",
+}
+
+with st.container(border=True, theme=card_theme):
+    st.subheader("Healthy")
+    st.metric("Availability", "99.99%")
+    st.button("View details", type="primary")
+```
+
+Scoped themes compose. An inner mapping inherits unspecified tokens from the nearest themed
+container:
+
+```python
+with st.container(theme={"primary_color": "green", "button_radius": "full"}):
+    st.button("Green pill", type="primary")
+
+    with st.container(theme={"primary_color": "orange"}):
+        st.button("Orange pill", type="primary")  # Inherits button_radius.
+```
+
+A scope can follow the app's light/dark mode:
+
+```python
+with st.container(border=True, theme=brand_theme):
+    st.subheader("Mode-aware card")
+    st.button("Continue", type="primary")
+```
+
+Behavior:
+
+- The override applies to the container surface and all descendants, including columns, tabs,
+  expanders, charts, and custom components created inside it.
+- The container paints its configured `background_color` and establishes its configured
+  `text_color`. Existing padding behavior is unchanged; use `border=True` for an inset card.
+- Siblings and ancestors remain unchanged.
+- Portaled descendants such as select menus, tooltips, and popover bodies keep the scoped theme.
+- Light/dark sections follow the effective parent mode unless `base` forces a mode.
+- Changing the mapping on a rerun updates the theme without resetting widget identity or state.
+- `theme=None` preserves current behavior and adds no theme provider.
+
+### Runtime themes with `st.set_page_config`
+
+Add a keyword-only `theme` parameter to the existing page-level configuration command:
+
+```python
+def st.set_page_config(
+    # Existing parameters...
+    *,
+    theme: ThemeConfig | None = None,
+) -> None:
+    ...
+```
+
+This supports a user-controlled theme without restarting the server:
+
+```python
+import streamlit as st
+
+mode = st.segmented_control(
+    "Theme",
+    ["light", "dark"],
+    default="light",
+    label_visibility="collapsed",
+)
+
+st.set_page_config(
+    theme={**brand_theme, "base": mode}
+)
+```
+
+If the app should continue following the user's Streamlit/system theme selection, omit `base`:
+
+```python
+st.set_page_config(theme=brand_theme)
+```
+
+The runtime override is:
+
+- Local to the current browser session. It does not modify `config.toml` or other sessions.
+- Applied immediately when the frontend receives the command; it does not trigger an additional
+  script rerun.
+- Layered over the user's currently selected/configured theme unless `base` selects a mode.
+- Re-resolved from `light` or `dark` whenever the underlying browser theme mode changes.
+- Not persisted across a new browser session by Streamlit. Apps can persist a choice in
+  `st.session_state`, a user profile, a cookie-backed component, or their own storage.
+
+`st.set_page_config` remains additive at the parameter level:
+
+- `theme=None` does not change the previous runtime theme override.
+- A non-empty mapping replaces the previous runtime override mapping as a whole. This makes the
+  result deterministic when app state changes and removes omitted old tokens.
+- `theme={}` clears the runtime override and restores the configured/user-selected app theme.
+- If multiple calls provide `theme` in one run, the last mapping wins.
+
+For page-specific themes, each page sets its mapping. A page that wants the normal app theme uses
+`theme={}` because page configuration otherwise inherits across navigation:
+
+```python
+# pages/finance.py
+st.set_page_config(theme={"primary_color": "#0F766E"})
+
+# pages/admin.py
+st.set_page_config(theme={"primary_color": "#DC2626"})
+
+# pages/home.py
+st.set_page_config(theme={})
+```
+
+`st.context.theme.type` reflects the effective page theme on the next rerun sent by the browser.
+It cannot reflect a theme command earlier in the same Python run because the new value does not
+exist in the browser until that run's forward message is processed.
+
+### Scope matrix
+
+| Use case | API | Scope |
+|---|---|---|
+| One button or chart | Wrap it in `st.container(theme=...)` | That container subtree |
+| A card, tab set, or group of columns | `st.container(theme=...)` | All nested content |
+| One page | `st.set_page_config(theme=...)` in that page | Current session and page |
+| Per-account preference | Load preference, then call `st.set_page_config(theme=...)` | Current session |
+| Deployment branding | Existing `config.toml` theme | App defaults for all sessions |
+
+## Alternatives Considered
+
+**Option 1: `theme=` on `st.container` and `st.set_page_config`** ✅ PREFERRED
+
+- Extends commands users already associate with composition and page configuration.
+- Uses one reusable, typed mapping for local and page-wide cases.
+- Adds one parameter rather than adding styling parameters to every element.
+- Keeps the implementation based on semantic tokens instead of DOM/CSS details.
+
+**Option 2: `with st.theme(primary_color="green"):` and `st.set_theme(...)`**
+
+- Direct keyword arguments provide excellent autocomplete.
+- A dedicated invisible theme block could avoid layout semantics.
+- Introduces two new commands, and `st.theme(...)` is ambiguous between declaring a global theme
+  and opening a local scope. A large and growing keyword signature would also duplicate the theme
+  schema.
+
+**Option 3: `styles={...}` or `theme={...}` on every element**
+
+- Makes one-element overrides direct.
+- Adds a parameter to dozens of commands, duplicates work across elements, and makes grouping
+  verbose. Raw styles would expose unstable CSS implementation details and permit combinations
+  Streamlit cannot keep visually coherent.
+
+**Option 4: Continue supporting CSS classes via `key=`**
+
+- Requires no new API and can express arbitrary CSS.
+- Remains global, depends on DOM structure, is difficult to validate, and does not address
+  per-session/page-wide runtime themes.
+
+## Out of Scope (Future Work)
+
+- Arbitrary CSS properties, class utilities, selectors, positioning, and animation.
+- Layout customization already covered by width, height, alignment, gap, and container APIs.
+- Typography and font loading. `base_font_size` is currently rooted at the global `html` element,
+  and remote font sources are injected into the document head; both need a separate audit.
+- A separate `sidebar` section and recursive `light`/`dark` sections. The flat mapping and its
+  one-level light/dark variants apply consistently to the main app and derived sidebar theme.
+- Theme parameters on `st.columns`, `st.tabs`, `st.expander`, or every element. They can be
+  composed inside a themed container first.
+- Scoped styling for inherently global effects such as `st.toast`, `st.balloons`, and `st.snow`.
+- Named theme registries or automatic account persistence.
+- New semantic widget variants such as `type="danger"`; scoped primary colors address some of
+  the visual need but do not replace a dedicated semantic API.
+
+## Checklist
+
+| Item | ✅ or comment |
+|---|---|
+| Works on SiS, Cloud, etc? | ✅ Uses the existing session protocol and frontend theme system. |
+| No breaking API changes | ✅ Both parameters are optional and keyword-only. |
+| No new dependencies | ✅ |
+| Metrics collected | Record command/scope usage only; never collect theme values. |
+| Any security/legal impact? | No raw CSS or new remote resources; reuse existing value validation. |
+| Any docs changes needed? | Add `st.container` and `st.set_page_config` docs plus a theming guide section. |

--- a/specs/2026-08-02-scoped-runtime-themes/product-spec.md
+++ b/specs/2026-08-02-scoped-runtime-themes/product-spec.md
@@ -126,9 +126,10 @@ the active variant immediately in the browser. It does not require a Python reru
 variant is provided, the other mode uses the shared values over its inherited base.
 
 Invalid keys and values raise a `StreamlitAPIException` with the invalid key/value and accepted
-alternatives. Colors accept hex, `rgb()`/`rgba()`, and CSS named colors (such as `"green"`), so the
-examples below are valid. Radii and chart palettes follow the same rules as their `config.toml`
-equivalents.
+alternatives. Colors accept hex, `rgb()`/`rgba()`, and W3C/CSS named colors (such as `"green"`), so
+the examples below are valid. These are standard CSS color names, not Streamlit's semantic palette
+names (the `red`/`orange`/`green` tokens used by markdown, badges, and dataframes). Radii and chart
+palettes follow the same rules as their `config.toml` equivalents.
 
 ### Scoped themes with `st.container`
 
@@ -142,6 +143,10 @@ def st.container(
 ) -> DeltaGenerator:
     ...
 ```
+
+This `theme` parameter is unrelated to the chart-level `theme` argument on `st.plotly_chart`,
+`st.altair_chart`, and similar commands, which is a `Literal["streamlit"] | None` toggle for
+Streamlit's chart styling. Container and page `theme=` always take a `ThemeConfig` mapping.
 
 The simplest use case remains a regular container around the target element:
 
@@ -359,6 +364,8 @@ processed that run's forward message.
 - Named theme registries or automatic account persistence.
 - New semantic widget variants such as `type="danger"`; scoped primary colors address some of
   the visual need but do not replace a dedicated semantic API.
+- Optional development-mode contrast warnings for low-contrast token combinations. Apps remain
+  responsible for WCAG contrast; automated warnings can be revisited during implementation.
 
 ## Checklist
 

--- a/specs/2026-08-02-scoped-runtime-themes/product-spec.md
+++ b/specs/2026-08-02-scoped-runtime-themes/product-spec.md
@@ -126,8 +126,9 @@ the active variant immediately in the browser. It does not require a Python reru
 variant is provided, the other mode uses the shared values over its inherited base.
 
 Invalid keys and values raise a `StreamlitAPIException` with the invalid key/value and accepted
-alternatives. The validation rules for colors, radii, and chart palettes match their existing
-`config.toml` equivalents.
+alternatives. Colors accept hex, `rgb()`/`rgba()`, and CSS named colors (such as `"green"`), so the
+examples below are valid. Radii and chart palettes follow the same rules as their `config.toml`
+equivalents.
 
 ### Scoped themes with `st.container`
 
@@ -246,7 +247,10 @@ st.set_page_config(theme={**brand_theme, "base": mode})
 Unlike most page settings, `theme` may be set after other commands have run, so the override can
 depend on widget values from the same run. On the first run of a new session the control returns
 its `default`, so the initial theme matches that default; persist the choice (for example in
-`st.session_state` or a user profile) to restore a returning user's selection.
+`st.session_state` or a user profile) to restore a returning user's selection. Because the override
+applies only when the browser processes that run's `PageConfig` message, a theme set later in a run
+can briefly show the configured theme on first paint (most noticeable on reconnect or slow
+networks).
 
 If the app should continue following the user's Streamlit/system theme selection, omit `base`:
 
@@ -267,8 +271,9 @@ The runtime override is:
 `st.set_page_config` remains additive at the parameter level:
 
 - `theme=None` does not change the previous runtime theme override.
-- A non-empty mapping replaces the previous runtime override mapping as a whole. This makes the
-  result deterministic when app state changes and removes omitted old tokens.
+- A non-empty mapping replaces the previous runtime override entirely, so tokens present in the old
+  override but absent from the new one are dropped. This keeps the result deterministic when app
+  state changes.
 - `theme={}` clears the runtime override and restores the configured/user-selected app theme.
 - If multiple calls provide `theme` in one run, the last mapping wins.
 

--- a/specs/2026-08-02-scoped-runtime-themes/product-spec.md
+++ b/specs/2026-08-02-scoped-runtime-themes/product-spec.md
@@ -58,9 +58,10 @@ CSS, positioning, or element internals.
 
 ### Theme mapping
 
-Introduce public `ThemeConfig` and `ThemeVariantConfig` `TypedDict`s. Python keys use
-`snake_case`, consistent with Streamlit's Python API. Each visual key corresponds to an existing
-theme token.
+Introduce public `ThemeConfig` and `ThemeVariantConfig` `TypedDict`s, re-exported from the
+top-level `streamlit` namespace (for example, `from streamlit import ThemeConfig`) so IDEs can
+discover them when annotating theme mappings. Python keys use `snake_case`, consistent with
+Streamlit's Python API. Each visual key corresponds to an existing theme token.
 
 ```python
 class ThemeVariantConfig(TypedDict, total=False):
@@ -188,6 +189,10 @@ with st.container(theme={"primary_color": "green", "button_radius": "full"}):
         st.button("Orange pill", type="primary")  # Inherits button_radius.
 ```
 
+Inheritance from the nearest themed container applies only when the inner scope omits `base` (or
+uses `"inherit"`). Setting `base="light"` or `base="dark"` resets the starting point to the app's
+configured variant, so an outer scope's tokens (such as `primary_color`) no longer carry through.
+
 A scope can follow the app's light/dark mode:
 
 ```python
@@ -269,8 +274,13 @@ The runtime override is:
 
 This is a deliberate difference from `st.container`, where `theme=None` and `theme={}` both mean
 "no scoped override." On `st.set_page_config`, `None` preserves the current runtime override while
-`{}` clears it, because the page-level command is additive across reruns and navigation. The scope
-matrix below summarizes when to reach for each command.
+`{}` clears it, because the page-level command is additive across reruns and navigation:
+
+| `theme` value | `st.set_page_config` | `st.container` |
+|---|---|---|
+| `None` (default) | Keep the current runtime override | No scoped override |
+| `{}` (empty) | Clear the runtime override | No scoped override |
+| `{...}` (non-empty) | Replace the runtime override | Apply the scoped override |
 
 For page-specific themes, each page sets its mapping. A page that wants the normal app theme uses
 `theme={}` because page configuration otherwise inherits across navigation:
@@ -286,9 +296,9 @@ st.set_page_config(theme={"primary_color": "#DC2626"})
 st.set_page_config(theme={})
 ```
 
-`st.context.theme.type` reflects the effective page theme on the next rerun sent by the browser.
-It cannot reflect a theme command earlier in the same Python run because the new value does not
-exist in the browser until that run's forward message is processed.
+`st.context.theme.type` reflects the effective page theme on the next rerun the browser sends. It
+cannot reflect a theme command from the current Python run because the browser has not yet
+processed that run's forward message.
 
 ### Scope matrix
 
@@ -354,4 +364,4 @@ exist in the browser until that run's forward message is processed.
 | No new dependencies | ✅ |
 | Metrics collected | Record command/scope usage only; never collect theme values. |
 | Any security/legal impact? | No raw CSS or new remote resources; reuse existing value validation. |
-| Any docs changes needed? | Add `st.container` and `st.set_page_config` docs plus a theming guide section. |
+| Any docs changes needed? | Add `st.container` and `st.set_page_config` docs plus a theming guide section, including a note that apps are responsible for color contrast (for example `primary_color`/`background_color`/`text_color` pairs), since the feature does not enforce WCAG. |

--- a/specs/2026-08-02-scoped-runtime-themes/tech-spec.md
+++ b/specs/2026-08-02-scoped-runtime-themes/tech-spec.md
@@ -95,8 +95,9 @@ active `light` or `dark` section follows the effective mode of the layer above i
 
 An explicit `base` also changes where unspecified tokens come from: it starts from the app's
 configured light/dark variant (falling back to the preset) instead of the nearest scoped
-container, so an outer scope's tokens do not inherit through it. Implementations must not merge the
-explicit-`base` path against `parentEmotion`.
+container, so an outer scope's tokens do not inherit through it. When `base` is explicit, the
+implementation must not inherit unspecified tokens from `parentEmotion`; it starts from the
+resolved app variant instead.
 
 ### Protobuf
 
@@ -163,7 +164,9 @@ The serializer is used by both public commands and must:
 3. Populate shared fields in `ThemeOverride.values` and populate the optional one-level
    `values.light`/`values.dark` messages with the same field schema.
 4. Reject `base`, `light`, or `dark` inside a variant mapping to prevent recursive sections.
-5. Validate CSS colors with the same parser used by config theming.
+5. Validate colors against hex, `rgb()`/`rgba()`, and CSS named colors (matching the frontend
+   `isColor`), rejecting invalid values instead of copying the config path's warn-and-continue
+   behavior.
 6. Validate radius literals/units and chart-palette lengths before enqueueing.
 7. Reject excluded fields rather than silently ignoring them.
 
@@ -212,8 +215,8 @@ the matching configured light/dark theme from `availableThemes`, falling back to
 Before calling `createTheme`, determine the mode from the explicit `base` or the inherited base
 theme, merge flat `values` with `values.light` or `values.dark`, and strip all section fields. Use
 the existing `mergeWith`/`skipProtobufDefaults` behavior so unset protobuf scalar defaults do not
-erase shared values. Select the variant before applying color overrides; this prevents a custom
-background color from making its own branch selection oscillate.
+erase shared values. Select the variant before applying color overrides; this prevents a
+mode-dependent color from causing the variant selection itself to flip back and forth.
 
 In `BlockNodeRenderer`, wrap the `FlexBoxContainer` for a block with `deltaBlock.theme`:
 

--- a/specs/2026-08-02-scoped-runtime-themes/tech-spec.md
+++ b/specs/2026-08-02-scoped-runtime-themes/tech-spec.md
@@ -110,6 +110,17 @@ The wrapper is necessary because `CustomThemeConfig.base` is a non-optional prot
 unset value is indistinguishable from `LIGHT`. Do not change the existing field's presence or move
 `CustomThemeConfig` to another proto file because `NewSession` is consumed by external services.
 
+The wrapper is only needed for `base`. The scalar visual tokens already carry proto3 field
+presence: `CustomThemeConfig` declares `show_widget_border` and `link_underline` (and the other
+override tokens) as `optional`, so an explicit `false`/empty value is distinguishable from an
+omitted field. `skipProtobufDefaults` therefore only guards against genuinely unset scalars and
+never erases a deliberate `false`.
+
+Importing `NewSession.proto` couples `Block`/`PageConfig` to the session-bootstrap schema. An
+alternative is a shared `Theme.proto` imported by all three messages, but relocating
+`CustomThemeConfig` would move its wire location and break external `NewSession` consumers, so this
+proposal keeps the message in place and revisits extraction only if the coupling becomes a problem.
+
 Import `NewSession.proto` from `Block.proto` and `PageConfig.proto`, then add:
 
 ```protobuf
@@ -212,9 +223,12 @@ containerElement = node.deltaBlock.theme ? (
 ```
 
 The provider must wrap the `FlexBoxContainer`, not just `ChildRenderer`, so the container's border,
-radii, gap-related styles, and surface use the effective scope. When a theme is present, set
-`backgroundColor: theme.colors.bgColor` and `color: theme.colors.bodyText` on
-`StyledFlexContainerBlock`. Do not add padding or a border beyond the existing `border` behavior.
+radii, gap-related styles, and surface use the effective scope. Gate surface painting on the tokens
+the scope actually sets: apply `backgroundColor: theme.colors.bgColor` only when the override
+includes `background_color`, and `color: theme.colors.bodyText` only when it includes `text_color`.
+A primary-only scope therefore adds no opaque `StyledFlexContainerBlock` background and preserves
+today's stacking behavior, matching the product spec. Do not add padding or a border beyond the
+existing `border` behavior.
 
 This design also handles elements inserted later through `container.button(...)`: their render-tree
 nodes remain descendants of the same block.
@@ -309,6 +323,8 @@ same render cost as a user changing the theme in Streamlit's menu today.
 ### Frontend unit tests
 
 - A themed block updates its own surface and descendants but not siblings/ancestors.
+- A scope that sets `background_color`/`text_color` paints the container surface, while a
+  primary-only scope leaves `StyledFlexContainerBlock` without an opaque background.
 - Nested partial scopes inherit unspecified tokens and override specified tokens.
 - A scope with light/dark sections switches variants when its inherited mode changes; an explicit
   base stays fixed.

--- a/specs/2026-08-02-scoped-runtime-themes/tech-spec.md
+++ b/specs/2026-08-02-scoped-runtime-themes/tech-spec.md
@@ -1,0 +1,360 @@
+---
+author: lukasmasuch
+created: 2026-08-02
+---
+
+# Scoped and Runtime Theme Overrides
+
+## Summary
+
+Implement theme overrides as a partial layer over an existing `ThemeConfig`. A block-level layer
+wraps only an `st.container` React subtree, while a session-level layer sits between the selected
+app theme and `RootStyleProvider`. Both use the existing `CustomThemeConfig`, theme derivation,
+Emotion, and BaseWeb infrastructure.
+
+The architecture is feasible without CSS selector rewriting. The frontend already scopes the
+sidebar through a nested `ThemeProvider`, charts and custom components read the Emotion theme from
+context, React context crosses portals, and the static theme code already merges shared plus
+light/dark sections.
+
+## Problem
+
+The current app theme arrives in `NewSession.custom_theme` and is converted into a full frontend
+`ThemeConfig`. `RootStyleProvider` provides one Emotion/BaseWeb theme to the app. The sidebar is a
+special case with its own nested provider, but ordinary render-tree blocks carry no theme data.
+
+This creates two limitations:
+
+- A backend block cannot describe a partial theme for its descendants.
+- `st.set_page_config` can send runtime page metadata, but no per-session theme layer exists; the
+  static `NewSession` theme and the user's browser selection are the only app-wide inputs.
+
+Relevant requests are [#10749](https://github.com/streamlit/streamlit/issues/10749),
+[#14172](https://github.com/streamlit/streamlit/issues/14172),
+[#8271](https://github.com/streamlit/streamlit/issues/8271), and
+[#6649](https://github.com/streamlit/streamlit/issues/6649).
+
+## Feasibility Findings
+
+### Existing primitives
+
+- `frontend/lib/src/components/core/ThemeProvider.tsx` already nests both Emotion and BaseWeb
+  theme providers.
+- `ThemedSidebar.tsx` proves that a full derived theme can be confined to a React subtree.
+- `createTheme`/`createEmotionTheme` already complete a partial `CustomThemeConfig` from a base
+  theme and recompute derived colors, radii, chart palettes, and the BaseWeb theme.
+- `handleSectionInheritance` already merges shared, light, and dark inputs while skipping protobuf
+  defaults; scoped/runtime resolution can reuse the same merge rules against a dynamic base.
+- Plotly, Vega-Lite, PyDeck, DataFrame, Components v1, and Components v2 consume the local Emotion
+  theme. They therefore update when rendered below a scoped provider.
+- Popovers, menus, and other React portals retain their creating React context even though their
+  DOM nodes mount under a body-level portal host.
+
+### Feasibility spike
+
+A temporary Vitest test used the repository's actual `createTheme`, `ThemeProvider`, Emotion, and
+portal dependencies. It verified that:
+
+1. Overriding only `primaryColor` preserved the inherited background color.
+2. A sibling outside the provider kept the original primary color.
+3. A child and a portaled child inside the provider both received the override.
+
+The focused test passed (`1 test, 1 passed`). The temporary file was removed after validation.
+
+### Known boundaries
+
+- `baseFontSize` is applied by root `Global` styles to `html`, so it cannot be honestly scoped by
+  a nested provider.
+- Font source declarations live in the document head and need global lifecycle management.
+- `st.toast` copies content into a global queue whose renderer is outside the originating block;
+  its scope cannot be preserved without changing the queue payload/rendering architecture.
+- A scoped `backgroundColor` does not paint a surface automatically today. The themed container
+  must explicitly use its effective `bgColor` and `bodyText` on its inner flex block.
+
+These are why the MVP uses an audited theme-token subset and excludes global effects/fonts.
+
+## Proposal
+
+### Theme layers
+
+Theme resolution follows a fixed order:
+
+```text
+Configured/user-selected app theme
+        ↓
+Session runtime override from st.set_page_config(theme=...)
+        ↓
+Nearest ancestor st.container(theme=...)
+        ↓
+Nested st.container(theme=...) overrides
+```
+
+Each layer is partial. Unspecified values come from the layer directly above it. A layer with an
+explicit light/dark `base` first selects that app mode and then applies its values. Otherwise, its
+active `light` or `dark` section follows the effective mode of the layer above it.
+
+### Protobuf
+
+Define a reusable wrapper next to `CustomThemeConfig` in `NewSession.proto`:
+
+```protobuf
+message ThemeOverride {
+  // Presence distinguishes inherited mode from an explicit LIGHT value.
+  optional CustomThemeConfig.BaseTheme base = 1;
+  // Flat values are shared; values.light/dark are optional mode overrides.
+  CustomThemeConfig values = 2;
+}
+```
+
+The wrapper is necessary because `CustomThemeConfig.base` is a non-optional proto3 enum whose
+unset value is indistinguishable from `LIGHT`. Do not change the existing field's presence or move
+`CustomThemeConfig` to another proto file because `NewSession` is consumed by external services.
+
+Import `NewSession.proto` from `Block.proto` and `PageConfig.proto`, then add:
+
+```protobuf
+message Block {
+  // Existing fields...
+  ThemeOverride theme = 18;
+  // Next ID: 19
+}
+
+message PageConfig {
+  // Existing fields...
+  ThemeOverride theme = 7;
+}
+```
+
+Message-field presence has two uses:
+
+- An absent `PageConfig.theme` means `theme=None`: keep the previous runtime layer.
+- A present but empty `PageConfig.theme` means `theme={}`: clear the runtime layer.
+
+For `Block.theme`, omit the message for `None` and empty mappings because both mean ordinary
+inheritance for a newly declared container.
+
+Regenerate Python and TypeScript protobufs with `make protobuf`.
+
+### Backend schema and serialization
+
+Add a shared `ThemeConfig` `TypedDict` and serializer under
+`lib/streamlit/elements/lib/theme_utils.py` (exact module name can follow nearby conventions).
+The serializer is used by both public commands and must:
+
+1. Require a mapping and reject unknown/camelCase keys with an actionable snake_case suggestion.
+2. Map `base="inherit"` to no wrapper `base`, and map light/dark to the optional enum.
+3. Populate shared fields in `ThemeOverride.values` and populate the optional one-level
+   `values.light`/`values.dark` messages with the same field schema.
+4. Reject `base`, `light`, or `dark` inside a variant mapping to prevent recursive sections.
+5. Validate CSS colors with the same parser used by config theming.
+6. Validate radius literals/units and chart-palette lengths before enqueueing.
+7. Reject excluded fields rather than silently ignoring them.
+
+Unlike startup configuration, public API validation should fail fast with
+`StreamlitAPIException`; logging a warning and falling back would make conditional runtime styling
+hard to debug.
+
+`st.container` copies a non-empty serialized override to `block_proto.theme`. The theme must not
+participate in `Block.id` or descendant widget IDs: changing appearance must not reset widgets.
+
+`st.set_page_config` sets `msg.page_config_changed.theme` whenever `theme` is not `None`. For an
+empty mapping, call `SetInParent()` without values so the frontend receives a present empty
+message. Multiple messages naturally produce last-write-wins behavior.
+
+### Scoped frontend provider
+
+Add a `ScopedThemeProvider` in `frontend/lib`:
+
+```tsx
+function ScopedThemeProvider({ override, children }): ReactElement {
+  const parentEmotion = useEmotionTheme()
+  const { availableThemes } = useContext(ThemeContext)
+
+  const scopedTheme = useMemo(
+    () => createThemeFromOverride(override, parentEmotion, availableThemes),
+    [override, parentEmotion, availableThemes]
+  )
+
+  return (
+    <ThemeProvider
+      theme={scopedTheme.emotion}
+      baseuiTheme={scopedTheme.basewebTheme}
+    >
+      {children}
+    </ThemeProvider>
+  )
+}
+```
+
+`createThemeFromOverride` should reuse `createTheme`, not mutate the parent theme. When `base` is
+absent, construct the base from the nearest Emotion theme rather than `ThemeContext.activeTheme`.
+This is required for nested scoped containers and containers inside the already-themed sidebar.
+Preserve `parentEmotion.inSidebar` when deriving the new theme. When `base` is explicit, resolve
+the matching configured light/dark theme from `availableThemes`, falling back to the preset.
+
+Before calling `createTheme`, determine the mode from the explicit `base` or the inherited base
+theme, merge flat `values` with `values.light` or `values.dark`, and strip all section fields. Use
+the existing `mergeWith`/`skipProtobufDefaults` behavior so unset protobuf scalar defaults do not
+erase shared values. Select the variant before applying color overrides; this prevents a custom
+background color from making its own branch selection oscillate.
+
+In `BlockNodeRenderer`, wrap the `FlexBoxContainer` for a block with `deltaBlock.theme`:
+
+```tsx
+const flexContainer = <FlexBoxContainer {...childProps} />
+containerElement = node.deltaBlock.theme ? (
+  <ScopedThemeProvider override={node.deltaBlock.theme}>
+    {flexContainer}
+  </ScopedThemeProvider>
+) : (
+  flexContainer
+)
+```
+
+The provider must wrap the `FlexBoxContainer`, not just `ChildRenderer`, so the container's border,
+radii, gap-related styles, and surface use the effective scope. When a theme is present, set
+`backgroundColor: theme.colors.bgColor` and `color: theme.colors.bodyText` on
+`StyledFlexContainerBlock`. Do not add padding or a border beyond the existing `border` behavior.
+
+This design also handles elements inserted later through `container.button(...)`: their render-tree
+nodes remain descendants of the same block.
+
+### Runtime frontend layer
+
+Do not pass runtime updates through `App.processThemeInput`. That method manages static available
+themes from `NewSession`; reusing it would replace available themes and could briefly reapply the
+static theme on every rerun.
+
+Instead, extend `useThemeManager` to track two independent values:
+
+- `selectedTheme`: the host/user/config-derived theme whose selection may be persisted.
+- `runtimeOverride`: the optional `ThemeOverride` received from `PageConfigChanged`.
+
+Compute the exported `activeTheme` as:
+
+```tsx
+const activeTheme = useMemo(
+  () =>
+    runtimeOverride
+      ? createThemeFromOverride(
+          runtimeOverride,
+          selectedTheme.emotion,
+          availableThemes
+        )
+      : selectedTheme,
+  [runtimeOverride, selectedTheme, availableThemes]
+)
+```
+
+Theme-menu selections update `selectedTheme`; the runtime layer remains applied until cleared.
+Only `selectedTheme` is cached as the user's browser preference. Changing static themes in a new
+session updates the base/available themes without clearing the runtime layer, preventing a
+static→runtime flash during reruns.
+
+Because `activeTheme` depends on `selectedTheme`, a runtime mapping with light/dark sections is
+re-resolved immediately when a user changes the Streamlit theme menu or an auto theme responds to
+the operating-system preference. The mapping follows that mode unless its wrapper `base` is
+explicit.
+
+Extend the page-config handler:
+
+- Absent theme field: no update.
+- Present empty field: set `runtimeOverride` to `undefined`.
+- Present non-empty field: replace `runtimeOverride`.
+
+`RootStyleProvider`, `ThemeContext.activeTheme`, host `SET_THEME_CONFIG` messages, exported custom
+component themes, and `App.getThemeColorScheme()` must all consume the effective `activeTheme`.
+This makes app-wide colors update immediately and makes `st.context.theme.type` correct on the
+next client-originated rerun. Do not trigger a rerun automatically.
+
+### Updates, reruns, and cleanup
+
+- Scoped providers are pure render-tree data and require no frontend state store or cleanup.
+- A full or fragment rerun can replace a block's override at the same delta path.
+- Changing a theme does not change container or widget identity.
+- The session runtime layer lives for the websocket/app session and is discarded on disconnect.
+- Navigation inherits the previous page-config layer until another page replaces or clears it,
+  matching other additive `st.set_page_config` fields.
+
+### Performance
+
+Only blocks with a theme mapping create a nested provider. Memoize the full theme by the decoded
+override, inherited Emotion theme, and available-theme identities. Theme creation is pure and does
+not traverse descendants; Emotion updates only consumers in that subtree.
+
+The runtime layer creates one full theme per change. It replaces the root theme once and has the
+same render cost as a user changing the theme in Streamlit's menu today.
+
+### Compatibility and security
+
+- Older frontends ignore unknown protobuf fields; older backends never send them.
+- No CSS text or selectors cross the protocol. Values pass existing theme validation and Emotion's
+  structured style generation.
+- Font URLs remain unsupported in the API, so this proposal adds no resource-loading or CSP path.
+- SiS, Community Cloud, embedded apps, and local apps use the same ForwardMsg/render-tree path.
+- Host theme messages must contain the effective runtime theme so an embedding host is not left
+  with stale colors.
+
+## Testing Plan
+
+### Python unit tests
+
+- Serialize every supported `ThemeConfig` key for `st.container` and `st.set_page_config`.
+- Verify `None`, empty, and non-empty presence semantics.
+- Verify base enum presence for inherit/light/dark.
+- Serialize shared plus optional light/dark sections and reject recursive sections.
+- Reject unknown/camelCase keys, invalid colors/radii, and invalid chart palettes.
+- Verify changing the theme does not change a keyed container ID.
+
+### Frontend unit tests
+
+- A themed block updates its own surface and descendants but not siblings/ancestors.
+- Nested partial scopes inherit unspecified tokens and override specified tokens.
+- A scope with light/dark sections switches variants when its inherited mode changes; an explicit
+  base stays fixed.
+- A scope inside the sidebar inherits the sidebar theme and preserves `inSidebar`.
+- Portaled content receives the scoped Emotion and BaseWeb theme.
+- Plotly/Vega/DataFrame and Components v1/v2 receive the local theme.
+- Runtime override replacement, empty reset, user selection changes, and static theme refreshes
+  produce the expected effective theme and light/dark variant without flashing.
+- Host messages and `getThemeColorScheme` use the effective theme.
+
+### E2E tests
+
+- Toggle a page-wide light/dark runtime mapping and assert app, sidebar, chart, and widget colors.
+- Change the Streamlit/system theme with `base` inherited and verify both page-wide and scoped
+  mappings switch variants without a script rerun.
+- Render green/red scoped primary buttons beside an unchanged button.
+- Verify a themed popover body/select menu and a chart palette.
+- Navigate among two themed pages and one page that clears the override.
+- Interact with a widget before and after a scoped theme change and verify its state is retained.
+
+Run focused unit tests during development, the new E2E file with `make run-e2e-test <file>`, and
+`make check` before finalizing.
+
+## Alternatives Considered
+
+### Dedicated `st.theme` block
+
+A new transparent block could wrap children in `ScopedThemeProvider` without adding a DOM node.
+It is technically feasible, but it adds a public container-like primitive and makes `st.theme(...)`
+ambiguous between local and app-wide behavior. `st.container(theme=...)` uses existing composition
+and gives `background_color` a concrete surface.
+
+### Per-element `styles`/`theme` fields
+
+This would require widespread public signatures and/or element protobuf fields. A CSS mapping
+would couple apps to DOM details; a theme mapping on every element would duplicate a capability
+already achieved by wrapping the element in one container.
+
+### CSS variables on a keyed wrapper
+
+Emitting local CSS custom properties is lightweight, but Streamlit components currently consume
+typed Emotion/BaseWeb themes and derived tokens. Reimplementing derivation as CSS variables would
+miss charts, canvas renderers, custom-component payloads, and BaseWeb components.
+
+### Reprocess runtime input as a new static custom theme
+
+Calling `processThemeInput` for every page-config update reuses more code but conflates a temporary
+session overlay with available/cached themes. It risks selection resets and static-theme flashes
+between NewSession and PageConfig messages. Keeping a separate runtime layer is more predictable.

--- a/specs/2026-08-02-scoped-runtime-themes/tech-spec.md
+++ b/specs/2026-08-02-scoped-runtime-themes/tech-spec.md
@@ -93,6 +93,11 @@ Each layer is partial. Unspecified values come from the layer directly above it.
 explicit light/dark `base` first selects that app mode and then applies its values. Otherwise, its
 active `light` or `dark` section follows the effective mode of the layer above it.
 
+An explicit `base` also changes where unspecified tokens come from: it starts from the app's
+configured light/dark variant (falling back to the preset) instead of the nearest scoped
+container, so an outer scope's tokens do not inherit through it. Implementations must not merge the
+explicit-`base` path against `parentEmotion`.
+
 ### Protobuf
 
 Define a reusable wrapper next to `CustomThemeConfig` in `NewSession.proto`:
@@ -116,8 +121,9 @@ override tokens) as `optional`, so an explicit `false`/empty value is distinguis
 omitted field. `skipProtobufDefaults` therefore only guards against genuinely unset scalars and
 never erases a deliberate `false`.
 
-Importing `NewSession.proto` couples `Block`/`PageConfig` to the session-bootstrap schema. An
-alternative is a shared `Theme.proto` imported by all three messages, but relocating
+Importing `NewSession.proto` into `Block.proto` and `PageConfig.proto` creates a dependency on the
+session-initialization message definitions. An alternative is a shared `Theme.proto` imported by
+all three messages, but relocating
 `CustomThemeConfig` would move its wire location and break external `NewSession` consumers, so this
 proposal keeps the message in place and revisits extraction only if the coupling becomes a problem.
 
@@ -285,6 +291,8 @@ next client-originated rerun. Do not trigger a rerun automatically.
 
 - Scoped providers are pure render-tree data and require no frontend state store or cleanup.
 - A full or fragment rerun can replace a block's override at the same delta path.
+- A fragment rerun replaces only the fragment's delta subtree; an enclosing themed container's
+  provider stays mounted and keeps scoping its descendants.
 - Changing a theme does not change container or widget identity.
 - The session runtime layer lives for the websocket/app session and is discarded on disconnect.
 - Navigation inherits the previous page-config layer until another page replaces or clears it,

--- a/specs/2026-08-02-scoped-runtime-themes/tech-spec.md
+++ b/specs/2026-08-02-scoped-runtime-themes/tech-spec.md
@@ -94,10 +94,9 @@ explicit light/dark `base` first selects that app mode and then applies its valu
 active `light` or `dark` section follows the effective mode of the layer above it.
 
 An explicit `base` also changes where unspecified tokens come from: it starts from the app's
-configured light/dark variant (falling back to the preset) instead of the nearest scoped
-container, so an outer scope's tokens do not inherit through it. When `base` is explicit, the
-implementation must not inherit unspecified tokens from `parentEmotion`; it starts from the
-resolved app variant instead.
+configured light/dark variant (falling back to the preset), not the nearest scoped container, so an
+outer scope's tokens do not inherit through it. The implementation must therefore not inherit
+unspecified tokens from `parentEmotion` in the explicit-`base` path.
 
 ### Protobuf
 
@@ -123,10 +122,10 @@ omitted field. `skipProtobufDefaults` therefore only guards against genuinely un
 never erases a deliberate `false`.
 
 Importing `NewSession.proto` into `Block.proto` and `PageConfig.proto` creates a dependency on the
-session-initialization message definitions. An alternative is a shared `Theme.proto` imported by
-all three messages, but relocating
-`CustomThemeConfig` would move its wire location and break external `NewSession` consumers, so this
-proposal keeps the message in place and revisits extraction only if the coupling becomes a problem.
+session-initialization message definitions. A shared `Theme.proto` imported by all three messages
+is an alternative, but relocating `CustomThemeConfig` would change its wire location and break
+external `NewSession` consumers. Keep it in place for this iteration and revisit extraction if the
+coupling becomes costly.
 
 Import `NewSession.proto` from `Block.proto` and `PageConfig.proto`, then add:
 
@@ -164,9 +163,11 @@ The serializer is used by both public commands and must:
 3. Populate shared fields in `ThemeOverride.values` and populate the optional one-level
    `values.light`/`values.dark` messages with the same field schema.
 4. Reject `base`, `light`, or `dark` inside a variant mapping to prevent recursive sections.
-5. Validate colors against hex, `rgb()`/`rgba()`, and CSS named colors (matching the frontend
-   `isColor`), rejecting invalid values instead of copying the config path's warn-and-continue
-   behavior.
+5. Validate colors against an explicit allowlist — hex, `rgb()`/`rgba()`, and CSS named colors —
+   and reject anything else instead of copying the config path's warn-and-continue behavior. Do
+   not reuse the frontend `isColor` helper: it runs in the browser and also accepts `hsl()`,
+   `currentColor`, and `transparent`, which this API excludes. Mirror the same allowlist in the
+   frontend check.
 6. Validate radius literals/units and chart-palette lengths before enqueueing.
 7. Reject excluded fields rather than silently ignoring them.
 


### PR DESCRIPTION
## Describe your changes

Product and tech specs for scoped and runtime theme overrides.

- Adds a typed `theme` mapping to `st.container` (scoped to a container subtree) and `st.set_page_config` (per-session runtime override), reusing existing semantic theme tokens rather than exposing raw CSS/DOM.
- **Product spec** — `ThemeConfig`/`ThemeVariantConfig` schema, `base` + `light`/`dark` variant behavior, presence semantics (`None` / `{}` / non-empty), scope matrix, and alternatives considered.
- **Tech spec** — `ThemeOverride` protobuf wrapper on `Block`/`PageConfig`, backend serialization/validation, `ScopedThemeProvider`, runtime theme layering in `useThemeManager`, and the testing plan.

## GitHub Issue Link (if applicable)

Related feature requests: #10749, #14172, #8271, #6649, #3656, #6291

## Testing Plan

- Spec/design documents only — no code changes, so no unit, E2E, or manual tests are required.

Made with [Cursor](https://cursor.com)