### PR TITLE
[chore] Switch AI workflows to Grok 4.5

### DIFF
--- a/.github/workflows/ai-fix-flaky-e2e-tests.yml
+++ b/.github/workflows/ai-fix-flaky-e2e-tests.yml
@@ -20,7 +20,7 @@ on:
         description: "Model to use for flaky test fixing"
         required: false
         type: string
-        default: "claude-opus-4-8-thinking-xhigh"
+        default: "cursor-grok-4.5-high"
       dry_run:
         description: "Run without creating PR"
         type: boolean
@@ -28,7 +28,7 @@ on:
         default: false
 
 env:
-  MODEL: ${{ inputs.model || 'claude-opus-4-8-thinking-xhigh' }}
+  MODEL: ${{ inputs.model || 'cursor-grok-4.5-high' }}
   TOP_N: ${{ inputs.top_n || 10 }}
   DAYS: ${{ inputs.days || 4 }}
 

--- a/.github/workflows/ai-issue-triage.yml
+++ b/.github/workflows/ai-issue-triage.yml
@@ -14,12 +14,12 @@ on:
         description: "Model to use for the triage"
         required: false
         type: string
-        default: "claude-opus-4-8-thinking-xhigh"
+        default: "cursor-grok-4.5-high"
 
 # Computed issue number and model for use in jobs
 env:
   ISSUE_NUMBER: ${{ github.event.inputs.issue_number || github.event.issue.number }}
-  MODEL: ${{ github.event.inputs.model || 'claude-opus-4-8-thinking-xhigh' }}
+  MODEL: ${{ github.event.inputs.model || 'cursor-grok-4.5-high' }}
 
 jobs:
   # Job 1: AI performs the triage analysis with READ-ONLY access

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -20,7 +20,7 @@ on:
 env:
   PR_NUMBER: ${{ github.event.inputs.pr_number || github.event.pull_request.number }}
   MODEL_INPUT: ${{ github.event.inputs.model || '' }}
-  DEFAULT_AI_PR_REVIEW_MODELS: ${{ vars.AI_PR_REVIEW_MODELS || 'gpt-5.3-codex-high,cursor-grok-4.5-high,claude-4.6-opus-high-thinking' }}
+  DEFAULT_AI_PR_REVIEW_MODELS: ${{ vars.AI_PR_REVIEW_MODELS || 'gpt-5.3-codex-high,claude-4.6-opus-high-thinking,cursor-grok-4.5-high' }}
   FINAL_AI_PR_REVIEW_MODELS: "gpt-5.4-xhigh,cursor-grok-4.5-high,claude-opus-4-8-thinking-xhigh"
 
 jobs:

--- a/.github/workflows/ai-qa-testing.yml
+++ b/.github/workflows/ai-qa-testing.yml
@@ -14,11 +14,11 @@ on:
         description: "Model to use for QA testing"
         required: false
         type: string
-        default: "claude-opus-4-8-thinking-xhigh"
+        default: "cursor-grok-4.5-high"
 
 env:
   PR_NUMBER: ${{ github.event.inputs.pr_number || github.event.pull_request.number }}
-  MODEL: ${{ github.event.inputs.model || 'claude-opus-4-8-thinking-xhigh' }}
+  MODEL: ${{ github.event.inputs.model || 'cursor-grok-4.5-high' }}
 
 jobs:
   check-secrets:

--- a/.github/workflows/ai-test-coverage.yml
+++ b/.github/workflows/ai-test-coverage.yml
@@ -11,7 +11,7 @@ on:
         description: "Model to use for coverage improvement"
         required: false
         type: string
-        default: "claude-opus-4-8-thinking-xhigh"
+        default: "cursor-grok-4.5-high"
       dry_run:
         description: "Run without creating PR"
         type: boolean
@@ -19,7 +19,7 @@ on:
         default: false
 
 env:
-  MODEL: ${{ inputs.model || 'claude-opus-4-8-thinking-xhigh' }}
+  MODEL: ${{ inputs.model || 'cursor-grok-4.5-high' }}
 
 jobs:
   check-secrets:

--- a/.github/workflows/ai-update-docs.yml
+++ b/.github/workflows/ai-update-docs.yml
@@ -15,7 +15,7 @@ on:
         description: "Model to use for documentation review"
         required: false
         type: string
-        default: "claude-opus-4-8-thinking-xhigh"
+        default: "cursor-grok-4.5-high"
       dry_run:
         description: "Run without creating PR"
         type: boolean
@@ -23,7 +23,7 @@ on:
         default: false
 
 env:
-  MODEL: ${{ inputs.model || 'claude-opus-4-8-thinking-xhigh' }}
+  MODEL: ${{ inputs.model || 'cursor-grok-4.5-high' }}
   PR_NUMBER: ${{ inputs.pr_number || '' }}
 
 jobs:


### PR DESCRIPTION
## Describe your changes

Switches the default model for AI GitHub Actions workflows from Claude Opus to Grok 4.5 (`cursor-grok-4.5-high`).

- Updates defaults in flaky e2e fix, issue triage, QA testing, test coverage, and docs update workflows
- Reorders `DEFAULT_AI_PR_REVIEW_MODELS` so `cursor-grok-4.5-high` is last, making it the judge model for consolidating multi-model reviews

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- No additional tests needed — YAML workflow default-string changes only; no product code changed

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.