### PR TITLE
[fix] Skip real-file rename test in nightly builds

### DIFF
--- a/lib/tests/scripts/update_name_test.py
+++ b/lib/tests/scripts/update_name_test.py
@@ -14,13 +14,27 @@
 
 from __future__ import annotations
 
+import re
 import shutil
 import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _UPDATE_NAME_SCRIPT = _REPO_ROOT / "scripts" / "update_name.py"
+_LIB_PYPROJECT = _REPO_ROOT / "lib" / "pyproject.toml"
+
+
+def _current_lib_package_name() -> str:
+    """Return the package name declared in the real ``lib/pyproject.toml``."""
+    for line in _LIB_PYPROJECT.read_text(encoding="utf-8").splitlines():
+        match = re.match(r'^name = "(?P<name>[^"]+)"$', line)
+        if match:
+            return match.group("name")
+    raise AssertionError(f'No `name = "..."` entry found in {_LIB_PYPROJECT}')
+
 
 _DEFAULT_LIB_PYPROJECT = """\
 [project]
@@ -161,6 +175,15 @@ test = [
     assert b"self-reference" in result.stderr
 
 
+@pytest.mark.skipif(
+    _current_lib_package_name() != "streamlit",
+    reason=(
+        "The real repo files have already been renamed away from 'streamlit' "
+        "(e.g. by the nightly build, which renames to 'streamlit-nightly' before "
+        "running the test suite), so the rename-from-'streamlit' guard no longer "
+        "applies."
+    ),
+)
 def test_update_name_renames_actual_repo_files(tmp_path: Path) -> None:
     """Renaming the real repo files leaves no stale ``streamlit[...]`` references.
 


### PR DESCRIPTION
## Describe your changes

Fixes the nightly `test_update_name_renames_actual_repo_files` failure ([run 30788011177](https://github.com/streamlit/streamlit/actions/runs/30788011177)).

- The nightly `create-nightly-tag` job runs `scripts/update_name.py streamlit-nightly`, commits the renamed `pyproject.toml`/`lib/pyproject.toml`, and tags it; the test suite then runs against that tag. The test copied those already-renamed files and re-ran the rename, which aborted because `update_root_pyproject_toml` only matches the literal `streamlit` anchors.
- Skip the test when the real `lib/pyproject.toml` name is no longer `streamlit`, keeping the drift guard fully active on PRs and `develop` while making it a no-op in the nightly (already-renamed) context. The production rename script is unchanged, preserving its strict "must have matched" guards.

## GitHub Issue Link (if applicable)

## Testing Plan

- `lib/tests/scripts/update_name_test.py` — verified the guarded test runs and passes on canonical files, and skips when files are renamed to `streamlit-nightly` (reproduced the double-rename failure locally to confirm the root cause).

Made with [Cursor](https://cursor.com)