### PR TITLE
[fix] Don't rerun nested fragments already re-rendered by a queued ancestor (#10719)

### DIFF
--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -18,7 +18,7 @@ import contextlib
 import inspect
 import threading
 from abc import abstractmethod
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Container, Iterator
 from copy import deepcopy
 from functools import wraps
 from typing import TYPE_CHECKING, Any, Final, NoReturn, Protocol, TypeVar, overload
@@ -153,6 +153,11 @@ class FragmentStorage(Protocol):
     @abstractmethod
     def order_fragment_ids(self, fragment_ids: list[str]) -> list[str]:
         """Return a stable ordering that keeps queued ancestors before descendants."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def has_ancestor_in(self, fragment_id: str, candidate_ids: Container[str]) -> bool:
+        """Return whether any ancestor of ``fragment_id`` is in ``candidate_ids``."""
         raise NotImplementedError
 
     @abstractmethod
@@ -356,6 +361,13 @@ class MemoryFragmentStorage(FragmentStorage):
                     break
 
             return ordered_fragment_ids
+
+    def has_ancestor_in(self, fragment_id: str, candidate_ids: Container[str]) -> bool:
+        with self._lock:
+            return any(
+                ancestor_id in candidate_ids
+                for ancestor_id in self._iter_ancestor_ids(fragment_id)
+            )
 
     def delete(self, key: str) -> None:
         with self._lock:

--- a/lib/streamlit/runtime/fragment.py
+++ b/lib/streamlit/runtime/fragment.py
@@ -335,15 +335,6 @@ class MemoryFragmentStorage(FragmentStorage):
     def order_fragment_ids(self, fragment_ids: list[str]) -> list[str]:
         """Run queued ancestors before descendants while preserving FIFO otherwise."""
         with self._lock:
-
-            def has_queued_ancestor(
-                fragment_id: str, queued_fragment_ids: set[str]
-            ) -> bool:
-                return any(
-                    ancestor_id in queued_fragment_ids
-                    for ancestor_id in self._iter_ancestor_ids(fragment_id)
-                )
-
             remaining_fragment_ids = list(fragment_ids)
             ordered_fragment_ids = []
 
@@ -351,7 +342,9 @@ class MemoryFragmentStorage(FragmentStorage):
                 queued_fragment_ids = set(remaining_fragment_ids)
 
                 for index, fragment_id in enumerate(remaining_fragment_ids):
-                    if not has_queued_ancestor(fragment_id, queued_fragment_ids):
+                    if not self._has_ancestor_in_unlocked(
+                        fragment_id, queued_fragment_ids
+                    ):
                         ordered_fragment_ids.append(fragment_id)
                         del remaining_fragment_ids[index]
                         break
@@ -364,10 +357,22 @@ class MemoryFragmentStorage(FragmentStorage):
 
     def has_ancestor_in(self, fragment_id: str, candidate_ids: Container[str]) -> bool:
         with self._lock:
-            return any(
-                ancestor_id in candidate_ids
-                for ancestor_id in self._iter_ancestor_ids(fragment_id)
-            )
+            return self._has_ancestor_in_unlocked(fragment_id, candidate_ids)
+
+    def _has_ancestor_in_unlocked(
+        self, fragment_id: str, candidate_ids: Container[str]
+    ) -> bool:
+        """Return whether any ancestor of ``fragment_id`` is in ``candidate_ids``.
+
+        Callers must hold ``self._lock``; use ``has_ancestor_in`` from outside
+        the lock. Extracted so ``order_fragment_ids`` (which already holds the
+        lock while walking the queue) and ``has_ancestor_in`` can share the
+        same predicate without deadlocking or drifting apart.
+        """
+        return any(
+            ancestor_id in candidate_ids
+            for ancestor_id in self._iter_ancestor_ids(fragment_id)
+        )
 
     def delete(self, key: str) -> None:
         with self._lock:

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -722,12 +722,12 @@ class ScriptRunner:
                     ctx.on_script_start()
 
                     if fragment_ids_this_run:
-                        # Fragment ids already executed during this run. Because
-                        # ``order_fragment_ids`` puts ancestors first, running an
-                        # ancestor also re-renders its descendants as part of its own
-                        # body. Executing such a descendant again from the queue would
-                        # re-create its widgets within the same script run and raise
-                        # StreamlitDuplicateElementId, which is what happens when a
+                        # Skip queued descendants whose ancestor already ran in this
+                        # pass. ``order_fragment_ids`` runs ancestors first, and an
+                        # ancestor re-renders its descendants as part of its own body,
+                        # so running a descendant again would re-create its widgets
+                        # within the same script run and raise
+                        # StreamlitDuplicateElementId. That is what happens when a
                         # parent and child both use ``run_every`` and their auto-reruns
                         # coalesce (see #10719).
                         executed_fragment_ids: set[str] = set()

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -722,7 +722,22 @@ class ScriptRunner:
                     ctx.on_script_start()
 
                     if fragment_ids_this_run:
+                        # Fragment ids already executed during this run. Because
+                        # ``order_fragment_ids`` puts ancestors first, running an
+                        # ancestor also re-renders its descendants as part of its own
+                        # body. Executing such a descendant again from the queue would
+                        # re-create its widgets within the same script run and raise
+                        # StreamlitDuplicateElementId, which is what happens when a
+                        # parent and child both use ``run_every`` and their auto-reruns
+                        # coalesce (see #10719).
+                        executed_fragment_ids: set[str] = set()
+
                         for fragment_id in fragment_ids_this_run:
+                            if self._fragment_storage.has_ancestor_in(
+                                fragment_id, executed_fragment_ids
+                            ):
+                                continue
+
                             registration_sequence_before = (
                                 self._fragment_storage.registration_sequence()
                             )
@@ -752,6 +767,12 @@ class ScriptRunner:
                                         fragment_id,
                                     )
                                 continue
+
+                            # Recorded before the call so a fragment that raises still
+                            # suppresses its queued descendants: it owns their
+                            # containers either way, and rerunning them here would
+                            # render them outside the parent that just failed.
+                            executed_fragment_ids.add(fragment_id)
 
                             try:
                                 wrapped_fragment()

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -722,14 +722,12 @@ class ScriptRunner:
                     ctx.on_script_start()
 
                     if fragment_ids_this_run:
-                        # Skip queued descendants whose ancestor already ran in this
-                        # pass. ``order_fragment_ids`` runs ancestors first, and an
-                        # ancestor re-renders its descendants as part of its own body,
-                        # so running a descendant again would re-create its widgets
-                        # within the same script run and raise
-                        # StreamlitDuplicateElementId. That is what happens when a
-                        # parent and child both use ``run_every`` and their auto-reruns
-                        # coalesce (see #10719).
+                        # Skip queued descendants whose ancestor already ran in
+                        # this pass — the ancestor re-renders them inline, so
+                        # running them again would duplicate their widgets and
+                        # raise StreamlitDuplicateElementId (for example, when
+                        # a parent and child both use ``run_every`` and their
+                        # auto-reruns coalesce; see #10719).
                         executed_fragment_ids: set[str] = set()
 
                         for fragment_id in fragment_ids_this_run:
@@ -768,10 +766,11 @@ class ScriptRunner:
                                     )
                                 continue
 
-                            # Recorded before the call so a fragment that raises still
-                            # suppresses its queued descendants: it owns their
-                            # containers either way, and rerunning them here would
-                            # render them outside the parent that just failed.
+                            # We record this before the call so a fragment
+                            # that raises still suppresses its queued
+                            # descendants: it owns their containers either way,
+                            # and rerunning them here would render them outside
+                            # the parent that just failed.
                             executed_fragment_ids.add(fragment_id)
 
                             try:

--- a/lib/tests/streamlit/runtime/fragment_test.py
+++ b/lib/tests/streamlit/runtime/fragment_test.py
@@ -1534,6 +1534,7 @@ def test_fragment_decorator_handles_pep649_annotations() -> None:
         ("registration_sequence", (), {}),
         ("ids_registered_after", (0,), {}),
         ("order_fragment_ids", ([],), {}),
+        ("has_ancestor_in", ("frag", set()), {}),
         ("delete", ("key",), {}),
         ("contains", ("key",), {}),
         ("register_outside_wrapper", ("frag", "container", object()), {}),

--- a/lib/tests/streamlit/runtime/fragment_test.py
+++ b/lib/tests/streamlit/runtime/fragment_test.py
@@ -392,6 +392,22 @@ class MemoryFragmentStorageTest(unittest.TestCase):
 
         assert self._storage.ids_registered_after(snapshot) == frozenset({"some_key"})
 
+    def test_has_ancestor_in_finds_transitive_ancestor(self):
+        """Any ancestor along the chain counts, not just the immediate parent."""
+        self._set_fragment_chain("outer", "middle", "inner")
+
+        assert self._storage.has_ancestor_in("inner", {"outer"})
+        assert self._storage.has_ancestor_in("inner", {"middle"})
+        assert self._storage.has_ancestor_in("middle", {"outer"})
+
+    def test_has_ancestor_in_excludes_self_and_descendants(self):
+        """A fragment is not its own ancestor, and descendants don't count."""
+        self._set_fragment_chain("outer", "inner")
+
+        assert not self._storage.has_ancestor_in("inner", {"inner"})
+        assert not self._storage.has_ancestor_in("outer", {"inner"})
+        assert not self._storage.has_ancestor_in("inner", set())
+
     def test_order_fragment_ids_empty_input_returns_empty_list(self):
         """An empty input list yields an empty ordering."""
         assert self._storage.order_fragment_ids([]) == []

--- a/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
@@ -640,6 +640,47 @@ class ScriptRunnerTest(unittest.TestCase):
         inner.assert_called_once()
         self._assert_no_exceptions(scriptrunner)
 
+    def test_fragment_queue_skips_descendant_when_ancestor_raises(self):
+        """A failing ancestor must still suppress its queued descendant.
+
+        The descendant is recorded as executed *before* the ancestor's body runs,
+        because the ancestor owns the descendant's container either way: if it
+        raised partway through, rerunning the descendant here would render it
+        outside the parent that just failed. Moving that bookkeeping after the
+        call would let the descendant run, so this pins the ordering.
+
+        The ancestor re-registers the descendant before raising. Without that,
+        ``clear_stale_descendants`` prunes the descendant during cleanup and the
+        lookup fails, which would make this pass for the wrong reason.
+        """
+        scriptrunner = TestScriptRunner("good_script.py")
+        inner = MagicMock()
+
+        def register_child_then_explode() -> None:
+            ctx = get_script_run_ctx()
+            assert ctx is not None
+            ctx.shared.new_fragment_ids.check_and_add("inner")
+            scriptrunner._fragment_storage.register(
+                "inner", inner, parent_fragment_id="outer"
+            )
+            raise RuntimeError("kaboom")
+
+        outer = MagicMock(side_effect=register_child_then_explode)
+        scriptrunner._fragment_storage.register("outer", outer, parent_fragment_id=None)
+        scriptrunner._fragment_storage.register(
+            "inner", inner, parent_fragment_id="outer"
+        )
+
+        scriptrunner.request_rerun(RerunData(fragment_id_queue=["inner", "outer"]))
+        scriptrunner.start()
+        scriptrunner.join()
+
+        outer.assert_called_once()
+        inner.assert_not_called()
+        assert scriptrunner._fragment_storage.contains("inner"), (
+            "the descendant must survive cleanup, or this test passes vacuously"
+        )
+
     def test_fragment_scoped_rerun_child_first_does_not_rerun_parent(self):
         """A child-scoped rerun must not requeue an already-run parent."""
         scriptrunner = TestScriptRunner("good_script.py")

--- a/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
@@ -643,11 +643,12 @@ class ScriptRunnerTest(unittest.TestCase):
     def test_fragment_queue_skips_descendant_when_ancestor_raises(self):
         """A failing ancestor must still suppress its queued descendant.
 
-        The descendant is recorded as executed *before* the ancestor's body runs,
-        because the ancestor owns the descendant's container either way: if it
-        raised partway through, rerunning the descendant here would render it
-        outside the parent that just failed. Moving that bookkeeping after the
-        call would let the descendant run, so this pins the ordering.
+        The ancestor is added to ``executed_fragment_ids`` *before* its own body
+        runs, so a descendant reached later in the queue is skipped by
+        ``has_ancestor_in`` even when that body raised. The ancestor owns the
+        descendant's container either way: rerunning the descendant here would
+        render it outside the parent that just failed. Moving that bookkeeping
+        after the call would let the descendant run, so this pins the ordering.
 
         The ancestor re-registers the descendant before raising. Without that,
         ``clear_stale_descendants`` prunes the descendant during cleanup and the

--- a/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
@@ -504,6 +504,7 @@ class ScriptRunnerTest(unittest.TestCase):
             scriptrunner._fragment_storage.register(
                 "inner", inner, parent_fragment_id="outer"
             )
+            inner()
 
         outer = MagicMock(side_effect=rerender_outer)
         scriptrunner._fragment_storage.register("outer", outer, parent_fragment_id=None)
@@ -516,6 +517,8 @@ class ScriptRunnerTest(unittest.TestCase):
         scriptrunner.join()
 
         outer.assert_called_once()
+        # The parent already re-rendered the child inline, so the child's own queue
+        # entry is skipped instead of running it a second time (#10719).
         inner.assert_called_once()
         assert scriptrunner._fragment_storage.contains("inner")
 
@@ -561,9 +564,81 @@ class ScriptRunnerTest(unittest.TestCase):
         scriptrunner.join()
 
         outer.assert_called_once()
-        assert middle.call_count == 2
-        assert grandchild.call_count == 3
+        # The outer rerun re-renders the whole chain inline, so the queued
+        # descendants are skipped rather than run again (#10719), and the
+        # grandchild must survive in storage for later reruns.
+        middle.assert_called_once()
+        grandchild.assert_called_once()
         assert scriptrunner._fragment_storage.contains("grandchild")
+
+    def test_fragment_queue_nested_widgets_are_not_duplicated(self):
+        """Coalesced parent+child auto-reruns must not re-create the child's widgets.
+
+        Regression test for issue #10719: two nested ``run_every`` fragments can have
+        their auto-reruns coalesced into a single queue. The parent re-renders the
+        child as part of its own body, so also running the child from the queue
+        registered its widgets twice and raised StreamlitDuplicateElementId.
+        """
+        scriptrunner = TestScriptRunner("good_script.py")
+        inner_errors: list[Exception] = []
+
+        def render_inner() -> None:
+            try:
+                st.button("inner button")
+            except Exception as e:
+                # Recorded rather than raised so the assertion below can name the
+                # duplicate-id failure instead of it being swallowed by the runner.
+                inner_errors.append(e)
+
+        inner = MagicMock(side_effect=render_inner)
+
+        def render_outer() -> None:
+            ctx = get_script_run_ctx()
+            assert ctx is not None
+            st.button("outer button")
+            ctx.shared.new_fragment_ids.check_and_add("inner")
+            scriptrunner._fragment_storage.register(
+                "inner", inner, parent_fragment_id="outer"
+            )
+            inner()
+
+        outer = MagicMock(side_effect=render_outer)
+        scriptrunner._fragment_storage.register("outer", outer, parent_fragment_id=None)
+        scriptrunner._fragment_storage.register(
+            "inner", inner, parent_fragment_id="outer"
+        )
+
+        scriptrunner.request_rerun(RerunData(fragment_id_queue=["inner", "outer"]))
+        scriptrunner.start()
+        scriptrunner.join()
+
+        assert inner_errors == []
+        inner.assert_called_once()
+        button_labels = [
+            element.button.label
+            for element in scriptrunner.elements()
+            if element.WhichOneof("type") == "button"
+        ]
+        assert button_labels == ["outer button", "inner button"]
+        self._assert_no_exceptions(scriptrunner)
+
+    def test_fragment_queue_runs_descendant_when_ancestor_is_gone(self):
+        """A queued descendant still runs if its queued ancestor never executed."""
+        scriptrunner = TestScriptRunner("good_script.py")
+        inner = MagicMock()
+
+        scriptrunner._fragment_storage.register(
+            "inner", inner, parent_fragment_id="outer"
+        )
+
+        # "outer" is queued but absent from storage, so it is skipped without running
+        # and must not suppress its descendant's own queued rerun.
+        scriptrunner.request_rerun(RerunData(fragment_id_queue=["inner", "outer"]))
+        scriptrunner.start()
+        scriptrunner.join()
+
+        inner.assert_called_once()
+        self._assert_no_exceptions(scriptrunner)
 
     def test_fragment_scoped_rerun_child_first_does_not_rerun_parent(self):
         """A child-scoped rerun must not requeue an already-run parent."""
@@ -586,6 +661,7 @@ class ScriptRunnerTest(unittest.TestCase):
             scriptrunner._fragment_storage.register(
                 "inner", inner, parent_fragment_id="outer"
             )
+            inner()
 
         outer = MagicMock(side_effect=rerender_outer)
         scriptrunner._fragment_storage.register("outer", outer, parent_fragment_id=None)
@@ -617,6 +693,8 @@ class ScriptRunnerTest(unittest.TestCase):
             with ThreadState.scoped(fragment_id="outer"):
                 if outer.call_count == 1:
                     st.rerun(scope="fragment")
+
+            inner()
 
         outer = MagicMock(side_effect=rerun_outer)
         scriptrunner._fragment_storage.register("outer", outer, parent_fragment_id=None)


### PR DESCRIPTION
## Describe your changes

Two nested fragments that both use `run_every` can have their auto-reruns coalesced into a single fragment queue. `order_fragment_ids` (added in #15130) runs the ancestor first, and the ancestor re-renders the child as part of its own body — so also running the child from the queue registered its widgets a second time in the same script run and raised `StreamlitDuplicateElementId`:

```python
import streamlit as st

@st.fragment(run_every=0.2)
def func2():
    st.button("OK2")

@st.fragment(run_every=0.5)
def func():
    st.button("OK")
    func2()

func()
```

This tracks the fragments actually executed during the queue loop and skips any queued fragment whose ancestor already ran.

Keying off *executed* rather than merely *queued* ancestors matters: when an ancestor is queued but has been evicted from storage, it is skipped without running, and its descendant's own rerun must still happen. `test_fragment_queue_runs_descendant_when_ancestor_is_gone` pins that, and fails if the check is relaxed to queued ancestors.

Four existing tests in `script_runner_test.py` asserted the old behaviour (`grandchild.call_count == 3` for a three-deep chain). Their mocks registered a child fragment without ever calling it, which `wrap` never does in production — registration is always immediately followed by execution. I made those mocks faithful and updated the counts that genuinely change; each test's original intent (storage preservation, `st.rerun(scope="fragment")` ordering) is unchanged and still asserted.

## GitHub Issue Link

- Fixes #10719

## Testing Plan

- **Unit Tests:** `test_fragment_queue_nested_widgets_are_not_duplicated` reproduces the issue with real `st.button` widgets and asserts no `StreamlitDuplicateElementId`; `test_fragment_queue_runs_descendant_when_ancestor_is_gone` guards against over-suppression; two `MemoryFragmentStorage` tests cover `has_ancestor_in` (transitive ancestors, self/descendant exclusion).
- **Mutation-verified, not vacuous:** removing the skip makes `test_fragment_queue_nested_widgets_are_not_duplicated` fail with exactly `StreamlitDuplicateElementId`; changing the check from executed to queued ancestors makes `test_fragment_queue_runs_descendant_when_ancestor_is_gone` fail.
- **Full suite:** `10922 passed, 66 skipped`. `ruff format`/`check`, `ty`, and `mypy` all clean.
- **E2E:** deliberately not added. Detection would be timing-dependent (it needs the two auto-reruns to coalesce), so it would only catch the regression probabilistically, and adding always-on 0.2s/0.5s timers to the shared `st_fragment_run_every.py` app risks destabilising the existing tests in that file. The existing `#15084` e2e assertions there remain valid — its outer fragments are not periodic, which is why this bug never surfaced in e2e. Happy to add one if you'd prefer the coverage.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes fragment queue execution semantics in `ScriptRunner`; behavior is well-tested but affects nested `run_every` and multi-fragment reruns.
> 
> **Overview**
> Fixes **duplicate widget IDs** when coalesced fragment queues run a parent before a nested child: the parent already executes the child inline, so the child's separate queue entry is now **skipped** if an ancestor ran earlier in the same pass.
> 
> `FragmentStorage` gains **`has_ancestor_in`** (shared with `order_fragment_ids` via `_has_ancestor_in_unlocked`). `ScriptRunner` tracks **`executed_fragment_ids`** and skips queued fragments whose ancestor is in that set—not merely queued—so a missing/evicted ancestor does not block the descendant. Fragments are recorded as executed **before** their body runs so failures still suppress queued descendants.
> 
> Tests cover nested `run_every` coalescing (#10719), over-suppression when an ancestor never runs, and ancestor-failure ordering; several mocks now call nested fragments inline like production.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f92c5d6c66bb840cbe704753c658c470e1eca7b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->