### PR TITLE
[fix] Close websocket on malformed BackMsg instead of leaking traceback

### DIFF
--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -974,7 +974,12 @@ class AppSession:
     def _create_exception_message(self, e: BaseException) -> ForwardMsg:
         """Create and return an Exception ForwardMsg."""
         msg = ForwardMsg()
-        exception_utils.marshall(msg.delta.new_element.exception, e)
+        # The is_uncaught_app_exception flag applies the client.showErrorDetails
+        # redaction. Without this flag, the session sends the internal message,
+        # type, and stack trace of the error to the browser.
+        exception_utils.marshall(
+            msg.delta.new_element.exception, e, is_uncaught_app_exception=True
+        )
         return msg
 
     def _handle_git_information_request(self) -> None:

--- a/lib/streamlit/runtime/runtime.py
+++ b/lib/streamlit/runtime/runtime.py
@@ -562,6 +562,13 @@ class Runtime:
     ) -> None:
         """Handle an Exception raised during deserialization of a BackMsg.
 
+        The bundled Starlette server does not call this method. A frame that
+        fails to parse is a protocol violation. That server closes the
+        connection instead. This entry point remains for other hosts. It reports
+        the failure through `AppSession`, which applies the
+        `client.showErrorDetails` redaction before it sends anything to the
+        browser.
+
         Parameters
         ----------
         session_id

--- a/lib/streamlit/web/server/starlette/starlette_websocket.py
+++ b/lib/streamlit/web/server/starlette/starlette_websocket.py
@@ -547,12 +547,14 @@ def create_websocket_handler(runtime: Runtime) -> Any:
                 try:
                     back_msg.ParseFromString(data)
                 except Exception as exc:
-                    _LOGGER.exception("Error deserializing back message")
-                    if session_id is not None:
-                        runtime.handle_backmsg_deserialization_exception(
-                            session_id, exc, client=client
-                        )
-                    continue
+                    # Treat a frame that is not a valid BackMsg as a protocol
+                    # violation: close with 1002 and keep the traceback on the
+                    # server only. A traceback that goes to the client exposes
+                    # internal file paths at every client.showErrorDetails
+                    # setting.
+                    _LOGGER.warning("Error deserializing back message", exc_info=exc)
+                    await websocket.close(code=1002)  # 1002 = Protocol Error
+                    break
 
                 msg_type = back_msg.WhichOneof("type")
 

--- a/lib/tests/streamlit/runtime/app_session_test.py
+++ b/lib/tests/streamlit/runtime/app_session_test.py
@@ -25,6 +25,7 @@ import pytest
 from parameterized import parameterized
 
 from streamlit import config
+from streamlit.elements.exception import _GENERIC_UNCAUGHT_EXCEPTION_TEXT
 from streamlit.errors import StreamlitAPIException
 from streamlit.proto.AppPage_pb2 import AppPage
 from streamlit.proto.BackMsg_pb2 import BackMsg
@@ -1292,6 +1293,69 @@ class AppSessionScriptEventTest(unittest.IsolatedAsyncioTestCase):
 
             handle_clear_cache_request.assert_called_once()
             handle_backmsg_exception.assert_called_once_with(error)
+
+    @parameterized.expand(
+        [
+            ("full", "boom", "RuntimeError", True),
+            (True, "boom", "RuntimeError", True),
+            ("true", "boom", "RuntimeError", True),
+            ("stacktrace", _GENERIC_UNCAUGHT_EXCEPTION_TEXT, "RuntimeError", True),
+            (False, _GENERIC_UNCAUGHT_EXCEPTION_TEXT, "RuntimeError", True),
+            ("type", _GENERIC_UNCAUGHT_EXCEPTION_TEXT, "RuntimeError", False),
+            ("none", _GENERIC_UNCAUGHT_EXCEPTION_TEXT, "", False),
+        ]
+    )
+    async def test_handle_backmsg_exception_redacts_per_show_error_details(
+        self,
+        show_error_details: str | bool,
+        expected_message: str,
+        expected_type: str,
+        expect_stack_trace: bool,
+    ):
+        """Test that client.showErrorDetails redacts the Exception ForwardMsg
+        that a BackMsg failure produces.
+        """
+        session = _create_test_session(asyncio.get_running_loop())
+
+        enqueued_msgs: list[ForwardMsg] = []
+        mock_queue = MagicMock(spec=ForwardMsgQueue)
+        mock_queue.enqueue = MagicMock(side_effect=enqueued_msgs.append)
+        session._browser_queue = mock_queue
+
+        with patch_config_options({"client.showErrorDetails": show_error_details}):
+            # Raise the error inside handle_backmsg. The traceback then contains
+            # Streamlit-internal frames, as it does in production.
+            with patch.object(
+                session,
+                "_handle_clear_cache_request",
+                side_effect=RuntimeError("boom"),
+            ):
+                msg = BackMsg()
+                msg.clear_cache = True
+                session.handle_backmsg(msg)
+
+            # An eventloop callback enqueues the Exception ForwardMsg.
+            await asyncio.sleep(0)
+
+        exception_msgs = [
+            msg
+            for msg in enqueued_msgs
+            if msg.WhichOneof("type") == "delta"
+            and msg.delta.new_element.WhichOneof("type") == "exception"
+        ]
+        assert len(exception_msgs) == 1
+        exception_proto = exception_msgs[0].delta.new_element.exception
+
+        assert exception_proto.message == expected_message
+        assert exception_proto.type == expected_type
+        assert bool(exception_proto.stack_trace) == expect_stack_trace
+
+        # No other field of the payload leaks the error.
+        serialized = exception_msgs[0].SerializeToString()
+        if expected_message != "boom":
+            assert b"boom" not in serialized
+        if not expect_stack_trace:
+            assert b"app_session.py" not in serialized
 
     @patch("streamlit.runtime.app_session.AppSession._create_scriptrunner", MagicMock())
     async def test_handle_backmsg_handles_debug_ids(self):

--- a/lib/tests/streamlit/web/server/starlette/starlette_app_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_app_test.py
@@ -30,6 +30,7 @@ from starlette.middleware import Middleware
 from starlette.responses import JSONResponse, PlainTextResponse
 from starlette.routing import Route
 from starlette.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
 
 from streamlit import file_util
 from streamlit.errors import StreamlitAPIException
@@ -167,6 +168,7 @@ class _DummyRuntime:
         self._active_sessions: set[str] = {"session123"}
         self.stopped = False
         self.last_backmsg = None
+        self.deserialization_exceptions: list[BaseException] = []
         self.last_user_info: dict[str, str | bool | None] | None = None
         self.last_existing_session_id: str | None = None
         self.script_health = (True, "ok")
@@ -232,7 +234,7 @@ class _DummyRuntime:
         exc: BaseException,
         client: object | None = None,
     ) -> None:
-        self.last_backmsg = (session_id, exc)
+        self.deserialization_exceptions.append(exc)
 
     async def start(self) -> None:  # pragma: no cover - lifecycle stub
         return None
@@ -1374,6 +1376,38 @@ def test_websocket_allows_debug_shutdown_in_dev_mode(tmp_path: Path) -> None:
 
     # Runtime should be stopped
     assert runtime.stopped is True
+
+
+def test_websocket_closes_on_malformed_backmsg(
+    starlette_client: tuple[TestClient, _DummyRuntime],
+) -> None:
+    """Test that a frame that fails to parse as a BackMsg closes the connection
+    with a protocol error. The server does not report the frame into the session.
+    """
+    client, runtime = starlette_client
+
+    with client.websocket_connect("/_stcore/stream") as websocket:
+        # Send a valid frame first. It shows that only the malformed frame closes
+        # the connection.
+        back_msg = BackMsg()
+        back_msg.rerun_script.query_string = ""
+        websocket.send_bytes(back_msg.SerializeToString())
+
+        websocket.send_bytes(b"\xff")
+
+        # The client waits for a ForwardMsg and gets a disconnect instead.
+        with pytest.raises(WebSocketDisconnect) as excinfo:
+            websocket.receive_bytes()
+
+    assert excinfo.value.code == 1002  # 1002 = Protocol Error
+
+    # The valid frame reaches the runtime. The server never routes the malformed
+    # frame into the session, so the session creates no Exception ForwardMsg for
+    # it.
+    assert runtime.last_backmsg is not None
+    _session_id, msg = runtime.last_backmsg
+    assert msg.WhichOneof("type") == "rerun_script"
+    assert runtime.deserialization_exceptions == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Describe your changes

A WebSocket frame that fails `BackMsg` deserialization used to send its exception back to the browser. The path ran through `AppSession._create_exception_message`, which called `exception_utils.marshall` without `is_uncaught_app_exception`, so the `client.showErrorDetails` redaction never ran. The browser got the exception message, the type, and a stack trace with absolute file paths. There is also no script run context on the event-loop thread, so the traceback filter could not strip internal frames.

Two changes:

- `starlette_websocket.py` now treats a frame that fails to parse as a protocol violation. It logs the traceback and closes with code 1002, and sends no exception payload at any `client.showErrorDetails` value including the `"full"` default. Redaction alone is not enough here: with no script run context, internal paths stay in the trace even when the flag is set. This also matches the oversize-frame handler right above it, which already closes with 1009.
- `_create_exception_message` now passes `is_uncaught_app_exception=True`, so an error raised while handling a *valid* `BackMsg` respects `client.showErrorDetails` too. That is the second half of the issue.

`Runtime.handle_backmsg_deserialization_exception` stays for other hosts and inherits the redaction through `AppSession`. The server log keeps the full traceback in every case.

A real browser cannot send a malformed frame, so only a hand-written client or a proxy corrupting a frame reaches this path. If one did, the frontend treats the close as `CONNECTION_CLOSED` and reconnects with the previous session ID, so the session survives. Before this change it cleared the app, ran a fake stop/start/stop cycle, and rendered a `DecodeError` element.

One thing worth a reviewer's opinion: the flag is named `is_uncaught_app_exception`, but its effect is really "apply the `showErrorDetails` redaction", and a BackMsg handling error is not an app exception. Reusing it keeps this diff small. A rename touches `marshall`, `error_util.py`, and about ten sites in `exception_test.py`, so I left it as a follow-up.

## GitHub Issue Link (if applicable)

Closes #16391

## Testing Plan

- Python unit tests. `app_session_test.py` gets a parametrized test across all seven `showErrorDetails` values that asserts the redacted message, type, and stack trace, plus a check that the serialized payload contains neither the exception text nor `app_session.py` when the trace is suppressed. `starlette_app_test.py` gets `test_websocket_closes_on_malformed_backmsg`, which drives the real Starlette route and the real `ParseFromString` through `TestClient`: send a valid frame, then `b"\xff"`, then assert the close code is 1002 and that nothing reached the session.
- No E2E test. Nothing user-visible is left after the fix, and Playwright cannot send a malformed binary frame without reimplementing the subprotocol handshake in page JS. The `TestClient` test covers the real transport and the real parse failure in-process instead.
- Manual. Ran the repro from the issue against a real server on both versions. On `develop` with `showErrorDetails = "none"` the client got an Exception `ForwardMsg` with `DecodeError` and an absolute path to `starlette_websocket.py`, which confirms the report. After the fix the socket closes with 1002 at both `"none"` and the `"full"` default, and the traceback is still in the server log.
- Regression runs. `lib/tests/streamlit/runtime/` and `lib/tests/streamlit/web/` pass (3812 passed, 8 skipped), `websocket_disconnect_test.py` and `websocket_reconnects_test.py` pass, and `make check` passes.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes WebSocket error handling and what the browser sees on protocol violations and BackMsg failures; behavior is more secure but clients that relied on in-app DecodeError UI for bad frames will only see disconnect/reconnect.
> 
> **Overview**
> Fixes a security/privacy issue where invalid WebSocket frames and some BackMsg handling errors could expose server exception text and absolute paths in the browser, regardless of `client.showErrorDetails`.
> 
> **Malformed `BackMsg` frames** on the Starlette WebSocket path are now treated as a protocol violation: the server logs at warning with traceback server-side, closes the socket with code **1002**, and no longer routes the parse failure into `AppSession` (so no Exception `ForwardMsg` is sent). This aligns with the existing oversize-frame behavior (1009).
> 
> **Valid BackMsg handling failures** now marshal exceptions with `is_uncaught_app_exception=True` in `_create_exception_message`, so message, type, and stack trace respect `client.showErrorDetails` redaction. `Runtime.handle_backmsg_deserialization_exception` is documented as unused by the bundled Starlette server but still available for other hosts via the same redaction path.
> 
> Tests cover `showErrorDetails` variants for BackMsg exceptions and assert a real Starlette route closes with 1002 on `b"\xff"` without session deserialization handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef8c7e4c7b3dbd86fd0db0beae121c258ac043ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->