### PR TITLE
[feature] Expose DataEditorState in streamlit.typing

### DIFF
--- a/.cursor/rules/python_lib.mdc
+++ b/.cursor/rules/python_lib.mdc
@@ -48,10 +48,12 @@ typing errors in parameters or return types by using mypy and `assert_type`.
   (e.g. `radio_types.py`, `button_types.py`).
 - For dict-like return values backed by `AttributeDictionary` /
   `ReadOnlyAttributeDictionary` subclasses (e.g. dataframe/chart selection
-  state, `ButtonColumn` click state), assert both attribute and bracket access
-  (e.g. `state.selection.rows` and `state["selection"]["rows"]`). Use a
-  separate `TypedDict` (`*Input`) for values users assign (e.g.
-  `selection_default`), not the returned attribute-dictionary class.
+  state, `ButtonColumn` click state, `st.data_editor` edit state), assert both
+  attribute and bracket access (e.g. `state.selection.rows` and
+  `state["selection"]["rows"]`, or `edit_state.edited_rows` and
+  `edit_state["edited_rows"]`). Use a separate `TypedDict` (`*Input`) for
+  values users assign (e.g. `selection_default`), not the returned
+  attribute-dictionary class.
 
 ## Docstrings for Public API
 

--- a/.github/instructions/python_lib.instructions.md
+++ b/.github/instructions/python_lib.instructions.md
@@ -46,10 +46,12 @@ typing errors in parameters or return types by using mypy and `assert_type`.
   (e.g. `radio_types.py`, `button_types.py`).
 - For dict-like return values backed by `AttributeDictionary` /
   `ReadOnlyAttributeDictionary` subclasses (e.g. dataframe/chart selection
-  state, `ButtonColumn` click state), assert both attribute and bracket access
-  (e.g. `state.selection.rows` and `state["selection"]["rows"]`). Use a
-  separate `TypedDict` (`*Input`) for values users assign (e.g.
-  `selection_default`), not the returned attribute-dictionary class.
+  state, `ButtonColumn` click state, `st.data_editor` edit state), assert both
+  attribute and bracket access (e.g. `state.selection.rows` and
+  `state["selection"]["rows"]`, or `edit_state.edited_rows` and
+  `edit_state["edited_rows"]`). Use a separate `TypedDict` (`*Input`) for
+  values users assign (e.g. `selection_default`), not the returned
+  attribute-dictionary class.
 
 ## Docstrings for Public API
 

--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/data-display.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/data-display.md
@@ -216,7 +216,7 @@ edited_df = st.data_editor(
 )
 ```
 
-Access pending edit details via `st.session_state.my_editor` — a read-only dict-like object with `edited_rows`, `added_rows`, and `deleted_rows` attributes (also supports key access), e.g. `st.session_state.my_editor.edited_rows`. Edit state cannot be assigned through Session State; Streamlit owns the pending-edit lifecycle.
+Access edit details via `st.session_state["my_editor"]["edited_rows"]`.
 
 **Preserving edits on data refresh** — With a `key` and `num_rows="fixed"`, edits are kept when the data's *values* change and only reset when its structure changes (columns, dtypes, row count, or index labels). An edit is dropped once its value matches the new data. Edits are matched by row position, so use a meaningful index if edits should follow specific rows when the data is reordered. Omit `key` to reset edits on every data change.
 

--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/data-display.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/data-display.md
@@ -216,7 +216,7 @@ edited_df = st.data_editor(
 )
 ```
 
-Access edit details via `st.session_state["my_editor"]["edited_rows"]`.
+Access pending edit details via `st.session_state.my_editor` — a read-only dict-like object with `edited_rows`, `added_rows`, and `deleted_rows` attributes (also supports key access), e.g. `st.session_state.my_editor.edited_rows`. Edit state cannot be assigned through Session State; Streamlit owns the pending-edit lifecycle.
 
 **Preserving edits on data refresh** — With a `key` and `num_rows="fixed"`, edits are kept when the data's *values* change and only reset when its structure changes (columns, dtypes, row count, or index labels). An edit is dropped once its value matches the new data. Edits are matched by row position, so use a meaningful index if edits should follow specific rows when the data is reordered. Omit `key` to reset edits on every data change.
 

--- a/lib/streamlit/AGENTS.md
+++ b/lib/streamlit/AGENTS.md
@@ -40,10 +40,12 @@ typing errors in parameters or return types by using mypy and `assert_type`.
   (e.g. `radio_types.py`, `button_types.py`).
 - For dict-like return values backed by `AttributeDictionary` /
   `ReadOnlyAttributeDictionary` subclasses (e.g. dataframe/chart selection
-  state, `ButtonColumn` click state), assert both attribute and bracket access
-  (e.g. `state.selection.rows` and `state["selection"]["rows"]`). Use a
-  separate `TypedDict` (`*Input`) for values users assign (e.g.
-  `selection_default`), not the returned attribute-dictionary class.
+  state, `ButtonColumn` click state, `st.data_editor` edit state), assert both
+  attribute and bracket access (e.g. `state.selection.rows` and
+  `state["selection"]["rows"]`, or `edit_state.edited_rows` and
+  `edit_state["edited_rows"]`). Use a separate `TypedDict` (`*Input`) for
+  values users assign (e.g. `selection_default`), not the returned
+  attribute-dictionary class.
 
 ## Docstrings for Public API
 

--- a/lib/streamlit/elements/widgets/data_editor.py
+++ b/lib/streamlit/elements/widgets/data_editor.py
@@ -117,8 +117,10 @@ class DataEditorEditState(ReadOnlyAttributeDictionary):
     """The schema for the data editor pending-edit state.
 
     The edit state is stored in a read-only dictionary-like object that
-    supports both key and attribute notation. Edit states cannot be
-    programmatically changed or set through Session State.
+    supports both key and attribute notation. Top-level assignment and
+    nested dict mutation raise ``TypeError``. List fields (``added_rows``,
+    ``deleted_rows``) are ordinary lists and are not frozen. Edit states
+    cannot be programmatically changed or set through Session State.
 
     Attributes
     ----------

--- a/lib/streamlit/elements/widgets/data_editor.py
+++ b/lib/streamlit/elements/widgets/data_editor.py
@@ -113,14 +113,14 @@ DataTypes: TypeAlias = Union[
 ]
 
 
-class DataEditorEditState(ReadOnlyAttributeDictionary):
-    """The schema for the data editor pending-edit state.
+class DataEditorState(ReadOnlyAttributeDictionary):
+    """The schema for the data editor state.
 
-    The edit state is stored in a read-only dictionary-like object that
+    The state is stored in a read-only dictionary-like object that
     supports both key and attribute notation. Top-level assignment and
     nested dict mutation raise ``TypeError``. List fields (``added_rows``,
-    ``deleted_rows``) are ordinary lists and are not frozen. Edit states
-    cannot be programmatically changed or set through Session State.
+    ``deleted_rows``) are ordinary lists and are not frozen. Data editor
+    states cannot be programmatically changed or set through Session State.
 
     Attributes
     ----------
@@ -162,7 +162,7 @@ class DataEditorEditState(ReadOnlyAttributeDictionary):
 class DataEditorSerde:
     """DataEditorSerde is used to serialize and deserialize the data editor state."""
 
-    def deserialize(self, ui_value: str | None) -> DataEditorEditState:
+    def deserialize(self, ui_value: str | None) -> DataEditorState:
         # Keep the payload as a plain dict until the end so missing-key and
         # row-key mutations below can still run before we wrap.
         data_editor_state: dict[str, Any] = (
@@ -184,9 +184,9 @@ class DataEditorSerde:
         data_editor_state["edited_rows"] = {
             int(k): v for k, v in data_editor_state["edited_rows"].items()
         }
-        return DataEditorEditState(data_editor_state)
+        return DataEditorState(data_editor_state)
 
-    def serialize(self, editing_state: DataEditorEditState) -> str:
+    def serialize(self, editing_state: DataEditorState) -> str:
         return json.dumps(editing_state, default=str)
 
 
@@ -551,7 +551,7 @@ def _apply_row_deletions(df: pd.DataFrame, deleted_rows: list[int]) -> None:
 
 def _apply_dataframe_edits(
     df: pd.DataFrame,
-    data_editor_state: DataEditorEditState,
+    data_editor_state: DataEditorState,
     dataframe_schema: DataframeSchema,
 ) -> None:
     """Apply edits to the provided dataframe (inplace).
@@ -563,7 +563,7 @@ def _apply_dataframe_edits(
     df : pd.DataFrame
         The dataframe to apply the edits to.
 
-    data_editor_state : DataEditorEditState
+    data_editor_state : DataEditorState
         The editing state of the data editor component.
 
     dataframe_schema: DataframeSchema

--- a/lib/streamlit/elements/widgets/data_editor.py
+++ b/lib/streamlit/elements/widgets/data_editor.py
@@ -23,14 +23,11 @@ from typing import (
     Final,
     Literal,
     TypeAlias,
-    TypedDict,
     TypeVar,
     Union,
     cast,
     overload,
 )
-
-from typing_extensions import Required
 
 from streamlit import dataframe_util
 from streamlit import logger as _logger
@@ -75,7 +72,7 @@ from streamlit.runtime.state import (
     register_widget,
 )
 from streamlit.type_util import is_list_like, is_type
-from streamlit.util import calc_hash, create_fast_hasher
+from streamlit.util import ReadOnlyAttributeDictionary, calc_hash, create_fast_hasher
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
@@ -116,64 +113,78 @@ DataTypes: TypeAlias = Union[
 ]
 
 
-class EditingState(TypedDict, total=False):
-    """
-    A dictionary representing the current state of the data editor.
+class DataEditorEditState(ReadOnlyAttributeDictionary):
+    """The schema for the data editor pending-edit state.
+
+    The edit state is stored in a read-only dictionary-like object that
+    supports both key and attribute notation. Edit states cannot be
+    programmatically changed or set through Session State.
 
     Attributes
     ----------
-    edited_rows : Dict[int, Dict[str, str | int | float | bool | None]]
-        An hierarchical mapping of edited cells based on:
-        row position -> column name -> value.
+    edited_rows : dict[int, dict[str, Any]]
+        A hierarchical mapping of edited cells based on row position ->
+        column name -> value. Row positions refer to the original source
+        dataframe before pending edits are applied.
 
-    added_rows : List[Dict[str, str | int | float | bool | None]]
+    added_rows : list[dict[str, Any]]
         A list of added rows, where each row is a mapping from column name to
         the cell value.
 
-    deleted_rows : List[int]
-        A list of deleted rows, where each row is the numerical position of
-        the deleted row.
+    deleted_rows : list[int]
+        A list of deleted rows, where each entry is the numerical position of
+        the deleted row in the original source dataframe.
     """
 
-    edited_rows: Required[dict[int, dict[str, str | int | float | bool | None]]]
-    added_rows: Required[list[dict[str, str | int | float | bool | None]]]
-    deleted_rows: Required[list[int]]
+    edited_rows: dict[int, dict[str, Any]]
+    added_rows: list[dict[str, Any]]
+    deleted_rows: list[int]
+
+    @overload
+    def __getitem__(self, key: Literal["edited_rows"]) -> dict[int, dict[str, Any]]: ...
+
+    @overload
+    def __getitem__(self, key: Literal["added_rows"]) -> list[dict[str, Any]]: ...
+
+    @overload
+    def __getitem__(self, key: Literal["deleted_rows"]) -> list[int]: ...
+
+    @overload
+    def __getitem__(self, key: Any) -> Any: ...
+
+    def __getitem__(self, key: Any) -> Any:
+        return super().__getitem__(key)
 
 
 @dataclass
 class DataEditorSerde:
     """DataEditorSerde is used to serialize and deserialize the data editor state."""
 
-    def deserialize(self, ui_value: str | None) -> EditingState:
-        data_editor_state: EditingState = cast(
-            "EditingState",
+    def deserialize(self, ui_value: str | None) -> DataEditorEditState:
+        # Keep the payload as a plain dict until the end so missing-key and
+        # row-key mutations below can still run before we wrap.
+        data_editor_state: dict[str, Any] = (
             {
                 "edited_rows": {},
                 "added_rows": [],
                 "deleted_rows": [],
             }
             if ui_value is None
-            else json.loads(ui_value),
+            else json.loads(ui_value)
         )
 
-        # Make sure that all editing state keys are present:
-        if "edited_rows" not in data_editor_state:
-            data_editor_state["edited_rows"] = {}  # type: ignore[unreachable]
-
-        if "deleted_rows" not in data_editor_state:
-            data_editor_state["deleted_rows"] = []  # type: ignore[unreachable]
-
-        if "added_rows" not in data_editor_state:
-            data_editor_state["added_rows"] = []  # type: ignore[unreachable]
+        data_editor_state.setdefault("edited_rows", {})
+        data_editor_state.setdefault("added_rows", [])
+        data_editor_state.setdefault("deleted_rows", [])
 
         # Convert the keys (numerical row positions) to integers.
         # The keys are strings because they are serialized to JSON.
         data_editor_state["edited_rows"] = {
             int(k): v for k, v in data_editor_state["edited_rows"].items()
         }
-        return data_editor_state
+        return DataEditorEditState(data_editor_state)
 
-    def serialize(self, editing_state: EditingState) -> str:
+    def serialize(self, editing_state: DataEditorEditState) -> str:
         return json.dumps(editing_state, default=str)
 
 
@@ -538,7 +549,7 @@ def _apply_row_deletions(df: pd.DataFrame, deleted_rows: list[int]) -> None:
 
 def _apply_dataframe_edits(
     df: pd.DataFrame,
-    data_editor_state: EditingState,
+    data_editor_state: DataEditorEditState,
     dataframe_schema: DataframeSchema,
 ) -> None:
     """Apply edits to the provided dataframe (inplace).
@@ -550,7 +561,7 @@ def _apply_dataframe_edits(
     df : pd.DataFrame
         The dataframe to apply the edits to.
 
-    data_editor_state : EditingState
+    data_editor_state : DataEditorEditState
         The editing state of the data editor component.
 
     dataframe_schema: DataframeSchema

--- a/lib/streamlit/elements/widgets/data_editor.py
+++ b/lib/streamlit/elements/widgets/data_editor.py
@@ -124,12 +124,12 @@ class DataEditorState(ReadOnlyAttributeDictionary):
 
     Attributes
     ----------
-    edited_rows : dict[int, dict[str, Any]]
+    edited_rows : dict[int, dict[str, str | int | float | bool | list[str] | None]]
         A hierarchical mapping of edited cells based on row position ->
         column name -> value. Row positions refer to the original source
         dataframe before pending edits are applied.
 
-    added_rows : list[dict[str, Any]]
+    added_rows : list[dict[str, str | int | float | bool | list[str] | None]]
         A list of added rows, where each row is a mapping from column name to
         the cell value.
 
@@ -138,15 +138,19 @@ class DataEditorState(ReadOnlyAttributeDictionary):
         the deleted row in the original source dataframe.
     """
 
-    edited_rows: dict[int, dict[str, Any]]
-    added_rows: list[dict[str, Any]]
+    edited_rows: dict[int, dict[str, str | int | float | bool | list[str] | None]]
+    added_rows: list[dict[str, str | int | float | bool | list[str] | None]]
     deleted_rows: list[int]
 
     @overload
-    def __getitem__(self, key: Literal["edited_rows"]) -> dict[int, dict[str, Any]]: ...
+    def __getitem__(
+        self, key: Literal["edited_rows"]
+    ) -> dict[int, dict[str, str | int | float | bool | list[str] | None]]: ...
 
     @overload
-    def __getitem__(self, key: Literal["added_rows"]) -> list[dict[str, Any]]: ...
+    def __getitem__(
+        self, key: Literal["added_rows"]
+    ) -> list[dict[str, str | int | float | bool | list[str] | None]]: ...
 
     @overload
     def __getitem__(self, key: Literal["deleted_rows"]) -> list[int]: ...

--- a/lib/streamlit/typing.py
+++ b/lib/streamlit/typing.py
@@ -38,13 +38,13 @@ from streamlit.elements.lib.column_config_utils import ButtonColumnClickState
 from streamlit.elements.plotly_chart import PlotlyState
 from streamlit.elements.vega_charts import VegaLiteState
 from streamlit.elements.widgets.chat import ChatInputValue
-from streamlit.elements.widgets.data_editor import DataEditorEditState
+from streamlit.elements.widgets.data_editor import DataEditorState
 from streamlit.runtime.uploaded_file_manager import UploadedFile
 
 __all__ = [
     "ButtonColumnClickState",
     "ChatInputValue",
-    "DataEditorEditState",
+    "DataEditorState",
     "DataframeState",
     "PlotlyState",
     "PydeckState",

--- a/lib/streamlit/typing.py
+++ b/lib/streamlit/typing.py
@@ -38,11 +38,13 @@ from streamlit.elements.lib.column_config_utils import ButtonColumnClickState
 from streamlit.elements.plotly_chart import PlotlyState
 from streamlit.elements.vega_charts import VegaLiteState
 from streamlit.elements.widgets.chat import ChatInputValue
+from streamlit.elements.widgets.data_editor import DataEditorEditState
 from streamlit.runtime.uploaded_file_manager import UploadedFile
 
 __all__ = [
     "ButtonColumnClickState",
     "ChatInputValue",
+    "DataEditorEditState",
     "DataframeState",
     "PlotlyState",
     "PydeckState",

--- a/lib/tests/streamlit/elements/data_editor_test.py
+++ b/lib/tests/streamlit/elements/data_editor_test.py
@@ -292,10 +292,11 @@ class DataEditorUtilTest(unittest.TestCase):
         assert result.deleted_rows == [1]
 
     def test_data_editor_edit_state_is_read_only(self):
-        """Pending edit state is read-only at the top and nested levels.
+        """Pending edit state rejects top-level and nested-dict mutation.
 
         It also keeps its typed class through deepcopy, since Session State
-        deep-copies widget values.
+        deep-copies widget values. List fields are ordinary lists and are not
+        frozen (same as other list-bearing widget states).
         """
         result = DataEditorSerde().deserialize(None)
 

--- a/lib/tests/streamlit/elements/data_editor_test.py
+++ b/lib/tests/streamlit/elements/data_editor_test.py
@@ -42,8 +42,8 @@ from streamlit.elements.lib.column_config_utils import (
     determine_dataframe_schema,
 )
 from streamlit.elements.widgets.data_editor import (
-    DataEditorEditState,
     DataEditorSerde,
+    DataEditorState,
     _apply_cell_edits,
     _apply_dataframe_edits,
     _apply_row_additions,
@@ -229,7 +229,7 @@ class DataEditorUtilTest(unittest.TestCase):
 
     def test_data_editor_serde_serialize_round_trips(self):
         """``DataEditorSerde.serialize`` produces JSON containing all editing-state keys."""
-        state = DataEditorEditState(
+        state = DataEditorState(
             {
                 "edited_rows": {0: {"col1": 1}},
                 "added_rows": [],
@@ -246,7 +246,7 @@ class DataEditorUtilTest(unittest.TestCase):
     def test_data_editor_serde_deserialize_none_returns_empty_state(self):
         """A None ui_value should produce an empty editing state."""
         result = DataEditorSerde().deserialize(None)
-        assert isinstance(result, DataEditorEditState)
+        assert isinstance(result, DataEditorState)
         assert result == {
             "edited_rows": {},
             "added_rows": [],
@@ -275,7 +275,7 @@ class DataEditorUtilTest(unittest.TestCase):
         assert result["edited_rows"] == {5: {"col1": 1}, 10: {"col1": 2}}
 
     def test_data_editor_serde_returns_typed_state_class(self):
-        """``deserialize`` returns a typed ``DataEditorEditState`` with attribute access."""
+        """``deserialize`` returns a typed ``DataEditorState`` with attribute access."""
         result = DataEditorSerde().deserialize(
             json.dumps(
                 {
@@ -286,12 +286,12 @@ class DataEditorUtilTest(unittest.TestCase):
             )
         )
 
-        assert isinstance(result, DataEditorEditState)
+        assert isinstance(result, DataEditorState)
         assert result.edited_rows == {0: {"col1": 1}}
         assert result["added_rows"] == [{"col1": 2}]
         assert result.deleted_rows == [1]
 
-    def test_data_editor_edit_state_is_read_only(self):
+    def test_data_editor_state_is_read_only(self):
         """Pending edit state rejects top-level and nested-dict mutation.
 
         It also keeps its typed class through deepcopy, since Session State
@@ -309,7 +309,7 @@ class DataEditorUtilTest(unittest.TestCase):
 
         # Read access still works, and deepcopy preserves the concrete type.
         assert result.edited_rows == {}
-        assert isinstance(copy.deepcopy(result), DataEditorEditState)
+        assert isinstance(copy.deepcopy(result), DataEditorState)
 
     def test_apply_cell_edits(self):
         """Test applying cell edits to a DataFrame."""
@@ -477,7 +477,7 @@ class DataEditorUtilTest(unittest.TestCase):
 
         _apply_dataframe_edits(
             df,
-            DataEditorEditState(
+            DataEditorState(
                 {
                     "deleted_rows": deleted_rows,
                     "added_rows": added_rows,
@@ -511,7 +511,7 @@ class DataEditorUtilTest(unittest.TestCase):
 
         _apply_dataframe_edits(
             df,
-            DataEditorEditState(
+            DataEditorState(
                 {
                     "deleted_rows": deleted_rows,
                     "added_rows": added_rows,
@@ -690,7 +690,7 @@ class DataEditorUtilTest(unittest.TestCase):
         # no longer present and the addition must not be rejected as a duplicate.
         _apply_dataframe_edits(
             df,
-            DataEditorEditState(
+            DataEditorState(
                 {
                     "deleted_rows": [0],
                     "added_rows": [
@@ -754,7 +754,7 @@ class DataEditorUtilTest(unittest.TestCase):
 
         _apply_dataframe_edits(
             df,
-            DataEditorEditState(
+            DataEditorState(
                 {
                     "deleted_rows": deleted_rows,
                     "added_rows": added_rows,
@@ -791,7 +791,7 @@ class DataEditorUtilTest(unittest.TestCase):
 
         _apply_dataframe_edits(
             df,
-            DataEditorEditState(
+            DataEditorState(
                 {
                     "deleted_rows": deleted_rows,
                     "added_rows": added_rows,

--- a/lib/tests/streamlit/elements/data_editor_test.py
+++ b/lib/tests/streamlit/elements/data_editor_test.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import copy
 import datetime
 import json
 import unittest
@@ -41,6 +42,7 @@ from streamlit.elements.lib.column_config_utils import (
     determine_dataframe_schema,
 )
 from streamlit.elements.widgets.data_editor import (
+    DataEditorEditState,
     DataEditorSerde,
     _apply_cell_edits,
     _apply_dataframe_edits,
@@ -227,11 +229,13 @@ class DataEditorUtilTest(unittest.TestCase):
 
     def test_data_editor_serde_serialize_round_trips(self):
         """``DataEditorSerde.serialize`` produces JSON containing all editing-state keys."""
-        state = {
-            "edited_rows": {0: {"col1": 1}},
-            "added_rows": [],
-            "deleted_rows": [],
-        }
+        state = DataEditorEditState(
+            {
+                "edited_rows": {0: {"col1": 1}},
+                "added_rows": [],
+                "deleted_rows": [],
+            }
+        )
         decoded = json.loads(DataEditorSerde().serialize(state))
         assert decoded == {
             "edited_rows": {"0": {"col1": 1}},
@@ -241,7 +245,9 @@ class DataEditorUtilTest(unittest.TestCase):
 
     def test_data_editor_serde_deserialize_none_returns_empty_state(self):
         """A None ui_value should produce an empty editing state."""
-        assert DataEditorSerde().deserialize(None) == {
+        result = DataEditorSerde().deserialize(None)
+        assert isinstance(result, DataEditorEditState)
+        assert result == {
             "edited_rows": {},
             "added_rows": [],
             "deleted_rows": [],
@@ -267,6 +273,42 @@ class DataEditorUtilTest(unittest.TestCase):
         )
         result = DataEditorSerde().deserialize(payload)
         assert result["edited_rows"] == {5: {"col1": 1}, 10: {"col1": 2}}
+
+    def test_data_editor_serde_returns_typed_state_class(self):
+        """``deserialize`` returns a typed ``DataEditorEditState`` with attribute access."""
+        result = DataEditorSerde().deserialize(
+            json.dumps(
+                {
+                    "edited_rows": {"0": {"col1": 1}},
+                    "added_rows": [{"col1": 2}],
+                    "deleted_rows": [1],
+                }
+            )
+        )
+
+        assert isinstance(result, DataEditorEditState)
+        assert result.edited_rows == {0: {"col1": 1}}
+        assert result["added_rows"] == [{"col1": 2}]
+        assert result.deleted_rows == [1]
+
+    def test_data_editor_edit_state_is_read_only(self):
+        """Pending edit state is read-only at the top and nested levels.
+
+        It also keeps its typed class through deepcopy, since Session State
+        deep-copies widget values.
+        """
+        result = DataEditorSerde().deserialize(None)
+
+        with pytest.raises(TypeError, match="Widget state is read-only"):
+            result["edited_rows"] = {}
+        with pytest.raises(TypeError, match="Widget state is read-only"):
+            result.edited_rows = {}  # type: ignore[misc]
+        with pytest.raises(TypeError, match="Widget state is read-only"):
+            result["edited_rows"][0] = {"col1": 1}
+
+        # Read access still works, and deepcopy preserves the concrete type.
+        assert result.edited_rows == {}
+        assert isinstance(copy.deepcopy(result), DataEditorEditState)
 
     def test_apply_cell_edits(self):
         """Test applying cell edits to a DataFrame."""
@@ -434,11 +476,13 @@ class DataEditorUtilTest(unittest.TestCase):
 
         _apply_dataframe_edits(
             df,
-            {
-                "deleted_rows": deleted_rows,
-                "added_rows": added_rows,
-                "edited_rows": edited_rows,
-            },
+            DataEditorEditState(
+                {
+                    "deleted_rows": deleted_rows,
+                    "added_rows": added_rows,
+                    "edited_rows": edited_rows,
+                }
+            ),
             determine_dataframe_schema(df, _get_arrow_schema(df)),
         )
 
@@ -466,11 +510,13 @@ class DataEditorUtilTest(unittest.TestCase):
 
         _apply_dataframe_edits(
             df,
-            {
-                "deleted_rows": deleted_rows,
-                "added_rows": added_rows,
-                "edited_rows": edited_rows,
-            },
+            DataEditorEditState(
+                {
+                    "deleted_rows": deleted_rows,
+                    "added_rows": added_rows,
+                    "edited_rows": edited_rows,
+                }
+            ),
             determine_dataframe_schema(df, _get_arrow_schema(df)),
         )
 
@@ -643,13 +689,15 @@ class DataEditorUtilTest(unittest.TestCase):
         # no longer present and the addition must not be rejected as a duplicate.
         _apply_dataframe_edits(
             df,
-            {
-                "deleted_rows": [0],
-                "added_rows": [
-                    {"_index": "victim@corp.com", "role": "admin", "balance": 0},
-                ],
-                "edited_rows": {},
-            },
+            DataEditorEditState(
+                {
+                    "deleted_rows": [0],
+                    "added_rows": [
+                        {"_index": "victim@corp.com", "role": "admin", "balance": 0},
+                    ],
+                    "edited_rows": {},
+                }
+            ),
             determine_dataframe_schema(df, _get_arrow_schema(df)),
         )
 
@@ -705,11 +753,13 @@ class DataEditorUtilTest(unittest.TestCase):
 
         _apply_dataframe_edits(
             df,
-            {
-                "deleted_rows": deleted_rows,
-                "added_rows": added_rows,
-                "edited_rows": edited_rows,
-            },
+            DataEditorEditState(
+                {
+                    "deleted_rows": deleted_rows,
+                    "added_rows": added_rows,
+                    "edited_rows": edited_rows,
+                }
+            ),
             determine_dataframe_schema(df, _get_arrow_schema(df)),
         )
 
@@ -740,11 +790,13 @@ class DataEditorUtilTest(unittest.TestCase):
 
         _apply_dataframe_edits(
             df,
-            {
-                "deleted_rows": deleted_rows,
-                "added_rows": added_rows,
-                "edited_rows": edited_rows,
-            },
+            DataEditorEditState(
+                {
+                    "deleted_rows": deleted_rows,
+                    "added_rows": added_rows,
+                    "edited_rows": edited_rows,
+                }
+            ),
             determine_dataframe_schema(df, _get_arrow_schema(df)),
         )
 

--- a/lib/tests/streamlit/typing/typing_namespace_types.py
+++ b/lib/tests/streamlit/typing/typing_namespace_types.py
@@ -62,10 +62,22 @@ if TYPE_CHECKING:
     # =====================================================================
 
     data_editor_state = cast("DataEditorState", object())
-    assert_type(data_editor_state.edited_rows, dict[int, dict[str, Any]])
-    assert_type(data_editor_state["edited_rows"], dict[int, dict[str, Any]])
-    assert_type(data_editor_state.added_rows, list[dict[str, Any]])
-    assert_type(data_editor_state["added_rows"], list[dict[str, Any]])
+    assert_type(
+        data_editor_state.edited_rows,
+        dict[int, dict[str, str | int | float | bool | list[str] | None]],
+    )
+    assert_type(
+        data_editor_state["edited_rows"],
+        dict[int, dict[str, str | int | float | bool | list[str] | None]],
+    )
+    assert_type(
+        data_editor_state.added_rows,
+        list[dict[str, str | int | float | bool | list[str] | None]],
+    )
+    assert_type(
+        data_editor_state["added_rows"],
+        list[dict[str, str | int | float | bool | list[str] | None]],
+    )
     assert_type(data_editor_state.deleted_rows, list[int])
     assert_type(data_editor_state["deleted_rows"], list[int])
 

--- a/lib/tests/streamlit/typing/typing_namespace_types.py
+++ b/lib/tests/streamlit/typing/typing_namespace_types.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     from streamlit.typing import (
         ButtonColumnClickState,
         ChatInputValue,
-        DataEditorEditState,
+        DataEditorState,
         DataframeState,
         PlotlyState,
         PydeckState,
@@ -58,16 +58,16 @@ if TYPE_CHECKING:
     assert_type(chat_input_value["audio"], UploadedFile | None)
 
     # =====================================================================
-    # DataEditorEditState: attribute and item access on pending edits
+    # DataEditorState: attribute and item access on pending edits
     # =====================================================================
 
-    data_editor_edit_state = cast("DataEditorEditState", object())
-    assert_type(data_editor_edit_state.edited_rows, dict[int, dict[str, Any]])
-    assert_type(data_editor_edit_state["edited_rows"], dict[int, dict[str, Any]])
-    assert_type(data_editor_edit_state.added_rows, list[dict[str, Any]])
-    assert_type(data_editor_edit_state["added_rows"], list[dict[str, Any]])
-    assert_type(data_editor_edit_state.deleted_rows, list[int])
-    assert_type(data_editor_edit_state["deleted_rows"], list[int])
+    data_editor_state = cast("DataEditorState", object())
+    assert_type(data_editor_state.edited_rows, dict[int, dict[str, Any]])
+    assert_type(data_editor_state["edited_rows"], dict[int, dict[str, Any]])
+    assert_type(data_editor_state.added_rows, list[dict[str, Any]])
+    assert_type(data_editor_state["added_rows"], list[dict[str, Any]])
+    assert_type(data_editor_state.deleted_rows, list[int])
+    assert_type(data_editor_state["deleted_rows"], list[int])
 
     # =====================================================================
     # DataframeState: attribute and item access on the selection payload

--- a/lib/tests/streamlit/typing/typing_namespace_types.py
+++ b/lib/tests/streamlit/typing/typing_namespace_types.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     from streamlit.typing import (
         ButtonColumnClickState,
         ChatInputValue,
+        DataEditorEditState,
         DataframeState,
         PlotlyState,
         PydeckState,
@@ -55,6 +56,18 @@ if TYPE_CHECKING:
     assert_type(chat_input_value["files"], list[UploadedFile])
     assert_type(chat_input_value.audio, UploadedFile | None)
     assert_type(chat_input_value["audio"], UploadedFile | None)
+
+    # =====================================================================
+    # DataEditorEditState: attribute and item access on pending edits
+    # =====================================================================
+
+    data_editor_edit_state = cast("DataEditorEditState", object())
+    assert_type(data_editor_edit_state.edited_rows, dict[int, dict[str, Any]])
+    assert_type(data_editor_edit_state["edited_rows"], dict[int, dict[str, Any]])
+    assert_type(data_editor_edit_state.added_rows, list[dict[str, Any]])
+    assert_type(data_editor_edit_state["added_rows"], list[dict[str, Any]])
+    assert_type(data_editor_edit_state.deleted_rows, list[int])
+    assert_type(data_editor_edit_state["deleted_rows"], list[int])
 
     # =====================================================================
     # DataframeState: attribute and item access on the selection payload

--- a/lib/tests/streamlit/typing_test.py
+++ b/lib/tests/streamlit/typing_test.py
@@ -27,14 +27,14 @@ from streamlit.elements.lib.column_config_utils import ButtonColumnClickState
 from streamlit.elements.plotly_chart import PlotlyState
 from streamlit.elements.vega_charts import VegaLiteState
 from streamlit.elements.widgets.chat import ChatInputValue
-from streamlit.elements.widgets.data_editor import DataEditorEditState
+from streamlit.elements.widgets.data_editor import DataEditorState
 from streamlit.proto.Common_pb2 import FileURLs as FileURLsProto
 from streamlit.runtime.uploaded_file_manager import UploadedFile, UploadedFileRec
 
 _EXPECTED_EXPORTS = {
     "ButtonColumnClickState",
     "ChatInputValue",
-    "DataEditorEditState",
+    "DataEditorState",
     "DataframeState",
     "PlotlyState",
     "PydeckState",
@@ -76,7 +76,7 @@ def test_exports_preserve_object_identity() -> None:
     """Each export is the same runtime object as its internal definition."""
     assert streamlit.typing.UploadedFile is UploadedFile
     assert streamlit.typing.ChatInputValue is ChatInputValue
-    assert streamlit.typing.DataEditorEditState is DataEditorEditState
+    assert streamlit.typing.DataEditorState is DataEditorState
     assert streamlit.typing.DataframeState is DataframeState
     assert streamlit.typing.PlotlyState is PlotlyState
     assert streamlit.typing.VegaLiteState is VegaLiteState
@@ -100,8 +100,8 @@ def test_chat_input_value_isinstance() -> None:
 def test_state_classes_isinstance() -> None:
     """The dict-backed state classes are instances of their public exports."""
     assert isinstance(
-        DataEditorEditState({"edited_rows": {}, "added_rows": [], "deleted_rows": []}),
-        streamlit.typing.DataEditorEditState,
+        DataEditorState({"edited_rows": {}, "added_rows": [], "deleted_rows": []}),
+        streamlit.typing.DataEditorState,
     )
     assert isinstance(
         DataframeState({"selection": {}}), streamlit.typing.DataframeState

--- a/lib/tests/streamlit/typing_test.py
+++ b/lib/tests/streamlit/typing_test.py
@@ -27,12 +27,14 @@ from streamlit.elements.lib.column_config_utils import ButtonColumnClickState
 from streamlit.elements.plotly_chart import PlotlyState
 from streamlit.elements.vega_charts import VegaLiteState
 from streamlit.elements.widgets.chat import ChatInputValue
+from streamlit.elements.widgets.data_editor import DataEditorEditState
 from streamlit.proto.Common_pb2 import FileURLs as FileURLsProto
 from streamlit.runtime.uploaded_file_manager import UploadedFile, UploadedFileRec
 
 _EXPECTED_EXPORTS = {
     "ButtonColumnClickState",
     "ChatInputValue",
+    "DataEditorEditState",
     "DataframeState",
     "PlotlyState",
     "PydeckState",
@@ -50,7 +52,7 @@ def test_import_surfaces_resolve_to_same_module() -> None:
 
 
 def test_all_matches_expected_exports() -> None:
-    """``__all__`` contains exactly the 7 curated public exports."""
+    """``__all__`` contains exactly the curated public exports."""
     assert set(streamlit.typing.__all__) == _EXPECTED_EXPORTS
 
 
@@ -74,6 +76,7 @@ def test_exports_preserve_object_identity() -> None:
     """Each export is the same runtime object as its internal definition."""
     assert streamlit.typing.UploadedFile is UploadedFile
     assert streamlit.typing.ChatInputValue is ChatInputValue
+    assert streamlit.typing.DataEditorEditState is DataEditorEditState
     assert streamlit.typing.DataframeState is DataframeState
     assert streamlit.typing.PlotlyState is PlotlyState
     assert streamlit.typing.VegaLiteState is VegaLiteState
@@ -96,6 +99,10 @@ def test_chat_input_value_isinstance() -> None:
 
 def test_state_classes_isinstance() -> None:
     """The dict-backed state classes are instances of their public exports."""
+    assert isinstance(
+        DataEditorEditState({"edited_rows": {}, "added_rows": [], "deleted_rows": []}),
+        streamlit.typing.DataEditorEditState,
+    )
     assert isinstance(
         DataframeState({"selection": {}}), streamlit.typing.DataframeState
     )


### PR DESCRIPTION
## Describe your changes

Exposes `DataEditorState` through `streamlit.typing` so apps can annotate pending `st.data_editor` edits with the concrete runtime type.

- Replaces the internal `EditingState` TypedDict with a `ReadOnlyAttributeDictionary` subclass (attribute and item access), matching other widget state types such as `DataframeState`
- `DataEditorSerde` wraps the normalized payload so `st.session_state[key]` returns the typed object and preserves it across Session State copies
- In-place mutation of edit state now raises `TypeError` (mutations never synced to the frontend); clear edits by returning a new source from a future `commit_edits` callback, not by mutating session state

## GitHub Issue Link (if applicable)

Related groundwork for [#7749](https://github.com/streamlit/streamlit/issues/7749) / [#6540](https://github.com/streamlit/streamlit/issues/6540) (`commit_edits` is not included here).

## Testing Plan

- [x] Unit Tests (JS and/or Python)
  - `lib/tests/streamlit/elements/data_editor_test.py` — serde wrap, read-only mutations, deepcopy type preservation
  - `lib/tests/streamlit/typing_test.py` / `typing_namespace_types.py` — `__all__`, identity, isinstance, attribute/item static types
- [ ] E2E Tests — not needed (Session State typing/wrapping only; no frontend changes)
- [ ] Manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

Made with [Cursor](https://cursor.com)