### PR TITLE
[chore] Enable first-party ty type checking

### DIFF
--- a/.cursor/rules/python.mdc
+++ b/.cursor/rules/python.mdc
@@ -65,6 +65,12 @@ alwaysApply: false
 - Add typing annotations to every new function, method or class member.
 - Use `typing_extensions` for back-porting newer typing features.
 - Use future annotations via `from __future__ import annotations`.
+- `make python-types` runs both `ty` and `mypy`. `ty` resolves first-party
+  `streamlit.*` imports (config in root `pyproject.toml`); prefer real
+  narrowing/annotation fixes over suppressions. When a checker-specific
+  suppression is needed, use a rule-specific comment such as
+  `# ty: ignore[redundant-cast]` (and keep `# type: ignore[...]` for mypy when
+  both apply).
 
 ## Relevant `make` commands
 

--- a/.github/instructions/python.instructions.md
+++ b/.github/instructions/python.instructions.md
@@ -63,6 +63,12 @@ applyTo: "**/*.py"
 - Add typing annotations to every new function, method or class member.
 - Use `typing_extensions` for back-porting newer typing features.
 - Use future annotations via `from __future__ import annotations`.
+- `make python-types` runs both `ty` and `mypy`. `ty` resolves first-party
+  `streamlit.*` imports (config in root `pyproject.toml`); prefer real
+  narrowing/annotation fixes over suppressions. When a checker-specific
+  suppression is needed, use a rule-specific comment such as
+  `# ty: ignore[redundant-cast]` (and keep `# type: ignore[...]` for mypy when
+  both apply).
 
 ## Relevant `make` commands
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -395,7 +395,7 @@ We've set up various formatting, linting, and type-checking rules that our Conti
 
 ### Python
 
-For Python, we use [ruff](https://github.com/astral-sh/ruff) for formatting & linting and [mypy](https://github.com/python/mypy) for type-checking.
+For Python, we use [ruff](https://github.com/astral-sh/ruff) for formatting & linting and [mypy](https://github.com/python/mypy) plus [ty](https://github.com/astral-sh/ty) for type-checking.
 
 #### Formatting
 

--- a/e2e_playwright/bidi_components/basics.py
+++ b/e2e_playwright/bidi_components/basics.py
@@ -20,6 +20,9 @@ import pandas as pd
 
 import streamlit as st
 
+# Exercise the public namespace path used by apps.
+component = st.components.v2.component  # ty: ignore[possibly-missing-submodule]
+
 if TYPE_CHECKING:
     from streamlit.components.v2.bidi_component import ComponentResult
     from streamlit.elements.lib.layout_utils import Height, Width
@@ -32,7 +35,7 @@ st.header("Custom Components v2 - Basics")
 # ---------------------------------------------------------------------------
 # Empty content: component with no HTML/CSS/JS should not error
 # ---------------------------------------------------------------------------
-_EMPTY_CMP = st.components.v2.component("bidi_empty_content", isolate_styles=False)
+_EMPTY_CMP = component("bidi_empty_content", isolate_styles=False)
 
 with st.container(key="empty_component_container"):
     st.subheader("Empty content")
@@ -91,7 +94,7 @@ _STATEFUL_HTML = """
 </div>
 """
 
-_STATEFUL_CMP = st.components.v2.component(
+_STATEFUL_CMP = component(
     "bidi_stateful",
     js=_STATEFUL_JS,
     html=_STATEFUL_HTML,
@@ -154,9 +157,7 @@ _TRIGGER_HTML = """
 </div>
 """
 
-_TRIGGER_CMP = st.components.v2.component(
-    "bidi_trigger", js=_TRIGGER_JS, html=_TRIGGER_HTML
-)
+_TRIGGER_CMP = component("bidi_trigger", js=_TRIGGER_JS, html=_TRIGGER_HTML)
 
 
 def trigger_component(
@@ -215,7 +216,7 @@ _CTX_HTML = """
 </div>
 """
 
-_CTX_CMP = st.components.v2.component(
+_CTX_CMP = component(
     name="bidi_ctx",
     js=_CTX_JS,
     html=_CTX_HTML,
@@ -482,7 +483,7 @@ div {
 }
 """
 
-    _BASIC_CMP = st.components.v2.component(
+    _BASIC_CMP = component(
         name="bidi_basic",
         js=_BASIC_JS,
         html=_BASIC_HTML,
@@ -564,7 +565,7 @@ export default function(component) {
 </form>
 """
 
-    _HOTKEY_CMP = st.components.v2.component(
+    _HOTKEY_CMP = component(
         name="bidi_hotkey_regression",
         js=_HOTKEY_JS,
         html=_HOTKEY_HTML,
@@ -605,7 +606,7 @@ export default function(component) {
 <div id="my-arrow-component"></div>
 """
 
-    _ARROW_CMP = st.components.v2.component(
+    _ARROW_CMP = component(
         name="my_arrow_component",
         js=_ARROW_JS,
         html=_ARROW_HTML,

--- a/e2e_playwright/bidi_components/basics.py
+++ b/e2e_playwright/bidi_components/basics.py
@@ -20,8 +20,7 @@ import pandas as pd
 
 import streamlit as st
 
-# Alias via the public st.components.v2 path; ty cannot resolve that submodule, so ignore once here.
-component = st.components.v2.component  # ty: ignore[possibly-missing-submodule]
+component = st.components.v2.component
 
 if TYPE_CHECKING:
     from streamlit.components.v2.bidi_component import ComponentResult

--- a/e2e_playwright/bidi_components/basics.py
+++ b/e2e_playwright/bidi_components/basics.py
@@ -20,8 +20,6 @@ import pandas as pd
 
 import streamlit as st
 
-component = st.components.v2.component
-
 if TYPE_CHECKING:
     from streamlit.components.v2.bidi_component import ComponentResult
     from streamlit.elements.lib.layout_utils import Height, Width
@@ -34,7 +32,7 @@ st.header("Custom Components v2 - Basics")
 # ---------------------------------------------------------------------------
 # Empty content: component with no HTML/CSS/JS should not error
 # ---------------------------------------------------------------------------
-_EMPTY_CMP = component("bidi_empty_content", isolate_styles=False)
+_EMPTY_CMP = st.components.v2.component("bidi_empty_content", isolate_styles=False)
 
 with st.container(key="empty_component_container"):
     st.subheader("Empty content")
@@ -93,7 +91,7 @@ _STATEFUL_HTML = """
 </div>
 """
 
-_STATEFUL_CMP = component(
+_STATEFUL_CMP = st.components.v2.component(
     "bidi_stateful",
     js=_STATEFUL_JS,
     html=_STATEFUL_HTML,
@@ -156,7 +154,9 @@ _TRIGGER_HTML = """
 </div>
 """
 
-_TRIGGER_CMP = component("bidi_trigger", js=_TRIGGER_JS, html=_TRIGGER_HTML)
+_TRIGGER_CMP = st.components.v2.component(
+    "bidi_trigger", js=_TRIGGER_JS, html=_TRIGGER_HTML
+)
 
 
 def trigger_component(
@@ -215,7 +215,7 @@ _CTX_HTML = """
 </div>
 """
 
-_CTX_CMP = component(
+_CTX_CMP = st.components.v2.component(
     name="bidi_ctx",
     js=_CTX_JS,
     html=_CTX_HTML,
@@ -482,7 +482,7 @@ div {
 }
 """
 
-    _BASIC_CMP = component(
+    _BASIC_CMP = st.components.v2.component(
         name="bidi_basic",
         js=_BASIC_JS,
         html=_BASIC_HTML,
@@ -564,7 +564,7 @@ export default function(component) {
 </form>
 """
 
-    _HOTKEY_CMP = component(
+    _HOTKEY_CMP = st.components.v2.component(
         name="bidi_hotkey_regression",
         js=_HOTKEY_JS,
         html=_HOTKEY_HTML,
@@ -605,7 +605,7 @@ export default function(component) {
 <div id="my-arrow-component"></div>
 """
 
-    _ARROW_CMP = component(
+    _ARROW_CMP = st.components.v2.component(
         name="my_arrow_component",
         js=_ARROW_JS,
         html=_ARROW_HTML,

--- a/e2e_playwright/bidi_components/basics.py
+++ b/e2e_playwright/bidi_components/basics.py
@@ -20,7 +20,7 @@ import pandas as pd
 
 import streamlit as st
 
-# Exercise the public namespace path used by apps.
+# Alias via the public st.components.v2 path; ty cannot resolve that submodule, so ignore once here.
 component = st.components.v2.component  # ty: ignore[possibly-missing-submodule]
 
 if TYPE_CHECKING:

--- a/e2e_playwright/bidi_components/error_handling.py
+++ b/e2e_playwright/bidi_components/error_handling.py
@@ -17,8 +17,7 @@ from pathlib import Path
 
 import streamlit as st
 
-# Alias via the public st.components.v2 path; ty cannot resolve that submodule, so ignore once here.
-component = st.components.v2.component  # ty: ignore[possibly-missing-submodule]
+component = st.components.v2.component
 
 st.header("Custom Components v2 - Error Handling")
 

--- a/e2e_playwright/bidi_components/error_handling.py
+++ b/e2e_playwright/bidi_components/error_handling.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 import streamlit as st
 
-# Exercise the public namespace path used by apps.
+# Alias via the public st.components.v2 path; ty cannot resolve that submodule, so ignore once here.
 component = st.components.v2.component  # ty: ignore[possibly-missing-submodule]
 
 st.header("Custom Components v2 - Error Handling")

--- a/e2e_playwright/bidi_components/error_handling.py
+++ b/e2e_playwright/bidi_components/error_handling.py
@@ -17,8 +17,6 @@ from pathlib import Path
 
 import streamlit as st
 
-component = st.components.v2.component
-
 st.header("Custom Components v2 - Error Handling")
 
 st.divider()
@@ -26,7 +24,7 @@ with st.container():
     st.subheader("Errors (intentionally broken components)")
 
     # Incorrect JS (no default export)
-    _incorrect_js = component(
+    _incorrect_js = st.components.v2.component(
         "incorrectJsComponent",
         html="""<h1>The JS is incorrect</h1>""",
         js="""
@@ -38,7 +36,7 @@ with st.container():
     _incorrect_js()
 
     # Incorrect CSS path
-    _incorrect_css = component(
+    _incorrect_css = st.components.v2.component(
         "incorrectCssPathComponent",
         html="""<h1>The CSS path is incorrect</h1>""",
         css=Path(__file__).parent / "incorrect_css_path.css",  # type: ignore[arg-type] # ty: ignore[invalid-argument-type]

--- a/e2e_playwright/bidi_components/error_handling.py
+++ b/e2e_playwright/bidi_components/error_handling.py
@@ -17,6 +17,9 @@ from pathlib import Path
 
 import streamlit as st
 
+# Exercise the public namespace path used by apps.
+component = st.components.v2.component  # ty: ignore[possibly-missing-submodule]
+
 st.header("Custom Components v2 - Error Handling")
 
 st.divider()
@@ -24,7 +27,7 @@ with st.container():
     st.subheader("Errors (intentionally broken components)")
 
     # Incorrect JS (no default export)
-    _incorrect_js = st.components.v2.component(
+    _incorrect_js = component(
         "incorrectJsComponent",
         html="""<h1>The JS is incorrect</h1>""",
         js="""
@@ -36,9 +39,9 @@ with st.container():
     _incorrect_js()
 
     # Incorrect CSS path
-    _incorrect_css = st.components.v2.component(
+    _incorrect_css = component(
         "incorrectCssPathComponent",
         html="""<h1>The CSS path is incorrect</h1>""",
-        css=Path(__file__).parent / "incorrect_css_path.css",  # type: ignore[arg-type]
+        css=Path(__file__).parent / "incorrect_css_path.css",  # type: ignore[arg-type] # ty: ignore[invalid-argument-type]
     )
     _incorrect_css()

--- a/e2e_playwright/bidi_components/session_state_interactions.py
+++ b/e2e_playwright/bidi_components/session_state_interactions.py
@@ -16,7 +16,10 @@
 import streamlit as st
 from streamlit.components.v2.bidi_component import ComponentResult
 
-interactive_text_input_definition = st.components.v2.component(
+# Exercise the public namespace path used by apps.
+component = st.components.v2.component  # ty: ignore[possibly-missing-submodule]
+
+interactive_text_input_definition = component(
     "interactive_text_input",
     html="""
     <label for='txt'>Enter text:</label>

--- a/e2e_playwright/bidi_components/session_state_interactions.py
+++ b/e2e_playwright/bidi_components/session_state_interactions.py
@@ -16,7 +16,7 @@
 import streamlit as st
 from streamlit.components.v2.bidi_component import ComponentResult
 
-# Exercise the public namespace path used by apps.
+# Alias via the public st.components.v2 path; ty cannot resolve that submodule, so ignore once here.
 component = st.components.v2.component  # ty: ignore[possibly-missing-submodule]
 
 interactive_text_input_definition = component(

--- a/e2e_playwright/bidi_components/session_state_interactions.py
+++ b/e2e_playwright/bidi_components/session_state_interactions.py
@@ -16,9 +16,7 @@
 import streamlit as st
 from streamlit.components.v2.bidi_component import ComponentResult
 
-component = st.components.v2.component
-
-interactive_text_input_definition = component(
+interactive_text_input_definition = st.components.v2.component(
     "interactive_text_input",
     html="""
     <label for='txt'>Enter text:</label>

--- a/e2e_playwright/bidi_components/session_state_interactions.py
+++ b/e2e_playwright/bidi_components/session_state_interactions.py
@@ -16,8 +16,7 @@
 import streamlit as st
 from streamlit.components.v2.bidi_component import ComponentResult
 
-# Alias via the public st.components.v2 path; ty cannot resolve that submodule, so ignore once here.
-component = st.components.v2.component  # ty: ignore[possibly-missing-submodule]
+component = st.components.v2.component
 
 interactive_text_input_definition = component(
     "interactive_text_input",

--- a/e2e_playwright/st_app_advanced.py
+++ b/e2e_playwright/st_app_advanced.py
@@ -128,7 +128,7 @@ app = st.App(
     ],
     middleware=[Middleware(CustomHeaderMiddleware)],
     lifespan=lifespan,
-    exception_handlers={CustomAPIError: custom_api_error_handler},  # type: ignore[dict-item]
+    exception_handlers={CustomAPIError: custom_api_error_handler},  # type: ignore[dict-item] # ty: ignore[invalid-argument-type]
     on_script_error=handle_script_error,
     secrets={
         "api_key": "test-api-key-12345",

--- a/e2e_playwright/st_components_v1_import_via_st.py
+++ b/e2e_playwright/st_components_v1_import_via_st.py
@@ -19,10 +19,6 @@
 
 import streamlit as st
 
-st.components.v1.html(  # ty: ignore[possibly-missing-submodule]
-    "<div>This import and usage worked!</div>"
-)
-st.write(str(st.components.v1.iframe))  # ty: ignore[possibly-missing-submodule]
-st.write(
-    str(st.components.v1.declare_component)  # ty: ignore[possibly-missing-submodule]
-)
+st.components.v1.html("<div>This import and usage worked!</div>")
+st.write(str(st.components.v1.iframe))
+st.write(str(st.components.v1.declare_component))

--- a/e2e_playwright/st_components_v1_import_via_st.py
+++ b/e2e_playwright/st_components_v1_import_via_st.py
@@ -19,6 +19,10 @@
 
 import streamlit as st
 
-st.components.v1.html("<div>This import and usage worked!</div>")
-st.write(str(st.components.v1.iframe))
-st.write(str(st.components.v1.declare_component))
+st.components.v1.html(  # ty: ignore[possibly-missing-submodule]
+    "<div>This import and usage worked!</div>"
+)
+st.write(str(st.components.v1.iframe))  # ty: ignore[possibly-missing-submodule]
+st.write(
+    str(st.components.v1.declare_component)  # ty: ignore[possibly-missing-submodule]
+)

--- a/e2e_playwright/st_dialog.py
+++ b/e2e_playwright/st_dialog.py
@@ -190,7 +190,7 @@ if st.button("Open Nested Dialogs"):
 def dialog_with_error() -> None:
     with st.form(key="forecast_form"):
         # foo is an invalid argument, so this shows an error
-        st.form_submit_button("Submit", foo="bar")  # type: ignore[call-arg]
+        st.form_submit_button("Submit", foo="bar")  # type: ignore[call-arg] # ty: ignore[unknown-argument]
 
 
 if st.button("Open Dialog with Key Error"):

--- a/e2e_playwright/st_pyplot.py
+++ b/e2e_playwright/st_pyplot.py
@@ -84,7 +84,7 @@ kwargs = {
 
 # We need to set clear_figure=True, otherwise the global object
 # test below would not work.
-st.pyplot(fig, clear_figure=True, **kwargs)  # type: ignore[arg-type]
+st.pyplot(fig, clear_figure=True, **kwargs)  # type: ignore[arg-type] # ty: ignore[invalid-argument-type]
 
 st.write("Figure using deprecated global object:")
 plot = plt.plot(data2)

--- a/e2e_playwright/st_sidebar.py
+++ b/e2e_playwright/st_sidebar.py
@@ -19,8 +19,6 @@ import pandas as pd
 
 import streamlit as st
 
-component = st.components.v2.component
-
 np.random.seed(0)
 data = np.random.randint(low=0, high=20, size=(20, 3))
 
@@ -100,7 +98,7 @@ _POPOVER_HTML = """
 </div>
 """
 
-_POPOVER_CMP = component(
+_POPOVER_CMP = st.components.v2.component(
     name="sidebar_popover_test",
     js=_POPOVER_JS,
     html=_POPOVER_HTML,

--- a/e2e_playwright/st_sidebar.py
+++ b/e2e_playwright/st_sidebar.py
@@ -19,7 +19,7 @@ import pandas as pd
 
 import streamlit as st
 
-# Exercise the public namespace path used by apps.
+# Alias via the public st.components.v2 path; ty cannot resolve that submodule, so ignore once here.
 component = st.components.v2.component  # ty: ignore[possibly-missing-submodule]
 
 np.random.seed(0)

--- a/e2e_playwright/st_sidebar.py
+++ b/e2e_playwright/st_sidebar.py
@@ -19,8 +19,7 @@ import pandas as pd
 
 import streamlit as st
 
-# Alias via the public st.components.v2 path; ty cannot resolve that submodule, so ignore once here.
-component = st.components.v2.component  # ty: ignore[possibly-missing-submodule]
+component = st.components.v2.component
 
 np.random.seed(0)
 data = np.random.randint(low=0, high=20, size=(20, 3))

--- a/e2e_playwright/st_sidebar.py
+++ b/e2e_playwright/st_sidebar.py
@@ -19,6 +19,9 @@ import pandas as pd
 
 import streamlit as st
 
+# Exercise the public namespace path used by apps.
+component = st.components.v2.component  # ty: ignore[possibly-missing-submodule]
+
 np.random.seed(0)
 data = np.random.randint(low=0, high=20, size=(20, 3))
 
@@ -98,7 +101,7 @@ _POPOVER_HTML = """
 </div>
 """
 
-_POPOVER_CMP = st.components.v2.component(
+_POPOVER_CMP = component(
     name="sidebar_popover_test",
     js=_POPOVER_JS,
     html=_POPOVER_HTML,

--- a/lib/AGENTS.md
+++ b/lib/AGENTS.md
@@ -57,6 +57,12 @@
 - Add typing annotations to every new function, method or class member.
 - Use `typing_extensions` for back-porting newer typing features.
 - Use future annotations via `from __future__ import annotations`.
+- `make python-types` runs both `ty` and `mypy`. `ty` resolves first-party
+  `streamlit.*` imports (config in root `pyproject.toml`); prefer real
+  narrowing/annotation fixes over suppressions. When a checker-specific
+  suppression is needed, use a rule-specific comment such as
+  `# ty: ignore[redundant-cast]` (and keep `# type: ignore[...]` for mypy when
+  both apply).
 
 ## Relevant `make` commands
 

--- a/lib/streamlit/.agents/skills/developing-with-streamlit/assets/templates/apps/dashboard-companies/streamlit_app.py
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/assets/templates/apps/dashboard-companies/streamlit_app.py
@@ -28,6 +28,7 @@ your actual data source (e.g., Snowflake queries, CRM APIs, etc.).
 """
 
 from datetime import date, timedelta
+from typing import cast
 
 import numpy as np
 import pandas as pd
@@ -295,11 +296,14 @@ with st.container(border=True):
     days_filter = timeframe_options.get(timeframe or "Last 28 days")
 
     # Account types
-    account_types = st.pills(
-        "Account types",
-        options=ACCOUNT_TYPES,
-        default=["Enterprise", "Growth", "Startup"],
-        selection_mode="multi",
+    account_types = cast(
+        "list[str]",
+        st.pills(
+            "Account types",
+            options=ACCOUNT_TYPES,
+            default=["Enterprise", "Growth", "Startup"],
+            selection_mode="multi",
+        ),
     )
 
 # Determine sort order

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -314,6 +314,8 @@ from streamlit.starlette import App as App
 # make it possible to call streamlit.components.v1.html etc. by importing it here
 # import in the very end to avoid partially-initialized module import errors, because
 # streamlit.components.v1 also uses some streamlit imports
+# Explicitly re-export the namespace because type checkers don't infer it from
+# the submodule import side effects below.
 from streamlit import components as components
 import streamlit.components.v1  # noqa: F401
 import streamlit.components.v2  # noqa: F401

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -314,5 +314,6 @@ from streamlit.starlette import App as App
 # make it possible to call streamlit.components.v1.html etc. by importing it here
 # import in the very end to avoid partially-initialized module import errors, because
 # streamlit.components.v1 also uses some streamlit imports
+from streamlit import components as components
 import streamlit.components.v1  # noqa: F401
 import streamlit.components.v2  # noqa: F401

--- a/lib/streamlit/commands/page_config.py
+++ b/lib/streamlit/commands/page_config.py
@@ -308,14 +308,16 @@ def set_menu_items_proto(
     lowercase_menu_items: MenuItems, menu_items_proto: PageConfigProto.MenuItems
 ) -> None:
     if GET_HELP_KEY in lowercase_menu_items:
-        if lowercase_menu_items[GET_HELP_KEY] is not None:
-            menu_items_proto.get_help_url = lowercase_menu_items[GET_HELP_KEY]
+        get_help_url = lowercase_menu_items[GET_HELP_KEY]
+        if get_help_url is not None:
+            menu_items_proto.get_help_url = get_help_url
         else:
             menu_items_proto.hide_get_help = True
 
     if REPORT_A_BUG_KEY in lowercase_menu_items:
-        if lowercase_menu_items[REPORT_A_BUG_KEY] is not None:
-            menu_items_proto.report_a_bug_url = lowercase_menu_items[REPORT_A_BUG_KEY]
+        report_a_bug_url = lowercase_menu_items[REPORT_A_BUG_KEY]
+        if report_a_bug_url is not None:
+            menu_items_proto.report_a_bug_url = report_a_bug_url
         else:
             menu_items_proto.hide_report_a_bug = True
 

--- a/lib/streamlit/connections/snowflake_connection.py
+++ b/lib/streamlit/connections/snowflake_connection.py
@@ -158,12 +158,12 @@ class BaseSnowflakeConnection(BaseConnection["InternalSnowflakeConnection"]):
             ttl
         ).replace(".", "_")
         _query.__qualname__ = f"{_query.__qualname__}_{self._connection_name}_{ttl_str}"
-        _query = cache_data(
+        cached_query = cache_data(
             show_spinner=show_spinner,
             ttl=ttl,
         )(_query)
 
-        return _query(self._connection_instance_id, sql, params)
+        return cached_query(self._connection_instance_id, sql, params)
 
     def write_pandas(
         self,

--- a/lib/streamlit/connections/sql_connection.py
+++ b/lib/streamlit/connections/sql_connection.py
@@ -343,12 +343,12 @@ class SQLConnection(BaseConnection["Engine"]):
             ttl
         ).replace(".", "_")
         _query.__qualname__ = f"{_query.__qualname__}_{self._connection_name}_{ttl_str}"
-        _query = cache_data(
+        cached_query = cache_data(
             show_spinner=show_spinner,
             ttl=ttl,
         )(_query)
 
-        return _query(
+        return cached_query(
             self._connection_instance_id,
             sql,
             index_col=index_col,

--- a/lib/streamlit/elements/arrow.py
+++ b/lib/streamlit/elements/arrow.py
@@ -1066,7 +1066,9 @@ class ArrowMixin:
             check_widget_policies(
                 self.dg,
                 key,
-                on_change=cast("WidgetCallback", on_select) if is_callback else None,
+                on_change=cast("WidgetCallback", on_select)  # ty: ignore[redundant-cast]
+                if is_callback
+                else None,
                 default_value=None,
                 writes_allowed=True,
                 enable_check_callback_rules=is_callback,

--- a/lib/streamlit/elements/deck_gl_json_chart.py
+++ b/lib/streamlit/elements/deck_gl_json_chart.py
@@ -601,7 +601,9 @@ class PydeckMixin:
             check_widget_policies(
                 self.dg,
                 key,
-                on_change=cast("WidgetCallback", on_select) if is_callback else None,
+                on_change=cast("WidgetCallback", on_select)  # ty: ignore[redundant-cast]
+                if is_callback
+                else None,
                 default_value=None,
                 writes_allowed=False,
                 enable_check_callback_rules=is_callback,

--- a/lib/streamlit/elements/graphviz_chart.py
+++ b/lib/streamlit/elements/graphviz_chart.py
@@ -206,9 +206,7 @@ def marshall(
     """
 
     if type_util.is_graphviz_chart(figure_or_dot):
-        chart = cast(
-            "graphviz.Graph | graphviz.Digraph | graphviz.Source", figure_or_dot
-        )
+        chart = figure_or_dot
         dot = chart.source
         engine = chart.engine
     elif isinstance(figure_or_dot, str):

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -924,7 +924,9 @@ class LayoutsMixin:
             check_widget_policies(
                 self.dg,
                 key,
-                on_change=cast("WidgetCallback", on_change) if is_callback else None,
+                on_change=cast("WidgetCallback", on_change)  # ty: ignore[redundant-cast]
+                if is_callback
+                else None,
                 default_value=None,
                 writes_allowed=True,
                 enable_check_callback_rules=is_callback,
@@ -1267,7 +1269,9 @@ class LayoutsMixin:
             check_widget_policies(
                 self.dg,
                 key,
-                on_change=cast("WidgetCallback", on_change) if is_callback else None,
+                on_change=cast("WidgetCallback", on_change)  # ty: ignore[redundant-cast]
+                if is_callback
+                else None,
                 default_value=None,
                 writes_allowed=True,
                 enable_check_callback_rules=is_callback,
@@ -1661,7 +1665,9 @@ class LayoutsMixin:
             check_widget_policies(
                 self.dg,
                 key,
-                on_change=cast("WidgetCallback", on_change) if is_callback else None,
+                on_change=cast("WidgetCallback", on_change)  # ty: ignore[redundant-cast]
+                if is_callback
+                else None,
                 default_value=None,
                 writes_allowed=True,
                 enable_check_callback_rules=is_callback,

--- a/lib/streamlit/elements/lib/built_in_chart_utils.py
+++ b/lib/streamlit/elements/lib/built_in_chart_utils.py
@@ -641,10 +641,10 @@ def _maybe_convert_color_column_in_place(
 
     first_color_datum = df[color_column].iat[0]
 
-    if is_hex_color_like(first_color_datum):  # type: ignore[arg-type]
+    if is_hex_color_like(first_color_datum):
         # Hex is already CSS-valid.
         pass
-    elif is_color_tuple_like(first_color_datum):  # type: ignore[arg-type]
+    elif is_color_tuple_like(first_color_datum):
         # Tuples need to be converted to CSS-valid.
         df.loc[:, color_column] = df[color_column].apply(to_css_color)
     else:
@@ -1204,7 +1204,7 @@ def _get_color_encoding(
 
             # If the 0th element in the color column looks like a color, we'll use
             # the color column's values as the colors in our chart.
-            if len(df[color_column]) and is_color_like(df[color_column].iat[0]):  # type: ignore[arg-type]
+            if len(df[color_column]) and is_color_like(df[color_column].iat[0]):
                 color_range = [to_css_color(c) for c in df[color_column].unique()]
                 color_enc["scale"] = alt.Scale(range=color_range)
                 # Don't show the color legend, because it will just show text with

--- a/lib/streamlit/elements/lib/color_util.py
+++ b/lib/streamlit/elements/lib/color_util.py
@@ -86,7 +86,7 @@ def to_css_color(color: MaybeColor) -> Color:
     raise StreamlitInvalidColorError(color)
 
 
-def is_css_color_like(color: MaybeColor) -> bool:
+def is_css_color_like(color: object) -> bool:
     """Check whether the input looks like something Vega can use.
 
     This is meant to be lightweight, and not a definitive answer. The definitive solution is to try
@@ -98,7 +98,7 @@ def is_css_color_like(color: MaybeColor) -> bool:
     return is_hex_color_like(color) or _is_cssrgb_color_like(color)
 
 
-def is_hex_color_like(color: MaybeColor) -> bool:
+def is_hex_color_like(color: object) -> bool:
     """Check whether the input looks like a hex color.
 
     This is meant to be lightweight, and not a definitive answer. The definitive solution is to try
@@ -112,7 +112,7 @@ def is_hex_color_like(color: MaybeColor) -> bool:
     )
 
 
-def _is_cssrgb_color_like(color: MaybeColor) -> bool:
+def _is_cssrgb_color_like(color: object) -> bool:
     """Check whether the input looks like a CSS rgb() or rgba() color string.
 
     This is meant to be lightweight, and not a definitive answer. The definitive solution is to try
@@ -124,7 +124,7 @@ def _is_cssrgb_color_like(color: MaybeColor) -> bool:
     return isinstance(color, str) and color.startswith(("rgb(", "rgba("))
 
 
-def is_color_tuple_like(color: MaybeColor) -> bool:
+def is_color_tuple_like(color: object) -> bool:
     """Check whether the input looks like a tuple color.
 
     This is meant to be lightweight, and not a definitive answer. The definitive solution is to try
@@ -137,7 +137,7 @@ def is_color_tuple_like(color: MaybeColor) -> bool:
     )
 
 
-def is_builtin_color_name(color: MaybeColor) -> bool:
+def is_builtin_color_name(color: object) -> bool:
     """Check whether the input is a built-in Streamlit color name.
 
     Built-in color names (red, orange, yellow, green, blue, violet, gray/grey, primary)
@@ -146,7 +146,7 @@ def is_builtin_color_name(color: MaybeColor) -> bool:
     return isinstance(color, str) and color.lower() in BUILTIN_COLOR_NAMES
 
 
-def is_color_like(color: MaybeColor) -> bool:
+def is_color_like(color: object) -> bool:
     """A fairly lightweight check of whether the input is a color.
 
     This isn't meant to be a definitive answer. The definitive solution is to

--- a/lib/streamlit/elements/lib/dialog.py
+++ b/lib/streamlit/elements/lib/dialog.py
@@ -197,7 +197,7 @@ class Dialog(DeltaGenerator):
     def close(self) -> None:
         self._update(False)
 
-    def __enter__(self) -> Self:  # type: ignore[override]
+    def __enter__(self) -> Self:  # type: ignore[override]  # ty: ignore[invalid-method-override]
         # This is a little dubious: we're returning a different type than
         # our superclass' `__enter__` function. Maybe DeltaGenerator.__enter__
         # should always return `self`?
@@ -206,8 +206,8 @@ class Dialog(DeltaGenerator):
 
     def __exit__(
         self,
-        exc_type: type[BaseException] | None,
-        exc_val: BaseException | None,
-        exc_tb: TracebackType | None,
+        typ: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
     ) -> Literal[False]:
-        return super().__exit__(exc_type, exc_val, exc_tb)
+        return super().__exit__(typ, exc, tb)

--- a/lib/streamlit/elements/lib/mutable_expander_container.py
+++ b/lib/streamlit/elements/lib/mutable_expander_container.py
@@ -112,14 +112,14 @@ class ExpanderContainer(DeltaGenerator):
     def open(self, value: bool | None) -> None:
         self._open = value
 
-    def __enter__(self) -> Self:  # type: ignore[override]
+    def __enter__(self) -> Self:  # type: ignore[override]  # ty: ignore[invalid-method-override]
         super().__enter__()
         return self
 
     def __exit__(
         self,
-        exc_type: type[BaseException] | None,
-        exc_val: BaseException | None,
-        exc_tb: TracebackType | None,
+        typ: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
     ) -> Literal[False]:
-        return super().__exit__(exc_type, exc_val, exc_tb)
+        return super().__exit__(typ, exc, tb)

--- a/lib/streamlit/elements/lib/mutable_popover_container.py
+++ b/lib/streamlit/elements/lib/mutable_popover_container.py
@@ -108,14 +108,14 @@ class PopoverContainer(DeltaGenerator):
     def open(self, value: bool | None) -> None:
         self._open = value
 
-    def __enter__(self) -> Self:  # type: ignore[override]
+    def __enter__(self) -> Self:  # type: ignore[override]  # ty: ignore[invalid-method-override]
         super().__enter__()
         return self
 
     def __exit__(
         self,
-        exc_type: type[BaseException] | None,
-        exc_val: BaseException | None,
-        exc_tb: TracebackType | None,
+        typ: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
     ) -> Literal[False]:
-        return super().__exit__(exc_type, exc_val, exc_tb)
+        return super().__exit__(typ, exc, tb)

--- a/lib/streamlit/elements/lib/mutable_status_container.py
+++ b/lib/streamlit/elements/lib/mutable_status_container.py
@@ -172,7 +172,7 @@ class StatusContainer(DeltaGenerator):
         self._current_proto = msg.delta.add_block
         enqueue_message(msg)
 
-    def __enter__(self) -> Self:  # type: ignore[override]
+    def __enter__(self) -> Self:  # type: ignore[override]  # ty: ignore[invalid-method-override]
         # This is a little dubious: we're returning a different type than
         # our superclass' `__enter__` function. Maybe DeltaGenerator.__enter__
         # should always return `self`?
@@ -181,9 +181,9 @@ class StatusContainer(DeltaGenerator):
 
     def __exit__(
         self,
-        exc_type: type[BaseException] | None,
-        exc_val: BaseException | None,
-        exc_tb: TracebackType | None,
+        typ: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
     ) -> Literal[False]:
         # Only update if the current state is running
         if self._current_state == "running":
@@ -193,10 +193,10 @@ class StatusContainer(DeltaGenerator):
             # (to complete) is applied. Adding a short timeout here allows the frontend
             # to render the update before.
             time.sleep(0.05)
-            if exc_type is not None:
+            if typ is not None:
                 # If an exception was raised in the context,
                 # we want to update the status to error.
                 self.update(state="error")
             else:
                 self.update(state="complete")
-        return super().__exit__(exc_type, exc_val, exc_tb)
+        return super().__exit__(typ, exc, tb)

--- a/lib/streamlit/elements/lib/mutable_tab_container.py
+++ b/lib/streamlit/elements/lib/mutable_tab_container.py
@@ -137,14 +137,14 @@ class TabContainer(DeltaGenerator):
     def open(self, value: bool | None) -> None:
         self._open = value
 
-    def __enter__(self) -> Self:  # type: ignore[override]
+    def __enter__(self) -> Self:  # type: ignore[override]  # ty: ignore[invalid-method-override]
         super().__enter__()
         return self
 
     def __exit__(
         self,
-        exc_type: type[BaseException] | None,
-        exc_val: BaseException | None,
-        exc_tb: TracebackType | None,
+        typ: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
     ) -> Literal[False]:
-        return super().__exit__(exc_type, exc_val, exc_tb)
+        return super().__exit__(typ, exc, tb)

--- a/lib/streamlit/elements/lib/options_selector_utils.py
+++ b/lib/streamlit/elements/lib/options_selector_utils.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from dataclasses import replace
 from enum import Enum, EnumMeta
-from typing import TYPE_CHECKING, Any, Final, Literal, TypeVar, overload
+from typing import TYPE_CHECKING, Any, Final, Literal, TypeVar, cast, overload
 
 from streamlit import config, logger
 from streamlit.dataframe_util import OptionSequence, convert_anything_to_list
@@ -240,8 +240,10 @@ def maybe_coerce_enum(
     the original RegisterWidgetResult.
     """
 
-    # If the value is not a Enum, return early
-    if not isinstance(register_widget_result.value, Enum):
+    value = register_widget_result.value
+
+    # If the value is not an Enum, return early
+    if not isinstance(value, Enum):
         return register_widget_result
 
     coerce_class: EnumMeta | None
@@ -251,12 +253,13 @@ def maybe_coerce_enum(
         coerce_class = _extract_common_class_from_iter(opt_sequence)
         if coerce_class is None:
             return register_widget_result
+    enum_class = cast("type[Enum]", coerce_class)
 
     # Use replace so other fields (e.g. incoming_serialized_value) are preserved
     # rather than dropped when only the value is coerced.
     return replace(
         register_widget_result,
-        value=_coerce_enum(register_widget_result.value, coerce_class),
+        value=_coerce_enum(value, enum_class),
     )
 
 
@@ -300,13 +303,15 @@ def maybe_coerce_enum_sequence(
         coerce_class = _extract_common_class_from_iter(opt_sequence)
         if coerce_class is None:
             return register_widget_result
+    enum_class = cast("type[Enum]", coerce_class)
 
     # Return a new RegisterWidgetResult with the coerced enum values sequence.
     # Use replace so other fields (e.g. incoming_serialized_value) are preserved.
     return replace(
         register_widget_result,
         value=type(register_widget_result.value)(
-            _coerce_enum(val, coerce_class) for val in register_widget_result.value
+            _coerce_enum(cast("Enum", val), enum_class)
+            for val in register_widget_result.value
         ),
     )
 

--- a/lib/streamlit/elements/lib/skeleton_placeholder.py
+++ b/lib/streamlit/elements/lib/skeleton_placeholder.py
@@ -117,7 +117,7 @@ class SkeletonPlaceholder(_SkeletonPlaceholderBase):
 
         return dir(DeltaGenerator)
 
-    def __enter__(self) -> Self:  # type: ignore[override]
+    def __enter__(self) -> Self:  # type: ignore[override]  # ty: ignore[invalid-method-override]
         """Enter context manager mode with 0.5s delay before showing skeleton.
 
         In context manager mode, we clear the immediately-shown skeleton and switch

--- a/lib/streamlit/elements/map.py
+++ b/lib/streamlit/elements/map.py
@@ -443,7 +443,7 @@ def _convert_color_arg_or_column(
 
     if color_col_name is not None:
         # Convert color column to the right format.
-        if len(data[color_col_name]) > 0 and is_color_like(data[color_col_name].iat[0]):  # type: ignore[arg-type]
+        if len(data[color_col_name]) > 0 and is_color_like(data[color_col_name].iat[0]):
             # Convert to object dtype first to support tuple values (pandas 3.x infers
             # string columns as StringDtype which can't hold tuples).
             data[color_col_name] = data[color_col_name].astype(object)

--- a/lib/streamlit/elements/plotly_chart.py
+++ b/lib/streamlit/elements/plotly_chart.py
@@ -721,7 +721,9 @@ class PlotlyMixin:
             check_widget_policies(
                 self.dg,
                 key,
-                on_change=cast("WidgetCallback", on_select) if is_callback else None,
+                on_change=cast("WidgetCallback", on_select)  # ty: ignore[redundant-cast]
+                if is_callback
+                else None,
                 default_value=None,
                 writes_allowed=False,
                 enable_check_callback_rules=is_callback,

--- a/lib/streamlit/elements/table.py
+++ b/lib/streamlit/elements/table.py
@@ -114,7 +114,7 @@ def _compute_hide_index(
     # For Styler objects, check the underlying data
     if dataframe_util.is_pandas_styler(data):
         # Styler.data is the underlying DataFrame
-        return dataframe_util.has_range_index(data.data)  # type: ignore[attr-defined]
+        return dataframe_util.has_range_index(data.data)  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
 
     # If data is already a pandas DataFrame, check directly without conversion
     if isinstance(data, pd.DataFrame):

--- a/lib/streamlit/elements/vega_charts.py
+++ b/lib/streamlit/elements/vega_charts.py
@@ -2316,7 +2316,9 @@ class VegaChartsMixin:
             check_widget_policies(
                 self.dg,
                 key,
-                on_change=cast("WidgetCallback", on_select) if is_callback else None,
+                on_change=cast("WidgetCallback", on_select)  # ty: ignore[redundant-cast]
+                if is_callback
+                else None,
                 default_value=None,
                 writes_allowed=False,
                 enable_check_callback_rules=is_callback,
@@ -2325,7 +2327,7 @@ class VegaChartsMixin:
         # Support passing data inside spec['datasets'] and spec['data'].
         # (The data gets pulled out of the spec dict later on.)
         if isinstance(data, dict) and spec is None:
-            spec = data
+            spec = cast("VegaLiteSpec", data)
             data = None
 
         if spec is None:

--- a/lib/streamlit/elements/widgets/button.py
+++ b/lib/streamlit/elements/widgets/button.py
@@ -1399,7 +1399,7 @@ class ButtonMixin:
         on_click_callback: WidgetCallback | None = (
             None
             if on_click is None or on_click in {"ignore", "rerun"}
-            else cast("WidgetCallback", on_click)
+            else cast("WidgetCallback", on_click)  # ty: ignore[redundant-cast]
         )
 
         normalized_shortcut: str | None = None
@@ -1510,7 +1510,7 @@ class ButtonMixin:
         on_click_callback: WidgetCallback | None = (
             None
             if on_click in {"ignore", "rerun"}
-            else cast("WidgetCallback", on_click)
+            else cast("WidgetCallback", on_click)  # ty: ignore[redundant-cast]
         )
 
         link_button_proto = LinkButtonProto()
@@ -1851,9 +1851,13 @@ def marshall_file(
             proto_download_button.url = ""
             return
 
+        data_callable = cast(  # type: ignore[redundant-cast]
+            "Callable[[], str | bytes | TextIO | BinaryIO | io.RawIOBase]", data
+        )
+
         # Register the callable for deferred execution
         file_id = runtime.get_instance().media_file_mgr.add_deferred(
-            data,
+            data_callable,
             mimetype,
             coordinates,
             file_name=file_name,

--- a/lib/streamlit/elements/widgets/button.py
+++ b/lib/streamlit/elements/widgets/button.py
@@ -1851,6 +1851,7 @@ def marshall_file(
             proto_download_button.url = ""
             return
 
+        # ty needs this cast; mypy already narrows via callable() above.
         data_callable = cast(  # type: ignore[redundant-cast]
             "Callable[[], str | bytes | TextIO | BinaryIO | io.RawIOBase]", data
         )

--- a/lib/streamlit/elements/widgets/chat.py
+++ b/lib/streamlit/elements/widgets/chat.py
@@ -406,8 +406,8 @@ class ChatInputSerde:
             _include_audio=self.accept_audio,
         )
 
-    def serialize(self, v: str | None) -> ChatInputValueProto:
-        return ChatInputValueProto(data=v)
+    def serialize(self, v: str | ChatInputValue | None) -> ChatInputValueProto:
+        return ChatInputValueProto(data=v.text if isinstance(v, ChatInputValue) else v)
 
 
 class ChatMixin:
@@ -1066,7 +1066,7 @@ class ChatMixin:
             accept_audio=accept_audio,
             allowed_types=file_type,
         )
-        widget_state = register_widget(  # type: ignore[misc]
+        widget_state = register_widget(
             chat_input_proto.id,
             on_change_handler=on_submit,
             args=args,
@@ -1091,7 +1091,7 @@ class ChatMixin:
         else:
             chat_input_proto.submit_mode = ChatInputProto.SubmitMode.SUBMIT_MODE_SUBMIT
 
-        if widget_state.value_changed and widget_state.value is not None:
+        if widget_state.value_changed and isinstance(widget_state.value, str):
             # Support for programmatically setting the text in the chat input
             # via session state. Since chat input has a trigger state,
             # it works a bit differently to other widgets. We are not changing

--- a/lib/streamlit/elements/widgets/chat.py
+++ b/lib/streamlit/elements/widgets/chat.py
@@ -1091,6 +1091,8 @@ class ChatMixin:
         else:
             chat_input_proto.submit_mode = ChatInputProto.SubmitMode.SUBMIT_MODE_SUBMIT
 
+        # Only plain str values are pushed to the frontend. ChatInputValue is the
+        # deserialized submit/return form and is not a valid programmatic set_value.
         if widget_state.value_changed and isinstance(widget_state.value, str):
             # Support for programmatically setting the text in the chat input
             # via session state. Since chat input has a trigger state,
@@ -1109,7 +1111,10 @@ class ChatMixin:
 
         if ctx:
             save_for_app_testing(ctx, element_id, widget_state.value)
-        has_one_shot = widget_state.value_changed and widget_state.value is not None
+        # Match the set_value guard so one-shot only fires when a str was pushed.
+        has_one_shot = widget_state.value_changed and isinstance(
+            widget_state.value, str
+        )
         if position == "bottom":
             # We need to enqueue the chat input into the bottom container
             # instead of the currently active dg.

--- a/lib/streamlit/elements/widgets/number_input.py
+++ b/lib/streamlit/elements/widgets/number_input.py
@@ -707,13 +707,12 @@ class NumberInputMixin:
             number_input_proto.query_param_key = str(key)
 
         # min_value and max_value are guaranteed to be Number (not None) after
-        # the JSNumber defaults above. The casts are needed for ty (which doesn't
-        # narrow the type), but mypy sees them as redundant.
+        # the JSNumber defaults above.
         serde = NumberInputSerde(
             value,
             data_type,
-            cast("Number", min_value),  # type: ignore[redundant-cast]
-            cast("Number", max_value),  # type: ignore[redundant-cast]
+            min_value,
+            max_value,
         )
         widget_state = register_widget(
             number_input_proto.id,

--- a/lib/streamlit/elements/widgets/slider.py
+++ b/lib/streamlit/elements/widgets/slider.py
@@ -994,11 +994,11 @@ class SliderMixin:
         # already known to be in the [min_value, max_value] range.)
         try:
             if all_ints:
-                JSNumber.validate_int_bounds(min_value, "`min_value`")
-                JSNumber.validate_int_bounds(max_value, "`max_value`")
+                JSNumber.validate_int_bounds(cast("int", min_value), "`min_value`")
+                JSNumber.validate_int_bounds(cast("int", max_value), "`max_value`")
             elif all_floats:
-                JSNumber.validate_float_bounds(min_value, "`min_value`")
-                JSNumber.validate_float_bounds(max_value, "`max_value`")
+                JSNumber.validate_float_bounds(cast("float", min_value), "`min_value`")
+                JSNumber.validate_float_bounds(cast("float", max_value), "`max_value`")
             elif all_timelikes:
                 # No validation yet. TODO: check between 0001-01-01 to 9999-12-31
                 pass
@@ -1066,8 +1066,8 @@ class SliderMixin:
         slider_proto.label = label
         slider_proto.format = format
         slider_proto.default[:] = prepared_value
-        slider_proto.min = min_value
-        slider_proto.max = max_value
+        slider_proto.min = cast("int | float", min_value)
+        slider_proto.max = cast("int | float", max_value)
         slider_proto.step = cast("float", step)
         slider_proto.data_type = data_type
         slider_proto.options[:] = []
@@ -1088,10 +1088,9 @@ class SliderMixin:
             data_type,
             single_value,
             orig_tz,
-            # Proto min/max are always serialized as doubles (dates/times
-            # become microsecond floats), so the cast is safe here.
-            min_value=cast("float", slider_proto.min),  # type: ignore[redundant-cast]
-            max_value=cast("float", slider_proto.max),  # type: ignore[redundant-cast]
+            # Proto min/max are doubles (dates/times become microsecond floats).
+            min_value=slider_proto.min,
+            max_value=slider_proto.max,
         )
 
         widget_state = register_widget(

--- a/lib/streamlit/navigation/page.py
+++ b/lib/streamlit/navigation/page.py
@@ -497,7 +497,7 @@ def _create_page(page: str | Path, *, default: bool = False) -> Page:
     page_object = Page.__new__(Page)
     # ``gather_metrics`` wraps ``__init__``, so ``__wrapped__`` is the original
     # initializer; calling it directly skips the telemetry recorded for st.Page.
-    Page.__init__.__wrapped__(  # type: ignore[attr-defined]
+    Page.__init__.__wrapped__(  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
         page_object, page, default=default
     )
     return page_object

--- a/lib/streamlit/runtime/caching/cache_data_api.py
+++ b/lib/streamlit/runtime/caching/cache_data_api.py
@@ -134,11 +134,6 @@ class CachedDataFuncInfo(CachedFuncInfo[P, R]):
     def cached_message_replay_ctx(self) -> CachedMessageReplayContext:
         return CACHE_DATA_MESSAGE_REPLAY_CTX
 
-    @property
-    def display_name(self) -> str:
-        """A human-readable name for the cached function."""
-        return f"{self.func.__module__}.{self.func.__qualname__}"
-
     def get_function_cache(self, function_key: str) -> Cache[R]:
         return _data_caches.get_cache(
             key=function_key,
@@ -157,8 +152,10 @@ class CachedDataFuncInfo(CachedFuncInfo[P, R]):
         When called, this method could log warnings if cache params are invalid
         for current storage.
         """
+        # self.func is typed as Callable, which does not expose __name__.
+        function_name = getattr(self.func, "__name__", "?")
         _data_caches.validate_cache_params(
-            function_name=self.func.__name__,
+            function_name=function_name,
             persist=self.persist,
             max_entries=self.max_entries,
             ttl=self.ttl,
@@ -321,8 +318,11 @@ class DataCaches(StatsProvider):
             self._function_caches = {}
 
     def get_stats(
-        self, _family_names: Sequence[str] | None = None
+        self, family_names: Sequence[str] | None = None
     ) -> dict[str, list[CacheStat]]:
+        # StatsProvider requires family_names; this provider always returns all families.
+        del family_names
+
         with self._caches_lock:
             # Shallow-clone our caches. We don't want to hold the global
             # lock during stats-gathering.
@@ -813,13 +813,13 @@ class DataCache(Cache[R]):
             return cast("dict[str, list[CacheStat]]", self.storage.get_stats())
         return {}
 
-    def read_result(self, key: str) -> CachedResult[R]:
+    def read_result(self, value_key: str) -> CachedResult[R]:
         """Read a value and messages from the cache. Raise `CacheKeyNotFoundError`
         if the value doesn't exist, and `CacheError` if the value exists but can't
         be unpickled.
         """
         try:
-            pickled_entry = self.storage.get(key)
+            pickled_entry = self.storage.get(value_key)
         except CacheStorageKeyNotFoundError as e:
             raise CacheKeyNotFoundError(str(e)) from e
         except CacheStorageError as e:
@@ -830,11 +830,11 @@ class DataCache(Cache[R]):
             if not isinstance(entry, CachedResult):
                 # Loaded an old cache file format, remove it and let the caller
                 # rerun the function.
-                self.storage.delete(key)
+                self.storage.delete(value_key)
                 raise CacheKeyNotFoundError()
             return entry
         except pickle.UnpicklingError as exc:
-            raise CacheError(f"Failed to unpickle {key}") from exc
+            raise CacheError(f"Failed to unpickle {value_key}") from exc
 
     def _is_stale(self, result: CachedResult[R]) -> bool:
         """Whether a present entry is in the stale grace window ``[ttl, 2*ttl)``."""
@@ -849,7 +849,7 @@ class DataCache(Cache[R]):
         ) >= self.fresh_ttl_seconds
 
     @gather_metrics("_cache_data_object")
-    def write_result(self, key: str, value: R, messages: list[MsgData]) -> None:
+    def write_result(self, value_key: str, value: R, messages: list[MsgData]) -> None:
         """Write a value and associated messages to the cache.
         The value must be pickleable.
         """
@@ -869,8 +869,8 @@ class DataCache(Cache[R]):
             )
             pickled_entry = pickle.dumps(entry)
         except (pickle.PicklingError, TypeError) as exc:
-            raise CacheError(f"Failed to pickle {key}") from exc
-        self.storage.set(key, pickled_entry)
+            raise CacheError(f"Failed to pickle {value_key}") from exc
+        self.storage.set(value_key, pickled_entry)
 
     def write_background_refresh_result(
         self,

--- a/lib/streamlit/runtime/caching/cache_data_api.py
+++ b/lib/streamlit/runtime/caching/cache_data_api.py
@@ -318,11 +318,9 @@ class DataCaches(StatsProvider):
             self._function_caches = {}
 
     def get_stats(
-        self, family_names: Sequence[str] | None = None
+        self,
+        family_names: Sequence[str] | None = None,  # noqa: ARG002
     ) -> dict[str, list[CacheStat]]:
-        # StatsProvider requires family_names; this provider always returns all families.
-        del family_names
-
         with self._caches_lock:
             # Shallow-clone our caches. We don't want to hold the global
             # lock during stats-gathering.

--- a/lib/streamlit/runtime/caching/cache_resource_api.py
+++ b/lib/streamlit/runtime/caching/cache_resource_api.py
@@ -212,11 +212,9 @@ class ResourceCaches(StatsProvider):
             cache.clear()
 
     def get_stats(
-        self, family_names: Sequence[str] | None = None
+        self,
+        family_names: Sequence[str] | None = None,  # noqa: ARG002
     ) -> dict[str, list[CacheStat]]:
-        # StatsProvider requires family_names; this provider always returns all families.
-        del family_names
-
         function_caches: list[ResourceCache[Any]]
         with self._caches_lock:
             # Shallow-clone our caches. We don't want to hold the global

--- a/lib/streamlit/runtime/caching/cache_resource_api.py
+++ b/lib/streamlit/runtime/caching/cache_resource_api.py
@@ -212,8 +212,11 @@ class ResourceCaches(StatsProvider):
             cache.clear()
 
     def get_stats(
-        self, _family_names: Sequence[str] | None = None
+        self, family_names: Sequence[str] | None = None
     ) -> dict[str, list[CacheStat]]:
+        # StatsProvider requires family_names; this provider always returns all families.
+        del family_names
+
         function_caches: list[ResourceCache[Any]]
         with self._caches_lock:
             # Shallow-clone our caches. We don't want to hold the global
@@ -291,11 +294,6 @@ class CachedResourceFuncInfo(CachedFuncInfo[P, R]):
     @property
     def cached_message_replay_ctx(self) -> CachedMessageReplayContext:
         return CACHE_RESOURCE_MESSAGE_REPLAY_CTX
-
-    @property
-    def display_name(self) -> str:
-        """A human-readable name for the cached function."""
-        return f"{self.func.__module__}.{self.func.__qualname__}"
 
     def get_function_cache(self, function_key: str) -> Cache[R]:
         return _resource_caches.get_cache(
@@ -753,26 +751,26 @@ class ResourceCache(Cache[R]):
             cache_utils.TTLCACHE_TIMER() - result.stored_at
         ) >= self.fresh_ttl_seconds
 
-    def read_result(self, key: str) -> CachedResult[R]:
+    def read_result(self, value_key: str) -> CachedResult[R]:
         """Read a value and associated messages from the cache.
         Raise `CacheKeyNotFoundError` if the value doesn't exist.
         """
         with self._mem_cache_lock:
-            if key not in self._mem_cache:
+            if value_key not in self._mem_cache:
                 # key does not exist in cache.
                 raise CacheKeyNotFoundError()
 
-            result = self._mem_cache[key]
+            result = self._mem_cache[value_key]
 
             if self.validate is not None and not self.validate(result.value):
                 # Validate failed: delete the entry and raise an error.
-                del self._mem_cache[key]
+                del self._mem_cache[value_key]
                 raise CacheKeyNotFoundError()
 
             return result
 
     @gather_metrics("_cache_resource_object")
-    def write_result(self, key: str, value: R, messages: list[MsgData]) -> None:
+    def write_result(self, value_key: str, value: R, messages: list[MsgData]) -> None:
         """Write a value and associated messages to the cache."""
         main_id = st._main._id
         sidebar_id = st.sidebar._id
@@ -782,7 +780,7 @@ class ResourceCache(Cache[R]):
             cache_utils.TTLCACHE_TIMER() if self.refresh_mode == "background" else None
         )
         with self._mem_cache_lock:
-            self._mem_cache[key] = CachedResult(
+            self._mem_cache[value_key] = CachedResult(
                 value, messages, main_id, sidebar_id, stored_at=stored_at
             )
 

--- a/lib/streamlit/runtime/caching/cache_utils.py
+++ b/lib/streamlit/runtime/caching/cache_utils.py
@@ -239,7 +239,7 @@ class Cache(Generic[R]):
         result = self.read_result(value_key)
         return CacheReadResult(result, is_stale=self._is_stale(result))
 
-    def _is_stale(self, _result: CachedResult[R]) -> bool:
+    def _is_stale(self, _result: CachedResult[R], /) -> bool:
         """Whether a present entry is past its fresh ttl.
 
         Always ``False`` for foreground caches. Background-mode caches override this to
@@ -390,6 +390,13 @@ class CachedFuncInfo(Generic[P, R]):
     @property
     def cached_message_replay_ctx(self) -> CachedMessageReplayContext:
         raise NotImplementedError
+
+    @property
+    def display_name(self) -> str:
+        """A human-readable name for the cached function."""
+        # self.func is typed as Callable, which does not expose these attributes.
+        func = cast("FunctionType", self.func)
+        return f"{func.__module__}.{func.__qualname__}"
 
     def get_function_cache(self, function_key: str) -> Cache[R]:
         """Get or create the function cache for the given key.

--- a/lib/streamlit/runtime/caching/cache_utils.py
+++ b/lib/streamlit/runtime/caching/cache_utils.py
@@ -395,8 +395,9 @@ class CachedFuncInfo(Generic[P, R]):
     def display_name(self) -> str:
         """A human-readable name for the cached function."""
         # self.func is typed as Callable, which does not expose these attributes.
-        func = cast("FunctionType", self.func)
-        return f"{func.__module__}.{func.__qualname__}"
+        module = getattr(self.func, "__module__", "?")
+        qualname = getattr(self.func, "__qualname__", "?")
+        return f"{module}.{qualname}"
 
     def get_function_cache(self, function_key: str) -> Cache[R]:
         """Get or create the function cache for the given key.

--- a/lib/streamlit/runtime/caching/cache_utils.py
+++ b/lib/streamlit/runtime/caching/cache_utils.py
@@ -239,6 +239,7 @@ class Cache(Generic[R]):
         result = self.read_result(value_key)
         return CacheReadResult(result, is_stale=self._is_stale(result))
 
+    # Positional-only so subclasses can name the parameter freely (e.g. result).
     def _is_stale(self, _result: CachedResult[R], /) -> bool:
         """Whether a present entry is past its fresh ttl.
 

--- a/lib/streamlit/runtime/connection_factory.py
+++ b/lib/streamlit/runtime/connection_factory.py
@@ -111,7 +111,7 @@ def _create_connection(
     def on_release_wrapped(connection: ConnectionClass) -> None:
         connection.close()
 
-    __create_connection = cache_resource(
+    cached_create_connection = cache_resource(
         max_entries=max_entries,
         show_spinner="Running `st.connection(...)`.",
         ttl=ttl,
@@ -119,7 +119,7 @@ def _create_connection(
         on_release=on_release_wrapped,
     )(__create_connection)
 
-    return __create_connection(name, connection_class, **kwargs)
+    return cached_create_connection(name, connection_class, **kwargs)
 
 
 def _get_first_party_connection(connection_class: str) -> type[BaseConnection[Any]]:

--- a/lib/streamlit/runtime/memory_media_file_storage.py
+++ b/lib/streamlit/runtime/memory_media_file_storage.py
@@ -208,11 +208,9 @@ class MemoryMediaFileStorage(MediaFileStorage, StatsProvider):
             raise MediaFileStorageError(f"Error opening '{filename}'") from ex
 
     def get_stats(
-        self, family_names: Sequence[str] | None = None
+        self,
+        family_names: Sequence[str] | None = None,  # noqa: ARG002
     ) -> dict[str, list[CacheStat]]:
-        # StatsProvider requires family_names; this provider always returns all families.
-        del family_names
-
         # We operate on a copy of our dict, to avoid race conditions
         # with other threads that may be manipulating the cache.
         files_by_id = self._files_by_id.copy()

--- a/lib/streamlit/runtime/memory_media_file_storage.py
+++ b/lib/streamlit/runtime/memory_media_file_storage.py
@@ -208,8 +208,11 @@ class MemoryMediaFileStorage(MediaFileStorage, StatsProvider):
             raise MediaFileStorageError(f"Error opening '{filename}'") from ex
 
     def get_stats(
-        self, _family_names: Sequence[str] | None = None
+        self, family_names: Sequence[str] | None = None
     ) -> dict[str, list[CacheStat]]:
+        # StatsProvider requires family_names; this provider always returns all families.
+        del family_names
+
         # We operate on a copy of our dict, to avoid race conditions
         # with other threads that may be manipulating the cache.
         files_by_id = self._files_by_id.copy()

--- a/lib/streamlit/runtime/memory_uploaded_file_manager.py
+++ b/lib/streamlit/runtime/memory_uploaded_file_manager.py
@@ -148,15 +148,13 @@ class MemoryUploadedFileManager(UploadedFileManager):
         return result
 
     def get_stats(
-        self, family_names: Sequence[str] | None = None
+        self,
+        family_names: Sequence[str] | None = None,  # noqa: ARG002
     ) -> dict[str, list[CacheStat]]:
         """Return the manager's CacheStats.
 
         Safe to call from any thread.
         """
-        # StatsProvider requires family_names; this provider always returns all families.
-        del family_names
-
         with self._lock:
             total_bytes = self._total_bytes
             file_count = self._file_count

--- a/lib/streamlit/runtime/memory_uploaded_file_manager.py
+++ b/lib/streamlit/runtime/memory_uploaded_file_manager.py
@@ -148,12 +148,15 @@ class MemoryUploadedFileManager(UploadedFileManager):
         return result
 
     def get_stats(
-        self, _family_names: Sequence[str] | None = None
+        self, family_names: Sequence[str] | None = None
     ) -> dict[str, list[CacheStat]]:
         """Return the manager's CacheStats.
 
         Safe to call from any thread.
         """
+        # StatsProvider requires family_names; this provider always returns all families.
+        del family_names
+
         with self._lock:
             total_bytes = self._total_bytes
             file_count = self._file_count

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -188,12 +188,12 @@ class WStates(MutableMapping[str, Any]):
 
         if is_array_value_field_name(value_field_name):
             # Array types are messages with data in a `data` field
-            value = cast("Any", value).data
+            value = value.data
         elif value_field_name == "json_value":
             value = json.loads(cast("str", value))
         elif value_field_name == "string_trigger_value":
             # StringTriggerValue is a message with data in a `data` field
-            value = cast("Any", value).data
+            value = value.data
 
         deserialized = metadata.deserializer(value)
 
@@ -1644,8 +1644,11 @@ class SessionState:
             return True
 
     def get_stats(
-        self, _family_names: Sequence[str] | None = None
+        self, family_names: Sequence[str] | None = None
     ) -> dict[str, list[CacheStat]]:
+        # StatsProvider requires family_names; this provider always returns all families.
+        del family_names
+
         if config.get_option("server.enableExpensiveMemoryStats"):
             from streamlit.runtime.stats import safe_sizeof
 
@@ -1720,8 +1723,11 @@ class SessionStateStatProvider(StatsProvider):
         return (CACHE_MEMORY_FAMILY,)
 
     def get_stats(
-        self, _family_names: Sequence[str] | None = None
+        self, family_names: Sequence[str] | None = None
     ) -> dict[str, list[CacheStat]]:
+        # StatsProvider requires family_names; this provider always returns all families.
+        del family_names
+
         stats: list[CacheStat] = []
         for session_info in self._session_mgr.list_active_sessions():
             session_state = session_info.session.session_state

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -1644,11 +1644,9 @@ class SessionState:
             return True
 
     def get_stats(
-        self, family_names: Sequence[str] | None = None
+        self,
+        family_names: Sequence[str] | None = None,  # noqa: ARG002
     ) -> dict[str, list[CacheStat]]:
-        # StatsProvider requires family_names; this provider always returns all families.
-        del family_names
-
         if config.get_option("server.enableExpensiveMemoryStats"):
             from streamlit.runtime.stats import safe_sizeof
 
@@ -1723,11 +1721,9 @@ class SessionStateStatProvider(StatsProvider):
         return (CACHE_MEMORY_FAMILY,)
 
     def get_stats(
-        self, family_names: Sequence[str] | None = None
+        self,
+        family_names: Sequence[str] | None = None,  # noqa: ARG002
     ) -> dict[str, list[CacheStat]]:
-        # StatsProvider requires family_names; this provider always returns all families.
-        del family_names
-
         stats: list[CacheStat] = []
         for session_info in self._session_mgr.list_active_sessions():
             session_state = session_info.session.session_state

--- a/lib/streamlit/runtime/stats.py
+++ b/lib/streamlit/runtime/stats.py
@@ -329,8 +329,10 @@ class StatsProvider(Protocol):
         family_names : Sequence[str] | None
             If provided, only stats for these metric families should be computed
             and returned. If None, stats for all families this provider supports
-            should be returned. Providers should check this parameter and skip
-            computing expensive stats for families that aren't requested.
+            should be returned. Providers that serve multiple families should
+            check this parameter and skip computing unrequested families.
+            Single-family providers may rely on StatsManager only dispatching
+            them when their family is requested.
 
         Returns
         -------

--- a/lib/streamlit/web/cli.py
+++ b/lib/streamlit/web/cli.py
@@ -419,10 +419,14 @@ def _main_run(
     discovery_result = discover_asgi_app(Path(main_script_path))
 
     if discovery_result.is_asgi_app:
+        app_import_string = discovery_result.import_string
+        if app_import_string is None:  # pragma: no cover - defensive
+            raise RuntimeError("ASGI app discovery did not return an import string")
+
         # Run as ASGI app with uvicorn
         bootstrap.run_asgi_app(
             main_script_path,
-            discovery_result.import_string,  # type: ignore[arg-type]
+            app_import_string,
             args,
             flag_options,
         )

--- a/lib/tests/streamlit/elements/chat_test.py
+++ b/lib/tests/streamlit/elements/chat_test.py
@@ -220,6 +220,15 @@ class ChatTest(DeltaGeneratorTestCase):
         assert c.value == "Foo"
         assert c.set_value is True
 
+    def test_rejects_non_str_programmatic_value_assignment(self):
+        """Non-str session-state values must not trigger set_value."""
+        st.session_state.my_key = ChatInputValue(text="Foo", files=[])
+        st.chat_input(key="my_key")
+
+        c = self.get_delta_from_queue().new_element.chat_input
+        assert c.set_value is False
+        assert c.value == ""
+
     def test_chat_input_cached_widget_replay_warning(self):
         """Test that a warning is shown when this widget is used inside a cached function."""
         st.cache_data(lambda: st.chat_input("the label"))()

--- a/lib/tests/streamlit/elements/chat_test.py
+++ b/lib/tests/streamlit/elements/chat_test.py
@@ -958,6 +958,20 @@ class ChatInputSerdeTest(DeltaGeneratorTestCase):
         assert isinstance(result, ChatInputValueProto)
         assert result.data == "test message"
 
+    def test_serialize_chat_input_value_uses_text(self):
+        """Test serialize extracts .text from a ChatInputValue."""
+        serde = ChatInputSerde(accept_files=True, accept_audio=False)
+        value = ChatInputValue(
+            text="structured message",
+            files=[],
+            _include_files=True,
+            _include_audio=False,
+        )
+        result = serde.serialize(value)
+
+        assert isinstance(result, ChatInputValueProto)
+        assert result.data == "structured message"
+
     def test_serialize_with_none(self):
         """Test serialize handles None value - field is not set."""
         serde = ChatInputSerde(accept_files=False, accept_audio=False)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -483,18 +483,6 @@ ignore_missing_imports = true
 [tool.ty.environment]
 root = ["./lib"]
 
-[tool.ty.analysis]
-# Preserve the historically loose cross-module behavior: treat all first-party
-# `streamlit.*` imports as `Any` instead of resolving them. This keeps ty focused
-# on stdlib/third-party correctness (as it was under the previous flattened root,
-# where `streamlit.*` was unresolved and silenced) without surfacing pre-existing
-# intra-package typing debt that is out of scope here. mypy still resolves and
-# checks first-party types, so this does not reduce overall type coverage.
-# TODO(https://github.com/astral-sh/ty/issues/2443): narrow or drop this once ty
-# handles a first-party `typing.py` without shadowing the stdlib module, so ty can
-# eventually add value on first-party code too.
-replace-imports-with-any = ["streamlit.**"]
-
 [tool.ty.src]
 include = ["lib/streamlit", "e2e_playwright", "scripts"]
 exclude = [
@@ -507,8 +495,3 @@ unresolved-import = "ignore"
 possibly-unresolved-reference = "error"
 unused-ignore-comment = "ignore"
 unused-type-ignore-comment = "ignore"
-# `streamlit.*` imports are replaced with `Any` (see [tool.ty.analysis]), so casts
-# to those types are reported as redundant. Disable the rule to avoid false
-# positives; mypy still enforces `warn_redundant_casts = true` with real type
-# resolution, so genuine redundant casts are still caught.
-redundant-cast = "ignore"


### PR DESCRIPTION
## Describe your changes

Enables Astral's `ty` type checker to resolve first-party `streamlit.*` imports (previously replaced with `Any`) and fixes the resulting type errors across the library and e2e apps.

- Drops `replace-imports-with-any = ["streamlit.**"]` and the `redundant-cast` ignore in `pyproject.toml` so `ty` checks real first-party types alongside mypy
- Prefers real narrowing/annotation fixes; uses dual `# type: ignore` / `# ty: ignore` only where mypy and ty disagree
- Fixes `ChatInputSerde` to serialize `ChatInputValue` via `.text`, and limits programmatic chat-input `set_value` to string session-state values
- Documents the dual-checker workflow in `CONTRIBUTING.md` and Python agent rules

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- Added unit coverage for `ChatInputSerde.serialize(ChatInputValue)`; existing unit and e2e suites cover other runtime behavior touched for type correctness
- [x] Unit Tests (JS and/or Python) — existing suite still passes under `make check`
- [ ] E2E Tests — e2e apps updated for ty (suppressions / public `st.components.v2` path); no new e2e scenarios


Made with [Cursor](https://cursor.com)