### PR TITLE
[fix] Pin starlette below 1.4.0

### DIFF
--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -87,7 +87,10 @@ dependencies = [
   # ASGI web-framework. 0.46.0 is the first version exposing
   # `DEFAULT_EXCLUDED_CONTENT_TYPES` from `starlette.middleware.gzip`, which our
   # gzip middleware imports.
-  "starlette>=0.46.0,<2",
+  # Starlette 1.4.0 changed GZipResponder's constructor (added required
+  # thread_minimum_size), which breaks our custom gzip middleware.
+  # See: https://github.com/streamlit/streamlit/issues/16341
+  "starlette>=0.46.0,<1.4.0",
   # ASGI server:
   "uvicorn>=0.30.0,<1",
   # Faster http parsing for Starlette server:

--- a/uv.lock
+++ b/uv.lock
@@ -4394,7 +4394,7 @@ requires-dist = [
     { name = "snowflake-connector-python", marker = "extra == 'snowflake'", specifier = ">=3.3.0" },
     { name = "snowflake-snowpark-python", extras = ["modin"], marker = "extra == 'snowflake'", specifier = ">=1.17.0" },
     { name = "sqlalchemy", marker = "extra == 'sql'", specifier = ">=2.0.0" },
-    { name = "starlette", specifier = ">=0.46.0,<2" },
+    { name = "starlette", specifier = ">=0.46.0,<1.4.0" },
     { name = "streamlit", extras = ["auth", "charts", "snowflake", "sql", "pdf", "performance"], marker = "extra == 'all'" },
     { name = "streamlit-pdf", marker = "extra == 'pdf'", specifier = ">=1.0.0" },
     { name = "tenacity", specifier = ">=8.1.0,<10" },


### PR DESCRIPTION
## Describe your changes

Caps the Starlette dependency at `<1.4.0` so fresh installs cannot resolve Starlette 1.4.0, which breaks Streamlit startup (`GZipResponder.__init__` missing `thread_minimum_size`).

## GitHub Issue Link (if applicable)

- Related to #16341

## Testing Plan

- No additional tests — dependency upper-bound only; resolved lock version remains Starlette 1.3.1
- Verified with `make check` on the changed files

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.