### PR TITLE
[chore] Remove fireEvent from frontend unit tests

### DIFF
--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -471,6 +471,10 @@ async function openCacheModal(): Promise<void> {
   })
 }
 
+/**
+ * Advances fake timers when active so userEvent delays don't hang under
+ * vi.useFakeTimers(). Passed as userEvent.setup({ advanceTimers }).
+ */
 function advanceUserEventTimers(delay: number): void {
   if (vi.isFakeTimers()) {
     vi.advanceTimersByTime(delay)

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -16,13 +16,7 @@
 
 import { act } from "react"
 
-import {
-  fireEvent,
-  render,
-  RenderResult,
-  screen,
-  waitFor,
-} from "@testing-library/react"
+import { render, RenderResult, screen, waitFor } from "@testing-library/react"
 import userEvent, {
   PointerEventsCheckLevel,
 } from "@testing-library/user-event"
@@ -463,17 +457,8 @@ function sendForwardMessage(
 }
 
 async function openCacheModal(): Promise<void> {
-  // eslint-disable-next-line testing-library/prefer-user-event -- keyboard shortcuts listen on document.body; userEvent dispatches to the focused element which may differ
-  fireEvent.keyDown(document.body, {
-    key: "c",
-    which: 67,
-  })
-
-  // eslint-disable-next-line testing-library/prefer-user-event -- keyboard shortcuts listen on document.body; userEvent dispatches to the focused element which may differ
-  fireEvent.keyUp(document.body, {
-    key: "c",
-    which: 67,
-  })
+  const user = userEvent.setup({ advanceTimers: advanceUserEventTimers })
+  await user.keyboard("c")
 
   expect(
     screen.getByText(
@@ -484,6 +469,12 @@ async function openCacheModal(): Promise<void> {
   await act(async () => {
     await vi.advanceTimersByTimeAsync(0)
   })
+}
+
+function advanceUserEventTimers(delay: number): void {
+  if (vi.isFakeTimers()) {
+    vi.advanceTimersByTime(delay)
+  }
 }
 
 describe("App", () => {
@@ -725,7 +716,8 @@ describe("App", () => {
     expect(metricsManager.enqueue).toHaveBeenCalledWith("updateReport")
   })
 
-  it("reruns when the user presses 'r'", () => {
+  it("reruns when the user presses 'r'", async () => {
+    const user = userEvent.setup({ advanceTimers: advanceUserEventTimers })
     renderApp(getProps())
 
     getMockConnectionManager(true)
@@ -734,11 +726,7 @@ describe("App", () => {
       getStoredValue<WidgetStateManager>(WidgetStateManager)
     expect(widgetStateManager.sendUpdateWidgetsMessage).not.toHaveBeenCalled()
 
-    // eslint-disable-next-line testing-library/prefer-user-event -- keyboard shortcuts listen on document.body; userEvent dispatches to the focused element which may differ
-    fireEvent.keyDown(document.body, {
-      key: "r",
-      which: 82,
-    })
+    await user.keyboard("r")
 
     expect(widgetStateManager.sendUpdateWidgetsMessage).toHaveBeenCalled()
   })
@@ -4182,16 +4170,13 @@ describe("App", () => {
   })
 
   describe("Test Main Menu shortcut functionality", () => {
-    it("Tests dev menu shortcuts cannot be accessed as a viewer", () => {
+    it("Tests dev menu shortcuts cannot be accessed as a viewer", async () => {
+      const user = userEvent.setup({ advanceTimers: advanceUserEventTimers })
       renderApp(getProps())
 
       getMockConnectionManager(true)
 
-      // eslint-disable-next-line testing-library/prefer-user-event -- keyboard shortcuts listen on document.body; userEvent dispatches to the focused element which may differ
-      fireEvent.keyPress(screen.getByTestId("stApp"), {
-        key: "c",
-        which: 67,
-      })
+      await user.keyboard("c")
 
       expect(
         screen.queryByText(
@@ -4447,7 +4432,8 @@ describe("App", () => {
       expect(sendUpdateWidgetsMessageSpy).toHaveBeenCalled()
     })
 
-    it("requests script rerun if wasRerunRequested is true", () => {
+    it("requests script rerun if wasRerunRequested is true", async () => {
+      const user = userEvent.setup({ advanceTimers: advanceUserEventTimers })
       renderApp(getProps())
       const widgetStateManager =
         getStoredValue<WidgetStateManager>(WidgetStateManager)
@@ -4462,11 +4448,7 @@ describe("App", () => {
 
       // trigger a state transition to RERUN_REQUESTED
       getMockConnectionManager(true)
-      // eslint-disable-next-line testing-library/prefer-user-event -- keyboard shortcuts listen on document.body; userEvent dispatches to the focused element which may differ
-      fireEvent.keyDown(document.body, {
-        key: "r",
-        which: 82,
-      })
+      await user.keyboard("r")
 
       act(() => {
         getMockConnectionManagerProp("connectionStateChanged")(
@@ -5586,7 +5568,11 @@ describe("App", () => {
       )
     })
 
-    it("retains embed query params even if the page hash is different", () => {
+    it("retains embed query params even if the page hash is different", async () => {
+      const user = userEvent.setup({
+        advanceTimers: advanceUserEventTimers,
+        pointerEventsCheck: PointerEventsCheckLevel.Never,
+      })
       const embedParams =
         "embed=true&embed_options=disable_scrolling&embed_options=show_padding"
       window.history.pushState({}, "", `/?${embedParams}`)
@@ -5632,8 +5618,7 @@ describe("App", () => {
       // Clear only the hostCommunicationMgr mock before navigation
       ;(hostCommunicationMgr.sendMessageToHost as Mock).mockClear()
 
-      // eslint-disable-next-line testing-library/prefer-user-event -- navLinks have pointer-events:none which userEvent.click respects but the real browser click works
-      fireEvent.click(navLinks[1])
+      await user.click(navLinks[1])
 
       expect(
         // @ts-expect-error
@@ -5896,6 +5881,7 @@ describe("App.hasReceivedNewSession flag behavior", () => {
   })
 
   it("ensures incrementMessageCacheRunCount is NOT called when hasReceivedNewSession is false", async () => {
+    const user = userEvent.setup({ advanceTimers: advanceUserEventTimers })
     renderApp(getProps())
     const connectionManager = getMockConnectionManager(true) // isConnected = true
     const sessionInfo = getStoredValue<SessionInfo>(SessionInfo)
@@ -5929,11 +5915,7 @@ describe("App.hasReceivedNewSession flag behavior", () => {
       scriptIsRunning: false,
     })
 
-    // eslint-disable-next-line testing-library/prefer-user-event -- keyboard shortcuts listen on document.body; userEvent dispatches to the focused element which may differ
-    fireEvent.keyDown(document.body, {
-      key: "r",
-      which: 82, // Key code for 'r'
-    })
+    await user.keyboard("r")
 
     // Wait for state updates from rerunScript to propagate if any were async.
     // sendRerunBackMsg, which sets hasReceivedNewSession to false, is called synchronously in this path.
@@ -6118,7 +6100,8 @@ describe("App.hasReceivedNewSession flag behavior", () => {
         ).toBeVisible()
       })
 
-      it("does not display error dialog if already dismissed", () => {
+      it("does not display error dialog if already dismissed", async () => {
+        const user = userEvent.setup({ advanceTimers: advanceUserEventTimers })
         renderApp(getProps())
         const connectionManager = getMockConnectionManager(false)
 
@@ -6131,10 +6114,7 @@ describe("App.hasReceivedNewSession flag behavior", () => {
 
         // Dismiss the dialog
         const closeButton = screen.getByRole("button", { name: /close/i })
-        act(() => {
-          // eslint-disable-next-line testing-library/prefer-user-event -- userEvent causes timeouts in this test
-          fireEvent.click(closeButton)
-        })
+        await user.click(closeButton)
 
         expect(screen.queryByText("Connection error")).toBeNull()
 
@@ -6196,7 +6176,8 @@ describe("App.hasReceivedNewSession flag behavior", () => {
     })
 
     describe("connection state transitions with error dismissal", () => {
-      it("resets dismissal state when reconnected", () => {
+      it("resets dismissal state when reconnected", async () => {
+        const user = userEvent.setup({ advanceTimers: advanceUserEventTimers })
         renderApp(getProps())
         const connectionManager = getMockConnectionManager(false)
 
@@ -6209,10 +6190,7 @@ describe("App.hasReceivedNewSession flag behavior", () => {
 
         // Dismiss the dialog
         const closeButton = screen.getByRole("button", { name: /close/i })
-        act(() => {
-          // eslint-disable-next-line testing-library/prefer-user-event -- userEvent causes timeouts in this test
-          fireEvent.click(closeButton)
-        })
+        await user.click(closeButton)
 
         expect(screen.queryByText("Connection error")).toBeNull()
 
@@ -6359,7 +6337,8 @@ describe("App.hasReceivedNewSession flag behavior", () => {
         expect(screen.queryByText(/Error 2/)).toBeNull()
       })
 
-      it("maintains dismissal state across multiple disconnections", () => {
+      it("maintains dismissal state across multiple disconnections", async () => {
+        const user = userEvent.setup({ advanceTimers: advanceUserEventTimers })
         renderApp(getProps())
         const connectionManager = getMockConnectionManager(false)
 
@@ -6370,10 +6349,7 @@ describe("App.hasReceivedNewSession flag behavior", () => {
 
         // Dismiss the dialog
         const closeButton = screen.getByRole("button", { name: /close/i })
-        act(() => {
-          // eslint-disable-next-line testing-library/prefer-user-event -- userEvent causes timeouts in this test
-          fireEvent.click(closeButton)
-        })
+        await user.click(closeButton)
 
         expect(screen.queryByText("Connection error")).toBeNull()
 

--- a/frontend/app/src/components/AppView/AppView.test.tsx
+++ b/frontend/app/src/components/AppView/AppView.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { act, fireEvent, screen } from "@testing-library/react"
+import { act, screen } from "@testing-library/react"
 
 import { shouldShowNavigation } from "@streamlit/app/src/components/Navigation/utils"
 import {
@@ -884,7 +884,7 @@ describe("AppView element", () => {
       const logoElement = screen.getByTestId("stHeaderLogo")
       expect(logoElement).toBeInTheDocument()
 
-      fireEvent.error(logoElement)
+      logoElement.dispatchEvent(new Event("error"))
 
       expect(sendClientErrorToHost).toHaveBeenCalledWith(
         "Header Logo",

--- a/frontend/app/src/components/Sidebar/Sidebar.test.tsx
+++ b/frontend/app/src/components/Sidebar/Sidebar.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { fireEvent, screen, within } from "@testing-library/react"
+import { screen, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 
 import {
@@ -494,7 +494,7 @@ describe("Sidebar Component", () => {
       expect(sidebarLogo).toBeInTheDocument()
 
       // Trigger the onerror event for the logo
-      fireEvent.error(sidebarLogo)
+      sidebarLogo.dispatchEvent(new Event("error"))
 
       expect(sendClientErrorToHost).toHaveBeenCalledWith(
         "Sidebar Logo",
@@ -655,7 +655,8 @@ describe("Sidebar Component", () => {
       mockWindowDimensions.innerWidth = 1024
     })
 
-    it("does not collapse sidebar when clicking outside on desktop viewport", () => {
+    it("does not collapse sidebar when clicking outside on desktop viewport", async () => {
+      const user = userEvent.setup()
       // Temporarily set to desktop viewport
       mockWindowDimensions.innerWidth = 1024
 
@@ -668,13 +669,13 @@ describe("Sidebar Component", () => {
 
       // Click on main app area - should NOT collapse on desktop
       const mainApp = screen.getByTestId("stApp")
-      // eslint-disable-next-line testing-library/prefer-user-event -- testing mousedown event handler directly, not general click behavior
-      fireEvent.mouseDown(mainApp)
+      await user.pointer({ target: mainApp, keys: "[MouseLeft]" })
 
       expect(mockOnToggleCollapse).not.toHaveBeenCalled()
     })
 
-    it("does not collapse sidebar when clicking inside sidebar", () => {
+    it("does not collapse sidebar when clicking inside sidebar", async () => {
+      const user = userEvent.setup()
       const mockOnToggleCollapse = vi.fn()
 
       renderSidebar({
@@ -683,8 +684,10 @@ describe("Sidebar Component", () => {
       })
 
       // Click inside sidebar
-      // eslint-disable-next-line testing-library/prefer-user-event -- testing mousedown event handler directly, not general click behavior
-      fireEvent.mouseDown(screen.getByTestId("stSidebarContent"))
+      await user.pointer({
+        target: screen.getByTestId("stSidebarContent"),
+        keys: "[MouseLeft]",
+      })
 
       expect(mockOnToggleCollapse).not.toHaveBeenCalled()
     })
@@ -695,7 +698,8 @@ describe("Sidebar Component", () => {
     // renderWithContexts. The critical behavior (NOT collapsing on portaled elements like
     // dropdowns) is validated by the negative tests below.
 
-    it("does not collapse sidebar when clicking outside the main app container (portaled elements)", () => {
+    it("does not collapse sidebar when clicking outside the main app container (portaled elements)", async () => {
+      const user = userEvent.setup()
       const mockOnToggleCollapse = vi.fn()
 
       renderSidebar({
@@ -709,13 +713,13 @@ describe("Sidebar Component", () => {
       document.body.appendChild(portalElement)
 
       // Click on element outside the main app container - should NOT collapse
-      // eslint-disable-next-line testing-library/prefer-user-event -- testing mousedown event handler directly, not general click behavior
-      fireEvent.mouseDown(portalElement)
+      await user.pointer({ target: portalElement, keys: "[MouseLeft]" })
 
       expect(mockOnToggleCollapse).not.toHaveBeenCalled()
     })
 
-    it("does not collapse when sidebar is already collapsed", () => {
+    it("does not collapse when sidebar is already collapsed", async () => {
+      const user = userEvent.setup()
       const mockOnToggleCollapse = vi.fn()
 
       renderSidebar({
@@ -725,8 +729,7 @@ describe("Sidebar Component", () => {
 
       // Click on main app area
       const mainApp = screen.getByTestId("stApp")
-      // eslint-disable-next-line testing-library/prefer-user-event -- testing mousedown event handler directly, not general click behavior
-      fireEvent.mouseDown(mainApp)
+      await user.pointer({ target: mainApp, keys: "[MouseLeft]" })
 
       expect(mockOnToggleCollapse).not.toHaveBeenCalled()
     })

--- a/frontend/app/src/hocs/withScreencast/withScreencast.test.tsx
+++ b/frontend/app/src/hocs/withScreencast/withScreencast.test.tsx
@@ -16,7 +16,7 @@
 
 import { FC, PureComponent, ReactElement } from "react"
 
-import { act, fireEvent, screen, waitFor } from "@testing-library/react"
+import { act, screen, waitFor } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 
 import ScreenCastRecorder from "@streamlit/app/src/util/ScreenCastRecorder"
@@ -156,7 +156,11 @@ describe("withScreencast HOC", () => {
     /** Drive the 3-second countdown to zero via its animation-end events. */
     const advanceCountdown = (): void => {
       for (let i = 0; i < 3; i++) {
-        fireEvent.animationEnd(screen.getByTestId("stCountdown"))
+        act(() => {
+          screen
+            .getByTestId("stCountdown")
+            .dispatchEvent(new Event("animationend", { bubbles: true }))
+        })
       }
     }
 

--- a/frontend/lib/src/components/elements/Audio/Audio.test.tsx
+++ b/frontend/lib/src/components/elements/Audio/Audio.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { fireEvent, screen } from "@testing-library/react"
+import { screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 
 import { Audio as AudioProto } from "@streamlit/protobuf"
@@ -164,7 +164,7 @@ describe("Audio Element", () => {
     render(<Audio {...props} />)
     const audioElement: HTMLAudioElement = screen.getByTestId("stAudio")
     audioElement.currentTime = 0
-    fireEvent.loadedMetadata(audioElement)
+    audioElement.dispatchEvent(new Event("loadedmetadata"))
     expect(audioElement.currentTime).toBe(14)
   })
 
@@ -187,7 +187,7 @@ describe("Audio Element", () => {
     render(<Audio {...getProps({ endTime: 5, loop: false, startTime: 0 })} />)
     const audioElement: HTMLAudioElement = screen.getByTestId("stAudio")
     audioElement.currentTime = 5.1
-    fireEvent.timeUpdate(audioElement)
+    audioElement.dispatchEvent(new Event("timeupdate"))
     expect(pauseSpy).toHaveBeenCalledTimes(1)
     pauseSpy.mockRestore()
   })
@@ -197,8 +197,8 @@ describe("Audio Element", () => {
     render(<Audio {...getProps({ endTime: 5, loop: false, startTime: 0 })} />)
     const audioElement: HTMLAudioElement = screen.getByTestId("stAudio")
     audioElement.currentTime = 5.2
-    fireEvent.timeUpdate(audioElement)
-    fireEvent.timeUpdate(audioElement)
+    audioElement.dispatchEvent(new Event("timeupdate"))
+    audioElement.dispatchEvent(new Event("timeupdate"))
     expect(pauseSpy).toHaveBeenCalledTimes(1)
     pauseSpy.mockRestore()
   })
@@ -218,7 +218,7 @@ describe("Audio Element", () => {
     )
     const audioElement: HTMLAudioElement = screen.getByTestId("stAudio")
     audioElement.currentTime = 5
-    fireEvent.timeUpdate(audioElement)
+    audioElement.dispatchEvent(new Event("timeupdate"))
     expect(audioElement.currentTime).toBe(2)
     expect(playSpy).toHaveBeenCalled()
     playSpy.mockRestore()
@@ -244,7 +244,7 @@ describe("Audio Element", () => {
     render(<Audio {...getProps({ loop: true, startTime: 0 })} />)
     const audioElement: HTMLAudioElement = screen.getByTestId("stAudio")
     audioElement.currentTime = 8
-    fireEvent.ended(audioElement)
+    audioElement.dispatchEvent(new Event("ended"))
     expect(audioElement.currentTime).toBe(0)
     expect(playSpy).toHaveBeenCalled()
     playSpy.mockRestore()
@@ -257,7 +257,7 @@ describe("Audio Element", () => {
     render(<Audio {...getProps({ loop: false, startTime: 3 })} />)
     const audioElement: HTMLAudioElement = screen.getByTestId("stAudio")
     audioElement.currentTime = 8
-    fireEvent.ended(audioElement)
+    audioElement.dispatchEvent(new Event("ended"))
     expect(audioElement.currentTime).toBe(8)
     expect(playSpy).not.toHaveBeenCalled()
     playSpy.mockRestore()
@@ -288,7 +288,7 @@ describe("Audio Element", () => {
     const audioElement = screen.getByTestId("stAudio")
     expect(audioElement).toBeInTheDocument()
 
-    fireEvent.error(audioElement)
+    audioElement.dispatchEvent(new Event("error"))
 
     expect(sendClientErrorToHost).toHaveBeenCalledWith(
       "Audio",

--- a/frontend/lib/src/components/elements/ImageList/ImageList.test.tsx
+++ b/frontend/lib/src/components/elements/ImageList/ImageList.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { fireEvent, screen } from "@testing-library/react"
+import { screen } from "@testing-library/react"
 
 import { ImageList as ImageListProto, streamlit } from "@streamlit/protobuf"
 
@@ -256,8 +256,7 @@ describe("ImageList Element", () => {
     const images = screen.getAllByRole("img")
     expect(images).toHaveLength(2)
 
-    // Trigger the error event on the first image using fireEvent
-    fireEvent.error(images[0])
+    images[0].dispatchEvent(new Event("error"))
 
     // Verify the error was sent with correct parameters
     expect(sendClientErrorToHost).toHaveBeenCalledWith(

--- a/frontend/lib/src/components/elements/Tabs/Tabs.test.tsx
+++ b/frontend/lib/src/components/elements/Tabs/Tabs.test.tsx
@@ -14,13 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  act,
-  fireEvent,
-  screen,
-  waitFor,
-  within,
-} from "@testing-library/react"
+import { act, screen, waitFor, within } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 
 import { Block as BlockProto } from "@streamlit/protobuf"
@@ -448,7 +442,9 @@ describe("st.tabs", () => {
         scrollWidth: 800,
         clientWidth: 200,
       })
-      fireEvent.scroll(tablist)
+      act(() => {
+        tablist.dispatchEvent(new Event("scroll"))
+      })
 
       await waitFor(() => {
         expect(screen.getByTestId("stTabsScrollRight")).toBeVisible()
@@ -464,7 +460,9 @@ describe("st.tabs", () => {
         scrollWidth: 700,
         clientWidth: 200,
       })
-      fireEvent.scroll(tablist)
+      act(() => {
+        tablist.dispatchEvent(new Event("scroll"))
+      })
 
       await waitFor(() => {
         expect(screen.getByTestId("stTabsScrollLeft")).toBeVisible()
@@ -482,7 +480,9 @@ describe("st.tabs", () => {
         scrollWidth: 900,
         clientWidth: 200,
       })
-      fireEvent.scroll(tablist)
+      act(() => {
+        tablist.dispatchEvent(new Event("scroll"))
+      })
 
       await waitFor(() => {
         expect(screen.getByTestId("stTabsScrollLeft")).toBeVisible()

--- a/frontend/lib/src/components/elements/Video/Video.test.tsx
+++ b/frontend/lib/src/components/elements/Video/Video.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { fireEvent, screen } from "@testing-library/react"
+import { screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 
 import { Video as VideoProto } from "@streamlit/protobuf"
@@ -105,7 +105,7 @@ describe("Video Element", () => {
     const videoElement = screen.getByTestId("stVideo")
     expect(videoElement).toBeInTheDocument()
 
-    fireEvent.error(videoElement)
+    videoElement.dispatchEvent(new Event("error"))
 
     expect(sendClientErrorToHost).toHaveBeenCalledWith(
       "Video",
@@ -258,12 +258,12 @@ describe("Video Element", () => {
       const { rerender } = render(<Video {...getProps({ startTime: 12 })} />)
       const video: HTMLVideoElement = await screen.findByTestId("stVideo")
       video.currentTime = 0
-      fireEvent.loadedMetadata(video)
+      video.dispatchEvent(new Event("loadedmetadata"))
       expect(video.currentTime).toBe(12)
 
       rerender(<Video {...getProps({ startTime: 3 })} />)
       video.currentTime = 0
-      fireEvent.loadedMetadata(video)
+      video.dispatchEvent(new Event("loadedmetadata"))
       expect(video.currentTime).toBe(3)
     })
   })
@@ -278,14 +278,14 @@ describe("Video Element", () => {
 
       await user.click(video)
       video.currentTime = 9
-      fireEvent.timeUpdate(video)
+      video.dispatchEvent(new Event("timeupdate"))
       expect(pauseSpy).not.toHaveBeenCalled()
 
       video.currentTime = 10
-      fireEvent.timeUpdate(video)
+      video.dispatchEvent(new Event("timeupdate"))
       expect(pauseSpy).toHaveBeenCalledTimes(1)
 
-      fireEvent.timeUpdate(video)
+      video.dispatchEvent(new Event("timeupdate"))
       expect(pauseSpy).toHaveBeenCalledTimes(1)
     })
 
@@ -302,7 +302,7 @@ describe("Video Element", () => {
 
       await user.click(video)
       video.currentTime = 10
-      fireEvent.timeUpdate(video)
+      video.dispatchEvent(new Event("timeupdate"))
       expect(video.currentTime).toBe(4)
       expect(playSpy).toHaveBeenCalledTimes(1)
     })
@@ -316,7 +316,7 @@ describe("Video Element", () => {
 
       await user.click(video)
       video.currentTime = 99
-      fireEvent.ended(video)
+      video.dispatchEvent(new Event("ended"))
       expect(video.currentTime).toBe(7)
       expect(playSpy).toHaveBeenCalledTimes(1)
     })

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
@@ -48,6 +48,7 @@ async function openDropdown(
   await user.click(screen.getByRole("button", { name: "Open" }))
 }
 
+/** Place the caret after the committed label so the next keystroke appends instead of replacing. */
 function moveCaretToEnd(input: HTMLElement): void {
   if (!(input instanceof HTMLInputElement)) {
     throw new TypeError("Expected the combobox to be an input element")

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
@@ -14,13 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  act,
-  createEvent,
-  fireEvent,
-  screen,
-  waitFor,
-} from "@testing-library/react"
+import { act, createEvent, screen, waitFor } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 
 import { streamlit } from "@streamlit/protobuf"
@@ -52,6 +46,13 @@ async function openDropdown(
   user: ReturnType<typeof userEvent.setup>
 ): Promise<void> {
   await user.click(screen.getByRole("button", { name: "Open" }))
+}
+
+function moveCaretToEnd(input: HTMLElement): void {
+  if (!(input instanceof HTMLInputElement)) {
+    throw new TypeError("Expected the combobox to be an input element")
+  }
+  input.setSelectionRange(input.value.length, input.value.length)
 }
 
 /** Force a non-zero viewport so the virtualizer renders a window of rows. */
@@ -479,7 +480,9 @@ describe("Selectbox widget", () => {
       data: "n",
     })
     const preventDefaultSpy = vi.spyOn(compositionEvent, "preventDefault")
-    fireEvent(selectboxInput, compositionEvent)
+    act(() => {
+      selectboxInput.dispatchEvent(compositionEvent)
+    })
     expect(preventDefaultSpy).toHaveBeenCalled()
     expect(selectboxInput).toHaveValue("")
     expect(screen.queryAllByRole("option")).toHaveLength(3)
@@ -524,10 +527,8 @@ describe("Selectbox widget", () => {
 
     await user.click(input)
     // Simulate the browser appending "c" behind the committed "Banana".
-    act(() => {
-      // eslint-disable-next-line testing-library/prefer-user-event
-      fireEvent.change(input, { target: { value: "Bananac" } })
-    })
+    moveCaretToEnd(input)
+    await user.keyboard("c")
 
     expect(input).toHaveValue("c")
     await waitFor(() => {
@@ -550,10 +551,8 @@ describe("Selectbox widget", () => {
 
     await user.click(input)
     // Simulate the browser appending "a" behind the committed "a".
-    act(() => {
-      // eslint-disable-next-line testing-library/prefer-user-event
-      fireEvent.change(input, { target: { value: "aa" } })
-    })
+    moveCaretToEnd(input)
+    await user.keyboard("a")
 
     expect(input).toHaveValue("a")
     // Filtering is active: "a"/"ab" match the query, "b" is filtered out.
@@ -579,11 +578,9 @@ describe("Selectbox widget", () => {
     expect(input).toHaveValue("foo")
 
     await user.click(input)
-    act(() => {
-      // Simulate the browser appending the keystrokes behind the committed label.
-      // eslint-disable-next-line testing-library/prefer-user-event
-      fireEvent.change(input, { target: { value: "foobar" } })
-    })
+    // Simulate the browser appending the keystrokes behind the committed label.
+    moveCaretToEnd(input)
+    await user.keyboard("bar")
 
     expect(input).toHaveValue("bar")
     await waitFor(() => {
@@ -770,13 +767,9 @@ describe("Selectbox widget", () => {
     const selectboxInput = screen.getByRole("combobox")
 
     // user.click focuses the input AND opens the dropdown (via RAC's press handler).
-    // Then fireEvent.change sets the input value without triggering a blur/focus
-    // cycle (which would close the dropdown via RAC's shouldCloseOnBlur path).
+    // keyboard enters text without another click or blur/focus cycle.
     await user.click(selectboxInput)
-    act(() => {
-      // eslint-disable-next-line testing-library/prefer-user-event
-      fireEvent.change(selectboxInput, { target: { value: "hello world!" } })
-    })
+    await user.keyboard("hello world!")
 
     await waitFor(() => {
       expect(

--- a/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.test.tsx
+++ b/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.test.tsx
@@ -68,6 +68,7 @@ const MOCK_COMPONENT_URL = "http://a.mock.url"
 const MOCK_WIDGET_ID = "mock_widget_id"
 const MOCK_COMPONENT_NAME = "mock_component_name"
 
+/** Dispatch a window MessageEvent inside act() so ComponentInstance state updates flush. */
 const dispatchMessageEvent = (event: MessageEvent): void => {
   act(() => {
     window.dispatchEvent(event)

--- a/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.test.tsx
+++ b/frontend/lib/src/components/widgets/CustomComponent/ComponentInstance.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { act, fireEvent, screen } from "@testing-library/react"
+import { act, screen } from "@testing-library/react"
 import { Mock, MockInstance } from "vitest"
 
 import {
@@ -67,6 +67,12 @@ vi.mock("~lib/WidgetStateManager")
 const MOCK_COMPONENT_URL = "http://a.mock.url"
 const MOCK_WIDGET_ID = "mock_widget_id"
 const MOCK_COMPONENT_NAME = "mock_component_name"
+
+const dispatchMessageEvent = (event: MessageEvent): void => {
+  act(() => {
+    window.dispatchEvent(event)
+  })
+}
 
 describe("ComponentInstance", () => {
   let logWarnSpy: MockInstance
@@ -276,8 +282,7 @@ describe("ComponentInstance", () => {
       // @ts-expect-error
       const postMessage = vi.spyOn(iframe.contentWindow, "postMessage")
       // SET COMPONENT_READY
-      fireEvent(
-        window,
+      dispatchMessageEvent(
         new MessageEvent("message", {
           data: {
             isStreamlitMessage: true,
@@ -310,8 +315,7 @@ describe("ComponentInstance", () => {
       const iframe = screen.getByTitle(MOCK_COMPONENT_NAME)
 
       // SET COMPONENT_READY
-      fireEvent(
-        window,
+      dispatchMessageEvent(
         new MessageEvent("message", {
           data: {
             isStreamlitMessage: true,
@@ -371,8 +375,7 @@ describe("ComponentInstance", () => {
       // @ts-expect-error
       const postMessage = vi.spyOn(iframe.contentWindow, "postMessage")
       // SET COMPONENT_READY
-      fireEvent(
-        window,
+      dispatchMessageEvent(
         new MessageEvent("message", {
           data: {
             isStreamlitMessage: true,
@@ -384,8 +387,7 @@ describe("ComponentInstance", () => {
         })
       )
       // SET COMPONENT_READY
-      fireEvent(
-        window,
+      dispatchMessageEvent(
         new MessageEvent("message", {
           data: {
             isStreamlitMessage: true,
@@ -419,8 +421,7 @@ describe("ComponentInstance", () => {
       // @ts-expect-error
       const postMessage = vi.spyOn(iframe.contentWindow, "postMessage")
       // SET COMPONENT_READY
-      fireEvent(
-        window,
+      dispatchMessageEvent(
         new MessageEvent("message", {
           data: {
             isStreamlitMessage: true,
@@ -475,8 +476,7 @@ describe("ComponentInstance", () => {
       // @ts-expect-error
       const postMessage = vi.spyOn(iframe.contentWindow, "postMessage")
       // SET COMPONENT_READY
-      fireEvent(
-        window,
+      dispatchMessageEvent(
         new MessageEvent("message", {
           data: {
             isStreamlitMessage: true,
@@ -531,8 +531,7 @@ describe("ComponentInstance", () => {
       )
       const iframe = screen.getByTitle(MOCK_COMPONENT_NAME)
       // SET COMPONENT_READY
-      fireEvent(
-        window,
+      dispatchMessageEvent(
         new MessageEvent("message", {
           data: {
             isStreamlitMessage: true,
@@ -678,8 +677,7 @@ describe("ComponentInstance", () => {
 
       const iframe = screen.getByTitle(MOCK_COMPONENT_NAME)
       // SET COMPONENT_READY
-      fireEvent(
-        window,
+      dispatchMessageEvent(
         new MessageEvent("message", {
           data: {
             isStreamlitMessage: true,
@@ -691,8 +689,7 @@ describe("ComponentInstance", () => {
         })
       )
       // SET COMPONENT_VALUE
-      fireEvent(
-        window,
+      dispatchMessageEvent(
         new MessageEvent("message", {
           data: {
             isStreamlitMessage: true,
@@ -739,8 +736,7 @@ describe("ComponentInstance", () => {
 
       const iframe = screen.getByTitle(MOCK_COMPONENT_NAME)
       // SET COMPONENT_READY
-      fireEvent(
-        window,
+      dispatchMessageEvent(
         new MessageEvent("message", {
           data: {
             isStreamlitMessage: true,
@@ -754,8 +750,7 @@ describe("ComponentInstance", () => {
 
       const bytesValue = new Uint8Array([0, 1, 2])
       // SET COMPONENT_VALUE
-      fireEvent(
-        window,
+      dispatchMessageEvent(
         new MessageEvent("message", {
           data: {
             isStreamlitMessage: true,
@@ -803,8 +798,7 @@ describe("ComponentInstance", () => {
       )
       const iframe = screen.getByTitle(MOCK_COMPONENT_NAME)
       // SET COMPONENT_VALUE
-      fireEvent(
-        window,
+      dispatchMessageEvent(
         new MessageEvent("message", {
           data: {
             isStreamlitMessage: true,
@@ -845,8 +839,7 @@ describe("ComponentInstance", () => {
         )
         const iframe = screen.getByTitle(MOCK_COMPONENT_NAME)
         // SET COMPONENT_READY
-        fireEvent(
-          window,
+        dispatchMessageEvent(
           new MessageEvent("message", {
             data: {
               isStreamlitMessage: true,
@@ -858,8 +851,7 @@ describe("ComponentInstance", () => {
           })
         )
         // SET IFRAME_HEIGHT
-        fireEvent(
-          window,
+        dispatchMessageEvent(
           new MessageEvent("message", {
             data: {
               isStreamlitMessage: true,
@@ -902,8 +894,7 @@ describe("ComponentInstance", () => {
         )
         const iframe = screen.getByTitle(MOCK_COMPONENT_NAME)
         // SET IFRAME_HEIGHT
-        fireEvent(
-          window,
+        dispatchMessageEvent(
           new MessageEvent("message", {
             data: {
               isStreamlitMessage: true,

--- a/frontend/lib/src/components/widgets/DataFrame/columns/cells/MultiSelectCell.test.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/cells/MultiSelectCell.test.tsx
@@ -309,6 +309,7 @@ describe("onPaste", () => {
   })
 })
 
+/** Open the cell's dropdown and click the given option to select it. */
 async function selectOption(
   user: ReturnType<typeof userEvent.setup>,
   container: HTMLElement,
@@ -322,6 +323,11 @@ async function selectOption(
   await user.click(within(listBox).getByText(optionText))
 }
 
+/**
+ * Open the cell's dropdown and report whether the given option is offered. Note
+ * this performs user interactions (opens the menu) rather than being a pure
+ * predicate, so it must be awaited.
+ */
 async function hasOption(
   user: ReturnType<typeof userEvent.setup>,
   container: HTMLElement,

--- a/frontend/lib/src/components/widgets/DataFrame/columns/cells/MultiSelectCell.test.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/cells/MultiSelectCell.test.tsx
@@ -310,10 +310,10 @@ describe("onPaste", () => {
 })
 
 async function selectOption(
+  user: ReturnType<typeof userEvent.setup>,
   container: HTMLElement,
   optionText: string
 ): Promise<void> {
-  const user = userEvent.setup()
   const inputElement = within(container).getByRole("combobox")
   await user.click(inputElement)
   await user.keyboard("{ArrowDown}")
@@ -323,10 +323,10 @@ async function selectOption(
 }
 
 async function hasOption(
+  user: ReturnType<typeof userEvent.setup>,
   container: HTMLElement,
   optionText: string
 ): Promise<boolean> {
-  const user = userEvent.setup()
   const inputElement = within(container).getByRole("combobox")
   await user.click(inputElement)
   await user.keyboard("{ArrowDown}")
@@ -394,6 +394,7 @@ describe("Multi Select Editor", () => {
   })
 
   it("allows to select values", async () => {
+    const user = userEvent.setup()
     const mockCell = getMockCell()
     const Editor = getEditor(mockCell)
 
@@ -409,16 +410,16 @@ describe("Multi Select Editor", () => {
     const cellEditor = screen.getByTestId("multi-select-cell")
     expect(cellEditor).toBeDefined()
 
-    await selectOption(cellEditor, "Option 1")
+    await selectOption(user, cellEditor, "Option 1")
     expect(mockCellOnChange).toHaveBeenCalledTimes(1)
     expect(mockCellOnChange).toBeCalledWith({
       ...mockCell,
       data: { ...mockCell.data, values: ["option1"] },
     })
 
-    expect(await hasOption(cellEditor, "Option 2")).toBeTruthy()
+    expect(await hasOption(user, cellEditor, "Option 2")).toBeTruthy()
 
-    await selectOption(cellEditor, "Option 2")
+    await selectOption(user, cellEditor, "Option 2")
     expect(mockCellOnChange).toHaveBeenCalledTimes(2)
     expect(mockCellOnChange).toBeCalledWith({
       ...mockCell,
@@ -426,8 +427,8 @@ describe("Multi Select Editor", () => {
     })
 
     // Option 1 and 2 should not be available anymore
-    expect(await hasOption(cellEditor, "Option 1")).toBeFalsy()
-    expect(await hasOption(cellEditor, "Option 2")).toBeFalsy()
+    expect(await hasOption(user, cellEditor, "Option 1")).toBeFalsy()
+    expect(await hasOption(user, cellEditor, "Option 2")).toBeFalsy()
   })
 
   it("is disabled if readonly", () => {
@@ -450,6 +451,7 @@ describe("Multi Select Editor", () => {
   })
 
   it("allowDuplicates allows to select values multiple times", async () => {
+    const user = userEvent.setup()
     const mockCell = getMockCell({ data: { allowDuplicates: true } })
     const Editor = getEditor(mockCell)
 
@@ -465,21 +467,21 @@ describe("Multi Select Editor", () => {
     const cellEditor = screen.getByTestId("multi-select-cell")
     expect(cellEditor).toBeDefined()
 
-    await selectOption(cellEditor, "Option 1")
+    await selectOption(user, cellEditor, "Option 1")
     expect(mockCellOnChange).toHaveBeenCalledTimes(1)
     expect(mockCellOnChange).toBeCalledWith({
       ...mockCell,
       data: { ...mockCell.data, values: ["option1"] },
     })
 
-    await selectOption(cellEditor, "Option 2")
+    await selectOption(user, cellEditor, "Option 2")
     expect(mockCellOnChange).toHaveBeenCalledTimes(2)
     expect(mockCellOnChange).toBeCalledWith({
       ...mockCell,
       data: { ...mockCell.data, values: ["option1", "option2"] },
     })
 
-    await selectOption(cellEditor, "Option 1")
+    await selectOption(user, cellEditor, "Option 1")
     expect(mockCellOnChange).toHaveBeenCalledTimes(3)
     expect(mockCellOnChange).toBeCalledWith({
       ...mockCell,

--- a/frontend/lib/src/components/widgets/DataFrame/columns/cells/MultiSelectCell.test.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/columns/cells/MultiSelectCell.test.tsx
@@ -19,13 +19,8 @@ import {
   GridCellKind,
   type Item,
 } from "@glideapps/glide-data-grid"
-import {
-  cleanup,
-  fireEvent,
-  render,
-  screen,
-  within,
-} from "@testing-library/react"
+import { cleanup, render, screen, within } from "@testing-library/react"
+import { userEvent } from "@testing-library/user-event"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
 import renderer, {
@@ -314,29 +309,27 @@ describe("onPaste", () => {
   })
 })
 
-const keyDownEvent = {
-  key: "ArrowDown",
-}
-
-// Using fireEvent instead of userEvent for react-select keyboard navigation
-// because userEvent has compatibility issues with react-select's event handling
 async function selectOption(
   container: HTMLElement,
   optionText: string
 ): Promise<void> {
+  const user = userEvent.setup()
   const inputElement = within(container).getByRole("combobox")
-  // eslint-disable-next-line testing-library/prefer-user-event -- react-select requires fireEvent for keyboard navigation
-  fireEvent.keyDown(inputElement, keyDownEvent)
+  await user.click(inputElement)
+  await user.keyboard("{ArrowDown}")
   const listBox = within(container).getByRole("listbox")
   await within(listBox).findByText(optionText)
-  // eslint-disable-next-line testing-library/prefer-user-event -- react-select requires fireEvent for click
-  fireEvent.click(within(listBox).getByText(optionText))
+  await user.click(within(listBox).getByText(optionText))
 }
 
-function hasOption(container: HTMLElement, optionText: string): boolean {
+async function hasOption(
+  container: HTMLElement,
+  optionText: string
+): Promise<boolean> {
+  const user = userEvent.setup()
   const inputElement = within(container).getByRole("combobox")
-  // eslint-disable-next-line testing-library/prefer-user-event -- react-select requires fireEvent for keyboard navigation
-  fireEvent.keyDown(inputElement, keyDownEvent)
+  await user.click(inputElement)
+  await user.keyboard("{ArrowDown}")
   const listBox = within(container).getByRole("listbox")
   return within(listBox).queryByText(optionText) !== null
 }
@@ -423,7 +416,7 @@ describe("Multi Select Editor", () => {
       data: { ...mockCell.data, values: ["option1"] },
     })
 
-    expect(hasOption(cellEditor, "Option 2")).toBeTruthy()
+    expect(await hasOption(cellEditor, "Option 2")).toBeTruthy()
 
     await selectOption(cellEditor, "Option 2")
     expect(mockCellOnChange).toHaveBeenCalledTimes(2)
@@ -433,8 +426,8 @@ describe("Multi Select Editor", () => {
     })
 
     // Option 1 and 2 should not be available anymore
-    expect(hasOption(cellEditor, "Option 1")).toBeFalsy()
-    expect(hasOption(cellEditor, "Option 2")).toBeFalsy()
+    expect(await hasOption(cellEditor, "Option 1")).toBeFalsy()
+    expect(await hasOption(cellEditor, "Option 2")).toBeFalsy()
   })
 
   it("is disabled if readonly", () => {
@@ -538,7 +531,8 @@ describe("Multi Select Editor", () => {
     expect(mockCellOnChange).not.toHaveBeenCalled()
   })
 
-  it("still allows removing pills via the remove button after text selection enhancement", () => {
+  it("still allows removing pills via the remove button after text selection enhancement", async () => {
+    const user = userEvent.setup()
     const mockCell = getMockCell({
       data: {
         kind: "multi-select-cell",
@@ -577,10 +571,8 @@ describe("Multi Select Editor", () => {
       multiValueContainer?.querySelector("svg")?.parentElement
     expect(removeButton).not.toBeNull()
 
-    // Click the remove button - using fireEvent for react-select compatibility
     if (removeButton) {
-      // eslint-disable-next-line testing-library/prefer-user-event -- react-select requires fireEvent for click
-      fireEvent.click(removeButton)
+      await user.click(removeButton)
     }
 
     // The onChange should have been called to remove the value
@@ -593,7 +585,8 @@ describe("Multi Select Editor", () => {
 
   it.each(["Enter", "Tab"])(
     "calls onFinishedEditing on %s with empty input",
-    key => {
+    async key => {
+      const user = userEvent.setup()
       const mockCell = getMockCell({ data: { values: [] } })
       const Editor = getEditor(mockCell)
 
@@ -607,13 +600,14 @@ describe("Multi Select Editor", () => {
         />
       )
 
-      // eslint-disable-next-line testing-library/prefer-user-event -- react-select requires fireEvent for keydown
-      fireEvent.keyDown(screen.getByRole("combobox"), { key })
+      await user.click(screen.getByRole("combobox"))
+      await user.keyboard(`{${key}}`)
       expect(onFinishedEditing).toHaveBeenCalledTimes(1)
     }
   )
 
-  it("submits typed value as new entry when allowCreation+allowDuplicates is true", () => {
+  it("submits typed value as new entry when allowCreation+allowDuplicates is true", async () => {
+    const user = userEvent.setup()
     const mockCell = getMockCell({
       data: {
         allowCreation: true,
@@ -636,10 +630,8 @@ describe("Multi Select Editor", () => {
     )
 
     const inputElement = screen.getByRole("combobox")
-    // eslint-disable-next-line testing-library/prefer-user-event -- react-select uses controlled input
-    fireEvent.change(inputElement, { target: { value: "new-value" } })
-    // eslint-disable-next-line testing-library/prefer-user-event -- react-select requires fireEvent for keydown
-    fireEvent.keyDown(inputElement, { key: "Enter" })
+    await user.type(inputElement, "new-value")
+    await user.keyboard("{Enter}")
 
     // Enter with text + allowCreation + allowDuplicates falls into the
     // inline-create path: the new value is added and editing stays open.

--- a/frontend/lib/src/components/widgets/DataFrame/menus/ButtonActionMenu.test.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/menus/ButtonActionMenu.test.tsx
@@ -14,8 +14,11 @@
  * limitations under the License.
  */
 
-import { fireEvent, screen } from "@testing-library/react"
-import { userEvent } from "@testing-library/user-event"
+import { act, screen } from "@testing-library/react"
+import {
+  PointerEventsCheckLevel,
+  userEvent,
+} from "@testing-library/user-event"
 
 import { render } from "~lib/test_util"
 
@@ -130,15 +133,15 @@ describe("ButtonActionMenu", () => {
     expect(onCloseMenu).toHaveBeenCalled()
   })
 
-  it("does not close when clicking the menu target anchor", () => {
+  it("does not close when clicking the menu target anchor", async () => {
+    const user = userEvent.setup({
+      pointerEventsCheck: PointerEventsCheckLevel.Never,
+    })
     const onCloseMenu = vi.fn()
     render(<ButtonActionMenu {...defaultProps} onCloseMenu={onCloseMenu} />)
 
     const menuTarget = screen.getByTestId("stDataFrameButtonActionMenuTarget")
-    // The anchor has pointer-events:none, so userEvent.click refuses to interact with it.
-    // Use fireEvent to test the capture-phase exclusion logic directly.
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.pointerDown(menuTarget)
+    await user.pointer({ target: menuTarget, keys: "[MouseLeft]" })
 
     expect(onCloseMenu).not.toHaveBeenCalled()
   })
@@ -147,7 +150,9 @@ describe("ButtonActionMenu", () => {
     const onCloseMenu = vi.fn()
     render(<ButtonActionMenu {...defaultProps} onCloseMenu={onCloseMenu} />)
 
-    fireEvent.scroll(document.body)
+    act(() => {
+      document.body.dispatchEvent(new Event("scroll"))
+    })
 
     expect(onCloseMenu).toHaveBeenCalled()
   })

--- a/frontend/lib/src/components/widgets/DataFrame/menus/ColumnMenu.test.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/menus/ColumnMenu.test.tsx
@@ -482,10 +482,16 @@ describe("DataFrame ColumnMenu", () => {
       insideSubMenu.setAttribute("data-testid", "stDataFrameStatisticsMenu")
       insideSubMenu.tabIndex = -1
       document.body.appendChild(insideSubMenu)
-      insideSubMenu.focus()
 
-      expect(statsMenuItem).toHaveAttribute("aria-expanded", "true")
-      insideSubMenu.remove()
+      try {
+        insideSubMenu.focus()
+
+        expect(statsMenuItem).toHaveAttribute("aria-expanded", "true")
+      } finally {
+        // Always remove the node so a failed assertion can't leak a
+        // testid-bearing element into subsequent tests.
+        insideSubMenu.remove()
+      }
     })
 
     it("closes the statistics sub-menu on keyboard-driven blur", async () => {
@@ -519,10 +525,16 @@ describe("DataFrame ColumnMenu", () => {
       )
       insideSubMenu.tabIndex = -1
       document.body.appendChild(insideSubMenu)
-      insideSubMenu.focus()
 
-      expect(formatMenuItem).toHaveAttribute("aria-expanded", "true")
-      insideSubMenu.remove()
+      try {
+        insideSubMenu.focus()
+
+        expect(formatMenuItem).toHaveAttribute("aria-expanded", "true")
+      } finally {
+        // Always remove the node so a failed assertion can't leak a
+        // testid-bearing element into subsequent tests.
+        insideSubMenu.remove()
+      }
     })
   })
 

--- a/frontend/lib/src/components/widgets/DataFrame/menus/ColumnMenu.test.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/menus/ColumnMenu.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { fireEvent, screen, waitFor, within } from "@testing-library/react"
+import { screen, waitFor, within } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 import { Field, Int64, Utf8 } from "apache-arrow"
 
@@ -31,11 +31,14 @@ import { sizes } from "~lib/theme/primitives/sizes"
 import ColumnMenu, { ColumnMenuProps } from "./ColumnMenu"
 
 describe("DataFrame ColumnMenu", () => {
-  // Mock navigator.clipboard
-  Object.assign(navigator, {
-    clipboard: {
-      writeText: vi.fn(),
-    },
+  const mockWriteText = vi.fn()
+
+  beforeEach(() => {
+    mockWriteText.mockReset()
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: mockWriteText },
+    })
   })
 
   const defaultProps: ColumnMenuProps = {
@@ -195,7 +198,8 @@ describe("DataFrame ColumnMenu", () => {
       expect(screen.queryByText("Format")).not.toBeInTheDocument()
     })
 
-    it("does not close format sub-menu on blur while pointer is down", () => {
+    it("does not close format sub-menu on blur while pointer is down", async () => {
+      const user = userEvent.setup()
       render(<ColumnMenu {...defaultProps} />)
 
       const formatMenuItem = screen.getByRole("menuitem", {
@@ -203,27 +207,23 @@ describe("DataFrame ColumnMenu", () => {
       })
 
       // Focus the Format item to open the sub-menu
-      fireEvent.focus(formatMenuItem)
+      await user.click(formatMenuItem)
       expect(formatMenuItem).toHaveAttribute("aria-expanded", "true")
 
       // Dispatch pointerdown on document to set the pointerDownRef flag.
-      // We use fireEvent here (not userEvent) because we're testing the
-      // document-level capture listener, not simulating a user click on a UI
-      // element. userEvent.pointer corrupts JSDOM's clipboard mock state.
-      // eslint-disable-next-line testing-library/prefer-user-event
-      fireEvent.pointerDown(document.body)
+      await user.pointer({ target: document.body, keys: "[MouseLeft>]" })
 
       // Blur the Format item while pointer is still down
-      fireEvent.blur(formatMenuItem)
+      formatMenuItem.blur()
 
       // Sub-menu should remain open because pointer is down
       expect(formatMenuItem).toHaveAttribute("aria-expanded", "true")
 
-      // eslint-disable-next-line testing-library/prefer-user-event
-      fireEvent.pointerUp(document.body)
+      await user.pointer({ keys: "[/MouseLeft]" })
     })
 
-    it("closes format sub-menu on keyboard-driven blur", () => {
+    it("closes format sub-menu on keyboard-driven blur", async () => {
+      const user = userEvent.setup()
       render(<ColumnMenu {...defaultProps} />)
 
       const formatMenuItem = screen.getByRole("menuitem", {
@@ -231,11 +231,11 @@ describe("DataFrame ColumnMenu", () => {
       })
 
       // Focus to open
-      fireEvent.focus(formatMenuItem)
+      await user.click(formatMenuItem)
       expect(formatMenuItem).toHaveAttribute("aria-expanded", "true")
 
       // Blur without pointer down (simulates Tab away)
-      fireEvent.blur(formatMenuItem)
+      await user.tab()
 
       // Sub-menu should close
       expect(formatMenuItem).toHaveAttribute("aria-expanded", "false")
@@ -312,11 +312,8 @@ describe("DataFrame ColumnMenu", () => {
   })
 
   describe("copy column name functionality (isCopied state)", () => {
-    // eslint-disable-next-line no-restricted-properties -- This is fine in tests
-    const mockWriteText = vi.mocked(navigator.clipboard.writeText)
-
     it("shows copy icon initially and switches to check icon after copy", async () => {
-      mockWriteText.mockResolvedValue()
+      mockWriteText.mockResolvedValue(undefined)
 
       render(<ColumnMenu {...defaultProps} />)
 
@@ -414,7 +411,8 @@ describe("DataFrame ColumnMenu", () => {
       expect(screen.queryByText("Statistics")).not.toBeInTheDocument()
     })
 
-    it("opens the statistics sub-menu on focus and closes the format sub-menu", () => {
+    it("opens the statistics sub-menu on focus and closes the format sub-menu", async () => {
+      const user = userEvent.setup()
       render(<ColumnMenu {...defaultProps} data={mockQuiver} />)
 
       const statsMenuItem = screen.getByRole("menuitem", {
@@ -423,70 +421,75 @@ describe("DataFrame ColumnMenu", () => {
       const formatMenuItem = screen.getByRole("menuitem", { name: /Format/ })
 
       // Open the format sub-menu first...
-      fireEvent.focus(formatMenuItem)
+      await user.click(formatMenuItem)
       expect(formatMenuItem).toHaveAttribute("aria-expanded", "true")
 
       // ...then focusing statistics should open it and close the format one.
-      fireEvent.focus(statsMenuItem)
+      await user.click(statsMenuItem)
       expect(statsMenuItem).toHaveAttribute("aria-expanded", "true")
       expect(formatMenuItem).toHaveAttribute("aria-expanded", "false")
     })
 
-    it("keeps the statistics sub-menu open on blur while the pointer is down", () => {
+    it("keeps the statistics sub-menu open on blur while the pointer is down", async () => {
+      const user = userEvent.setup()
       render(<ColumnMenu {...defaultProps} data={mockQuiver} />)
 
       const statsMenuItem = screen.getByRole("menuitem", {
         name: /Statistics/,
       })
-      fireEvent.focus(statsMenuItem)
+      await user.click(statsMenuItem)
       expect(statsMenuItem).toHaveAttribute("aria-expanded", "true")
 
-      // eslint-disable-next-line testing-library/prefer-user-event
-      fireEvent.pointerDown(document.body)
-      fireEvent.blur(statsMenuItem)
+      await user.pointer({ target: document.body, keys: "[MouseLeft>]" })
+      statsMenuItem.blur()
 
       expect(statsMenuItem).toHaveAttribute("aria-expanded", "true")
 
-      // eslint-disable-next-line testing-library/prefer-user-event
-      fireEvent.pointerUp(document.body)
+      await user.pointer({ keys: "[/MouseLeft]" })
     })
 
-    it("keeps the statistics sub-menu open when blur moves focus into the sub-menu", () => {
+    it("keeps the statistics sub-menu open when blur moves focus into the sub-menu", async () => {
+      const user = userEvent.setup()
       render(<ColumnMenu {...defaultProps} data={mockQuiver} />)
 
       const statsMenuItem = screen.getByRole("menuitem", {
         name: /Statistics/,
       })
-      fireEvent.focus(statsMenuItem)
+      await user.click(statsMenuItem)
       expect(statsMenuItem).toHaveAttribute("aria-expanded", "true")
 
       const insideSubMenu = document.createElement("div")
       insideSubMenu.setAttribute("data-testid", "stDataFrameStatisticsMenu")
-      fireEvent.blur(statsMenuItem, { relatedTarget: insideSubMenu })
+      insideSubMenu.tabIndex = -1
+      document.body.appendChild(insideSubMenu)
+      insideSubMenu.focus()
 
       expect(statsMenuItem).toHaveAttribute("aria-expanded", "true")
+      insideSubMenu.remove()
     })
 
-    it("closes the statistics sub-menu on keyboard-driven blur", () => {
+    it("closes the statistics sub-menu on keyboard-driven blur", async () => {
+      const user = userEvent.setup()
       render(<ColumnMenu {...defaultProps} data={mockQuiver} />)
 
       const statsMenuItem = screen.getByRole("menuitem", {
         name: /Statistics/,
       })
-      fireEvent.focus(statsMenuItem)
+      await user.click(statsMenuItem)
       expect(statsMenuItem).toHaveAttribute("aria-expanded", "true")
 
-      fireEvent.blur(statsMenuItem)
+      await user.tab()
       expect(statsMenuItem).toHaveAttribute("aria-expanded", "false")
     })
   })
 
   describe("format sub-menu blur into portal", () => {
-    it("keeps the format sub-menu open when blur moves focus into the sub-menu", () => {
+    it("keeps the format sub-menu open when blur moves focus into the sub-menu", async () => {
+      const user = userEvent.setup()
       render(<ColumnMenu {...defaultProps} />)
 
       const formatMenuItem = screen.getByRole("menuitem", { name: /Format/ })
-      fireEvent.focus(formatMenuItem)
+      await user.click(formatMenuItem)
       expect(formatMenuItem).toHaveAttribute("aria-expanded", "true")
 
       const insideSubMenu = document.createElement("div")
@@ -494,9 +497,12 @@ describe("DataFrame ColumnMenu", () => {
         "data-testid",
         "stDataFrameColumnFormattingMenu"
       )
-      fireEvent.blur(formatMenuItem, { relatedTarget: insideSubMenu })
+      insideSubMenu.tabIndex = -1
+      document.body.appendChild(insideSubMenu)
+      insideSubMenu.focus()
 
       expect(formatMenuItem).toHaveAttribute("aria-expanded", "true")
+      insideSubMenu.remove()
     })
   })
 
@@ -520,7 +526,8 @@ describe("DataFrame ColumnMenu", () => {
   describe("click-outside sub-menu guard", () => {
     it.each(["stDataFrameStatisticsMenu", "stDataFrameColumnFormattingMenu"])(
       "does not close the menu on pointer down inside a %s sub-menu",
-      testId => {
+      async testId => {
+        const user = userEvent.setup()
         render(<ColumnMenu {...defaultProps} />)
 
         const subMenuNode = document.createElement("div")
@@ -528,8 +535,7 @@ describe("DataFrame ColumnMenu", () => {
         document.body.appendChild(subMenuNode)
 
         try {
-          // eslint-disable-next-line testing-library/prefer-user-event
-          fireEvent.pointerDown(subMenuNode)
+          await user.pointer({ target: subMenuNode, keys: "[MouseLeft]" })
 
           expect(defaultProps.onCloseMenu).not.toHaveBeenCalled()
         } finally {

--- a/frontend/lib/src/components/widgets/DataFrame/menus/ColumnMenu.test.tsx
+++ b/frontend/lib/src/components/widgets/DataFrame/menus/ColumnMenu.test.tsx
@@ -33,12 +33,32 @@ import ColumnMenu, { ColumnMenuProps } from "./ColumnMenu"
 describe("DataFrame ColumnMenu", () => {
   const mockWriteText = vi.fn()
 
+  // Capture the original clipboard descriptor (if any) so the mock installed
+  // below can be fully restored in afterEach and does not leak across tests.
+  const originalClipboardDescriptor = Object.getOwnPropertyDescriptor(
+    navigator,
+    "clipboard"
+  )
+
   beforeEach(() => {
     mockWriteText.mockReset()
     Object.defineProperty(navigator, "clipboard", {
       configurable: true,
       value: { writeText: mockWriteText },
     })
+  })
+
+  afterEach(() => {
+    if (originalClipboardDescriptor) {
+      Object.defineProperty(
+        navigator,
+        "clipboard",
+        originalClipboardDescriptor
+      )
+    } else {
+      // jsdom has no native clipboard, so remove the mock we installed.
+      Reflect.deleteProperty(navigator, "clipboard")
+    }
   })
 
   const defaultProps: ColumnMenuProps = {
@@ -206,7 +226,7 @@ describe("DataFrame ColumnMenu", () => {
         name: /Format/,
       })
 
-      // Focus the Format item to open the sub-menu
+      // Click the Format item to open the sub-menu
       await user.click(formatMenuItem)
       expect(formatMenuItem).toHaveAttribute("aria-expanded", "true")
 
@@ -230,7 +250,7 @@ describe("DataFrame ColumnMenu", () => {
         name: /Format/,
       })
 
-      // Focus to open
+      // Click to open
       await user.click(formatMenuItem)
       expect(formatMenuItem).toHaveAttribute("aria-expanded", "true")
 
@@ -411,7 +431,7 @@ describe("DataFrame ColumnMenu", () => {
       expect(screen.queryByText("Statistics")).not.toBeInTheDocument()
     })
 
-    it("opens the statistics sub-menu on focus and closes the format sub-menu", async () => {
+    it("opens the statistics sub-menu on click and closes the format sub-menu", async () => {
       const user = userEvent.setup()
       render(<ColumnMenu {...defaultProps} data={mockQuiver} />)
 
@@ -424,7 +444,7 @@ describe("DataFrame ColumnMenu", () => {
       await user.click(formatMenuItem)
       expect(formatMenuItem).toHaveAttribute("aria-expanded", "true")
 
-      // ...then focusing statistics should open it and close the format one.
+      // ...then clicking statistics should open it and close the format one.
       await user.click(statsMenuItem)
       expect(statsMenuItem).toHaveAttribute("aria-expanded", "true")
       expect(formatMenuItem).toHaveAttribute("aria-expanded", "false")

--- a/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
@@ -14,13 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  act,
-  fireEvent,
-  screen,
-  waitFor,
-  within,
-} from "@testing-library/react"
+import { act, screen, waitFor, within } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 import moment from "moment"
 import { setInteractionModality } from "react-aria/private/interactions/useFocusVisible"
@@ -280,28 +274,38 @@ describe("DateInput widget", () => {
     expect(props.widgetMgr.setStringArrayValue).not.toHaveBeenCalled()
   })
 
-  it("resets its value to default when it's closed with empty input", () => {
+  it("resets its value to default when it's closed with empty input", async () => {
+    const user = userEvent.setup()
     const props = getProps()
     vi.spyOn(props.widgetMgr, "setStringArrayValue")
 
     render(<DateInput {...props} />)
     const dateInput = screen.getByTestId("stDateInputField")
 
-    // eslint-disable-next-line testing-library/prefer-user-event -- fireEvent.change needed to set value to null (userEvent.clear sets to empty string, not null)
-    fireEvent.change(dateInput, {
-      target: { value: newDateDisplay },
-    })
+    await user.clear(dateInput)
+    await user.type(dateInput, newDateDisplay)
 
     expect(dateInput).toHaveValue(newDateDisplay)
 
-    // Simulating clearing the date input
-    // eslint-disable-next-line testing-library/prefer-user-event -- fireEvent.change needed to set value to null (userEvent.clear sets to empty string, not null)
-    fireEvent.change(dateInput, {
-      target: { value: null },
-    })
+    await user.clear(dateInput)
+    expect(props.widgetMgr.setStringArrayValue).toHaveBeenLastCalledWith(
+      props.element,
+      [],
+      { fromUi: true },
+      undefined
+    )
 
-    // Simulating the close action
-    fireEvent.blur(dateInput)
+    // BaseUI still checks the deprecated keyCode field when Tab closes the
+    // datepicker. userEvent correctly leaves that field unset, so dispatch the
+    // legacy-compatible close event after exercising input through userEvent.
+    const closeEvent = new KeyboardEvent("keydown", {
+      bubbles: true,
+      key: "Tab",
+    })
+    Object.defineProperty(closeEvent, "keyCode", { value: 9 })
+    act(() => {
+      dateInput.dispatchEvent(closeEvent)
+    })
     expect(dateInput).toHaveValue(originalDateDisplay)
   })
 

--- a/frontend/lib/src/components/widgets/FileUploader/FileDropzone.test.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileDropzone.test.tsx
@@ -14,12 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  createEvent,
-  fireEvent,
-  screen,
-  waitFor,
-} from "@testing-library/react"
+import { act, createEvent, screen, waitFor } from "@testing-library/react"
 
 import { render } from "~lib/test_util"
 
@@ -195,7 +190,9 @@ describe("FileDropzone widget", () => {
         items: [{ kind: "file", type: "text/plain" }],
       },
     })
-    fireEvent(dropzone, dragEvent)
+    act(() => {
+      dropzone.dispatchEvent(dragEvent)
+    })
 
     await waitFor(() => {
       expect(screen.getByText("Drag and drop files here")).toBeInTheDocument()
@@ -215,7 +212,9 @@ describe("FileDropzone widget", () => {
         items: [{ kind: "file", type: "text/plain" }],
       },
     })
-    fireEvent(dropzone, dragEvent)
+    act(() => {
+      dropzone.dispatchEvent(dragEvent)
+    })
 
     await waitFor(() => {
       expect(screen.getByText("Drag and drop a file here")).toBeInTheDocument()
@@ -235,7 +234,9 @@ describe("FileDropzone widget", () => {
         items: [{ kind: "file", type: "text/plain" }],
       },
     })
-    fireEvent(dropzone, dragEvent)
+    act(() => {
+      dropzone.dispatchEvent(dragEvent)
+    })
 
     await waitFor(() => {
       expect(

--- a/frontend/lib/src/components/widgets/FileUploader/FileUploader.test.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileUploader.test.tsx
@@ -16,7 +16,7 @@
 
 import {
   act,
-  fireEvent,
+  createEvent,
   screen,
   waitFor,
   within,
@@ -54,6 +54,24 @@ const createFile = (
     })
   }
   return file
+}
+
+const dropFiles = (dropzone: HTMLElement, files: File[]): void => {
+  const dropEvent = createEvent.drop(dropzone)
+  Object.defineProperty(dropEvent, "dataTransfer", {
+    value: {
+      types: ["Files"],
+      files,
+      items: files.map(file => ({
+        kind: "file",
+        type: file.type,
+        getAsFile: () => file,
+      })),
+    },
+  })
+  act(() => {
+    dropzone.dispatchEvent(dropEvent)
+  })
 }
 
 const buildFileUploaderStateProto = (
@@ -268,17 +286,7 @@ describe("FileUploader widget tests", () => {
       }),
     ]
 
-    fireEvent.drop(fileDropZone, {
-      dataTransfer: {
-        types: ["Files"],
-        files: filesToUpload,
-        items: filesToUpload.map(file => ({
-          kind: "file",
-          type: file.type,
-          getAsFile: () => file,
-        })),
-      },
-    })
+    dropFiles(fileDropZone, filesToUpload)
 
     await waitFor(() =>
       expect(props.uploadClient.uploadFile).toHaveBeenCalledTimes(1)
@@ -354,11 +362,12 @@ describe("FileUploader widget tests", () => {
   })
 
   it("uploads multiple files, even if some have errors", async () => {
+    const user = userEvent.setup({ applyAccept: false })
     const props = getProps({ multipleFiles: true, type: [".txt"] })
     vi.spyOn(props.widgetMgr, "setFileUploaderStateValue")
     render(<FileUploader {...props} />)
 
-    const fileDropZone = screen.getByTestId("stFileUploaderDropzone")
+    const fileDropZoneInput = screen.getByTestId("stFileUploaderDropzoneInput")
 
     const filesToUpload = [
       new File(["Text in a file!"], "filename1.txt", {
@@ -375,17 +384,7 @@ describe("FileUploader widget tests", () => {
       }),
     ]
 
-    fireEvent.drop(fileDropZone, {
-      dataTransfer: {
-        types: ["Files"],
-        files: filesToUpload,
-        items: filesToUpload.map(file => ({
-          kind: "file",
-          type: file.type,
-          getAsFile: () => file,
-        })),
-      },
-    })
+    await user.upload(fileDropZoneInput, filesToUpload)
 
     await waitFor(() =>
       expect(props.uploadClient.uploadFile).toHaveBeenCalledTimes(2)
@@ -419,6 +418,7 @@ describe("FileUploader widget tests", () => {
   })
 
   it("uploads directory with multiple files successfully", async () => {
+    const user = userEvent.setup()
     const props = getProps({
       multipleFiles: true,
       acceptDirectory: true,
@@ -427,7 +427,7 @@ describe("FileUploader widget tests", () => {
     vi.spyOn(props.widgetMgr, "setFileUploaderStateValue")
     render(<FileUploader {...props} />)
 
-    const fileDropZone = screen.getByTestId("stFileUploaderDropzone")
+    const fileDropZoneInput = screen.getByTestId("stFileUploaderDropzoneInput")
 
     // Simulate directory upload with files in different folders
     const directoryFiles = [
@@ -437,17 +437,7 @@ describe("FileUploader widget tests", () => {
       createFile("project/config.txt", "project/config.txt"),
     ]
 
-    fireEvent.drop(fileDropZone, {
-      dataTransfer: {
-        types: ["Files"],
-        files: directoryFiles,
-        items: directoryFiles.map(file => ({
-          kind: "file",
-          type: file.type,
-          getAsFile: () => file,
-        })),
-      },
-    })
+    await user.upload(fileDropZoneInput, directoryFiles)
 
     await waitFor(() =>
       expect(props.uploadClient.uploadFile).toHaveBeenCalledTimes(4)
@@ -464,6 +454,7 @@ describe("FileUploader widget tests", () => {
   })
 
   it("filters directory upload files by type restrictions", async () => {
+    const user = userEvent.setup({ applyAccept: false })
     const props = getProps({
       multipleFiles: true,
       acceptDirectory: true,
@@ -472,7 +463,7 @@ describe("FileUploader widget tests", () => {
     vi.spyOn(props.widgetMgr, "setFileUploaderStateValue")
     render(<FileUploader {...props} />)
 
-    const fileDropZone = screen.getByTestId("stFileUploaderDropzone")
+    const fileDropZoneInput = screen.getByTestId("stFileUploaderDropzoneInput")
 
     // Mix of valid and invalid files for directory upload
     const mixedFiles = [
@@ -482,17 +473,7 @@ describe("FileUploader widget tests", () => {
       createFile("docs/document.pdf", "docs/document.pdf", "application/pdf"),
     ]
 
-    fireEvent.drop(fileDropZone, {
-      dataTransfer: {
-        types: ["Files"],
-        files: mixedFiles,
-        items: mixedFiles.map(file => ({
-          kind: "file",
-          type: file.type,
-          getAsFile: () => file,
-        })),
-      },
-    })
+    await user.upload(fileDropZoneInput, mixedFiles)
 
     await waitFor(() =>
       expect(props.uploadClient.uploadFile).toHaveBeenCalledTimes(2)
@@ -579,14 +560,9 @@ describe("FileUploader widget tests", () => {
 
     const fileDropZone = screen.getByTestId("stFileUploaderDropzone")
 
-    // Simulate empty directory
-    fireEvent.drop(fileDropZone, {
-      dataTransfer: {
-        types: ["Files"],
-        files: [],
-        items: [],
-      },
-    })
+    // Simulate empty directory. userEvent.upload no-ops on an empty selection,
+    // so dispatch the drop directly to actually exercise the empty-drop path.
+    dropFiles(fileDropZone, [])
 
     await waitFor(() => {
       // No upload calls should be made
@@ -774,11 +750,11 @@ describe("FileUploader widget tests", () => {
   })
 
   it("can delete file with ErrorStatus", async () => {
-    const user = userEvent.setup()
+    const user = userEvent.setup({ applyAccept: false })
     const props = getProps({ multipleFiles: false, type: [".txt"] })
     render(<FileUploader {...props} />)
 
-    const fileDropZone = screen.getByTestId("stFileUploaderDropzone")
+    const fileDropZoneInput = screen.getByTestId("stFileUploaderDropzoneInput")
 
     const filesToUpload = [
       new File(["Another PDF file"], "anotherpdffile.pdf", {
@@ -788,17 +764,7 @@ describe("FileUploader widget tests", () => {
     ]
 
     // Drop a file with an error (wrong extension)
-    fireEvent.drop(fileDropZone, {
-      dataTransfer: {
-        types: ["Files"],
-        files: filesToUpload,
-        items: filesToUpload.map(file => ({
-          kind: "file",
-          type: file.type,
-          getAsFile: () => file,
-        })),
-      },
-    })
+    await user.upload(fileDropZoneInput, filesToUpload)
 
     await waitFor(() =>
       expect(screen.getAllByTestId("stFileChip").length).toBe(1)
@@ -837,10 +803,11 @@ describe("FileUploader widget tests", () => {
   })
 
   it("shows an ErrorStatus when File extension is not allowed", async () => {
+    const user = userEvent.setup({ applyAccept: false })
     const props = getProps({ multipleFiles: false, type: [".png"] })
     render(<FileUploader {...props} />)
 
-    const fileDropZone = screen.getByTestId("stFileUploaderDropzone")
+    const fileDropZoneInput = screen.getByTestId("stFileUploaderDropzoneInput")
 
     const filesToUpload = [
       new File(["TXT file"], "txtfile.txt", {
@@ -850,17 +817,7 @@ describe("FileUploader widget tests", () => {
     ]
 
     // Drop a file with an error (wrong extension)
-    fireEvent.drop(fileDropZone, {
-      dataTransfer: {
-        types: ["Files"],
-        files: filesToUpload,
-        items: filesToUpload.map(file => ({
-          kind: "file",
-          type: file.type,
-          getAsFile: () => file,
-        })),
-      },
-    })
+    await user.upload(fileDropZoneInput, filesToUpload)
 
     await waitFor(() =>
       expect(screen.getAllByTestId("stFileChip").length).toBe(1)

--- a/frontend/lib/src/components/widgets/FileUploader/FileUploader.test.tsx
+++ b/frontend/lib/src/components/widgets/FileUploader/FileUploader.test.tsx
@@ -56,6 +56,12 @@ const createFile = (
   return file
 }
 
+/**
+ * Dispatch a drag-and-drop of `files` onto a dropzone container. `userEvent.upload`
+ * only targets `<input>` elements, so it cannot simulate drops on arbitrary dropzone
+ * containers or multi-file selection on a non-multiple input — this helper builds the
+ * drop event manually to exercise those paths.
+ */
 const dropFiles = (dropzone: HTMLElement, files: File[]): void => {
   const dropEvent = createEvent.drop(dropzone)
   Object.defineProperty(dropEvent, "dataTransfer", {
@@ -286,6 +292,8 @@ describe("FileUploader widget tests", () => {
       }),
     ]
 
+    // Drop multiple files onto a single-file dropzone; user.upload on a
+    // non-multiple input cannot exercise this rejection path.
     dropFiles(fileDropZone, filesToUpload)
 
     await waitFor(() =>

--- a/frontend/lib/src/components/widgets/TextInput/TextInput.test.tsx
+++ b/frontend/lib/src/components/widgets/TextInput/TextInput.test.tsx
@@ -285,8 +285,7 @@ describe("TextInput widget", () => {
     render(<TextInput {...props} />)
     const textInput = screen.getByRole("textbox")
 
-    // userEvent is necessary to simulate the full interaction chain
-    // (focus → keydown → keyup); fireEvent only dispatches raw DOM events
+    // Simulate the full interaction chain (focus → keydown → keyup).
     await user.click(textInput)
     await user.keyboard("testing{Enter}")
 
@@ -309,8 +308,7 @@ describe("TextInput widget", () => {
 
     expect(props.widgetMgr.setStringValue).toHaveBeenCalledTimes(1)
 
-    // userEvent is necessary to simulate the full interaction chain
-    // (focus → keydown → keyup); fireEvent only dispatches raw DOM events
+    // Simulate the full interaction chain (focus → keydown → keyup).
     await user.click(textInput)
     await user.keyboard("testing{Enter}")
 


### PR DESCRIPTION
## Describe your changes

Removes `fireEvent` from 17 frontend unit test files, replacing it with the `testing-library`-recommended alternatives so the `testing-library/prefer-user-event` eslint-disable comments can be dropped.

- Real user interactions (clicks, typing, keyboard, pointer) now use `userEvent`.
- Raw DOM/media/lifecycle events (`error`, `loadedmetadata`, `timeupdate`, `scroll`, drag/drop, window `message`) are dispatched directly via `dispatchEvent`/`createEvent`, wrapped in `act()` only where they trigger React state updates.

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- Test-only change; behavior is unchanged. Existing unit tests continue to pass with the migrated event mechanisms.
- [x] Unit Tests (JS and/or Python)