### PR TITLE
[fix] Restore port auto-increment on Windows

### DIFF
--- a/lib/streamlit/web/server/starlette/starlette_server.py
+++ b/lib/streamlit/web/server/starlette/starlette_server.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 
 import asyncio
 import errno
+import os
 import socket
 import sys
 from typing import TYPE_CHECKING, Any, Final
@@ -243,7 +244,8 @@ def _bind_socket(address: str, port: int, backlog: int) -> socket.socket:
 
     1. Detect port conflicts before creating the uvicorn.Server instance
     2. Enable port retry logic when the configured port is already in use
-    3. Have explicit control over socket options (SO_REUSEADDR, IPV6_V6ONLY)
+    3. Have explicit control over socket options (IPV6_V6ONLY, and SO_REUSEADDR
+       everywhere except Windows)
 
     Parameters
     ----------
@@ -268,7 +270,14 @@ def _bind_socket(address: str, port: int, backlog: int) -> socket.socket:
 
     sock = socket.socket(family=family)
     try:
-        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        # Skip SO_REUSEADDR on Windows: there it lets a socket bind a port that
+        # another live socket is already listening on, so bind() never reports a
+        # conflict and the caller's free-port search keeps handing back the same
+        # port (see #16296). Windows' default bind already rejects the conflict.
+        # Tornado's bind_sockets skipped it too, so this restores the behavior
+        # Streamlit had before the Starlette migration.
+        if os.name != "nt":
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 
         if family == socket.AF_INET6:
             # Allow both IPv4 and IPv6 clients when binding to "::".

--- a/lib/tests/streamlit/web/server/starlette/starlette_server_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_server_test.py
@@ -59,14 +59,62 @@ class TestBindSocket:
             result = _bind_socket("127.0.0.1", 8501, 100)
 
             mock_socket_cls.assert_called_once_with(family=socket.AF_INET)
-            mock_sock.setsockopt.assert_called_with(
-                socket.SOL_SOCKET, socket.SO_REUSEADDR, 1
-            )
             mock_sock.bind.assert_called_once_with(("127.0.0.1", 8501))
             mock_sock.listen.assert_called_once_with(100)
             mock_sock.setblocking.assert_called_once_with(False)
             mock_sock.set_inheritable.assert_called_once_with(True)
             assert result == mock_sock
+
+    @pytest.mark.parametrize("address", ["127.0.0.1", "::"])
+    def test_sets_reuseaddr_on_non_windows_platforms(self, address: str) -> None:
+        """Test that SO_REUSEADDR is set on platforms other than Windows."""
+
+        mock_sock = mock.MagicMock()
+        with (
+            patch("socket.socket", return_value=mock_sock),
+            patch("os.name", "posix"),
+        ):
+            _bind_socket(address, 8501, 100)
+
+            mock_sock.setsockopt.assert_any_call(
+                socket.SOL_SOCKET, socket.SO_REUSEADDR, 1
+            )
+
+    @pytest.mark.parametrize("address", ["127.0.0.1", "::"])
+    def test_skips_reuseaddr_on_windows(self, address: str) -> None:
+        """Test that SO_REUSEADDR is not set on Windows.
+
+        On Windows the option lets a second socket bind a port that another live
+        socket is already listening on, which hides port conflicts from the
+        caller's free-port search (see #16296). "::" is the default bind address,
+        so it is the family the conflict actually surfaces on.
+        """
+
+        mock_sock = mock.MagicMock()
+        with (
+            patch("socket.socket", return_value=mock_sock),
+            patch("os.name", "nt"),
+        ):
+            _bind_socket(address, 8501, 100)
+
+            assert (
+                mock.call(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                not in mock_sock.setsockopt.call_args_list
+            )
+
+    def test_sets_ipv6_v6only_on_windows(self) -> None:
+        """Test that Windows still gets IPV6_V6ONLY even though SO_REUSEADDR is skipped."""
+
+        mock_sock = mock.MagicMock()
+        with (
+            patch("socket.socket", return_value=mock_sock),
+            patch("os.name", "nt"),
+        ):
+            _bind_socket("::", 8501, 100)
+
+            mock_sock.setsockopt.assert_any_call(
+                socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0
+            )
 
     def test_creates_ipv6_socket(self) -> None:
         """Test that IPv6 address creates AF_INET6 socket."""
@@ -112,6 +160,29 @@ class TestBindSocket:
                 _bind_socket("127.0.0.1", 8501, 100)
 
             mock_sock.close.assert_called_once()
+
+    def test_raises_eaddrinuse_for_port_that_is_already_listening(self) -> None:
+        """Test that binding a port another socket listens on raises EADDRINUSE.
+
+        The caller's free-port search only advances when bind() fails here. If it
+        silently succeeds, every Streamlit process lands on the same port
+        (see #16296). This runs against the host platform's real bind semantics,
+        so it pins that _bind_socket propagates the underlying errno rather than
+        wrapping or swallowing it. It does not cover the Windows SO_REUSEADDR
+        branch, which test_skips_reuseaddr_on_windows pins instead.
+        """
+
+        with socket.socket() as occupied_sock:
+            occupied_sock.bind(("127.0.0.1", 0))
+            occupied_sock.listen(1)
+            occupied_port = occupied_sock.getsockname()[1]
+
+            # Message wording differs per platform, so match only the word they
+            # share. The errno assertion below is the real check.
+            with pytest.raises(OSError, match=r"(?i)address") as exc_info:
+                _bind_socket("127.0.0.1", occupied_port, 100)
+
+            assert exc_info.value.errno == errno.EADDRINUSE
 
 
 class TestGetBindAddress:


### PR DESCRIPTION
## Describe your changes

`_bind_socket()` set `SO_REUSEADDR` unconditionally. On POSIX that option only permits rebinding sockets left in `TIME_WAIT`, but on Windows it permits two **live** sockets to bind the same address and port. So a second `streamlit run` bound 8501 successfully, `bind()` never raised `EADDRINUSE`, and the port-retry loop in `UvicornServer.start()` never advanced. Every process claimed 8501 and only the first was reachable. Regression from the 1.57 Tornado to Starlette/Uvicorn migration.

- Skip `SO_REUSEADDR` on Windows, matching the `if os.name != "nt"` guard in Tornado's `netutil.bind_sockets` that Streamlit's binding went through before 1.57. POSIX behavior is byte-for-byte unchanged.
- Rejected the alternative of setting `SO_EXCLUSIVEADDRUSE` on Windows instead. [Microsoft documents](https://learn.microsoft.com/en-us/windows/win32/winsock/using-so-reuseaddr-and-so-exclusiveaddruse) that a listening socket with that option set cannot rebind its port until accepted connections go inactive. Every Streamlit listener accepts websockets, so quitting with a browser tab open and restarting would jump to 8502 - a worse regression than the one being fixed.
- Side benefit: the same doc calls `SO_REUSEADDR` on Windows a socket-hijacking vector requiring no special privileges, so dropping it closes that window on our own listener.

Both bind paths are covered, since `UvicornServer.start()` and `UvicornRunner.run()` (the `st.App` path) share `_bind_socket()`. Uvicorn does not re-set the option on a socket handed to it pre-bound.

Unchanged from POSIX: a wildcard bind followed by a specific-address bind (`--server.address 127.0.0.1`) still both succeed on 8501 on Windows. POSIX permits this too, so the fix converges the platforms rather than adding a Windows quirk.

## GitHub Issue Link (if applicable)

- Closes #16296

## Testing Plan

- **Unit Tests (Python)** in `starlette_server_test.py`: the `SO_REUSEADDR` branch is asserted both ways (set on `posix`, absent on `nt`), parametrized over `127.0.0.1` and the default `::` dual-stack address; `IPV6_V6ONLY` is asserted to survive the Windows branch; and a real-socket test pins that `_bind_socket()` propagates `errno.EADDRINUSE` for an already-listening port, which is the contract both retry loops depend on.
- **Manual testing on Windows is still needed and has not been done.** There is no Windows runner in CI, and on POSIX these tests pass with or without the fix, so nothing here actually exercises the bug. A reviewer on Windows should confirm: (a) two `streamlit run` invocations land on 8501 and 8502 and both are reachable; (b) quitting with a browser tab open and immediately restarting still lands on 8501, i.e. no `TIME_WAIT` regression; (c) `--server.port 8501` with 8501 occupied still errors with `Port 8501 is not available` and exits 1.
- Verified on macOS that POSIX is unaffected: three concurrent `streamlit run` processes bound 8501/8502/8503 (confirmed via `lsof`), and forcing the `nt` branch locally still binds and still rejects a conflicting port with `EADDRINUSE`.
- No E2E tests: this is a platform-gated socket option applied before any request is served, with no rendered surface.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared server bind path used by both Uvicorn entry points; change is narrow and POSIX behavior is preserved, but incorrect platform detection could affect bind semantics on Windows.
> 
> **Overview**
> Fixes a regression where multiple `streamlit run` processes on Windows could all bind the same port (#16296) because **`SO_REUSEADDR` on Windows allows binding a port another live socket is already listening on**, so `bind()` never returned `EADDRINUSE` and the port-retry loop in `UvicornServer` / `UvicornRunner` never advanced.
> 
> **`_bind_socket()`** now sets `SO_REUSEADDR` only when `os.name != "nt"`, matching pre–Starlette Tornado behavior; POSIX binding is unchanged. IPv6 `IPV6_V6ONLY` handling is unchanged on all platforms.
> 
> Tests assert the Windows vs non-Windows `SO_REUSEADDR` branches (including `::`), that Windows still sets `IPV6_V6ONLY`, and that binding an already-listening port surfaces `errno.EADDRINUSE` for the retry logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a7cba1b10406da70206b85840b2f04d7c29975d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->