### PR TITLE
Fix: theme update application to `st.plotly_chart`

### DIFF
--- a/frontend/lib/src/components/elements/PlotlyChart/PlotlyChart.test.tsx
+++ b/frontend/lib/src/components/elements/PlotlyChart/PlotlyChart.test.tsx
@@ -43,15 +43,23 @@ vi.mock("~lib/hooks/useCalculatedDimensions", () => ({
   }),
 }))
 
+// Mutable holder so individual tests can simulate a theme change (e.g. a
+// light<->dark toggle) by swapping the value returned by useEmotionTheme.
+const themeHolder = vi.hoisted<{ current: unknown }>(() => ({ current: null }))
+
 vi.mock("~lib/hooks/useEmotionTheme", () => ({
-  useEmotionTheme: () => mockTheme.emotion,
+  useEmotionTheme: () => themeHolder.current,
 }))
 
-vi.mock("./utils", () => ({
-  applyTheming: vi.fn(spec => spec),
-  handleSelection: vi.fn(),
-  sendEmptySelection: vi.fn(),
-}))
+vi.mock("./utils", async importOriginal => {
+  const actual = await importOriginal<typeof import("./utils")>()
+  return {
+    ...actual,
+    applyTheming: vi.fn(spec => spec),
+    handleSelection: vi.fn(),
+    sendEmptySelection: vi.fn(),
+  }
+})
 
 vi.mock("~lib/components/widgets/Form/FormClearHelper", () => {
   return {
@@ -126,7 +134,9 @@ describe("PlotlyChart Component", () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(applyTheming).mockImplementation(spec => spec)
     widgetMgr = createWidgetManager()
+    themeHolder.current = mockTheme.emotion
   })
 
   it("renders without crashing", () => {
@@ -154,6 +164,146 @@ describe("PlotlyChart Component", () => {
 
     const lastCallProps = getLastPlotProps()
     expect(lastCallProps.layout.title).toBe("Recovered")
+  })
+
+  it("re-themes from the original spec when the theme changes", () => {
+    const buildTree = (): React.ReactElement => (
+      <ElementFullscreenContext.Provider
+        value={{
+          expanded: false,
+          width: 600,
+          height: 500,
+          expand: vi.fn(),
+          collapse: vi.fn(),
+        }}
+      >
+        <PlotlyChart
+          element={DEFAULT_ELEMENT}
+          widgetMgr={widgetMgr}
+          disabled={false}
+          width={600}
+        />
+      </ElementFullscreenContext.Provider>
+    )
+
+    const { rerender } = render(buildTree())
+    // Ignore the initial theming from the useState initializer; we only care
+    // about what happens on the subsequent theme change.
+    vi.mocked(applyTheming).mockClear()
+
+    // Simulate a theme change (e.g. light -> dark) and re-render.
+    const newTheme = { ...mockTheme.emotion }
+    themeHolder.current = newTheme
+    act(() => {
+      rerender(buildTree())
+    })
+
+    // The figure must be re-themed from the pristine spec (which still holds
+    // the categorical/sequential/diverging palette placeholders) using the new
+    // theme - not from the already-themed figure, whose placeholders were
+    // consumed on the previous render.
+    expect(applyTheming).toHaveBeenCalledWith(
+      expect.objectContaining({
+        layout: expect.objectContaining({ title: "Test Chart" }),
+      }),
+      "streamlit",
+      newTheme
+    )
+
+    // The pristine spec has no runtime dimensions baked into its layout, which
+    // confirms we re-themed the original spec rather than the current figure.
+    const rethemeCall = vi
+      .mocked(applyTheming)
+      .mock.calls.find(call => call[2] === newTheme)
+    expect(
+      (rethemeCall?.[0] as { layout?: { width?: number } })?.layout?.width
+    ).toBeUndefined()
+  })
+
+  it("preserves selection modes and axis ranges across theme changes", () => {
+    const selectableElement = new PlotlyChartProto({
+      ...DEFAULT_ELEMENT,
+      selectionMode: [
+        PlotlyChartProto.SelectionMode.POINTS,
+        PlotlyChartProto.SelectionMode.BOX,
+      ],
+    })
+
+    // Seed recovered figure state with interactive fields that would otherwise
+    // be wiped by re-theming from the pristine spec.
+    const interactiveFigure = {
+      data: [{ type: "scatter", x: [1, 2], y: [1, 2], selectedpoints: [1] }],
+      layout: {
+        title: "Recovered",
+        width: 600,
+        height: 450,
+        clickmode: "event+select",
+        hovermode: "closest",
+        dragmode: "pan",
+        xaxis: { range: [0, 10], autorange: false, gridcolor: "#old" },
+        yaxis: { range: [0, 20], gridcolor: "#old" },
+      },
+    }
+    vi.mocked(widgetMgr.getElementState).mockReturnValue(interactiveFigure)
+
+    // applyTheming is mocked as identity-ish, so re-theme returns the pristine
+    // spec plus fresh themed axis styling. preserveFigureInteractionState must
+    // carry interactive fields back from the previous figure.
+    vi.mocked(applyTheming).mockImplementation(spec => {
+      const figure = spec as {
+        data: unknown[]
+        layout?: Record<string, unknown>
+        frames?: unknown
+      }
+      return {
+        ...figure,
+        layout: {
+          ...figure.layout,
+          xaxis: { gridcolor: "#new" },
+          yaxis: { gridcolor: "#new" },
+        },
+      } as typeof spec
+    })
+
+    const buildTree = (): React.ReactElement => (
+      <ElementFullscreenContext.Provider
+        value={{
+          expanded: false,
+          width: 600,
+          height: 500,
+          expand: vi.fn(),
+          collapse: vi.fn(),
+        }}
+      >
+        <PlotlyChart
+          element={selectableElement}
+          widgetMgr={widgetMgr}
+          disabled={false}
+          width={600}
+        />
+      </ElementFullscreenContext.Provider>
+    )
+
+    const { rerender } = render(buildTree())
+
+    const newTheme = { ...mockTheme.emotion }
+    themeHolder.current = newTheme
+    act(() => {
+      rerender(buildTree())
+    })
+
+    const lastCallProps = getLastPlotProps()
+    expect(lastCallProps.layout.clickmode).toBe("event+select")
+    expect(lastCallProps.layout.hovermode).toBe("closest")
+    expect(lastCallProps.layout.dragmode).toBe("pan")
+    expect(lastCallProps.layout.xaxis?.range).toEqual([0, 10])
+    expect(lastCallProps.layout.yaxis?.range).toEqual([0, 20])
+    // Themed styling comes from the rethemed figure, not the previous theme.
+    expect(lastCallProps.layout.xaxis?.gridcolor).toBe("#new")
+    expect(lastCallProps.layout.yaxis?.gridcolor).toBe("#new")
+    expect(lastCallProps.data[0]).toEqual(
+      expect.objectContaining({ selectedpoints: [1] })
+    )
   })
 
   it("updates dimensions based on context", () => {
@@ -387,5 +537,132 @@ describe("PlotlyChart Component", () => {
     })
 
     expect(expandMock).toHaveBeenCalled()
+  })
+
+  it("does not preserve interaction state when element id changes", () => {
+    const firstElement = new PlotlyChartProto({
+      ...DEFAULT_ELEMENT,
+      id: "chart_A",
+      spec: JSON.stringify({
+        data: [{ type: "scatter", x: [1, 2], y: [1, 2] }],
+        layout: { title: "Chart A" },
+      }),
+    })
+
+    const secondElement = new PlotlyChartProto({
+      ...DEFAULT_ELEMENT,
+      id: "chart_B",
+      spec: JSON.stringify({
+        data: [{ type: "bar", x: [3, 4], y: [3, 4] }],
+        layout: { title: "Chart B" },
+      }),
+    })
+
+    const buildTree = (element: PlotlyChartProto): React.ReactElement => (
+      <ElementFullscreenContext.Provider
+        value={{
+          expanded: false,
+          width: 600,
+          height: 500,
+          expand: vi.fn(),
+          collapse: vi.fn(),
+        }}
+      >
+        <PlotlyChart
+          element={element}
+          widgetMgr={widgetMgr}
+          disabled={false}
+          width={600}
+        />
+      </ElementFullscreenContext.Provider>
+    )
+
+    const { rerender } = render(buildTree(firstElement))
+
+    vi.mocked(applyTheming).mockClear()
+
+    act(() => {
+      rerender(buildTree(secondElement))
+    })
+
+    // applyTheming should be called with the new element's pristine spec
+    expect(applyTheming).toHaveBeenCalledWith(
+      expect.objectContaining({
+        layout: expect.objectContaining({ title: "Chart B" }),
+      }),
+      "streamlit",
+      expect.anything()
+    )
+
+    const lastCallProps = getLastPlotProps()
+    // The new chart should not carry over interactive state from the old one
+    expect(lastCallProps.layout.clickmode).toBeUndefined()
+    expect(lastCallProps.layout.dragmode).toBeUndefined()
+    expect(lastCallProps.layout.xaxis?.range).toBeUndefined()
+  })
+
+  it("onUpdate does not revert theme when Plotly fires with the rethemed figure", () => {
+    const buildTree = (): React.ReactElement => (
+      <ElementFullscreenContext.Provider
+        value={{
+          expanded: false,
+          width: 600,
+          height: 500,
+          expand: vi.fn(),
+          collapse: vi.fn(),
+        }}
+      >
+        <PlotlyChart
+          element={DEFAULT_ELEMENT}
+          widgetMgr={widgetMgr}
+          disabled={false}
+          width={600}
+        />
+      </ElementFullscreenContext.Provider>
+    )
+
+    const { rerender } = render(buildTree())
+
+    // Simulate a theme change that produces visibly different output.
+    vi.mocked(applyTheming).mockImplementation(spec => {
+      const figure = spec as {
+        data: unknown[]
+        layout?: Record<string, unknown>
+        frames?: unknown
+      }
+      return {
+        ...figure,
+        layout: {
+          ...figure.layout,
+          paper_bgcolor: "#new_theme_bg",
+        },
+      } as typeof spec
+    })
+
+    const newTheme = { ...mockTheme.emotion }
+    themeHolder.current = newTheme
+    act(() => {
+      rerender(buildTree())
+    })
+
+    // Verify theme was applied
+    let lastCallProps = getLastPlotProps()
+    expect(lastCallProps.layout.paper_bgcolor).toBe("#new_theme_bg")
+
+    // Simulate Plotly's onUpdate firing with the correctly themed figure
+    // (this is what happens after Plotly processes the new props).
+    const themedFigure = {
+      data: lastCallProps.data,
+      layout: { ...lastCallProps.layout, paper_bgcolor: "#new_theme_bg" },
+      frames: null,
+    }
+
+    act(() => {
+      lastCallProps.onUpdate?.(themedFigure, document.createElement("div"))
+    })
+
+    lastCallProps = getLastPlotProps()
+    // The theme colors should persist after onUpdate
+    expect(lastCallProps.layout.paper_bgcolor).toBe("#new_theme_bg")
   })
 })

--- a/frontend/lib/src/components/elements/PlotlyChart/PlotlyChart.tsx
+++ b/frontend/lib/src/components/elements/PlotlyChart/PlotlyChart.tsx
@@ -21,6 +21,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react"
 
@@ -45,6 +46,7 @@ import {
   applyTheming,
   handleClickEvent,
   handleSelection,
+  preserveFigureInteractionState,
   sendEmptySelection,
 } from "./utils"
 
@@ -217,12 +219,66 @@ export function PlotlyChart({
     expand,
   ])
 
+  // Tracks the theme inputs that were last applied to the figure so we can
+  // distinguish a genuine theme change from the initial render (or a React
+  // StrictMode double-invocation), where the figure is already themed by the
+  // useState initializer above.
+  const lastAppliedThemeRef = useRef<{
+    theme: typeof theme
+    chartTheme: string
+    id: string
+  } | null>(null)
+
   useEffect(() => {
-    // If the theme changes, we need to reapply the theming to the figure
+    const previous = lastAppliedThemeRef.current
+    lastAppliedThemeRef.current = {
+      theme,
+      chartTheme: element.theme,
+      id: element.id,
+    }
+
+    if (
+      previous === null ||
+      (previous.theme === theme &&
+        previous.chartTheme === element.theme &&
+        previous.id === element.id)
+    ) {
+      // First application for this mount, or nothing relevant changed. The
+      // figure was already themed by the useState initializer, so there's
+      // nothing to redo (and re-theming here would clobber any figure state
+      // recovered from the widget manager on mount).
+      return
+    }
+
+    // Re-theme from the pristine spec rather than the current figure. The
+    // categorical/sequential/diverging palette placeholders are consumed the
+    // first time they're replaced, so re-theming the already-themed figure
+    // would leave the previous theme's chart colors in place.
     setPlotlyFigure((prevState: PlotlyFigureType) => {
-      return applyTheming(prevState, element.theme, theme)
+      const rethemedFigure = applyTheming(
+        initialFigureSpec,
+        element.theme,
+        theme
+      )
+
+      // Element id changed => this is a different chart; don't carry over
+      // zoom/selection from the previous one. Theme-only changes preserve
+      // interaction so selection modes and axis ranges survive the palette
+      // refresh.
+      if (previous.id !== element.id) {
+        return {
+          ...rethemedFigure,
+          layout: {
+            ...rethemedFigure.layout,
+            width: prevState.layout?.width ?? rethemedFigure.layout?.width,
+            height: prevState.layout?.height ?? rethemedFigure.layout?.height,
+          },
+        }
+      }
+
+      return preserveFigureInteractionState(rethemedFigure, prevState)
     })
-  }, [element.id, theme, element.theme])
+  }, [element.id, theme, element.theme, initialFigureSpec])
 
   useEffect(() => {
     let updatedClickMode: typeof initialFigureSpec.layout.clickmode =

--- a/frontend/lib/src/components/elements/PlotlyChart/utils.test.ts
+++ b/frontend/lib/src/components/elements/PlotlyChart/utils.test.ts
@@ -29,6 +29,7 @@ import {
   handleSelection,
   parseBoxSelection,
   parseLassoPath,
+  preserveFigureInteractionState,
   sendEmptySelection,
 } from "./utils"
 
@@ -127,6 +128,112 @@ describe("PlotlyChart utils", () => {
       applyTheming(mockPlotlyFigure, chartTheme, mockTheme.emotion)
 
       expect(layoutWithThemeDefaults).toHaveBeenCalled()
+    })
+  })
+
+  describe("preserveFigureInteractionState", () => {
+    it("preserves selection modes, dimensions, axis ranges, and selected points", () => {
+      const rethemed = {
+        data: [
+          { type: "scatter", marker: { color: "#00ff00" } },
+          { type: "scatter", marker: { color: "#0000ff" } },
+        ],
+        layout: {
+          paper_bgcolor: "#111111",
+          xaxis: { gridcolor: "#222222", title: "x" },
+          yaxis: { gridcolor: "#333333", title: "y" },
+          xaxis2: { gridcolor: "#444444" },
+        },
+        frames: [],
+      }
+      const previous = {
+        data: [
+          {
+            type: "scatter",
+            marker: { color: "#ff0000" },
+            selectedpoints: [0, 2],
+          },
+          { type: "scatter", marker: { color: "#00ffff" } },
+        ],
+        layout: {
+          width: 800,
+          height: 400,
+          clickmode: "event+select",
+          hovermode: "closest",
+          dragmode: "select",
+          selections: [{ type: "rect", x0: 0, x1: 1, y0: 0, y1: 1 }],
+          paper_bgcolor: "#ffffff",
+          xaxis: {
+            range: [1, 5],
+            autorange: false,
+            gridcolor: "#aaaaaa",
+            rangeslider: { range: [1, 3] },
+          },
+          yaxis: { range: [10, 20], gridcolor: "#bbbbbb" },
+          xaxis2: { range: [0, 1], gridcolor: "#cccccc" },
+        },
+        frames: [],
+      }
+
+      const result = preserveFigureInteractionState(
+        rethemed as never,
+        previous as never
+      )
+
+      // Themed styling comes from the rethemed figure.
+      expect(result.layout.paper_bgcolor).toBe("#111111")
+      expect(result.layout.xaxis?.gridcolor).toBe("#222222")
+      expect(result.layout.yaxis?.gridcolor).toBe("#333333")
+      expect(result.data[0]).toEqual(
+        expect.objectContaining({ marker: { color: "#00ff00" } })
+      )
+
+      // Interactive state comes from the previous figure.
+      expect(result.layout.width).toBe(800)
+      expect(result.layout.height).toBe(400)
+      expect(result.layout.clickmode).toBe("event+select")
+      expect(result.layout.hovermode).toBe("closest")
+      expect(result.layout.dragmode).toBe("select")
+      // `selections` exists at runtime but is not in Plotly's Layout type
+      expect((result.layout as Record<string, unknown>).selections).toEqual([
+        { type: "rect", x0: 0, x1: 1, y0: 0, y1: 1 },
+      ])
+      expect(result.layout.xaxis?.range).toEqual([1, 5])
+      expect(result.layout.xaxis?.autorange).toBe(false)
+      expect(result.layout.xaxis?.rangeslider).toEqual({ range: [1, 3] })
+      expect(result.layout.yaxis?.range).toEqual([10, 20])
+      expect(result.layout.xaxis2?.range).toEqual([0, 1])
+      expect(result.data[0]).toEqual(
+        expect.objectContaining({ selectedpoints: [0, 2] })
+      )
+      // Traces without selectedpoints are left alone.
+      expect(
+        (result.data[1] as { selectedpoints?: unknown }).selectedpoints
+      ).toBeUndefined()
+    })
+
+    it("does not invent interactive state when the previous figure has none", () => {
+      const rethemed = {
+        data: [{ type: "scatter" }],
+        layout: { xaxis: { title: "x" } },
+        frames: [],
+      }
+      const previous = {
+        data: [{ type: "scatter" }],
+        layout: {},
+        frames: [],
+      }
+
+      const result = preserveFigureInteractionState(
+        rethemed as never,
+        previous as never
+      )
+
+      expect(result.layout.clickmode).toBeUndefined()
+      expect(result.layout.xaxis).toEqual({ title: "x" })
+      expect(
+        (result.data[0] as { selectedpoints?: unknown }).selectedpoints
+      ).toBeUndefined()
     })
   })
 

--- a/frontend/lib/src/components/elements/PlotlyChart/utils.ts
+++ b/frontend/lib/src/components/elements/PlotlyChart/utils.ts
@@ -204,6 +204,113 @@ export function applyTheming(
   return spec
 }
 
+const AXIS_KEY_PATTERN = /^(x|y)axis\d*$/
+
+/**
+ * Interactive axis fields that should survive a theme re-derivation.
+ * Deliberately excludes themed styling (gridcolor, tickfont, etc.) so we
+ * don't reintroduce colors from the previous theme.
+ */
+const AXIS_INTERACTIVE_KEYS = ["range", "autorange"] as const
+
+/**
+ * Layout fields that reflect user interaction or Streamlit selection-mode
+ * configuration, not theme styling.
+ */
+const LAYOUT_INTERACTIVE_KEYS = [
+  "width",
+  "height",
+  "clickmode",
+  "hovermode",
+  "dragmode",
+  "selections",
+] as const
+
+function preserveAxisInteraction(
+  nextAxis: Record<string, unknown> | undefined,
+  prevAxis: Record<string, unknown> | undefined
+): Record<string, unknown> | undefined {
+  if (!prevAxis) {
+    return nextAxis
+  }
+
+  const preserved: Record<string, unknown> = { ...nextAxis }
+  for (const key of AXIS_INTERACTIVE_KEYS) {
+    if (prevAxis[key] !== undefined) {
+      preserved[key] = prevAxis[key]
+    }
+  }
+
+  const prevSlider = prevAxis.rangeslider
+  if (
+    prevSlider !== null &&
+    typeof prevSlider === "object" &&
+    "range" in prevSlider &&
+    prevSlider.range !== undefined
+  ) {
+    const existingSlider =
+      preserved.rangeslider !== null &&
+      typeof preserved.rangeslider === "object"
+        ? preserved.rangeslider
+        : {}
+    preserved.rangeslider = { ...existingSlider, range: prevSlider.range }
+  }
+
+  return preserved
+}
+
+/**
+ * After re-theming from the pristine figure spec (required so categorical /
+ * sequential / diverging palette placeholders can be re-applied), restore
+ * interactive state from the previously rendered figure.
+ *
+ * Only copies known interaction fields — never themed styling — so previous
+ * theme colors cannot leak back into the chart.
+ */
+export function preserveFigureInteractionState(
+  rethemedFigure: PlotlyFigureType,
+  previousFigure: PlotlyFigureType
+): PlotlyFigureType {
+  const prevLayout = (previousFigure.layout ?? {}) as Record<string, unknown>
+  const nextLayout: Record<string, unknown> = {
+    ...rethemedFigure.layout,
+  }
+
+  for (const key of LAYOUT_INTERACTIVE_KEYS) {
+    if (prevLayout[key] !== undefined) {
+      nextLayout[key] = prevLayout[key]
+    }
+  }
+
+  for (const key of Object.keys(prevLayout)) {
+    if (AXIS_KEY_PATTERN.test(key)) {
+      nextLayout[key] = preserveAxisInteraction(
+        nextLayout[key] as Record<string, unknown> | undefined,
+        prevLayout[key] as Record<string, unknown> | undefined
+      )
+    }
+  }
+
+  const nextData = rethemedFigure.data.map((trace, index) => {
+    const prevTrace = previousFigure.data[index] as
+      | (Plotly.Data & { selectedpoints?: unknown })
+      | undefined
+    if (prevTrace?.selectedpoints === undefined) {
+      return trace
+    }
+    return {
+      ...trace,
+      selectedpoints: prevTrace.selectedpoints,
+    }
+  })
+
+  return {
+    ...rethemedFigure,
+    data: nextData,
+    layout: nextLayout,
+  }
+}
+
 /**
  * Handles the selection event from Plotly and sends the selection state to the backend.
  * The selection state is sent as a stringified JSON object.


### PR DESCRIPTION
## Describe your changes
- Fixes `chartCategoricalColors` (and sequential/diverging) not applying to Plotly charts until a full page reload when the theme changes at runtime (e.g., light/dark toggle or config.toml edit + rerun)
- Root cause: the frontend replaces placeholder hex colors (`#000001`–`#000040`) in the figure spec with actual theme colors via string replacement — once consumed, subsequent theme changes couldn't find the placeholders in the already-themed figure
- Fix: always re-theme from the original (pristine) figure spec, then restore user interaction state (zoom, selections, axis ranges) via an explicit allowlist that excludes themed styling

## How it works
1. **`initialFigureSpec`** (memoized from `element.spec`) retains the placeholder colors permanently
2. On theme change, `applyTheming(initialFigureSpec, ...)` produces a freshly-themed figure
3. **`preserveFigureInteractionState`** copies back only known interaction fields (`range`, `autorange`, `width`, `height`, `clickmode`, `hovermode`, `dragmode`, `selections`, `selectedpoints`, `rangeslider.range`) — never themed colors like `gridcolor` or `tickfont`
4. A **`lastAppliedThemeRef`** guard distinguishes genuine theme changes from the initial mount (where the figure is already themed by the `useState` initializer)

## GitHub Issue Link
Closes #11974 

## Testing Plan
- JS Unit Tests: ✅  Added
- Manual Testing/QA: 🚧 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches figure state and theme application for a core visualization element; logic is scoped to theme/id changes with allowlisted field copying to avoid leaking old theme colors.
> 
> **Overview**
> Fixes **`st.plotly_chart`** not picking up new categorical/sequential/diverging colors when the app theme changes at runtime, because palette placeholders are only present in the original spec and were lost after the first `applyTheming` pass.
> 
> On a real theme or chart-theme change, **`PlotlyChart`** now re-runs **`applyTheming`** on the memoized **`initialFigureSpec`** instead of the live figure, then merges back interaction-only state via new **`preserveFigureInteractionState`** (zoom ranges, selection modes, dimensions, selections, `selectedpoints`, etc.) while keeping fresh themed styling. A **`lastAppliedThemeRef`** skips re-theming on first mount so widget-recovered figure state is not wiped; when **`element.id`** changes, interaction state from the prior chart is not carried over.
> 
> Unit tests cover theme toggles, interaction preservation, id swaps, and **`onUpdate`** after re-theme.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae0b64f15fc682ff16f641ad8b4da965344b86cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->