### PR TITLE
[fix] st.status in an outside container blanks the app

### DIFF
--- a/.claude/skills/understanding-streamlit-architecture/references/backend.md
+++ b/.claude/skills/understanding-streamlit-architecture/references/backend.md
@@ -112,6 +112,12 @@ The `st` object users interact with.
 - `LockedCursor`: Fixed position for updating elements
 - Delta path: `[0, 2, 3]` uniquely identifies element position
 
+**Block delta paths**: `_block()` does not always write to the position that the parent cursor points to.
+
+- It can redirect the write into one or more outside-container wrapper blocks, so the new block lands deeper in the tree (see the fragment system section below).
+- Blocks that re-send their own proto later, such as `st.status` and `st.dialog`, must read `DeltaGenerator._block_delta_path` after `_block()` returns. Do not read `delta_path` from the parent cursor.
+- A stored path that points at a wrapper instead of the block makes the update overwrite the wrapper and blank the app.
+
 **Element creation**:
 ```
 st.button("Click")
@@ -232,6 +238,14 @@ sequenceDiagram
 - Elements track both `scriptRunId` and `fragmentId`
 - During fragment reruns, stale cleanup uses `scriptRunId` + `fragmentIdsThisRun` to prune affected subtrees while preserving unrelated nodes
 - Main script elements are preserved during fragment-only reruns
+
+**Outside-container writes**:
+- A fragment can write into a container that the script declares outside the fragment body.
+- The first such write creates a layout-transparent wrapper block inside that container. See `_needs_outside_wrapper()` and `_get_or_create_outside_wrapper()` in `lib/streamlit/delta_generator.py`.
+- The wrapper isolates the writes of one fragment, so repeated fragment reruns overwrite in place instead of appending past the end of the outside container.
+- `FragmentStorage` caches each wrapper as an `OutsideContainerWrapper` (`lib/streamlit/runtime/outside_container_wrapper.py`), keyed by fragment and container.
+- Before a fragment reruns, the runtime evicts the wrappers whose outside containers this fragment rebuilds, then re-emits and resets the wrappers that survive (`_reset_outside_wrappers()` in `lib/streamlit/runtime/fragment.py`). A full script run clears all wrappers.
+- Each wrapper adds a level to the delta path. Code that stores a delta path for a later update must use the path that the write actually reached. See `_block_delta_path` in the `DeltaGenerator` section above.
 
 **Script events for fragments**:
 - `FRAGMENT_STOPPED_WITH_SUCCESS`: Fragment completed successfully

--- a/e2e_playwright/st_fragment_basics.py
+++ b/e2e_playwright/st_fragment_basics.py
@@ -345,3 +345,28 @@ with widget_outside_container:
     st.markdown("widget-outside footer")
 
 st.markdown(f"app-level marker: {uuid4()}")
+
+
+# Regression scenario for issue #16281: a fragment writes an st.status into a container
+# declared outside the fragment, then opens that status twice. Exiting the first `with`
+# block marks the status complete, which re-sends the status block proto. Before the fix
+# that message landed on the fragment's transparent wrapper instead of the status block,
+# so the write in the second `with` block had no parent and crashed the app.
+status_container_outside = st.container(key="status_container_outside")
+with status_container_outside:
+    st.markdown("status-outside header")
+
+
+@st.fragment
+def status_outside_fragment():
+    st.button("rerun status outside", key="rerun_status_outside")
+    status = status_container_outside.status("status outside", expanded=True)
+    with status:
+        st.markdown("status first write")
+    with status:
+        st.markdown("status second write")
+
+
+status_outside_fragment()
+with status_container_outside:
+    st.markdown("status-outside footer")

--- a/e2e_playwright/st_fragment_basics_test.py
+++ b/e2e_playwright/st_fragment_basics_test.py
@@ -24,6 +24,7 @@ from e2e_playwright.shared.app_utils import (
     expect_no_exception,
     get_button,
     get_element_by_key,
+    get_expander,
     select_selectbox_option,
     type_time,
 )
@@ -682,3 +683,36 @@ def test_widget_in_outside_container_triggers_fragment_rerun(app: Page):
     expect(markdowns.last).to_have_text("widget-outside footer")
 
     expect_no_exception(app)
+
+
+def _expect_status_outside_intact(app: Page) -> None:
+    """Assert the outside container holds all of its expected contents.
+
+    Checks the header, the footer, a single status expander, and both status writes.
+    """
+    container = get_element_by_key(app, "status_container_outside")
+    markdowns = container.get_by_test_id("stMarkdown")
+    status_markdowns = get_expander(app, "status outside").get_by_test_id("stMarkdown")
+
+    expect(markdowns.first).to_have_text("status-outside header")
+    expect(markdowns.last).to_have_text("status-outside footer")
+    expect(container.get_by_test_id("stExpander")).to_have_count(1)
+    for text in ("status first write", "status second write"):
+        expect(status_markdowns.filter(has_text=text)).to_have_count(1)
+    expect_no_exception(app)
+
+
+def test_status_in_outside_container_keeps_contents(app: Page):
+    """A fragment's st.status on an outside container keeps its contents.
+
+    The status re-sends its own block proto when the first `with` block exits. Before
+    the fix for issue #16281 that message landed on the fragment's transparent wrapper,
+    which dropped the whole subtree and blanked the app.
+    """
+    _expect_status_outside_intact(app)
+
+    _click_button_centered(app, "rerun status outside")
+
+    # The fragment rerun re-creates the wrapper at its stored slot, so the layout must
+    # look the same as before the rerun.
+    _expect_status_outside_intact(app)

--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -459,6 +459,26 @@ class DeltaGenerator(
         return self._provided_cursor is None
 
     @property
+    def _block_delta_path(self) -> list[int]:
+        """The absolute delta path where `_block()` placed this block.
+
+        Only read this on a DeltaGenerator that `_block()` returned, whose cursor
+        `parent_path` is the block's own path. On a DeltaGenerator that `_enqueue()`
+        returned, the same expression gives the parent block's path instead.
+
+        `_block()` can redirect the write into layout-transparent wrapper blocks, which
+        places the block deeper than the parent cursor points to (see issue #16281).
+        Elements that re-send their own block proto later (`st.status`, `st.dialog`)
+        must therefore store this path instead of deriving it from the parent cursor.
+
+        The path is empty when there is no cursor, for example in bare mode.
+        """
+        own_cursor = self._cursor
+        if own_cursor is None:
+            return []
+        return [own_cursor.root_container, *own_cursor.parent_path]
+
+    @property
     def _id(self) -> str:
         return str(id(self))
 

--- a/lib/streamlit/elements/lib/dialog.py
+++ b/lib/streamlit/elements/lib/dialog.py
@@ -147,15 +147,14 @@ class Dialog(DeltaGenerator):
                 value_type="trigger_value",
             )
 
-        # We store the delta path here, because in _update we enqueue a new proto
-        # message to update the open status. Without this, the dialog content is gone
-        # when the _update message is sent
-        delta_path: list[int] = (
-            parent._active_dg._cursor.delta_path if parent._active_dg._cursor else []
-        )
         dialog = cast("Dialog", parent._block(block_proto=block_proto, dg_type=Dialog))
 
-        dialog._delta_path = delta_path
+        # `_update` re-sends the block proto at this path. Use the path `_block()` wrote
+        # to, not the parent cursor, so the update targets the block even if a wrapper
+        # sits between them. Dialogs land top level in the event container, which never
+        # gets a wrapper, so this is a no-op today and stays correct if that changes.
+        # Same idiom as StatusContainer. See issue #16281.
+        dialog._delta_path = dialog._block_delta_path
         dialog._current_proto = block_proto
 
         return dialog

--- a/lib/streamlit/elements/lib/mutable_status_container.py
+++ b/lib/streamlit/elements/lib/mutable_status_container.py
@@ -78,17 +78,14 @@ class StatusContainer(DeltaGenerator):
         validate_width(width=width)
         block_proto.width_config.CopyFrom(get_width_config(width))
 
-        delta_path: list[int] = (
-            parent._active_dg._cursor.delta_path if parent._active_dg._cursor else []
-        )
-
         status_container = cast(
             "StatusContainer",
             parent._block(block_proto=block_proto, dg_type=StatusContainer),
         )
 
-        # Apply initial configuration
-        status_container._delta_path = delta_path
+        # `update()` re-sends the block proto at this path. Use the path `_block()` wrote
+        # to, which can be deeper than the parent cursor points to. See issue #16281.
+        status_container._delta_path = status_container._block_delta_path
         status_container._current_proto = block_proto
         status_container._current_state = state
 

--- a/lib/tests/streamlit/delta_generator_test.py
+++ b/lib/tests/streamlit/delta_generator_test.py
@@ -1368,6 +1368,17 @@ def _message_queue(test_case: DeltaGeneratorTestCase) -> list:
     return [msg for msg in test_case.forward_msg_queue._queue if msg.HasField("delta")]
 
 
+def _enter_fragment(
+    test_case: DeltaGeneratorTestCase,
+    *,
+    fragment_id: str = "frag",
+    delta_path: tuple[int, ...] = (0, 99),
+) -> None:
+    """Make the current thread look like a running fragment until the test ends."""
+    ThreadState.update(fragment_id=fragment_id, delta_path=delta_path)
+    test_case.addCleanup(lambda: ThreadState.update(fragment_id=None, delta_path=None))
+
+
 class BlockCreationDeltaPathTest(DeltaGeneratorTestCase):
     """Tests that _block emits add_block messages at the correct delta path."""
 
@@ -1392,6 +1403,54 @@ class BlockCreationDeltaPathTest(DeltaGeneratorTestCase):
         assert msg.metadata.delta_path == make_delta_path(
             RootContainer.MAIN, (0, 0, 0), 0
         )
+
+
+class BlockDeltaPathTest(DeltaGeneratorTestCase):
+    """Tests that `_block_delta_path` reports the path `_block` enqueued to."""
+
+    def test_matches_add_block_path_without_fragment(self) -> None:
+        """Without a fragment, the property equals the emitted add_block path."""
+        st.text("first")
+        container = st.container()
+
+        msg = self.get_message_from_queue()
+        assert msg.delta.WhichOneof("type") == "add_block"
+        assert container._block_delta_path == list(msg.metadata.delta_path)
+        assert container._block_delta_path == make_delta_path(RootContainer.MAIN, (), 1)
+
+    def test_matches_add_block_path_for_redirected_write(self) -> None:
+        """For a redirected write, the property points at the block, not the wrapper."""
+        outside = st.container()
+        self.clear_queue()
+        _enter_fragment(self)
+
+        nested = outside.container()
+
+        wrapper_msg, block_msg = _message_queue(self)[:2]
+        assert wrapper_msg.delta.add_block.WhichOneof("type") == "transparent"
+        assert nested._block_delta_path == list(block_msg.metadata.delta_path)
+        assert nested._block_delta_path != list(wrapper_msg.metadata.delta_path)
+
+    def test_matches_add_block_path_for_empty_outside_container(self) -> None:
+        """The property matches the block path for an `st.empty()` outside container.
+
+        `st.empty()` gives the wrapper a locked cursor instead of a running one, so
+        this covers the second of the two wrapper cursor types.
+        """
+        outside = st.empty()
+        self.clear_queue()
+        _enter_fragment(self)
+
+        nested = outside.container()
+
+        block_msg = _message_queue(self)[-1]
+        assert block_msg.delta.add_block.WhichOneof("type") == "flex_container"
+        assert nested._block_delta_path == list(block_msg.metadata.delta_path)
+
+    def test_returns_empty_list_without_root_container(self) -> None:
+        """A DeltaGenerator with no root container has no cursor, so no path."""
+        bare_dg = DeltaGenerator(root_container=None)
+        assert bare_dg._block_delta_path == []
 
 
 class NeedsOutsideWrapperTest(DeltaGeneratorTestCase):
@@ -1491,19 +1550,13 @@ class NeedsOutsideWrapperTest(DeltaGeneratorTestCase):
 class OutsideWrapperCreationTest(DeltaGeneratorTestCase):
     """Tests for wrapper creation and redirection through the public write path."""
 
-    def _enter_fragment(
-        self, fragment_id: str = "frag", delta_path: tuple[int, ...] = (0, 99)
-    ) -> None:
-        ThreadState.update(fragment_id=fragment_id, delta_path=delta_path)
-        self.addCleanup(lambda: ThreadState.update(fragment_id=None, delta_path=None))
-
     def test_outside_write_emits_transparent_block_then_nested_element(self) -> None:
         """An outside write inserts a transparent wrapper, then nests the element."""
         outside = st.container()
         outside_path = list(outside._cursor.delta_path)
         self.clear_queue()
 
-        self._enter_fragment()
+        _enter_fragment(self)
         outside.markdown("hi")
 
         msgs = _message_queue(self)
@@ -1515,7 +1568,7 @@ class OutsideWrapperCreationTest(DeltaGeneratorTestCase):
     def test_outside_write_registers_single_wrapper(self) -> None:
         """Repeated writes to the same outside container reuse one wrapper."""
         outside = st.container()
-        self._enter_fragment()
+        _enter_fragment(self)
 
         outside.markdown("one")
         outside.markdown("two")
@@ -1526,7 +1579,7 @@ class OutsideWrapperCreationTest(DeltaGeneratorTestCase):
     def test_nested_container_produces_single_wrapper(self) -> None:
         """Creating a nested container inside an outside container only allocates one wrapper."""
         outside = st.container()
-        self._enter_fragment()
+        _enter_fragment(self)
 
         nested = outside.container()
         nested.markdown("deep")
@@ -1557,7 +1610,7 @@ class OutsideWrapperCreationTest(DeltaGeneratorTestCase):
         """
         outside = st.container()
         self.script_run_ctx.fragment_ids_this_run = ["frag"]
-        self._enter_fragment()
+        _enter_fragment(self)
 
         with pytest.raises(StreamlitAPIException) as exc_info:
             outside.markdown("hi")
@@ -1570,12 +1623,12 @@ class OutsideWrapperCreationTest(DeltaGeneratorTestCase):
         of the running fragments (e.g. a parent), a new wrapper is allowed.
         This supports nested fragments writing into parent-owned containers.
         """
-        self._enter_fragment(fragment_id="parent_frag")
+        _enter_fragment(self, fragment_id="parent_frag")
         inside_container = st.container()
         ThreadState.update(fragment_id=None, delta_path=None)
 
         self.script_run_ctx.fragment_ids_this_run = ["parent_frag"]
-        self._enter_fragment(fragment_id="child_frag")
+        _enter_fragment(self, fragment_id="child_frag")
 
         inside_container.markdown("child write")
 
@@ -1587,7 +1640,7 @@ class OutsideWrapperCreationTest(DeltaGeneratorTestCase):
     def test_empty_outside_container_produces_locked_wrapper(self) -> None:
         """An st.empty() outside container produces a locked wrapper cursor."""
         outside = st.empty()
-        self._enter_fragment()
+        _enter_fragment(self)
 
         outside.markdown("hi")
 
@@ -1600,7 +1653,7 @@ class OutsideWrapperCreationTest(DeltaGeneratorTestCase):
     def test_bottom_root_wrapper_records_no_creating_fragment(self) -> None:
         """Root containers like bottom aren't created by any fragment, so the wrapper records None."""
         bottom_dg = get_dg_singleton_instance().bottom_dg
-        self._enter_fragment()
+        _enter_fragment(self)
 
         bottom_dg.markdown("hi")
 

--- a/lib/tests/streamlit/elements/dialog_decorator_test.py
+++ b/lib/tests/streamlit/elements/dialog_decorator_test.py
@@ -16,13 +16,19 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 import streamlit as st
 from streamlit.errors import StreamlitAPIException
+from streamlit.proto.RootContainer_pb2 import RootContainer
 from streamlit.runtime.scriptrunner_utils.script_run_context import ThreadState
+from tests.delta_generator_test_case import DeltaGeneratorTestCase
+
+if TYPE_CHECKING:
+    from streamlit.delta_generator import DeltaGenerator
 
 
 def test_dialog_raises_from_parallel_worker() -> None:
@@ -77,3 +83,82 @@ def test_dialog_allowed_when_not_parallel_worker() -> None:
             mock_check.assert_called_once_with("@st.dialog")
     finally:
         ThreadState.initialize(is_parallel_worker=False)
+
+
+class DialogDeltaPathTest(DeltaGeneratorTestCase):
+    """Tests that `@st.dialog` stores and reuses the delta path of its own block."""
+
+    def _block_paths(self, block_type: str) -> list[list[int]]:
+        """Return the delta paths of every queued add_block message of `block_type`."""
+        return [
+            list(msg.metadata.delta_path)
+            for msg in self.forward_msg_queue._queue
+            if msg.HasField("delta")
+            and msg.delta.WhichOneof("type") == "add_block"
+            and msg.delta.add_block.WhichOneof("type") == block_type
+        ]
+
+    def test_dialog_open_reuses_event_container_path(self) -> None:
+        """A dialog opened from a fragment re-sends its block at the same path.
+
+        `Dialog._update` enqueues the `dialog` block proto again at the path that
+        `_create()` stored. Dialogs live on the event container, which never gets a
+        layout-transparent wrapper, so no wrapper insertion can invalidate the stored
+        path. This test pins that behavior and fails if dialog creation ever moves off
+        the event container.
+        """
+        outside_container = st.container()
+
+        @st.dialog("Delta path dialog")
+        def my_dialog() -> None:
+            st.write("content")
+
+        ThreadState.update(fragment_id="frag", delta_path=(0, 99))
+        self.addCleanup(lambda: ThreadState.update(fragment_id=None, delta_path=None))
+        with outside_container:
+            my_dialog()
+
+        dialog_paths = self._block_paths("dialog")
+        # One message from _create(), one from the open() that the decorator calls.
+        assert len(dialog_paths) == 2
+        assert dialog_paths[0][0] == RootContainer.EVENT
+        assert dialog_paths[-1] == dialog_paths[0]
+
+    def test_dialog_update_targets_the_block_when_a_wrapper_redirects_it(self) -> None:
+        """The stored path follows the block when `_block()` redirects the write.
+
+        The event container is not wrapper-eligible today, so the test above cannot
+        tell `_block_delta_path` apart from the old parent-cursor prediction. This
+        test forces `_needs_outside_wrapper()` to accept the event container, which
+        makes `_block()` redirect the dialog into a transparent wrapper. The stored
+        path must then point at the dialog, not at the wrapper.
+        """
+
+        def _wrapper_only_for_event_container(
+            dg: DeltaGenerator, ts: object, fragment_storage: object
+        ) -> bool:
+            return dg._root_container == RootContainer.EVENT and dg._is_top_level
+
+        @st.dialog("Wrapped dialog")
+        def my_dialog() -> None:
+            st.write("content")
+
+        ThreadState.update(fragment_id="frag", delta_path=(0, 99))
+        self.addCleanup(lambda: ThreadState.update(fragment_id=None, delta_path=None))
+
+        with patch(
+            "streamlit.delta_generator._needs_outside_wrapper",
+            side_effect=_wrapper_only_for_event_container,
+        ):
+            my_dialog()
+
+        wrapper_paths = self._block_paths("transparent")
+        dialog_paths = self._block_paths("dialog")
+
+        assert len(wrapper_paths) == 1
+        assert wrapper_paths[0][0] == RootContainer.EVENT
+        assert len(dialog_paths) == 2
+        # `_block()` placed the dialog one level inside the wrapper.
+        assert dialog_paths[0] == [*wrapper_paths[0], 0]
+        # The re-send from open() must target the dialog block, not the wrapper.
+        assert dialog_paths[-1] == dialog_paths[0]

--- a/lib/tests/streamlit/elements/layouts_test.py
+++ b/lib/tests/streamlit/elements/layouts_test.py
@@ -31,7 +31,9 @@ from streamlit.errors import (
 )
 from streamlit.proto.Block_pb2 import Block as BlockProto
 from streamlit.proto.GapSize_pb2 import GapSize
+from streamlit.proto.RootContainer_pb2 import RootContainer
 from streamlit.proto.WidgetStates_pb2 import WidgetState, WidgetStates
+from streamlit.runtime.scriptrunner_utils.script_run_context import ThreadState
 from streamlit.runtime.state.session_state import get_script_run_ctx
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 from tests.streamlit.elements.layout_test_utils import WidthConfigFields
@@ -1440,6 +1442,159 @@ class StatusContainerTest(DeltaGeneratorTestCase):
         """Test that invalid type values raise StreamlitValueError."""
         with pytest.raises(StreamlitValueError):
             st.status("label", type="invalid")
+
+
+class StatusContainerDeltaPathTest(DeltaGeneratorTestCase):
+    """Tests that `st.status` re-sends its block proto at the block's real path.
+
+    `update()` enqueues the `expandable` block proto again at the path that `_create()`
+    stored. If that stored path points at the wrapper instead of the block, the frontend
+    replaces the wrong node and drops the status contents (see issue #16281).
+    """
+
+    def _enter_fragment(
+        self, fragment_id: str = "frag", delta_path: tuple[int, ...] = (0, 99)
+    ) -> None:
+        """Make the current thread look like a running fragment."""
+        ThreadState.update(fragment_id=fragment_id, delta_path=delta_path)
+        self.addCleanup(lambda: ThreadState.update(fragment_id=None, delta_path=None))
+
+    def _add_block_paths(self, block_type: str) -> list[list[int]]:
+        """Return the delta paths of every queued `add_block` of one block type."""
+        return [
+            list(msg.metadata.delta_path)
+            for msg in self.forward_msg_queue._queue
+            if msg.HasField("delta")
+            and msg.delta.WhichOneof("type") == "add_block"
+            and msg.delta.add_block.WhichOneof("type") == block_type
+        ]
+
+    def _new_element_paths(self) -> list[list[int]]:
+        """Return the delta paths of every queued `new_element` message."""
+        return [
+            list(msg.metadata.delta_path)
+            for msg in self.forward_msg_queue._queue
+            if msg.HasField("delta") and msg.delta.WhichOneof("type") == "new_element"
+        ]
+
+    def test_update_targets_status_block_without_fragment(self) -> None:
+        """Baseline: with no fragment, the update lands on the status block."""
+        st.title("head")
+        outside = st.container()
+
+        with outside.status("label"):
+            st.code("first")
+
+        status_paths = self._add_block_paths("expandable")
+        assert len(status_paths) == 2
+        assert status_paths[0] == [RootContainer.MAIN, 1, 0]
+        assert status_paths[-1] == status_paths[0]
+        # No fragment runs, so no transparent wrapper is created at all.
+        assert self._add_block_paths("transparent") == []
+
+    def test_update_targets_status_block_for_outside_container_write(self) -> None:
+        """A fragment status on an outside container updates at the block's real path.
+
+        This reproduces the reported crash: two separate `with` blocks write an
+        element after the update message.
+        """
+        st.title("head")
+        outside = st.container()
+        self._enter_fragment()
+
+        status = outside.status("query")
+        with status:
+            st.code("first")
+        with status:
+            st.text("second")
+
+        status_paths = self._add_block_paths("expandable")
+        assert len(status_paths) == 2
+        assert status_paths[0] == [RootContainer.MAIN, 1, 0, 0]
+        assert status_paths[-1] == status_paths[0]
+        # The write after the update must still resolve inside the status block.
+        second_element_path = self._new_element_paths()[-1]
+        assert second_element_path[: len(status_paths[0])] == status_paths[0]
+
+    def test_update_targets_status_block_for_single_with_block(self) -> None:
+        """One `with` block sends an update too, so its path must be right as well.
+
+        `__exit__` calls `update(state="complete")` and nothing writes afterwards, so
+        a wrong path corrupts the tree without a visible crash.
+        """
+        st.title("head")
+        outside = st.container()
+        self._enter_fragment()
+
+        with outside.status("query"):
+            st.code("first")
+
+        status_paths = self._add_block_paths("expandable")
+        wrapper_paths = self._add_block_paths("transparent")
+        assert len(status_paths) == 2
+        assert len(wrapper_paths) == 1
+        assert status_paths[-1] == status_paths[0]
+        assert status_paths[-1] != wrapper_paths[0]
+
+    def test_update_targets_status_block_with_two_wrapper_levels(self) -> None:
+        """Two nested wrapper levels still produce the correct update path.
+
+        A parent fragment creates a container inside an outside container, then a
+        child fragment creates a status on that container. Each fragment registers
+        its own wrapper, so the status sits two wrapper levels deep.
+        """
+        st.title("head")
+        outside = st.container()
+
+        self._enter_fragment(fragment_id="parent_frag")
+        inside = outside.container()
+
+        self._enter_fragment(fragment_id="child_frag")
+        with inside.status("query"):
+            st.code("first")
+
+        status_paths = self._add_block_paths("expandable")
+        wrapper_paths = self._add_block_paths("transparent")
+        assert len(wrapper_paths) == 2
+        assert len(status_paths) == 2
+        # The status lands at [MAIN, outside container, parent wrapper, inner container,
+        # child wrapper, status], so the path holds six entries.
+        assert len(status_paths[0]) == 6
+        assert status_paths[-1] == status_paths[0]
+        # A mis-stored path lands on a wrapper, so name both wrappers directly instead
+        # of trusting the length check to separate them.
+        for wrapper_path in wrapper_paths:
+            assert status_paths[-1] != wrapper_path
+
+    def test_update_targets_status_block_for_empty_outside_container(self) -> None:
+        """The update lands on the status block for an `st.empty()` outside container.
+
+        `st.empty()` gives the wrapper a locked cursor instead of a running one, so
+        this covers the second of the two wrapper cursor types.
+        """
+        st.title("head")
+        outside = st.empty()
+        self._enter_fragment()
+
+        with outside.status("query"):
+            st.code("first")
+
+        status_paths = self._add_block_paths("expandable")
+        assert len(status_paths) == 2
+        assert status_paths[0] == [RootContainer.MAIN, 1, 0]
+        assert status_paths[-1] == status_paths[0]
+
+    def test_update_targets_status_block_in_sidebar(self) -> None:
+        """A fragment status in the sidebar updates at the block's real path."""
+        self._enter_fragment()
+
+        with st.sidebar.status("query"):
+            st.code("first")
+
+        status_paths = self._add_block_paths("expandable")
+        assert len(status_paths) == 2
+        assert status_paths[0] == [RootContainer.SIDEBAR, 0, 0]
+        assert status_paths[-1] == status_paths[0]
 
 
 class TabsTest(DeltaGeneratorTestCase):


### PR DESCRIPTION
## Describe your changes

A fragment that calls `.status()` on a container declared outside the fragment corrupts the element tree. When that status is opened with two separate `with` blocks, the app goes blank and the console throws `Uncaught Error: Cannot set a node at a delta path`. This is a regression: it works in `1.58.0` and fails in every version from `1.59.0` onward.

- `StatusContainer._create` predicted the block's delta path from the parent cursor before the block existed. `_block()` redirects a fragment's write into a layout-transparent wrapper, so the block lands deeper than the prediction and the stored path pointed at the wrapper instead. `update()`, which `__exit__` calls implicitly, then re-sent the `expandable` proto at the wrapper's path. `AppRoot.addBlock` inherits children only when the block types match, so the whole subtree was dropped and the next element had no parent.
- A new derived property, `DeltaGenerator._block_delta_path`, reads the path back from the cursor that `_block()` produced. It is depth-agnostic, so it also holds for nested fragments that stack several wrappers, and it is a no-op when no redirection happens.
- `Dialog._create` stored its path the same way and gets the same change. It cannot reach the bug today, because `@st.dialog` always lands top level in the event container, which never gets a wrapper. The change keeps both re-senders on one idiom, and a test that forces the redirect pins it.
- A single `with` block hit the same defect with no visible crash, because nothing was written after the misdirected message. That case corrupted the element tree silently and now has a regression test.

Two notes for reviewers:

- The property derives the path from the returned block's cursor rather than having `_block()` record the path it enqueued. The derivation rests on `open_block()` building the child `parent_path` from the same `(parent_path, index)` snapshot that `_block()` enqueues at, for both `RunningCursor` and `LockedCursor`. `BlockDeltaPathTest` asserts the property against the actual emitted `metadata.delta_path`, so that equivalence is pinned where it can break.
- I audited every `_delta_path` use in `lib/streamlit`. Only `Dialog` and `StatusContainer` store a path and later re-enqueue a proto with it; everything else calls `_get_delta_path_str()`, which reads the path at call time for coordinates and widget IDs. Separately, `st.spinner` looks like a related but distinct defect: `_transient` reads the cursor directly (`delta_generator.py:705`) and never applies the outside-write redirection at all. I found that by reading the code, not by reproducing it in a browser, and it is out of scope here.

## GitHub Issue Link (if applicable)

- Closes #16281

## Testing Plan

- Unit Tests (Python): `StatusContainerDeltaPathTest` in `layouts_test.py` covers the reported crash, the silent single-`with` case, two wrapper levels, `st.empty()` as the outside container (the locked-cursor branch), the sidebar, and a no-fragment baseline that guards against a behavior change. `BlockDeltaPathTest` in `delta_generator_test.py` pins the property to the emitted `add_block` path. `DialogDeltaPathTest` covers dialogs twice: one test records that they stay on the event container, and one forces `_block()` to redirect a dialog into a wrapper so the `dialog.py` call site has real regression coverage.
- The unit coverage is confirmed red-before-green for both call sites. Reverting only the `StatusContainer._create` line makes 5 of the new status tests fail. Restoring the pre-PR `Dialog._create` code, which predicts the path before `_block()` runs, makes the new wrapper-redirect test fail with `assert [2, 0] == [2, 0, 0]`, where `[2, 0]` is the wrapper and `[2, 0, 0]` is the dialog. All 381 tests in the three touched files pass with the fix.
- E2E Tests: `test_status_in_outside_container_keeps_contents` in `st_fragment_basics_test.py`, covering the initial render and a fragment rerun.
- Manual testing: a QA pass on 2026-07-31 reproduced the original crash in a browser and confirmed the fix, with 41 browser checks and 27 delta-stream probes. It covered 7 outside-container shapes (`st.container`, `st.popover`, `st.expander`, `st.empty`, a column, the sidebar, `st.tabs`), repeated fragment and full-script reruns, normal status behavior with no fragment, dialog open/close/switch, nested fragments, and `st.form`. `st_fragment_basics_test.py` passed in that run (33 passed, 1 pre-existing skip).

One caveat on the e2e test: Playwright cannot launch a browser in my workspace (`libatk-1.0.so.0` is missing from the system), so I could not re-run it after this branch's final cleanup, which extracted the repeated assertions into a helper and reworded two comments. The 2026-07-31 pass above predates that cleanup, and I have no artifact confirming the e2e test fails on the unfixed code. CI is the check for both.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes delta-path handling for `st.status` and `st.dialog` block re-sends in fragment outside-container flows; scope is narrow but incorrect paths corrupt the element tree.
> 
> **Overview**
> Fixes **#16281**: a fragment calling **`st.status()`** on an outside container could blank the app when the first `with` block exited (implicit complete update) and a second `with` wrote again—the update targeted the fragment’s transparent **wrapper** path instead of the status block.
> 
> Adds **`DeltaGenerator._block_delta_path`** so callers read the path **`_block()`** actually enqueued to (including wrapper redirection). **`StatusContainer`** and **`Dialog`** now set **`_delta_path`** from that property instead of the parent cursor before the block exists.
> 
> Regression coverage: unit tests for the property, status paths (nested wrappers, `st.empty()`, sidebar), dialog paths (including a forced wrapper redirect); e2e scenario with two `with` blocks and a fragment rerun. Architecture docs note that blocks which re-send their own proto must use **`_block_delta_path`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c88212487483f751bf34a3a4ec7a6c7dff1b8ab9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->