### PR TITLE
[fix] Judge each skills-install target on its own, per detected harness

### DIFF
--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1620,7 +1620,10 @@ export class App extends PureComponent<Props, State> {
         // which would conflate "installed" with a permanent opt-out. The card
         // shows its own success confirmation and auto-dismisses.
         this.trackSkillsNudge(
-          skillsNudgeInstallSuccessLabel(result.fallbackReason)
+          skillsNudgeInstallSuccessLabel(
+            result.fallbackReason,
+            result.degradedTargets
+          )
         )
         return result.detail ?? undefined
       })

--- a/frontend/app/src/components/SkillsNudgeToast/skillsNudge.test.ts
+++ b/frontend/app/src/components/SkillsNudgeToast/skillsNudge.test.ts
@@ -197,6 +197,37 @@ describe("skillsNudge preferences", () => {
         "skillsNudgeInstallSucceeded:symlinks_no_privilege"
       )
     })
+
+    it("appends a degraded best-effort target as a third segment", () => {
+      expect(
+        skillsNudgeInstallSuccessLabel("symlink_failed", "agents_skills")
+      ).toBe("skillsNudgeInstallSucceeded:symlink_failed:agents_skills")
+    })
+
+    it("keeps segment 2 empty when a degraded install had no reroute", () => {
+      // The double colon is deliberate and load-bearing. Downstream queries read
+      // the fallback reason with `split_part(label, ':', 2)`, which returns "" here
+      // — exactly what a plain success has always yielded for that segment. Putting
+      // the target in segment 2 instead would fork the fallback-reason vocabulary
+      // and silently break every one of those queries.
+      expect(skillsNudgeInstallSuccessLabel(null, "agents_skills")).toBe(
+        "skillsNudgeInstallSucceeded::agents_skills"
+      )
+      expect(skillsNudgeInstallSuccessLabel("", "agents_skills")).toBe(
+        "skillsNudgeInstallSucceeded::agents_skills"
+      )
+    })
+
+    it("is the bare label when an older backend omits degraded targets", () => {
+      // protobuf sends "" for an unset string; neither that nor undefined may
+      // produce a dangling ":" suffix.
+      expect(skillsNudgeInstallSuccessLabel(undefined, "")).toBe(
+        "skillsNudgeInstallSucceeded"
+      )
+      expect(skillsNudgeInstallSuccessLabel(null, null)).toBe(
+        "skillsNudgeInstallSucceeded"
+      )
+    })
   })
 
   describe("skillsNudgeInstallFailureLabel", () => {

--- a/frontend/app/src/components/SkillsNudgeToast/skillsNudge.ts
+++ b/frontend/app/src/components/SkillsNudgeToast/skillsNudge.ts
@@ -169,13 +169,25 @@ export function skillsNudgeSuppressedLabel(reason: string): string {
  * label suffix because a fallback install is otherwise indistinguishable from a
  * project install in the success telemetry, and the causes point at different
  * fixes — only Developer Mode being off is something a user can simply turn on.
+ *
+ * `degradedTargets` names any *best-effort* install target whose write failed while
+ * every authoritative target succeeded — the install reached the agent, so it is a
+ * success, but a target we still write did not land. It goes in a THIRD segment so
+ * segment 2 keeps meaning `fallbackReason` for every existing query. A degraded
+ * install with no fallback therefore emits an empty segment 2
+ * (`skillsNudgeInstallSucceeded::agents_skills`), which is exactly what a plain
+ * success yields for that segment today — deliberate, so `split_part(label, ':', 2)`
+ * keeps returning the same thing it always has.
  */
 export function skillsNudgeInstallSuccessLabel(
-  fallbackReason?: string | null
+  fallbackReason?: string | null,
+  degradedTargets?: string | null
 ): string {
-  return fallbackReason
-    ? `skillsNudgeInstallSucceeded:${fallbackReason}`
-    : "skillsNudgeInstallSucceeded"
+  if (!fallbackReason && !degradedTargets) {
+    return "skillsNudgeInstallSucceeded"
+  }
+  const base = `skillsNudgeInstallSucceeded:${fallbackReason ?? ""}`
+  return degradedTargets ? `${base}:${degradedTargets}` : base
 }
 
 /**

--- a/frontend/lib/src/BackendOperationClient.test.ts
+++ b/frontend/lib/src/BackendOperationClient.test.ts
@@ -342,6 +342,49 @@ describe("BackendOperationClient", () => {
     expect(payload.fallbackReason).toBeFalsy()
   })
 
+  it("preserves degraded_targets on a successful install", async () => {
+    const sendRequest = vi.fn()
+    const client = createClient(sendRequest)
+
+    const promise = client.requestInstallSkills()
+    const request = sendRequest.mock.calls[0][0] as BackendOperationRequest
+
+    client.onResponse(
+      new BackendOperationResponse({
+        requestId: request.requestId,
+        installSkills: {
+          detail: "Installed to ~/.claude/skills",
+          degradedTargets: "agents_skills",
+        },
+      })
+    )
+
+    // A best-effort target failing does NOT fail the install, so this rides the
+    // success payload — it is the only signal that the demoted target went wrong.
+    const payload = await promise
+    expect(payload.degradedTargets).toBe("agents_skills")
+    expect(payload.fallbackReason).toBeFalsy()
+  })
+
+  it("leaves degradedTargets empty for a clean install", async () => {
+    const sendRequest = vi.fn()
+    const client = createClient(sendRequest)
+
+    const promise = client.requestInstallSkills()
+    const request = sendRequest.mock.calls[0][0] as BackendOperationRequest
+
+    client.onResponse(
+      new BackendOperationResponse({
+        requestId: request.requestId,
+        installSkills: { detail: "Installed" },
+      })
+    )
+
+    const payload = await promise
+    // Must stay falsy, or App would tag a clean install as degraded.
+    expect(payload.degradedTargets).toBeFalsy()
+  })
+
   it("sends dismiss skills nudge requests and resolves on the ack", async () => {
     const sendRequest = vi.fn()
     const client = createClient(sendRequest)

--- a/frontend/lib/src/BackendOperationClient.ts
+++ b/frontend/lib/src/BackendOperationClient.ts
@@ -233,18 +233,22 @@ export class BackendOperationClient {
   /**
    * Request a one-click install of the bundled Streamlit agent skills.
    *
-   * @returns A promise that resolves with an optional outcome detail and a
+   * @returns A promise that resolves with an optional outcome detail, a
    * `fallbackReason` naming why a project install was rerouted to a global copy
-   * (empty when it wasn't), or rejects with a {@link BackendOperationError} whose
-   * `reason` classifies the failure for telemetry.
+   * (empty when it wasn't), and `degradedTargets` naming any best-effort install
+   * target whose write failed while the install still reached the agent (empty when
+   * none did), or rejects with a {@link BackendOperationError} whose `reason`
+   * classifies the failure for telemetry.
    */
   public requestInstallSkills(): Promise<{
     detail?: string | null
     fallbackReason?: string | null
+    degradedTargets?: string | null
   }> {
     return this.request<{
       detail?: string | null
       fallbackReason?: string | null
+      degradedTargets?: string | null
     }>("installSkills", {}, INSTALL_SKILLS_REQUEST_TIMEOUT_MS)
   }
 

--- a/lib/streamlit/runtime/backend_operation_handler.py
+++ b/lib/streamlit/runtime/backend_operation_handler.py
@@ -283,7 +283,7 @@ class InstallSkillsHandler(BackendOperationHandler):
             # rather than being flattened to "unknown".
             reason: str
             if isinstance(ex, skills.InstallError):
-                reason = ex.reason
+                reason = ex.telemetry_reason
             elif isinstance(ex, OSError):
                 reason = skills.classify_write_error(ex)
             else:
@@ -303,6 +303,12 @@ class InstallSkillsHandler(BackendOperationHandler):
             install_skills=InstallSkillsResponsePayload(
                 detail=skills.summarize_install(result),
                 fallback_reason=result.fallback_reason or "",
+                # A best-effort target that failed while every authoritative one
+                # landed. The install succeeded and is reported as such; this keeps
+                # the demoted target's failure rate observable instead of silent.
+                # Sorted and comma-joined so the value stays a stable, bounded
+                # string regardless of target iteration order.
+                degraded_targets=",".join(sorted(set(result.degraded_targets))),
             ),
         )
 

--- a/lib/streamlit/web/skills.py
+++ b/lib/streamlit/web/skills.py
@@ -24,12 +24,15 @@ import tempfile
 from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
-from typing import Final, Literal
+from typing import TYPE_CHECKING, Final, Literal, NamedTuple
 
 import click
 
 import streamlit
 from streamlit.logger import get_logger
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 _LOGGER: Final = get_logger(__name__)
 
@@ -64,6 +67,17 @@ _FallbackReason = Literal[
     "symlinks_unsupported",  # The filesystem/OS has no directory symlinks.
     "symlink_failed",  # Pre-check passed, then an individual link would not lay.
 ]
+
+# Which install target a failure happened on. Emitted as a THIRD label segment
+# (``skillsNudgeInstallFailed:write_denied:claude_skills``) rather than folded into
+# the reason, so downstream queries that read the reason with
+# ``split_part(label, ':', 2)`` keep resolving unchanged. Closed for the same reason
+# the vocabularies above are: it reaches telemetry verbatim.
+_InstallTargetName = Literal["claude_skills", "agents_skills"]
+
+# Harness keys (matching :data:`_HARNESSES`) for the two dirs an install writes.
+_CLAUDE_HARNESS: Final[str] = "claude"
+_AGENTS_HARNESS: Final[str] = "agents"
 
 # OSError.errno -> reason. Built by name so a platform missing one of these (they
 # are not all defined everywhere) simply omits it rather than failing at import.
@@ -116,15 +130,38 @@ def classify_write_error(error: OSError) -> _InstallFailureReason:
 class InstallError(click.ClickException):
     """A skills-install failure carrying a stable machine-readable ``reason`` code.
 
-    The backend-operation handler forwards the ``reason`` to the client, which emits
-    it as a telemetry label suffix - hence the fixed :data:`_InstallFailureReason`
-    vocabulary, never user input. Behaves like a plain ``click.ClickException``
-    otherwise, so raising it changes nothing a user sees.
+    The backend-operation handler forwards :attr:`telemetry_reason` to the client,
+    which emits it as a telemetry label suffix - hence the fixed
+    :data:`_InstallFailureReason` vocabulary, never user input. Behaves like a plain
+    ``click.ClickException`` otherwise, so raising it changes nothing a user sees.
     """
 
-    def __init__(self, message: str, *, reason: _InstallFailureReason) -> None:
+    def __init__(
+        self,
+        message: str,
+        *,
+        reason: _InstallFailureReason,
+        target: _InstallTargetName | None = None,
+    ) -> None:
         super().__init__(message)
         self.reason = reason
+        # Which install target produced the failure, when it can be attributed to
+        # one. ``None`` for causes that are not per-target (a missing bundled
+        # source, a non-interactive terminal) or when targets disagreed.
+        self.target = target
+
+    @property
+    def telemetry_reason(self) -> str:
+        """The reason, with the failing target appended when one is known.
+
+        Composed here rather than in the handler so the whole emitted vocabulary
+        stays in this module. The target becomes a THIRD label segment, which is
+        what keeps it additive: ``split_part(label, ':', 2)`` still returns the bare
+        reason, so every downstream query reading segment 2 resolves unchanged.
+        Folding the target into the reason instead (``write_denied_claude``) would
+        fork the closed vocabulary above and break them silently.
+        """
+        return f"{self.reason}:{self.target}" if self.target else self.reason
 
 
 def _generate_gitignore_snippet(
@@ -145,6 +182,28 @@ def _generate_gitignore_snippet(
     return "\n".join(lines)
 
 
+@dataclass(frozen=True)
+class _InstallTarget:
+    """One directory a skills install writes to, and what a failure there means."""
+
+    path: Path
+    # Names this target in telemetry - see :data:`_InstallTargetName`.
+    telemetry_name: _InstallTargetName
+    # The load-bearing bit. A DETECTED harness is known to read an authoritative
+    # target, so a failure there means the install reached no agent and must be
+    # reported as a failure. A best-effort target has no verified reader, so a
+    # failure there must not fail an install that otherwise delivered. See
+    # :func:`_authoritative_harnesses` for how this is decided.
+    authoritative: bool
+
+
+class _TargetWriteFailure(NamedTuple):
+    """A single target's failed write: where it happened, and the classified cause."""
+
+    target: _InstallTarget
+    reason: _InstallFailureReason
+
+
 @dataclass
 class _InstallResult:
     """Result of a skill installation attempt."""
@@ -162,6 +221,11 @@ class _InstallResult:
     # target had which. Separate from the display strings above, which carry raw
     # OSError text that must not reach the browser.
     write_reasons: set[_InstallFailureReason] = field(default_factory=set)
+    # Best-effort targets whose write failed while the install still delivered to
+    # every authoritative one. Reported on the SUCCESS label, so demoting a target
+    # from "fails the install" to "best effort" does not make its failure rate
+    # unobservable - an attribution never emitted cannot be backfilled.
+    degraded_targets: list[_InstallTargetName] = field(default_factory=list)
     # Set when a project install was rerouted to a global copy, naming why. Surfaced
     # to telemetry so that cohort is countable - see InstallSkillsResponsePayload.
     fallback_reason: _FallbackReason | None = None
@@ -274,46 +338,113 @@ def _find_project_root(start: Path | None = None) -> Path:
     return start_dir
 
 
-def _get_project_target_dirs(project_root: Path) -> list[Path]:
+def _claude_code_installed() -> bool:
+    """Whether Claude Code is present on this machine, i.e. ``~/.claude`` exists.
+
+    ``is_dir()`` rather than ``exists()``: a *file* at ``~/.claude`` is not an
+    install, and treating it as one would add a ``.claude/skills`` target whose every
+    write then fails on the non-directory parent.
+    """
+    return (Path.home() / ".claude").is_dir()
+
+
+def _authoritative_harnesses() -> frozenset[str]:
+    """The harnesses whose skills dir must hold the skill for an install to count.
+
+    Claude Code is the only harness verified to read a directory we write. It reads
+    ``.claude/skills`` and ignores ``.agents/skills`` entirely (streamlit#16282), so
+    when Claude Code is present ``.claude/skills`` is what an install has to land and
+    ``.agents/skills`` is best-effort - written for harnesses that may or may not
+    read it, and never the reason an install that reached Claude Code is called a
+    failure.
+
+    When Claude Code is absent, none of our targets has a verified reader at all and
+    ``.agents/skills`` is the only one we write, so it carries authority by default.
+    That is a deliberate choice between two wrong answers: an empty set would make
+    "installed" unreachable, so the nudge would fire forever at a user for whom no
+    install could ever satisfy the gate. The real fix is a target such a harness
+    actually reads; until then this keeps that cohort's behavior as it is today
+    rather than regressing it.
+
+    Returning a set, and gating on "every member is satisfied", is what makes
+    requiring *all* targets safe - the objection that sank this in #16279. We ask
+    only for the dirs a DETECTED harness reads, so someone who deliberately keeps the
+    skill in one place is not nudged forever: the place they keep it is the place
+    their agent reads.
+    """
+    return frozenset(
+        {_CLAUDE_HARNESS} if _claude_code_installed() else {_AGENTS_HARNESS}
+    )
+
+
+def _skill_install_targets(root: Path) -> list[_InstallTarget]:
+    """Build the ordered install targets under ``root`` (a project root, or home).
+
+    Authoritative targets come FIRST so an install interrupted partway through
+    (Ctrl-C, a crash, a disk filling up) has already laid the copy an agent actually
+    reads, rather than only the best-effort one.
+    """
+    authoritative = _authoritative_harnesses()
+    targets: list[_InstallTarget] = []
+
+    if _claude_code_installed():
+        targets.append(
+            _InstallTarget(
+                path=root / ".claude" / "skills",
+                telemetry_name="claude_skills",
+                authoritative=_CLAUDE_HARNESS in authoritative,
+            )
+        )
+
+    # Always written: the cross-harness convention dir. Kept unconditional because
+    # its readership is unverified rather than disproven - cortex, for one, reads a
+    # PROJECT-level .agents/skills - so dropping it could silently break a harness
+    # nobody has probed.
+    targets.append(
+        _InstallTarget(
+            path=root / ".agents" / "skills",
+            telemetry_name="agents_skills",
+            authoritative=_AGENTS_HARNESS in authoritative,
+        )
+    )
+    return targets
+
+
+def _get_project_target_dirs(project_root: Path) -> list[_InstallTarget]:
     """Get target directories for project skill installation.
 
-    Always targets .agents/skills/. Also targets .claude/skills/
-    when ~/.claude exists (Claude Code is installed).
+    Targets ``.claude/skills/`` first when ``~/.claude`` exists (Claude Code is
+    installed), then always ``.agents/skills/``. See :func:`_skill_install_targets`
+    for the ordering, and :func:`_authoritative_harnesses` for which of them a
+    failure may fail the install on.
     """
-    targets = [project_root / ".agents" / "skills"]
-
-    claude_home = Path.home() / ".claude"
-    if claude_home.exists():
-        targets.append(project_root / ".claude" / "skills")
-
-    return targets
+    return _skill_install_targets(project_root)
 
 
-def _get_global_target_dirs() -> list[Path]:
+def _get_global_target_dirs() -> list[_InstallTarget]:
     """Get target directories for global skill installation.
 
-    Always targets ~/.agents/skills/. Also targets ~/.claude/skills/
-    when ~/.claude exists (Claude Code is installed).
+    The same targets as a project install, rooted at the home directory:
+    ``~/.claude/skills/`` first when ``~/.claude`` exists, then always
+    ``~/.agents/skills/``.
     """
-    home = Path.home()
-    targets = [home / ".agents" / "skills"]
-
-    claude_home = home / ".claude"
-    if claude_home.exists():
-        targets.append(claude_home / "skills")
-
-    return targets
+    return _skill_install_targets(Path.home())
 
 
 def are_skills_installed() -> bool:
     """Check whether Streamlit agent skills appear to be installed.
 
     Returns ``True`` if the bundled skill is present (as a symlink, copied
-    directory, or regular directory) in any of the project-local or global
-    target directories. This is a best-effort check used to decide whether to
-    recommend installing skills; it does not validate skill contents.
+    directory, or regular directory) in any *authoritative* project-local or global
+    target directory - one a detected harness is known to read. This is a
+    best-effort check used to decide whether to recommend installing skills; it does
+    not validate skill contents.
+
+    Best-effort targets are skipped deliberately. Counting them would suppress this
+    recommendation for a user whose only copy sits where their agent cannot see it -
+    the partial-install trap: told the install failed, then never offered a retry.
     """
-    candidate_dirs: list[Path] = []
+    candidate_targets: list[_InstallTarget] = []
     try:
         project_root = _find_project_root()
     except (OSError, RuntimeError):
@@ -322,20 +453,22 @@ def are_skills_installed() -> bool:
         pass
     else:
         try:
-            candidate_dirs.extend(_get_project_target_dirs(project_root))
+            candidate_targets.extend(_get_project_target_dirs(project_root))
         except (OSError, RuntimeError):
             # Same reasoning as above; still check global dirs.
             pass
 
     try:
-        candidate_dirs.extend(_get_global_target_dirs())
+        candidate_targets.extend(_get_global_target_dirs())
     except (OSError, RuntimeError):
         # Keep any project dirs already collected above instead of discarding
         # them; still a best-effort check, so just skip the global dirs.
         pass
 
-    for target_dir in candidate_dirs:
-        skill_path = target_dir / _GLOBAL_SKILL_NAME
+    for target in candidate_targets:
+        if not target.authoritative:
+            continue
+        skill_path = target.path / _GLOBAL_SKILL_NAME
         try:
             if skill_path.is_symlink() or skill_path.exists():
                 return True
@@ -668,7 +801,7 @@ def _prompt_install_mode() -> str:
 def _confirm_project_installation(
     project_root: Path,
     skills: list[str],
-    target_dirs: list[Path],
+    targets: list[_InstallTarget],
 ) -> bool:
     """Show project installation plan and confirm with user."""
     click.echo()
@@ -683,11 +816,11 @@ def _confirm_project_installation(
         )
 
     click.secho("\nTarget directories:", bold=True)
-    for target_dir in target_dirs:
+    for target in targets:
         try:
-            rel_path = target_dir.relative_to(project_root)
+            rel_path = target.path.relative_to(project_root)
         except ValueError:
-            rel_path = target_dir
+            rel_path = target.path
         click.echo(
             f"  {click.style('•', fg='magenta')} "
             f"{click.style(str(rel_path) + '/', fg='cyan')}"
@@ -697,7 +830,7 @@ def _confirm_project_installation(
     return click.confirm("Proceed with installation?", default=True)
 
 
-def _confirm_global_installation(target_dirs: list[Path]) -> bool:
+def _confirm_global_installation(targets: list[_InstallTarget]) -> bool:
     """Show global installation plan and confirm with user."""
     click.echo()
     click.echo("Installing globally")
@@ -716,11 +849,11 @@ def _confirm_global_installation(target_dirs: list[Path]) -> bool:
 
     click.secho("\nTarget directories:", bold=True)
     home = Path.home()
-    for target_dir in target_dirs:
+    for target in targets:
         try:
-            rel_path = Path("~") / target_dir.relative_to(home)
+            rel_path = Path("~") / target.path.relative_to(home)
         except ValueError:
-            rel_path = target_dir
+            rel_path = target.path
         click.echo(
             f"  {click.style('•', fg='magenta')} "
             f"{click.style(str(rel_path) + '/', fg='cyan')}"
@@ -768,27 +901,34 @@ def _conflict_error(skipped: list[str]) -> InstallError:
     )
 
 
-def _write_error(result: _InstallResult) -> InstallError:
+def _write_error(
+    result: _InstallResult, failures: Sequence[_TargetWriteFailure]
+) -> InstallError:
     """Build a "couldn't write" error for filesystem failures during copy.
 
     Distinct from :func:`_conflict_error`, which reports pre-existing files.
 
-    The reason follows what the failed targets agreed on:
+    ``failures`` are the failures that *justify* the error - in practice the
+    authoritative ones, whose targets a detected harness reads. Best-effort failures
+    are still named in the message (the user should see everything that did not land)
+    but never decide the reason or the target, so a dead-weight target cannot
+    mislabel a failure a load-bearing one caused.
 
-    - all agreed on one cause -> that cause
-    - they disagreed -> the generic ``write_failed``, because claiming "permission
-      denied" for a set that was half permissions and half disk-full would point
-      whoever reads the telemetry at the wrong fix
+    The reason and the target each follow what the failed targets agreed on:
+
+    - all agreed -> that cause / that target
+    - they disagreed -> the generic ``write_failed`` / no target, because claiming
+      "permission denied on .claude/skills" for a set that was half permissions and
+      half disk-full would point whoever reads the telemetry at the wrong fix
     """
     joined = ", ".join(_concise_install_paths(result.errored))
-    reasons = result.write_reasons
-    reason: _InstallFailureReason = (
-        next(iter(reasons)) if len(reasons) == 1 else "write_failed"
-    )
+    reasons = {failure.reason for failure in failures}
+    names = {failure.target.telemetry_name for failure in failures}
     return InstallError(
         f"Could not write {joined}. Check folder permissions and free disk "
         "space, then try again.",
-        reason=reason,
+        reason=next(iter(reasons)) if len(reasons) == 1 else "write_failed",
+        target=next(iter(names)) if len(names) == 1 else None,
     )
 
 
@@ -821,7 +961,7 @@ def _install_project_skills(
     # root resolves from the running app's directory (matching the nudge's skill
     # detection), instead of the server's working directory.
     project_root = _find_project_root(Path(app_dir) if app_dir else None)
-    target_dirs = _get_project_target_dirs(project_root)
+    targets = _get_project_target_dirs(project_root)
 
     symlink_blocker = _symlink_blocker(project_root, source_skills_dir / skills[0])
     if symlink_blocker is not None:
@@ -850,7 +990,7 @@ def _install_project_skills(
         )
 
     # Confirm installation
-    if not yes and not _confirm_project_installation(project_root, skills, target_dirs):
+    if not yes and not _confirm_project_installation(project_root, skills, targets):
         click.echo("Installation cancelled.")
         raise click.Abort()
 
@@ -860,9 +1000,9 @@ def _install_project_skills(
     bundled_skill_names = set(skills)
 
     for skill_name in skills:
-        for target_dir in target_dirs:
+        for target in targets:
             success = _install_skill_symlink(
-                skill_name, source_skills_dir, target_dir, result, bundled_skill_names
+                skill_name, source_skills_dir, target.path, result, bundled_skill_names
             )
             if not success:
                 symlink_failed = True
@@ -926,7 +1066,7 @@ def _install_project_skills(
         click.echo()
         click.secho("Recommended .gitignore snippet:", fg="bright_black", bold=True)
         gitignore_snippet = _generate_gitignore_snippet(
-            skills, target_dirs, project_root
+            skills, [target.path for target in targets], project_root
         )
         for line in gitignore_snippet.splitlines():
             click.secho(f"  {line}", fg="bright_black")
@@ -948,10 +1088,10 @@ def _install_global_skills(*, yes: bool = False) -> _InstallResult:
     ``discover.py`` still resolves the version-matched content skills at runtime,
     so a single global install stays correct across Streamlit versions.
     """
-    target_dirs = _get_global_target_dirs()
+    targets = _get_global_target_dirs()
 
     # Confirm installation
-    if not yes and not _confirm_global_installation(target_dirs):
+    if not yes and not _confirm_global_installation(targets):
         click.echo("Installation cancelled.")
         raise click.Abort()
 
@@ -983,27 +1123,62 @@ def _install_global_skills(*, yes: bool = False) -> _InstallResult:
             reason="source_incomplete",
         )
 
-    # Install to each target directory
+    # Install to each target directory, keeping a per-target result so each target's
+    # outcome can be judged on its own. One shared _InstallResult cannot support
+    # that: ``write_reasons`` is a set, so two targets failing the same way are
+    # indistinguishable from one, and nothing records WHICH target failed.
     result = _InstallResult()
     # For global install, only one skill is installed but we use a set for consistency
     bundled_skill_names = {_GLOBAL_SKILL_NAME}
-    for target_dir in target_dirs:
+    failures: list[_TargetWriteFailure] = []
+    for target in targets:
+        target_result = _InstallResult()
         _install_skill_copy(
             _GLOBAL_SKILL_NAME,
             meta_skill_dir,
-            target_dir,
-            result,
+            target.path,
+            target_result,
             bundled_skill_names,
         )
+        if target_result.errored:
+            # This target installs exactly one skill, so it has at most one cause;
+            # the len check is for the type checker and for a target that somehow
+            # reported two.
+            reasons = target_result.write_reasons
+            failures.append(
+                _TargetWriteFailure(
+                    target=target,
+                    reason=next(iter(reasons)) if len(reasons) == 1 else "write_failed",
+                )
+            )
+            if not target.authoritative:
+                result.degraded_targets.append(target.telemetry_name)
+        result.installed += target_result.installed
+        result.up_to_date += target_result.up_to_date
+        result.skipped += target_result.skipped
+        result.errored += target_result.errored
+        result.write_reasons |= target_result.write_reasons
 
     # Report results
     _print_result(result)
 
-    # A write failure on ANY target is a hard failure, even if another target
-    # succeeded - otherwise a partial install (e.g. ~/.agents ok but ~/.claude
-    # denied) reports success and drops skillsNudgeInstallFailed:write_failed.
-    if result.errored:
-        raise _write_error(result)
+    # A write failure on an AUTHORITATIVE target is a hard failure: a detected
+    # harness reads that path, so the install reached no agent. A failure on a
+    # best-effort target is not, and used to be - reporting failure to a developer
+    # whose ~/.claude/skills was written and whose Claude Code therefore works
+    # perfectly. That false negative is what this replaces. The best-effort failure
+    # is not swallowed: it rides the success label via ``degraded_targets``.
+    authoritative_failures = [
+        failure for failure in failures if failure.target.authoritative
+    ]
+    if authoritative_failures:
+        raise _write_error(result, authoritative_failures)
+
+    # Nothing landed anywhere. Unreachable while _authoritative_harnesses guarantees
+    # one authoritative target, but a target added later must not be able to turn a
+    # total failure into a silent success.
+    if failures and not (result.installed or result.up_to_date):
+        raise _write_error(result, failures)
 
     if result.installed or result.up_to_date:
         click.echo()
@@ -1257,6 +1432,32 @@ def _detect_installed_skills_cached(app_dir: str | None) -> tuple[str, ...]:
         return ()
 
 
+def _authoritative_skills_installed(app_dir: str | None) -> bool:
+    """Whether every harness that READS what we install actually has the skill.
+
+    :func:`detect_installed_skills` reports the skill anywhere it is found across 8
+    harnesses x 4 roots. That breadth is right for the page-profile telemetry it
+    feeds and wrong as a nudge gate: after a partial install that landed
+    ``.agents/skills`` and was denied ``.claude/skills``, it reports the skill as
+    installed and both nudges go quiet permanently - while Claude Code, which does
+    not read ``.agents/skills``, has nothing. The developer is told the install
+    failed, is never offered a retry, and holds the one copy nothing reads.
+
+    So gate on the authoritative harnesses instead. See
+    :func:`_authoritative_harnesses` for why requiring *all* of them does not nudge
+    forever at someone who deliberately keeps the skill in a single place.
+    """
+    authoritative = _authoritative_harnesses()
+    # Tokens are "<location>:<harness>:<skill>", so index 1 is the harness. Any
+    # location satisfies a harness: a project-local .claude/skills is read by Claude
+    # Code just as a global one is.
+    installed = {token.split(":")[1] for token in detect_installed_skills(app_dir)}
+    # The empty-set guard matters: ``frozenset() <= anything`` is True, so without it
+    # an authority set that somehow came back empty would read as "installed" and
+    # suppress the nudge for everyone.
+    return bool(authoritative) and authoritative <= installed
+
+
 def detect_installed_agents() -> list[str]:
     """Detect agent harnesses installed under the user's home directory.
 
@@ -1335,8 +1536,8 @@ def _one_click_install_would_be_refused(app_dir: str | None) -> bool:
         # Symlink mode installs every (skill, target) pair, so it only refuses
         # when a real file/dir blocks all of them.
         project_pairs = [
-            target_dir / skill_name
-            for target_dir in _get_project_target_dirs(project_root)
+            target.path / skill_name
+            for target in _get_project_target_dirs(project_root)
             for skill_name in skill_names
         ]
         project_all_blocked = bool(project_pairs) and all(
@@ -1346,7 +1547,7 @@ def _one_click_install_would_be_refused(app_dir: str | None) -> bool:
         # The copy fallback installs only the single global skill, and replaces a
         # real dir rather than conflicting - hence the narrower rule.
         global_pairs = [
-            target_dir / _GLOBAL_SKILL_NAME for target_dir in _get_global_target_dirs()
+            target.path / _GLOBAL_SKILL_NAME for target in _get_global_target_dirs()
         ]
         global_all_blocked = bool(global_pairs) and all(
             _copy_target_would_conflict(path) for path in global_pairs
@@ -1441,8 +1642,9 @@ def nudge_suppression_reason(app_dir: str | None = None) -> _NudgeSuppressionRea
         # installed yet.
         if not detect_installed_agents():
             return "no_agent"
-        # An agent is present; recommend installing only if our skills aren't.
-        if detect_installed_skills(app_dir):
+        # An agent is present; recommend installing only if our skills aren't
+        # already where that agent would read them.
+        if _authoritative_skills_installed(app_dir):
             return "installed"
         # No SKILL.md marker found. Withhold only on a deterministic conflict at
         # every target; the other always-fail causes (missing bundled package, a

--- a/lib/tests/streamlit/runtime/backend_operation_handler_test.py
+++ b/lib/tests/streamlit/runtime/backend_operation_handler_test.py
@@ -250,6 +250,83 @@ def test_install_skills_handler_forwards_global_fallback_flag() -> None:
     assert response.install_skills.fallback_reason == "symlink_failed"
 
 
+def test_install_skills_handler_forwards_degraded_targets() -> None:
+    """A best-effort target that failed rides the SUCCESS response, not a failure.
+
+    The install reached the agent, so it is a success - but demoting a target from
+    "fails the install" to "best effort" must not make its failure rate
+    unobservable, and an attribution never emitted cannot be backfilled.
+    """
+    install_result = skills._InstallResult(
+        installed=["~/.claude/skills/foo"], degraded_targets=["agents_skills"]
+    )
+    with (
+        patch("streamlit.config.get_option", return_value=False),
+        patch.object(skills, "detect_installed_agents", return_value=["claude"]),
+        patch("streamlit.web.skills.install_skills", return_value=install_result),
+        patch.object(skills, "clear_installed_skills_cache"),
+    ):
+        response = asyncio.run(
+            InstallSkillsHandler(lambda: "/app/dir").handle(
+                _install_skills_request(), "session-id"
+            )
+        )
+
+    assert response.install_skills.degraded_targets == "agents_skills"
+    # Still a success: no error, and the failure must not reach error_reason.
+    assert response.error_msg == ""
+    assert response.error_reason == ""
+
+
+def test_install_skills_handler_reports_no_degraded_targets_on_a_clean_install() -> (
+    None
+):
+    """A clean install leaves ``degraded_targets`` empty rather than absent-but-set."""
+    install_result = skills._InstallResult(installed=["~/.claude/skills/foo"])
+    with (
+        patch("streamlit.config.get_option", return_value=False),
+        patch.object(skills, "detect_installed_agents", return_value=["claude"]),
+        patch("streamlit.web.skills.install_skills", return_value=install_result),
+        patch.object(skills, "clear_installed_skills_cache"),
+    ):
+        response = asyncio.run(
+            InstallSkillsHandler(lambda: "/app/dir").handle(
+                _install_skills_request(), "session-id"
+            )
+        )
+
+    assert response.install_skills.degraded_targets == ""
+
+
+def test_install_skills_handler_forwards_the_failing_target() -> None:
+    """The failing target reaches ``error_reason`` as a THIRD label segment.
+
+    Downstream queries read the reason with ``split_part(label, ':', 2)``, so the
+    target has to be its own segment: folding it into the reason
+    (``write_denied_claude``) would fork the closed vocabulary and break them
+    silently. Pinned as a literal for that reason.
+    """
+    with (
+        patch("streamlit.config.get_option", return_value=False),
+        patch.object(skills, "detect_installed_agents", return_value=["claude"]),
+        patch(
+            "streamlit.web.skills.install_skills",
+            side_effect=skills.InstallError(
+                "Could not write ~/.claude/skills/developing-with-streamlit.",
+                reason="write_denied",
+                target="claude_skills",
+            ),
+        ),
+    ):
+        response = asyncio.run(
+            InstallSkillsHandler(lambda: "/app/dir").handle(
+                _install_skills_request(), "session-id"
+            )
+        )
+
+    assert response.error_reason == "write_denied:claude_skills"
+
+
 def test_install_skills_handler_reports_failure() -> None:
     """Install failures are returned via the response's error message."""
     with (

--- a/lib/tests/streamlit/web/skills_test.py
+++ b/lib/tests/streamlit/web/skills_test.py
@@ -46,6 +46,29 @@ def _skip_if_symlinks_not_supported(tmp_path: Path) -> None:
         )
 
 
+def _target(
+    path: Path,
+    name: str = "claude_skills",
+    *,
+    authoritative: bool = True,
+) -> skills._InstallTarget:
+    """Build an ``_InstallTarget`` for tests that stub out target resolution.
+
+    Defaults to an authoritative ``claude_skills`` target, which is what most tests
+    want: the pre-existing behavior (a failure fails the install, presence suppresses
+    the nudge) applies to authoritative targets, so a test that predates the
+    authority split keeps asserting the same thing.
+    """
+    return skills._InstallTarget(
+        path=path, telemetry_name=name, authoritative=authoritative
+    )
+
+
+def _target_paths(targets: list[skills._InstallTarget]) -> list[Path]:
+    """Extract the paths from a list of install targets, for path-only assertions."""
+    return [target.path for target in targets]
+
+
 @pytest.fixture
 def runner() -> CliRunner:
     """Create a CliRunner for testing CLI commands."""
@@ -399,7 +422,7 @@ class TestGetProjectTargetDirs:
         """Always includes .agents/skills/ in targets."""
         with patch("pathlib.Path.home", return_value=tmp_path / "home"):
             result = skills._get_project_target_dirs(tmp_path)
-        assert tmp_path / ".agents" / "skills" in result
+        assert tmp_path / ".agents" / "skills" in _target_paths(result)
 
     @pytest.mark.parametrize(
         ("claude_home_exists", "expected_in_result"),
@@ -418,7 +441,41 @@ class TestGetProjectTargetDirs:
         with patch("pathlib.Path.home", return_value=home):
             result = skills._get_project_target_dirs(tmp_path)
 
-        assert (tmp_path / ".claude" / "skills" in result) == expected_in_result
+        assert (
+            tmp_path / ".claude" / "skills" in _target_paths(result)
+        ) == expected_in_result
+
+    def test_orders_the_authoritative_target_first(self, tmp_path: Path) -> None:
+        """Writes .claude/skills before the best-effort .agents/skills.
+
+        An install interrupted partway through should already have laid the copy an
+        agent actually reads, not only the one whose readership is unverified.
+        """
+        home = tmp_path / "home"
+        (home / ".claude").mkdir(parents=True)
+
+        with patch("pathlib.Path.home", return_value=home):
+            result = skills._get_project_target_dirs(tmp_path)
+
+        assert _target_paths(result) == [
+            tmp_path / ".claude" / "skills",
+            tmp_path / ".agents" / "skills",
+        ]
+
+    def test_a_file_at_claude_home_is_not_an_install(self, tmp_path: Path) -> None:
+        """A regular file at ~/.claude adds no target.
+
+        ``exists()`` would accept it and then every write to the target would fail on
+        the non-directory parent.
+        """
+        home = tmp_path / "home"
+        home.mkdir(parents=True)
+        (home / ".claude").write_text("not a directory")
+
+        with patch("pathlib.Path.home", return_value=home):
+            result = skills._get_project_target_dirs(tmp_path)
+
+        assert _target_paths(result) == [tmp_path / ".agents" / "skills"]
 
 
 class TestGetGlobalTargetDirs:
@@ -432,7 +489,7 @@ class TestGetGlobalTargetDirs:
         with patch("pathlib.Path.home", return_value=home):
             result = skills._get_global_target_dirs()
 
-        assert home / ".agents" / "skills" in result
+        assert home / ".agents" / "skills" in _target_paths(result)
 
     @pytest.mark.parametrize(
         ("claude_home_exists", "expected_in_result"),
@@ -451,7 +508,51 @@ class TestGetGlobalTargetDirs:
         with patch("pathlib.Path.home", return_value=home):
             result = skills._get_global_target_dirs()
 
-        assert (home / ".claude" / "skills" in result) == expected_in_result
+        assert (
+            home / ".claude" / "skills" in _target_paths(result)
+        ) == expected_in_result
+
+
+class TestInstallTargetAuthority:
+    """Tests for which install target carries authority, and why."""
+
+    def test_claude_is_authoritative_and_agents_is_best_effort(
+        self, tmp_path: Path
+    ) -> None:
+        """With Claude Code present, only .claude/skills decides the outcome.
+
+        Claude Code reads .claude/skills and ignores .agents/skills entirely, so a
+        failure to write .agents/skills must not fail an install that reached it.
+        """
+        home = tmp_path / "home"
+        (home / ".claude").mkdir(parents=True)
+
+        with patch("pathlib.Path.home", return_value=home):
+            targets = {
+                t.telemetry_name: t.authoritative
+                for t in skills._get_global_target_dirs()
+            }
+
+        assert targets == {"claude_skills": True, "agents_skills": False}
+
+    def test_agents_carries_authority_when_claude_code_is_absent(
+        self, tmp_path: Path
+    ) -> None:
+        """Without Claude Code, .agents/skills is the only target, so it must decide.
+
+        An empty authority set would make "installed" unreachable and nudge such a
+        user forever with no install that could ever satisfy the gate.
+        """
+        home = tmp_path / "home"
+        home.mkdir(parents=True)
+
+        with patch("pathlib.Path.home", return_value=home):
+            targets = {
+                t.telemetry_name: t.authoritative
+                for t in skills._get_global_target_dirs()
+            }
+
+        assert targets == {"agents_skills": True}
 
 
 class TestAreSkillsInstalled:
@@ -465,11 +566,63 @@ class TestAreSkillsInstalled:
         with (
             patch.object(skills, "_find_project_root", return_value=tmp_path),
             patch.object(
-                skills, "_get_project_target_dirs", return_value=[project_dir]
+                skills, "_get_project_target_dirs", return_value=[_target(project_dir)]
             ),
-            patch.object(skills, "_get_global_target_dirs", return_value=[global_dir]),
+            patch.object(
+                skills, "_get_global_target_dirs", return_value=[_target(global_dir)]
+            ),
         ):
             assert skills.are_skills_installed() is False
+
+    def test_ignores_a_skill_that_only_sits_in_a_best_effort_target(
+        self, tmp_path: Path
+    ) -> None:
+        """A skill in a best-effort target does not count as installed.
+
+        The CLI-startup half of the partial-install trap. Nothing verified reads
+        ``.agents/skills``, so counting it would stop recommending ``streamlit
+        skills`` to a developer whose only copy sits where their agent cannot see it.
+        """
+        best_effort = tmp_path / "home" / ".agents" / "skills"
+        (best_effort / skills._GLOBAL_SKILL_NAME).mkdir(parents=True)
+
+        with (
+            patch.object(skills, "_find_project_root", return_value=tmp_path),
+            patch.object(skills, "_get_project_target_dirs", return_value=[]),
+            patch.object(
+                skills,
+                "_get_global_target_dirs",
+                return_value=[
+                    _target(best_effort, "agents_skills", authoritative=False)
+                ],
+            ),
+        ):
+            assert skills.are_skills_installed() is False
+
+    def test_counts_a_skill_in_any_authoritative_target(self, tmp_path: Path) -> None:
+        """One authoritative target holding the skill is enough.
+
+        Requiring every authoritative *dir* would re-nudge anyone with only a global
+        install; a harness reads its project and home dirs alike, so either satisfies
+        it. Paired with the negative above, this pins the boundary.
+        """
+        authoritative = tmp_path / "home" / ".claude" / "skills"
+        (authoritative / skills._GLOBAL_SKILL_NAME).mkdir(parents=True)
+        best_effort = tmp_path / "home" / ".agents" / "skills"
+
+        with (
+            patch.object(skills, "_find_project_root", return_value=tmp_path),
+            patch.object(skills, "_get_project_target_dirs", return_value=[]),
+            patch.object(
+                skills,
+                "_get_global_target_dirs",
+                return_value=[
+                    _target(authoritative, "claude_skills"),
+                    _target(best_effort, "agents_skills", authoritative=False),
+                ],
+            ),
+        ):
+            assert skills.are_skills_installed() is True
 
     def test_returns_true_when_installed_in_project(self, tmp_path: Path) -> None:
         """Returns True when the bundled skill exists in a project target dir."""
@@ -480,9 +633,11 @@ class TestAreSkillsInstalled:
         with (
             patch.object(skills, "_find_project_root", return_value=tmp_path),
             patch.object(
-                skills, "_get_project_target_dirs", return_value=[project_dir]
+                skills, "_get_project_target_dirs", return_value=[_target(project_dir)]
             ),
-            patch.object(skills, "_get_global_target_dirs", return_value=[global_dir]),
+            patch.object(
+                skills, "_get_global_target_dirs", return_value=[_target(global_dir)]
+            ),
         ):
             assert skills.are_skills_installed() is True
 
@@ -499,7 +654,9 @@ class TestAreSkillsInstalled:
         with (
             patch.object(skills, "_find_project_root", return_value=tmp_path),
             patch.object(skills, "_get_project_target_dirs", return_value=[]),
-            patch.object(skills, "_get_global_target_dirs", return_value=[global_dir]),
+            patch.object(
+                skills, "_get_global_target_dirs", return_value=[_target(global_dir)]
+            ),
         ):
             assert skills.are_skills_installed() is True
 
@@ -533,7 +690,7 @@ class TestAreSkillsInstalled:
         with (
             patch.object(skills, "_find_project_root", return_value=tmp_path),
             patch.object(
-                skills, "_get_project_target_dirs", return_value=[project_dir]
+                skills, "_get_project_target_dirs", return_value=[_target(project_dir)]
             ),
             patch.object(
                 skills, "_get_global_target_dirs", side_effect=OSError("no home")
@@ -550,7 +707,9 @@ class TestAreSkillsInstalled:
 
         with (
             patch.object(skills, "_find_project_root", side_effect=OSError("no cwd")),
-            patch.object(skills, "_get_global_target_dirs", return_value=[global_dir]),
+            patch.object(
+                skills, "_get_global_target_dirs", return_value=[_target(global_dir)]
+            ),
         ):
             assert skills.are_skills_installed() is True
 
@@ -566,7 +725,9 @@ class TestAreSkillsInstalled:
             patch.object(
                 skills, "_get_project_target_dirs", side_effect=OSError("no home")
             ),
-            patch.object(skills, "_get_global_target_dirs", return_value=[global_dir]),
+            patch.object(
+                skills, "_get_global_target_dirs", return_value=[_target(global_dir)]
+            ),
         ):
             assert skills.are_skills_installed() is True
 
@@ -1145,7 +1306,7 @@ class TestConfirmProjectInstallation:
             result = skills._confirm_project_installation(
                 project_root=tmp_path,
                 skills=["test-skill"],
-                target_dirs=[tmp_path / ".agents" / "skills"],
+                targets=[_target(tmp_path / ".agents" / "skills")],
             )
         assert result is False
 
@@ -1155,7 +1316,7 @@ class TestConfirmProjectInstallation:
             result = skills._confirm_project_installation(
                 project_root=tmp_path,
                 skills=["test-skill"],
-                target_dirs=[tmp_path / ".agents" / "skills"],
+                targets=[_target(tmp_path / ".agents" / "skills")],
             )
         assert result is True
 
@@ -1170,7 +1331,7 @@ class TestConfirmGlobalInstallation:
             patch("pathlib.Path.home", return_value=tmp_path),
         ):
             result = skills._confirm_global_installation(
-                target_dirs=[tmp_path / ".agents" / "skills"],
+                targets=[_target(tmp_path / ".agents" / "skills")],
             )
         assert result is False
 
@@ -1597,16 +1758,18 @@ class TestGlobalInstallationConflicts:
 
         assert exc.value.reason == "write_denied"
 
-    def test_generalises_when_targets_fail_for_different_reasons(
+    def test_reason_follows_the_authoritative_target_when_targets_disagree(
         self, tmp_path: Path, mock_meta_skill_dir: Path
     ) -> None:
-        """Disagreeing targets report the generic write_failed, not a guess.
+        """Two targets failing differently report the AUTHORITATIVE target's cause.
 
-        Claiming "permission denied" when one target was denied and the other was out
-        of disk would send whoever reads the telemetry after half the problem.
+        ``.claude/skills`` is what Claude Code reads, so its cause is the one that
+        explains why nothing reached an agent. Generalising to ``write_failed`` here
+        would discard the specific, actionable cause in favour of the one target
+        whose readership is unverified.
         """
         home = tmp_path / "home"
-        # ~/.claude present -> _get_global_target_dirs yields two targets.
+        # ~/.claude present -> two targets, .claude/skills first and authoritative.
         (home / ".claude").mkdir(parents=True)
 
         with (
@@ -1626,40 +1789,156 @@ class TestGlobalInstallationConflicts:
         ):
             skills._install_global_skills(yes=True)
 
-        assert exc.value.reason == "write_failed"
+        assert exc.value.reason == "write_denied"
+        assert exc.value.telemetry_reason == "write_denied:claude_skills"
 
-    def test_partial_write_failure_reports_write_failed_not_success(
-        self, tmp_path: Path, mock_meta_skill_dir: Path
-    ) -> None:
-        """One target succeeds, another OSErrors -> hard write_failed, not success.
+    def test_generalises_when_authoritative_targets_disagree(self) -> None:
+        """Disagreeing authoritative targets report generic write_failed and no target.
 
-        ``_get_global_target_dirs`` returns TWO targets when ``~/.claude`` exists. If
-        ``~/.agents`` copies OK (result.installed non-empty) but ``~/.claude`` raises
-        OSError (result.errored), the success branch used to win over the errored
-        branch - so a half-installed system reported success and emitted no
-        write_failed telemetry for exactly the locked-down cohort under study. Any
-        errored target must fail loud.
+        Claiming "permission denied on .claude/skills" for a set that was half
+        permissions and half disk-full would send whoever reads the telemetry after
+        half the problem. Exercised directly because only one target is authoritative
+        today, so the installer cannot currently produce this pair - it must stay
+        correct for whenever a second one is added.
         """
-        home = tmp_path / "home"
-        # ~/.claude present -> _get_global_target_dirs yields both targets.
-        (home / ".claude").mkdir(parents=True)
+        result = skills._InstallResult(errored=["~/a (copy failed: x)"])
+        error = skills._write_error(
+            result,
+            [
+                skills._TargetWriteFailure(
+                    target=_target(Path("/a"), "claude_skills"),
+                    reason="write_denied",
+                ),
+                skills._TargetWriteFailure(
+                    target=_target(Path("/b"), "agents_skills"),
+                    reason="write_no_space",
+                ),
+            ],
+        )
 
+        assert error.reason == "write_failed"
+        # No target either: attributing a mixed set to one of them would be a guess.
+        assert error.target is None
+        assert error.telemetry_reason == "write_failed"
+
+
+class TestGlobalInstallPerTargetOutcomes:
+    """The four states of a two-target global install, judged per target.
+
+    ``.claude/skills`` is authoritative (Claude Code reads it) and ``.agents/skills``
+    is best-effort (nothing verified reads it - streamlit#16282), so the two targets
+    must not share a single verdict.
+    """
+
+    @staticmethod
+    def _install(
+        home: Path, meta_skill_dir: Path, copytree_side_effect: list[object]
+    ) -> skills._InstallResult:
         with (
             patch("pathlib.Path.home", return_value=home),
-            patch.object(
-                skills, "_get_meta_skill_dir", return_value=mock_meta_skill_dir
-            ),
-            # First target (~/.agents) copies fine; second (~/.claude) fails.
-            patch.object(
-                skills.shutil,
-                "copytree",
-                side_effect=[None, OSError("Permission denied")],
-            ),
-            pytest.raises(skills.InstallError) as exc,
+            patch.object(skills, "_get_meta_skill_dir", return_value=meta_skill_dir),
+            patch.object(skills.shutil, "copytree", side_effect=copytree_side_effect),
         ):
-            skills._install_global_skills(yes=True)
+            return skills._install_global_skills(yes=True)
 
-        assert exc.value.reason == "write_failed"
+    def test_both_targets_succeed_is_a_clean_success(
+        self, tmp_path: Path, mock_meta_skill_dir: Path
+    ) -> None:
+        """Nothing failed, so nothing is degraded."""
+        home = tmp_path / "home"
+        (home / ".claude").mkdir(parents=True)
+
+        result = self._install(home, mock_meta_skill_dir, [None, None])
+
+        assert len(result.installed) == 2
+        assert result.degraded_targets == []
+
+    def test_best_effort_failure_still_succeeds_and_is_recorded(
+        self, tmp_path: Path, mock_meta_skill_dir: Path
+    ) -> None:
+        """.claude/skills lands, .agents/skills is denied -> SUCCESS, not failure.
+
+        This is the false negative the authority split exists to fix: the developer's
+        Claude Code works perfectly, and the old code reported a hard write failure at
+        them anyway. The best-effort failure is not swallowed - it rides the success
+        label via ``degraded_targets``, so demoting the target does not make its
+        failure rate unobservable.
+        """
+        home = tmp_path / "home"
+        (home / ".claude").mkdir(parents=True)
+
+        # .claude/skills is written first, so it is the one that succeeds here.
+        result = self._install(
+            home,
+            mock_meta_skill_dir,
+            [None, OSError(errno.EACCES, "Permission denied")],
+        )
+
+        assert result.installed == ["~/.claude/skills/developing-with-streamlit"]
+        assert result.degraded_targets == ["agents_skills"]
+
+    def test_authoritative_failure_fails_and_names_its_target(
+        self, tmp_path: Path, mock_meta_skill_dir: Path
+    ) -> None:
+        """.agents/skills lands, .claude/skills is denied -> hard failure.
+
+        The mirror of the case above, and the trap state: Claude Code got nothing, so
+        this must fail loudly *and* keep nudging. The target reaches telemetry as a
+        THIRD label segment so ``split_part(label, ':', 2)`` still yields the reason.
+        """
+        home = tmp_path / "home"
+        (home / ".claude").mkdir(parents=True)
+
+        with pytest.raises(skills.InstallError) as exc:
+            self._install(
+                home,
+                mock_meta_skill_dir,
+                [OSError(errno.EACCES, "Permission denied"), None],
+            )
+
+        assert exc.value.reason == "write_denied"
+        assert exc.value.target == "claude_skills"
+        assert exc.value.telemetry_reason == "write_denied:claude_skills"
+
+    def test_both_targets_failing_is_a_failure(
+        self, tmp_path: Path, mock_meta_skill_dir: Path
+    ) -> None:
+        """Nothing landed anywhere, so the install failed."""
+        home = tmp_path / "home"
+        (home / ".claude").mkdir(parents=True)
+
+        with pytest.raises(skills.InstallError) as exc:
+            self._install(
+                home,
+                mock_meta_skill_dir,
+                [
+                    OSError(errno.EACCES, "Permission denied"),
+                    OSError(errno.EACCES, "Permission denied"),
+                ],
+            )
+
+        assert exc.value.reason == "write_denied"
+
+    def test_agents_failure_is_hard_when_claude_code_is_absent(
+        self, tmp_path: Path, mock_meta_skill_dir: Path
+    ) -> None:
+        """Without Claude Code, .agents/skills is the sole target, so it must fail hard.
+
+        The demotion is conditional, not permanent: with no ~/.claude there is no
+        second target to have delivered, so treating this as a best-effort failure
+        would report success for an install that wrote nothing at all.
+        """
+        home = tmp_path / "home"
+        home.mkdir(parents=True)
+
+        with pytest.raises(skills.InstallError) as exc:
+            self._install(
+                home,
+                mock_meta_skill_dir,
+                [OSError(errno.EACCES, "Permission denied")],
+            )
+
+        assert exc.value.telemetry_reason == "write_denied:agents_skills"
 
 
 class TestInteractiveModeSelection:
@@ -1711,6 +1990,7 @@ def _evaluate_nudge(
     installed_skills: tuple[str, ...] = (),
     marker_exists: bool = False,
     would_be_refused: bool = False,
+    claude_code_installed: bool = True,
 ) -> bool:
     """Run ``should_show_skills_nudge`` with the given conditions patched in."""
     return not _evaluate_nudge_reason(
@@ -1721,6 +2001,7 @@ def _evaluate_nudge(
         installed_skills=installed_skills,
         marker_exists=marker_exists,
         would_be_refused=would_be_refused,
+        claude_code_installed=claude_code_installed,
     )
 
 
@@ -1733,6 +2014,7 @@ def _evaluate_nudge_reason(
     installed_skills: tuple[str, ...] = (),
     marker_exists: bool = False,
     would_be_refused: bool = False,
+    claude_code_installed: bool = True,
 ) -> str:
     """Run ``nudge_suppression_reason`` with the given conditions patched in."""
     marker = tmp_path / ".skills_nudge_dismissed"
@@ -1751,6 +2033,13 @@ def _evaluate_nudge_reason(
         patch(
             "streamlit.web.skills.detect_installed_skills",
             return_value=list(installed_skills),
+        ),
+        # Which harness is authoritative is decided by whether ~/.claude exists, so
+        # pin it: unpatched, whether the runner's home has Claude Code installed
+        # would decide whether a ``home:claude:...`` token counts as installed.
+        patch(
+            "streamlit.web.skills._claude_code_installed",
+            return_value=claude_code_installed,
         ),
         # Keep the gate hermetic: otherwise the conflict-aware suppression check
         # hits the real filesystem (a dev machine's ~/.claude makes .claude/skills
@@ -1831,6 +2120,83 @@ def test_should_show_skills_nudge_hidden_when_skills_installed(tmp_path: Path) -
         )
         is False
     )
+
+
+class TestNudgeAfterAPartialInstall:
+    """The partial-install trap: a skill only where the agent cannot read it.
+
+    Both nudges used to go quiet if the skill turned up in ANY of 8 harness dirs x 4
+    roots. So after a global install that landed ``~/.agents/skills`` and was denied
+    ``~/.claude/skills``, the developer was told the install failed, both nudges went
+    silent permanently, and the copy they held was the one Claude Code does not read.
+    They were never offered the retry that would have fixed it.
+    """
+
+    def test_best_effort_only_install_keeps_nudging_claude_code_users(
+        self, tmp_path: Path
+    ) -> None:
+        """A skill in .agents/skills alone does not satisfy a Claude Code user."""
+        assert (
+            _evaluate_nudge(
+                tmp_path,
+                installed_skills=("home:agents:developing-with-streamlit",),
+                claude_code_installed=True,
+            )
+            is True
+        )
+
+    def test_best_effort_only_install_satisfies_a_user_without_claude_code(
+        self, tmp_path: Path
+    ) -> None:
+        """The mirror: with no ~/.claude, .agents/skills is all we write, so it counts.
+
+        Without this the nudge would fire forever at that cohort - no install we can
+        perform would ever satisfy the gate. This is the "two wrong answers" fork in
+        ``_authoritative_harnesses``, pinned so the choice is deliberate.
+        """
+        assert (
+            _evaluate_nudge(
+                tmp_path,
+                agents=("codex",),
+                installed_skills=("home:agents:developing-with-streamlit",),
+                claude_code_installed=False,
+            )
+            is False
+        )
+
+    def test_a_project_local_claude_install_satisfies_the_gate(
+        self, tmp_path: Path
+    ) -> None:
+        """Any location satisfies the harness: Claude Code reads project dirs too.
+
+        Authority is per harness, not per path, so a developer who deliberately keeps
+        the skill project-local is not nudged at.
+        """
+        assert (
+            _evaluate_nudge(
+                tmp_path,
+                installed_skills=("app:claude:developing-with-streamlit",),
+                claude_code_installed=True,
+            )
+            is False
+        )
+
+    def test_another_harnesss_skill_does_not_satisfy_claude_code(
+        self, tmp_path: Path
+    ) -> None:
+        """A skill under some other harness's dir says nothing about Claude Code.
+
+        ``detect_installed_skills`` scans all 8 harnesses; only the ones a detected
+        harness reads may quiet the nudge.
+        """
+        assert (
+            _evaluate_nudge(
+                tmp_path,
+                installed_skills=("home:cursor:developing-with-streamlit",),
+                claude_code_installed=True,
+            )
+            is True
+        )
 
 
 def test_should_show_skills_nudge_hidden_when_install_would_conflict(
@@ -2253,9 +2619,15 @@ class TestOneClickInstallWouldBeRefused:
             patch.object(
                 skills, "_find_project_root", return_value=project_root or source_dir
             ),
-            patch.object(skills, "_get_project_target_dirs", return_value=target_dirs),
             patch.object(
-                skills, "_get_global_target_dirs", return_value=global_target_dirs or []
+                skills,
+                "_get_project_target_dirs",
+                return_value=[_target(d) for d in target_dirs],
+            ),
+            patch.object(
+                skills,
+                "_get_global_target_dirs",
+                return_value=[_target(d) for d in global_target_dirs or []],
             ),
             patch.object(
                 skills,
@@ -2593,8 +2965,8 @@ class TestNudgeGateSideEffects:
                 skills,
                 "_get_project_target_dirs",
                 return_value=[
-                    project / ".agents" / "skills",
-                    project / ".claude" / "skills",
+                    _target(project / ".agents" / "skills"),
+                    _target(project / ".claude" / "skills"),
                 ],
             ),
             patch.object(skills, "_get_global_target_dirs", return_value=[]),
@@ -2626,7 +2998,11 @@ class TestNudgeGateSideEffects:
         with (
             patch.object(skills, "_get_source_skills_dir", return_value=source_dir),
             patch.object(skills, "_find_project_root", return_value=project),
-            patch.object(skills, "_get_project_target_dirs", return_value=target_dirs),
+            patch.object(
+                skills,
+                "_get_project_target_dirs",
+                return_value=[_target(d) for d in target_dirs],
+            ),
             patch.object(skills, "_get_global_target_dirs", return_value=[]),
             patch.object(skills._LOGGER, "warning") as mock_warning,
         ):
@@ -2653,7 +3029,10 @@ class TestNudgeGateSideEffects:
             patch.object(
                 skills,
                 "_get_project_target_dirs",
-                return_value=[project / ".agents" / "skills", free_target],
+                return_value=[
+                    _target(project / ".agents" / "skills"),
+                    _target(free_target),
+                ],
             ),
             patch.object(skills, "_get_global_target_dirs", return_value=[]),
             patch.object(skills._LOGGER, "warning") as mock_warning,
@@ -2741,7 +3120,7 @@ class TestAreSkillsInstalledErrorHandling:
             patch.object(
                 skills,
                 "_get_project_target_dirs",
-                return_value=[first_dir, second_dir],
+                return_value=[_target(first_dir), _target(second_dir)],
             ),
             patch.object(skills, "_get_global_target_dirs", return_value=[]),
             patch("pathlib.Path.is_symlink", patched_is_symlink),
@@ -2763,7 +3142,7 @@ class TestConfirmProjectInstallationEdgeCases:
             result = skills._confirm_project_installation(
                 project_root=project_root,
                 skills=["my-skill"],
-                target_dirs=[unrelated_dir],
+                targets=[_target(unrelated_dir)],
             )
 
         assert result is True
@@ -2783,7 +3162,9 @@ class TestConfirmGlobalInstallationEdgeCases:
             patch("pathlib.Path.home", return_value=home),
             patch("click.confirm", return_value=True),
         ):
-            result = skills._confirm_global_installation(target_dirs=[unrelated_dir])
+            result = skills._confirm_global_installation(
+                targets=[_target(unrelated_dir)]
+            )
 
         assert result is True
 
@@ -2951,15 +3332,21 @@ class TestInstallProjectSkillsFallbackSignal:
 @pytest.mark.parametrize(
     "reason",
     sorted(
-        {*get_args(skills._InstallFailureReason), *get_args(skills._FallbackReason)}
+        {
+            *get_args(skills._InstallFailureReason),
+            *get_args(skills._FallbackReason),
+            *get_args(skills._InstallTargetName),
+        }
     ),
 )
 def test_every_reason_in_the_vocabulary_is_named_by_a_test(reason: str) -> None:
-    """Fail when a reason is added to either vocabulary and no test names it.
+    """Fail when a reason is added to any vocabulary and no test names it.
 
     mypy constrains raise sites to the vocabulary but says nothing about the reverse
     direction: a value can be added, shipped, and never exercised, so nobody notices
     it is unreachable or mis-tagged until an analysis query returns an empty bucket.
+    Install-target tokens are covered too - they reach telemetry as a label segment,
+    so an unexercised one is the same gap.
 
     This is a tripwire on that gap, not proof the covering assertion is a good one -
     it only checks the literal appears somewhere in this file. The classes below are

--- a/proto/streamlit/proto/ForwardMsg.proto
+++ b/proto/streamlit/proto/ForwardMsg.proto
@@ -163,6 +163,19 @@ message InstallSkillsResponsePayload {
   // then succeed, so this is where that cohort's diagnostic signal lives
   // (skillsNudgeInstallSucceeded:<fallback_reason>).
   string fallback_reason = 2;
+
+  // Best-effort install targets whose write failed while every authoritative target
+  // succeeded, comma-separated and sorted; empty when nothing was degraded. Values
+  // are install-target tokens ("agents_skills", "claude_skills").
+  //
+  // An authoritative target is one a DETECTED agent harness is known to read, so a
+  // failure there fails the install. A best-effort target has no verified reader
+  // (nothing has been shown to read ~/.agents/skills - see streamlit#16282), so its
+  // failure must NOT fail an install that reached the agent. This field is how that
+  // demotion stays measurable: it rides the SUCCESS label as a third segment
+  // (skillsNudgeInstallSucceeded:<fallback_reason>:<degraded_targets>), so segment 2
+  // keeps meaning fallback_reason for every existing query.
+  string degraded_targets = 3;
 }
 
 // Acknowledgement payload for dismissing the skills nudge. Carries no data;


### PR DESCRIPTION
## Summary

**Claude Code does not read `~/.agents/skills`** — the directory a global skills install writes *first* and *unconditionally*. It reads `.claude/skills`, which we write second and only when `~/.claude` exists. Treating the two as an all-or-nothing pair produces two bugs from one cause, so this makes each target carry its own verdict, decided by whether a **detected harness** actually reads it.

**A partial install where `~/.claude/skills` lands and `~/.agents/skills` fails is reported as a total failure** — at a developer whose Claude Code works perfectly. That false negative is **new in 1.61**: #16279 made a partial write fail hard, where 1.60 reported success (which happened to be the right answer).

**The mirror case is worse.** `~/.agents/skills` lands, `~/.claude/skills` is denied. Both nudges gate on the skill existing in **any** of 8 harness dirs × 4 roots, so the `.agents` marker silences them permanently. The developer is told the install failed, is never offered a retry, and holds the one copy nothing reads.

| `.claude` | `.agents` | Emitted before | Emitted now |
|---|---|---|---|
| ok | ok | Succeeded | Succeeded |
| ok | fail | **Failed** ← false negative | `Succeeded::agents_skills` |
| fail | ok | Failed *(then nudge goes silent forever)* | `Failed:write_denied:claude_skills`, **nudge keeps showing** |
| fail | fail | Failed | `Failed:write_denied:claude_skills` |

## What changed

**Authority is per detected harness.** `_authoritative_harnesses()` returns `{claude}` when `~/.claude` exists, else `{agents}`. An authoritative target's failure fails the install; a best-effort target's does not. Only an authoritative directory can quiet a nudge.

This is what makes requiring "all targets" safe — the objection that deferred the fix in #16279 ("requiring the skill in all targets would nudge forever at anyone who deliberately keeps it in one place. The fix needs a notion of which target is authoritative"). We require only the dirs a **detected** harness reads, so the place someone keeps the skill *is* the place their agent reads. Authority is per harness, not per path, so a project-local `.claude/skills` satisfies Claude Code exactly as a global one does.

**The `{agents}` fallback is a choice between two wrong answers**, and it is deliberate. With no `~/.claude` none of our targets has a verified reader, but `.agents/skills` is the only thing we write — an empty authority set would make `"installed"` unreachable and nudge that cohort forever with no install that could ever satisfy the gate. This preserves today's behaviour for them rather than regressing it. The real fix is a target such a harness reads; see Follow-ups.

**Authoritative targets are written first**, so an install interrupted partway (Ctrl-C, crash, disk filling) has already laid the copy an agent reads rather than only the dead-weight one.

**Telemetry gains a target dimension.** The failing target rides `error_reason` as a **third** segment (`write_denied:claude_skills`), composed in `InstallError.telemetry_reason`. `split_part(label, ':', 2)` still returns the bare reason, so the snowflake-eng/sis-datascience#18655 queries resolve unchanged — and the failure path needs **no proto or frontend change** at all, since the frontend already passes `error_reason` through as the label suffix.

A new `degraded_targets` field (**field 3**, no renumbering) carries best-effort failures on the **success** label. Without it, demoting a target from "fails the install" to "best effort" would move a cohort from a labelled bucket into an unlabelled one — losing the only signal that would tell us whether the demotion was right. An attribution never emitted cannot be backfilled.

## Heads-up for dashboards

Two discontinuities, both additive per the #15966 precedent (no dashboard migration required; existing queries keep resolving):

1. **`skillsNudgeInstallFailed:write_*` will step down.** Installs that reached Claude Code but failed on `.agents/skills` now count as successes. **1.61's bucket over-counts** — it includes installs that worked. Worth annotating, or 1.61-vs-1.60 will read as a regression and someone will chase the wrong cause.
2. **A degraded success with no reroute emits an empty segment 2** — `skillsNudgeInstallSucceeded::agents_skills`. Deliberate: `split_part(label, ':', 2)` returns `""`, exactly what a plain success has always yielded there. Putting the target in segment 2 would fork the closed `fallback_reason` vocabulary.

## Findings: confirmed, extended, and refuted

Line references are this branch's `develop` base (`3fff60df70`). The brief's numbers came from `b86f523f` and had drifted.

**Confirmed by reading the code:**

| Finding | Location |
|---|---|
| `.agents/skills` written first and unconditionally, `.claude/skills` second and conditional | `skills.py:292` (pre-change) |
| Hard-fail when ANY target errored | `skills.py:1005-1006` (pre-change) — brief said `:970-971` |
| CLI nudge gates on "any candidate dir" | `bootstrap.py:296` → `skills.py:308` |
| In-app nudge gates on "any of 8 harnesses × 4 roots" | `app_session.py:951` → `skills.py:1396`, `:1189` |
| `_HARNESSES` knows 8 harnesses; a global install writes at most 2 | `skills.py:1154` — brief said `:1119` |
| `_write_error()` has exactly one call site, inside `_install_global_skills` | verified — so `write_*` reasons only ever describe the global-copy path |

**Confirmed empirically, a fourth independent time.** All 7 directories in `~/.agents/skills` have a well-formed `SKILL.md`. Exactly the 2 that *also* exist in `~/.claude/skills` (`agent-browser`, `skill-creator`) are visible to a running Claude Code session; the 5 that exist **only** in `~/.agents/skills` (`find-skills`, `finding-streamlit-skills`, `gh-cli`, `gstack`, `pr-naming`) are not. No skill filtering in `settings.json`. A controlled comparison, not a bare absence.

**Refuted — the brief's cherry-pick premise.** It stated "none of these bugs is a 1.61 *regression* — 1.61 is no worse than 1.60." The false negative **is** a 1.61 regression, documented in #16279's own body: *"a partial global install — say `~/.agents/skills` writes fine but `~/.claude/skills` is denied — previously reported success. It now fails."* Run it in the direction that matters and 1.60 was right by accident.

### New: cortex does not read `~/.agents/skills` either

The brief flagged cortex as "the cheapest to check since we own that loader." Reading it (v1.1.53):

| Scope | Cortex's skill roots |
|---|---|
| global | `join(homedir(), ".claude", "skills")` — **unconditional** — and `~/.snowflake/cortex/skills` |
| project | `.cortex/skills`, `.claude/skills`, `.snova/skills`, `.agents/skills` |

Two consequences:

1. **`~/.agents/skills` has zero verified readers.** Both harnesses anyone has probed ignore it at home level. Project-level `.agents/skills` *is* read by cortex, so only the **global** primary is dead weight — which is why this PR keeps writing it rather than dropping it.
2. **A cortex-only developer's global install delivers nothing and reports success.** Cortex reads `~/.claude/skills` unconditionally; we write it only when `~/.claude` exists. No Claude Code → we write `~/.agents/skills` alone → cortex cannot see it → success reported → nudge suppressed. Silent total non-delivery.

**(2) is not fixed here, deliberately.** Cortex ships its own bundled OSS Streamlit sub-skill, so installing ours into `~/.snowflake/cortex/skills` could duplicate or shadow it. Writing to an unverified path on the strength of the same unsourced `_HARNESSES` table that produced this bug is the mistake this PR exists to stop repeating. It needs that one question answered first.

## Cherry-pick verdict for 1.61.0: **no — ship as-is**

Even though the false negative is a genuine 1.61 regression, the blast radius is a **lying error message, not a broken install**:

- That cohort's skill **works** — Claude Code reads `~/.claude/skills`, which landed.
- Their nudge correctly stays quiet (the `.claude` marker is present), so they are not nagged.
- The harm is one "Could not write…" toast shown to someone whose install succeeded.

Against that: ~340 lines changing what "success" means and re-gating the nudge for every user, into a release branch on cut day, in the same file as an open draft (#16280), with no E2E coverage of the filesystem-failure paths. Not close.

I did check whether a **telemetry-only** slice is separable, since "an attribution never emitted cannot be backfilled" is the one argument that does not wait. It is: per-target bookkeeping + `target` on `InstallError` + a one-line handler change, ~30 lines, no proto change, no frontend change, no behaviour change. Still no, on two grounds: it buys sizing data for a cohort whose install *works*, and #16279's dashboards were only just migrated to read the segment-2 suffix — adding segment 3 unannounced on cut day lands on analysts mid-migration. Two weeks costs little for a dimension that has never existed.

**One thing worth doing today at zero cost:** annotate 1.61's `skillsNudgeInstallFailed:write_*` as over-counting (see Heads-up above).

## Scope and disjointness from #16280

**Disjoint.** `_install_skill_copy` and `_install_skill_symlink` keep their exact signatures and bodies — the functions #16280 reworks. Per-target attribution is achieved by giving each target its own `_InstallResult` in the *caller* and merging, rather than threading a target through the copy helper. My `skills.py` hunks sit in the target resolvers, `_write_error`, `_install_global_skills`'s loop, and the nudge gates; #16280's sit inside the two install helpers.

**Left alone:** `_install_project_skills` bails out on the first symlink failure at any target and falls back to a global copy. That is a genuine recovery (the developer ends up with a working install and a `Succeeded:<fallback_reason>` label), and the region belongs to #16280.

**Also left alone:** `_one_click_install_would_be_refused`. Its "conflicts at every target" rule is already correct under per-target authority — a conflict at one target while another is free still lets the install make progress.

## Testing

**Python — 1026 pass** across `lib/tests/streamlit/web/` and `backend_operation_handler_test.py`; `python-lint`, `python-types` (mypy + ty) clean.

New coverage, all four states of the two-target install rather than the two the old code could express:

- [x] `.claude` ok + `.agents` fail → **success** with `degraded_targets == ["agents_skills"]` — the false negative, pinned
- [x] `.claude` fail + `.agents` ok → hard failure, `telemetry_reason == "write_denied:claude_skills"`
- [x] both ok → clean success, nothing degraded; both fail → failure
- [x] no Claude Code → `.agents/skills` failure is **hard** (`write_denied:agents_skills`), because the demotion is conditional, not permanent
- [x] disagreeing targets report the **authoritative** target's cause, not the generic `write_failed` — the specific cause is the actionable one
- [x] `_write_error` still generalises to `write_failed`/no target for disagreeing *authoritative* failures (exercised directly; only one target is authoritative today, so the installer cannot currently produce that pair)
- [x] nudge: `.agents`-only install **keeps nudging** a Claude Code user; **satisfies** a user without Claude Code; a project-local `.claude` install satisfies the gate; another harness's skill does not
- [x] `are_skills_installed`: ignores a best-effort-only skill, counts any authoritative one
- [x] target order is claude-first; a *file* at `~/.claude` adds no target
- [x] the vocabulary guard test now enumerates `_InstallTargetName` too, so a target added without a test naming it fails CI

**Frontend — 47 pass** (`skillsNudge.test.ts` 28, `BackendOperationClient.test.ts` 19), including the empty-segment-2 degraded label and `degradedTargets` surviving the client hop. `frontend-lint`/`frontend-types` report no errors in the changed files (23 pre-existing unbuilt-workspace-dep errors on this checkout, identical with the branch stashed).

**No E2E test.** These paths need a filesystem induced to fail mid-operation, which Playwright cannot arrange — the same limitation #16280 documents. The unit tests patch `copytree` to fail on a chosen target.

## Follow-ups

1. **A target a non-Claude harness reads.** Highest value: it closes the cortex-only silent non-delivery above, and would let `_authoritative_harnesses()` drop its `{agents}` fallback. Blocked on whether cortex's bundled Streamlit sub-skill collides with ours.
2. **Probe the remaining five harnesses** (codex, copilot, cursor, gemini, opencode). `_HARNESSES` asserts home skills dirs for all of them that nobody has verified; `specs/2026-05-11-streamlit-skills-cli/product-spec.md:90` justifies both targets as "Works for Claude and other agents" without ever sourcing it. Two of two probed harnesses now contradict it for the global case.
3. **Reconsider `~/.agents/skills` as the global primary** once (2) lands. If nothing reads it globally, it is a write we make first and unconditionally for no one.
