### PR TITLE
[fix] Accept same-window self-posts in host message guard

### DIFF
--- a/frontend/lib/src/hostComm/HostCommunicationManager.test.tsx
+++ b/frontend/lib/src/hostComm/HostCommunicationManager.test.tsx
@@ -758,6 +758,126 @@ describe("HostCommunicationManager messaging", () => {
     }
   })
 
+  it("processes messages from a genuine same-window self-post (in-iframe embed preamble)", () => {
+    // When embedded, window.parent is an untrusted third-party page, so the
+    // in-iframe embed preamble delivers host messages by posting to this
+    // window itself (event.source === window). Unlike a child frame (whose
+    // source is the child's own window), a same-window self-post is a
+    // legitimate delivery path and must be processed.
+    const originalParent = window.parent
+    Object.defineProperty(window, "parent", {
+      value: { postMessage: vi.fn() },
+      configurable: true,
+    })
+
+    try {
+      const message = newHostMessageEvent({
+        data: {
+          stCommVersion: HOST_COMM_VERSION,
+          type: "SET_FILE_UPLOAD_CLIENT_CONFIG",
+          prefix: "https://someprefix.com/hello/",
+          headers: {
+            header1: "header1value",
+          },
+        },
+        origin: "https://devel.streamlit.test",
+        source: window,
+      })
+      dispatchEvent("message", message)
+
+      expect(
+        // @ts-expect-error - props are private
+        hostCommunicationMgr.props.fileUploadClientConfigChanged
+      ).toHaveBeenCalledWith({
+        prefix: "https://someprefix.com/hello/",
+        headers: {
+          header1: "header1value",
+        },
+      })
+    } finally {
+      Object.defineProperty(window, "parent", {
+        value: originalParent,
+        configurable: true,
+      })
+    }
+  })
+
+  it("ignores script-dispatched (untrusted) self-posts even when embedded", () => {
+    // The self-post exception must still be gated by event.isTrusted: a
+    // synthetic (dispatchEvent) event with source === window must be rejected
+    // so injected scripts cannot fabricate host commands.
+    const originalParent = window.parent
+    Object.defineProperty(window, "parent", {
+      value: { postMessage: vi.fn() },
+      configurable: true,
+    })
+
+    try {
+      const message = new MessageEvent("message", {
+        data: {
+          stCommVersion: HOST_COMM_VERSION,
+          type: "SET_FILE_UPLOAD_CLIENT_CONFIG",
+          prefix: "https://evil.example/upload/",
+          headers: {
+            "X-Xsrftoken": "exfiltrated-token",
+          },
+        },
+        origin: "https://devel.streamlit.test",
+        source: window,
+      })
+      // Guard the precondition so the test can only pass via the isTrusted
+      // check: a natively constructed event is untrusted while its source is a
+      // genuine same-window self-post and its origin is allowed.
+      expect(message.isTrusted).toBe(false)
+      dispatchEvent("message", message)
+
+      expect(
+        // @ts-expect-error - props are private
+        hostCommunicationMgr.props.fileUploadClientConfigChanged
+      ).not.toHaveBeenCalled()
+    } finally {
+      Object.defineProperty(window, "parent", {
+        value: originalParent,
+        configurable: true,
+      })
+    }
+  })
+
+  it("ignores self-posts from a disallowed origin even when embedded", () => {
+    // The self-post exception must not bypass the allowedOrigins check.
+    const originalParent = window.parent
+    Object.defineProperty(window, "parent", {
+      value: { postMessage: vi.fn() },
+      configurable: true,
+    })
+
+    try {
+      const message = newHostMessageEvent({
+        data: {
+          stCommVersion: HOST_COMM_VERSION,
+          type: "SET_FILE_UPLOAD_CLIENT_CONFIG",
+          prefix: "https://evil.example/upload/",
+          headers: {
+            "X-Xsrftoken": "exfiltrated-token",
+          },
+        },
+        origin: "https://not-allowed.example",
+        source: window,
+      })
+      dispatchEvent("message", message)
+
+      expect(
+        // @ts-expect-error - props are private
+        hostCommunicationMgr.props.fileUploadClientConfigChanged
+      ).not.toHaveBeenCalled()
+    } finally {
+      Object.defineProperty(window, "parent", {
+        value: originalParent,
+        configurable: true,
+      })
+    }
+  })
+
   it("ignores script-dispatched host messages even when source and origin match", () => {
     const message = new MessageEvent("message", {
       data: {
@@ -1132,5 +1252,50 @@ describe("HostCommunicationManager external auth token handling", () => {
     await expect(hostCommunicationMgr.deferredAuthToken.promise).resolves.toBe(
       "i am a NEW auth token"
     )
+  })
+
+  it("resolves the auth token from a genuine same-window self-post when embedded (in-iframe embed preamble)", async () => {
+    const { dispatchEvent } = mockEventListeners()
+
+    // Simulate being embedded in a third-party page: window.parent is not a
+    // trusted relay, so the in-iframe embed preamble delivers SET_AUTH_TOKEN
+    // by posting to this window itself (event.source === window).
+    const originalParent = window.parent
+    Object.defineProperty(window, "parent", {
+      value: { postMessage: vi.fn() },
+      configurable: true,
+    })
+
+    try {
+      hostCommunicationMgr.setAllowedOrigins({
+        allowedOrigins: ["http://devel.streamlit.test"],
+        useExternalAuthToken: true,
+      })
+
+      setTimeout(() => {
+        dispatchEvent(
+          "message",
+          newHostMessageEvent({
+            data: {
+              stCommVersion: HOST_COMM_VERSION,
+              type: "SET_AUTH_TOKEN",
+              authToken: "self-posted auth token",
+            },
+            origin: "http://devel.streamlit.test",
+            source: window,
+          })
+        )
+      })
+
+      await expect(
+        // @ts-expect-error - deferredAuthToken is private
+        hostCommunicationMgr.deferredAuthToken.promise
+      ).resolves.toBe("self-posted auth token")
+    } finally {
+      Object.defineProperty(window, "parent", {
+        value: originalParent,
+        configurable: true,
+      })
+    }
   })
 })

--- a/frontend/lib/src/hostComm/HostCommunicationManager.test.tsx
+++ b/frontend/lib/src/hostComm/HostCommunicationManager.test.tsx
@@ -73,6 +73,32 @@ function newHostMessageEvent(init: MessageEventInit): MessageEvent {
   } as unknown as MessageEvent
 }
 
+/**
+ * Runs `fn` with `window.parent` replaced by a stub so `receiveHostMessage`
+ * treats the app as embedded in a third-party iframe (`window !== window.parent`),
+ * then restores the original `window.parent`. This mirrors the environment in
+ * which an in-iframe embed preamble delivers host messages via a same-window
+ * self-post (`event.source === window`). Supports both synchronous and async
+ * `fn`, keeping the stub in place until an async `fn` settles.
+ */
+async function withEmbeddedWindow(
+  fn: () => void | Promise<void>
+): Promise<void> {
+  const originalParent = window.parent
+  Object.defineProperty(window, "parent", {
+    value: { postMessage: vi.fn() },
+    configurable: true,
+  })
+  try {
+    await fn()
+  } finally {
+    Object.defineProperty(window, "parent", {
+      value: originalParent,
+      configurable: true,
+    })
+  }
+}
+
 describe("HostCommunicationManager messaging", () => {
   let hostCommunicationMgr: HostCommunicationManager
 
@@ -758,19 +784,13 @@ describe("HostCommunicationManager messaging", () => {
     }
   })
 
-  it("processes messages from a genuine same-window self-post (in-iframe embed preamble)", () => {
+  it("processes messages from a genuine same-window self-post (in-iframe embed preamble)", async () => {
     // When embedded, window.parent is an untrusted third-party page, so the
     // in-iframe embed preamble delivers host messages by posting to this
     // window itself (event.source === window). Unlike a child frame (whose
     // source is the child's own window), a same-window self-post is a
     // legitimate delivery path and must be processed.
-    const originalParent = window.parent
-    Object.defineProperty(window, "parent", {
-      value: { postMessage: vi.fn() },
-      configurable: true,
-    })
-
-    try {
+    await withEmbeddedWindow(() => {
       const message = newHostMessageEvent({
         data: {
           stCommVersion: HOST_COMM_VERSION,
@@ -794,25 +814,14 @@ describe("HostCommunicationManager messaging", () => {
           header1: "header1value",
         },
       })
-    } finally {
-      Object.defineProperty(window, "parent", {
-        value: originalParent,
-        configurable: true,
-      })
-    }
+    })
   })
 
-  it("ignores script-dispatched (untrusted) self-posts even when embedded", () => {
+  it("ignores script-dispatched (untrusted) self-posts even when embedded", async () => {
     // The self-post exception must still be gated by event.isTrusted: a
     // synthetic (dispatchEvent) event with source === window must be rejected
     // so injected scripts cannot fabricate host commands.
-    const originalParent = window.parent
-    Object.defineProperty(window, "parent", {
-      value: { postMessage: vi.fn() },
-      configurable: true,
-    })
-
-    try {
+    await withEmbeddedWindow(() => {
       const message = new MessageEvent("message", {
         data: {
           stCommVersion: HOST_COMM_VERSION,
@@ -835,23 +844,12 @@ describe("HostCommunicationManager messaging", () => {
         // @ts-expect-error - props are private
         hostCommunicationMgr.props.fileUploadClientConfigChanged
       ).not.toHaveBeenCalled()
-    } finally {
-      Object.defineProperty(window, "parent", {
-        value: originalParent,
-        configurable: true,
-      })
-    }
+    })
   })
 
-  it("ignores self-posts from a disallowed origin even when embedded", () => {
+  it("ignores self-posts from a disallowed origin even when embedded", async () => {
     // The self-post exception must not bypass the allowedOrigins check.
-    const originalParent = window.parent
-    Object.defineProperty(window, "parent", {
-      value: { postMessage: vi.fn() },
-      configurable: true,
-    })
-
-    try {
+    await withEmbeddedWindow(() => {
       const message = newHostMessageEvent({
         data: {
           stCommVersion: HOST_COMM_VERSION,
@@ -870,12 +868,7 @@ describe("HostCommunicationManager messaging", () => {
         // @ts-expect-error - props are private
         hostCommunicationMgr.props.fileUploadClientConfigChanged
       ).not.toHaveBeenCalled()
-    } finally {
-      Object.defineProperty(window, "parent", {
-        value: originalParent,
-        configurable: true,
-      })
-    }
+    })
   })
 
   it("ignores script-dispatched host messages even when source and origin match", () => {
@@ -944,13 +937,15 @@ describe("HostCommunicationManager messaging", () => {
     })
     dispatchEvent("message", message)
 
-    // Args mirror the LOG.debug call: isTrusted, sourceIsParent, allowedOrigin,
-    // origin. The event is untrusted (script-constructed) but its source is the
-    // parent and its origin is allowed, so only the isTrusted guard fails.
+    // Args mirror the LOG.debug call: isTrusted, sourceIsParent, selfPost,
+    // allowedOrigin, origin. The event is untrusted (script-constructed) but
+    // its source is the parent (not a self-post) and its origin is allowed, so
+    // only the isTrusted guard fails.
     expect(debugSpy).toHaveBeenCalledExactlyOnceWith(
       expect.stringContaining("Ignoring host message"),
       false,
       true,
+      false,
       true,
       "https://devel.streamlit.test"
     )
@@ -974,40 +969,63 @@ describe("HostCommunicationManager messaging", () => {
     debugSpy.mockRestore()
   })
 
-  it("does not log a debug message for the guest's own self-posted messages", () => {
+  it("does not log a debug message for the guest's own self-posted messages", async () => {
     const debugSpy = vi
       .spyOn(getLogger("HostCommunicationManager"), "debug")
       .mockImplementation(() => {})
 
-    // Simulate being embedded so window.parent differs from window; otherwise
-    // jsdom makes window.parent === window and a self-post is indistinguishable
-    // from a top-level parent message.
-    const originalParent = window.parent
-    Object.defineProperty(window, "parent", {
-      value: { postMessage: vi.fn() },
-      configurable: true,
-    })
+    try {
+      // Simulate being embedded so window.parent differs from window; otherwise
+      // jsdom makes window.parent === window and a self-post is
+      // indistinguishable from a top-level parent message.
+      await withEmbeddedWindow(() => {
+        // Mimics the GUEST_READY message the manager posts to its own window
+        // when embedded: a genuine host-versioned payload whose source is this
+        // window (not the parent). It is intentionally ignored and, being the
+        // app's own per-load self-post, must not be logged.
+        const message = new MessageEvent("message", {
+          data: {
+            stCommVersion: HOST_COMM_VERSION,
+            type: "GUEST_READY",
+          },
+          origin: "https://devel.streamlit.test",
+          source: window,
+        })
+        dispatchEvent("message", message)
+
+        expect(debugSpy).not.toHaveBeenCalled()
+      })
+    } finally {
+      debugSpy.mockRestore()
+    }
+  })
+
+  it("logs a debug message for a dropped non-GUEST_READY self-post", async () => {
+    const debugSpy = vi
+      .spyOn(getLogger("HostCommunicationManager"), "debug")
+      .mockImplementation(() => {})
 
     try {
-      // Mimics the GUEST_READY message the manager posts to its own window when
-      // embedded: a genuine host-versioned payload whose source is this window
-      // (not the parent). It is intentionally ignored and must not be logged.
-      const message = new MessageEvent("message", {
-        data: {
-          stCommVersion: HOST_COMM_VERSION,
-          type: "GUEST_READY",
-        },
-        origin: "https://devel.streamlit.test",
-        source: window,
-      })
-      dispatchEvent("message", message)
+      // A dropped same-window self-post that is NOT the app's own GUEST_READY
+      // (here a SET_AUTH_TOKEN from a disallowed origin) must still be logged so
+      // an in-iframe embed preamble's delivery problems remain diagnosable.
+      await withEmbeddedWindow(() => {
+        dispatchEvent(
+          "message",
+          newHostMessageEvent({
+            data: {
+              stCommVersion: HOST_COMM_VERSION,
+              type: "SET_AUTH_TOKEN",
+              authToken: "dropped token",
+            },
+            origin: "https://not-allowed.example",
+            source: window,
+          })
+        )
 
-      expect(debugSpy).not.toHaveBeenCalled()
-    } finally {
-      Object.defineProperty(window, "parent", {
-        value: originalParent,
-        configurable: true,
+        expect(debugSpy).toHaveBeenCalled()
       })
+    } finally {
       debugSpy.mockRestore()
     }
   })
@@ -1260,13 +1278,7 @@ describe("HostCommunicationManager external auth token handling", () => {
     // Simulate being embedded in a third-party page: window.parent is not a
     // trusted relay, so the in-iframe embed preamble delivers SET_AUTH_TOKEN
     // by posting to this window itself (event.source === window).
-    const originalParent = window.parent
-    Object.defineProperty(window, "parent", {
-      value: { postMessage: vi.fn() },
-      configurable: true,
-    })
-
-    try {
+    await withEmbeddedWindow(async () => {
       hostCommunicationMgr.setAllowedOrigins({
         allowedOrigins: ["http://devel.streamlit.test"],
         useExternalAuthToken: true,
@@ -1291,11 +1303,6 @@ describe("HostCommunicationManager external auth token handling", () => {
         // @ts-expect-error - deferredAuthToken is private
         hostCommunicationMgr.deferredAuthToken.promise
       ).resolves.toBe("self-posted auth token")
-    } finally {
-      Object.defineProperty(window, "parent", {
-        value: originalParent,
-        configurable: true,
-      })
-    }
+    })
   })
 })

--- a/frontend/lib/src/hostComm/HostCommunicationManager.tsx
+++ b/frontend/lib/src/hostComm/HostCommunicationManager.tsx
@@ -229,18 +229,24 @@ export default class HostCommunicationManager {
       this.allowedOrigins.some(allowed => isValidOrigin(allowed, event.origin))
 
     if (!isTrustedMessage || !isHostMessage || !isAllowedOrigin) {
-      // Only log when the payload looks like a genuine host message so we
-      // don't spam logs for the many unrelated postMessages this global
-      // handler receives. This helps diagnose cases where a legitimate host's
-      // messages are unexpectedly dropped (e.g. an intermediate iframe wrapper
-      // posting from a non-direct-parent window). Skip self-posts to avoid
-      // per-load noise from the app's own GUEST_READY self-post (whose origin
-      // may not be allow-listed).
-      if (isHostMessage && !isSelfPost) {
+      // The app posts a GUEST_READY message to its own window on load (see
+      // openHostCommunication). That self-post is expected to be dropped here
+      // (it uses window.location.origin, which need not be allow-listed), so we
+      // skip logging it to avoid per-load noise.
+      const isSelfPostGuestReady =
+        isSelfPost && (message?.type as string) === "GUEST_READY"
+      // Only log when the payload looks like a genuine host message so we don't
+      // spam logs for the many unrelated postMessages this global handler
+      // receives. This helps diagnose cases where a legitimate host's messages
+      // are unexpectedly dropped -- including a dropped same-window self-post
+      // from an in-iframe embed preamble (e.g. a SET_AUTH_TOKEN whose origin is
+      // not allow-listed), which the earlier blanket self-post skip hid.
+      if (isHostMessage && !isSelfPostGuestReady) {
         LOG.debug(
-          "Ignoring host message: isTrusted=%s, sourceIsParent=%s, allowedOrigin=%s, origin=%s",
+          "Ignoring host message: isTrusted=%s, sourceIsParent=%s, selfPost=%s, allowedOrigin=%s, origin=%s",
           event.isTrusted,
           isFromParent,
+          isSelfPost,
           isAllowedOrigin,
           event.origin
         )

--- a/frontend/lib/src/hostComm/HostCommunicationManager.tsx
+++ b/frontend/lib/src/hostComm/HostCommunicationManager.tsx
@@ -206,10 +206,20 @@ export default class HostCommunicationManager {
     // frame-ancestors header, it doesn't hurt to be extra safe). We avoid
     // processing messages received from origins we haven't explicitly
     // labeled as trusted, and only accept trusted postMessage events from the
-    // direct parent frame so same-origin child iframes cannot spoof host
-    // commands.
+    // direct parent frame (or a genuine same-window self-post, see below) so
+    // same-origin child iframes cannot spoof host commands.
     const isFromParent = event.source === window.parent
-    const isTrustedParentMessage = event.isTrusted && isFromParent
+    // Genuine same-window self-post used by an in-iframe embed preamble to
+    // deliver host messages (e.g. SET_AUTH_TOKEN) to the library when there is
+    // no trusted parent frame to relay them (window.parent is a third-party
+    // page). The browser sets event.source to the calling window, so this can
+    // only match a post from this very window (not a child frame, whose source
+    // would be the child's window). Trusting it grants no extra privilege
+    // since any script in this same window already has full same-origin access.
+    const isSelfPost = event.source === window && window !== window.parent
+    // Reject script-dispatched (synthetic) events, and only accept messages
+    // from the direct parent frame or a genuine same-window self-post.
+    const isTrustedMessage = event.isTrusted && (isFromParent || isSelfPost)
     const isHostMessage = message?.stCommVersion === HOST_COMM_VERSION
     // Only parse origins for genuine host messages; this global handler
     // receives many unrelated postMessages and isValidOrigin allocates
@@ -217,17 +227,15 @@ export default class HostCommunicationManager {
     const isAllowedOrigin =
       isHostMessage &&
       this.allowedOrigins.some(allowed => isValidOrigin(allowed, event.origin))
-    // When embedded, the guest posts its own GUEST_READY to this window (see
-    // openHostCommunication); that self-post is intentionally ignored here and
-    // should not be logged as a dropped host message.
-    const isSelfPost = event.source === window && window !== window.parent
 
-    if (!isTrustedParentMessage || !isHostMessage || !isAllowedOrigin) {
+    if (!isTrustedMessage || !isHostMessage || !isAllowedOrigin) {
       // Only log when the payload looks like a genuine host message so we
       // don't spam logs for the many unrelated postMessages this global
       // handler receives. This helps diagnose cases where a legitimate host's
       // messages are unexpectedly dropped (e.g. an intermediate iframe wrapper
-      // posting from a non-direct-parent window).
+      // posting from a non-direct-parent window). Skip self-posts to avoid
+      // per-load noise from the app's own GUEST_READY self-post (whose origin
+      // may not be allow-listed).
       if (isHostMessage && !isSelfPost) {
         LOG.debug(
           "Ignoring host message: isTrusted=%s, sourceIsParent=%s, allowedOrigin=%s, origin=%s",


### PR DESCRIPTION
## Describe your changes

Restores embedded Streamlit-in-Snowflake (SiS) auth delivery that was broken by the anti-spoofing guard added in #15800.

- `HostCommunicationManager.receiveHostMessage` now trusts a genuine **same-window self-post** (`event.source === window && window !== window.parent`) in addition to the direct parent frame. This lets an in-iframe embed preamble deliver `SET_AUTH_TOKEN` to the library when `window.parent` is an untrusted third-party page, where the token is posted to the iframe's own window rather than relayed through the parent.
- The `event.isTrusted` and `allowedOrigins` guards are unchanged, so script-dispatched (synthetic) events and same-origin **child** iframes (whose `event.source` is the child window, not `window`) remain rejected — the #15800 protection against child-frame/script spoofing is fully preserved. Trusting a same-window self-post grants no new privilege, since any script already running in that window has full same-origin access.

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- Unit Tests (JS) in `frontend/lib/src/hostComm/HostCommunicationManager.test.tsx`:
  - Positive: a same-window self-post of `SET_FILE_UPLOAD_CLIENT_CONFIG` is processed when embedded, and `SET_AUTH_TOKEN` resolves the deferred auth token (the exact broken flow).
  - Negative: an untrusted (script-dispatched) self-post and a self-post from a disallowed origin are both rejected — pinning that `isTrusted` and `allowedOrigins` still gate the new branch.
- Follow-up: external e2e coverage of the embedded self-post auth path (`@pytest.mark.external_test`) is recommended. The existing `hostframe.html` harness only models a parent→guest relay, so covering the same-window self-post requires injecting a same-origin preamble into the guest document.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.