### PR TITLE
[fix] Add MD5 fallback for FIPS-limited blake2b

### DIFF
--- a/lib/streamlit/util.py
+++ b/lib/streamlit/util.py
@@ -69,9 +69,9 @@ def repr_(self: Any) -> str:
 def create_fast_hasher() -> _Hash:
     """Create a fast hasher for incremental hashing.
 
-    Uses BLAKE2b where the provider supports configurable digest sizes and
-    falls back to MD5 for FIPS providers that only expose fixed-size BLAKE2b.
-    Both produce 32-character hex digests (16 bytes).
+    Prefers BLAKE2b with a 16-byte digest. If the platform BLAKE2b provider
+    rejects a custom ``digest_size`` (common on FIPS/OpenSSL builds), falls
+    back to MD5. Both produce 32-character hex digests (16 bytes).
     """
     try:
         return hashlib.blake2b(digest_size=16, usedforsecurity=False)  # type: ignore[return-value]  # ty: ignore[invalid-return-type]

--- a/lib/streamlit/util.py
+++ b/lib/streamlit/util.py
@@ -75,9 +75,10 @@ def create_fast_hasher() -> _Hash:
     """
     try:
         return hashlib.blake2b(digest_size=16, usedforsecurity=False)  # type: ignore[return-value]  # ty: ignore[invalid-return-type]
-    except TypeError:
+    except (TypeError, ValueError):
         # Some FIPS-enabled Python builds replace the standard BLAKE2b
-        # implementation with an OpenSSL wrapper that rejects custom digest sizes.
+        # implementation with an OpenSSL wrapper that rejects a custom digest
+        # size, raising TypeError or ValueError depending on the provider.
         return hashlib.new("md5", usedforsecurity=False)
 
 

--- a/lib/streamlit/util.py
+++ b/lib/streamlit/util.py
@@ -69,16 +69,23 @@ def repr_(self: Any) -> str:
 def create_fast_hasher() -> _Hash:
     """Create a fast hasher for incremental hashing.
 
-    Uses BLAKE2b which produces 32-character hex digests (16 bytes).
+    Uses BLAKE2b where the provider supports configurable digest sizes and
+    falls back to MD5 for FIPS providers that only expose fixed-size BLAKE2b.
+    Both produce 32-character hex digests (16 bytes).
     """
-    return hashlib.blake2b(digest_size=16, usedforsecurity=False)  # type: ignore[return-value]  # ty: ignore[invalid-return-type]
+    try:
+        return hashlib.blake2b(digest_size=16, usedforsecurity=False)  # type: ignore[return-value]  # ty: ignore[invalid-return-type]
+    except TypeError:
+        # Some FIPS-enabled Python builds replace the standard BLAKE2b
+        # implementation with an OpenSSL wrapper that rejects custom digest sizes.
+        return hashlib.new("md5", usedforsecurity=False)
 
 
 def calc_hash(s: bytes | str) -> str:
     """Return a fast hash of the given string.
 
-    Uses BLAKE2b (~2.4x faster than MD5) and produces 32-character hex digests.
-    This should not be used for security-related purposes.
+    Uses BLAKE2b (~2.4x faster than MD5) where supported, with an MD5 fallback
+    for limited FIPS providers. This should not be used for security purposes.
     """
     b = s.encode("utf-8") if isinstance(s, str) else s
     h = create_fast_hasher()

--- a/lib/tests/streamlit/util_test.py
+++ b/lib/tests/streamlit/util_test.py
@@ -89,6 +89,24 @@ class UtilTest(unittest.TestCase):
         expected = hashlib.new("md5", data, usedforsecurity=False).hexdigest()
         assert hasher.hexdigest() == expected
 
+    def test_create_fast_hasher_falls_back_when_blake2b_raises_value_error(
+        self,
+    ) -> None:
+        """Test MD5 fallback when blake2b rejects digest_size with ValueError."""
+
+        def openssl_blake2b_rejecting_digest_size(
+            *args: object, **kwargs: object
+        ) -> _Hash:
+            raise ValueError("digest_size is invalid for openssl_blake2b()")
+
+        data = b"test data"
+        with patch.object(hashlib, "blake2b", openssl_blake2b_rejecting_digest_size):
+            hasher = util.create_fast_hasher()
+            hasher.update(data)
+
+        expected = hashlib.new("md5", data, usedforsecurity=False).hexdigest()
+        assert hasher.hexdigest() == expected
+
     def test_create_fast_hasher_produces_consistent_results(self):
         """Test that create_fast_hasher produces consistent hash results."""
         h1 = util.create_fast_hasher()

--- a/lib/tests/streamlit/util_test.py
+++ b/lib/tests/streamlit/util_test.py
@@ -15,9 +15,11 @@
 from __future__ import annotations
 
 import copy
+import hashlib
 import json
 import random
 import unittest
+from unittest.mock import patch
 
 import pytest
 
@@ -65,6 +67,21 @@ class UtilTest(unittest.TestCase):
         assert hasattr(hasher, "update")
         assert hasattr(hasher, "hexdigest")
         assert hasattr(hasher, "digest")
+
+    def test_create_fast_hasher_falls_back_for_fixed_size_blake2b(self):
+        """Test fallback for FIPS builds whose BLAKE2b has a fixed digest size."""
+        original_blake2b = hashlib.blake2b
+
+        def openssl_blake2b(data: bytes = b"", *, usedforsecurity: bool = True):
+            return original_blake2b(data, usedforsecurity=usedforsecurity)
+
+        data = b"test data"
+        with patch.object(hashlib, "blake2b", openssl_blake2b):
+            hasher = util.create_fast_hasher()
+            hasher.update(data)
+
+        expected = hashlib.new("md5", data, usedforsecurity=False).hexdigest()
+        assert hasher.hexdigest() == expected
 
     def test_create_fast_hasher_produces_consistent_results(self):
         """Test that create_fast_hasher produces consistent hash results."""

--- a/lib/tests/streamlit/util_test.py
+++ b/lib/tests/streamlit/util_test.py
@@ -19,12 +19,16 @@ import hashlib
 import json
 import random
 import unittest
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
 
 from streamlit import util
 from streamlit.util import AttributeDictionary, ReadOnlyAttributeDictionary
+
+if TYPE_CHECKING:
+    from hashlib import _Hash
 
 
 class UtilTest(unittest.TestCase):
@@ -68,11 +72,13 @@ class UtilTest(unittest.TestCase):
         assert hasattr(hasher, "hexdigest")
         assert hasattr(hasher, "digest")
 
-    def test_create_fast_hasher_falls_back_for_fixed_size_blake2b(self):
+    def test_create_fast_hasher_falls_back_for_fixed_size_blake2b(self) -> None:
         """Test fallback for FIPS builds whose BLAKE2b has a fixed digest size."""
         original_blake2b = hashlib.blake2b
 
-        def openssl_blake2b(data: bytes = b"", *, usedforsecurity: bool = True):
+        def openssl_blake2b(
+            data: bytes = b"", *, usedforsecurity: bool = True
+        ) -> _Hash:
             return original_blake2b(data, usedforsecurity=usedforsecurity)
 
         data = b"test data"


### PR DESCRIPTION
## Describe your changes

`create_fast_hasher()` now falls back to `hashlib.new("md5", usedforsecurity=False)` when the platform's `blake2b` rejects a custom `digest_size`. This prevents crashes in element ID generation, cache key computation, and file watching on FIPS-enabled Python builds, whose OpenSSL-backed `blake2b` only exposes a fixed digest size and raises `TypeError`/`ValueError` for a custom one (which persisted even after the earlier `usedforsecurity=False` fix).

Both the BLAKE2b and MD5 paths produce a 32-character (16-byte) hex digest, so all call sites are unaffected.

## GitHub Issue Link (if applicable)

- Closes #15148

## Testing Plan

- `lib/tests/streamlit/util_test.py` — Adds `test_create_fast_hasher_falls_back_for_fixed_size_blake2b`, which simulates the OpenSSL-backed `blake2b` (no `digest_size` support) and asserts the MD5 fallback is used.