### PR TITLE
[fix] Correct the server.enableCORS=false startup warning

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -1019,8 +1019,10 @@ _create_option(
         Enables support for Cross-Origin Resource Sharing (CORS) protection,
         for added security.
 
-        If XSRF protection is enabled and CORS protection is disabled at the
-        same time, Streamlit will enable them both instead.
+        If you set this option to `False`, Streamlit sends
+        `Access-Control-Allow-Origin: *` on most HTTP routes and accepts a
+        WebSocket connection from any origin. Streamlit does not enable this
+        option for you when `server.enableXsrfProtection` is `True`.
     """,
     default_val=True,
     type_=bool,
@@ -1069,8 +1071,9 @@ _create_option(
         Enables support for Cross-Site Request Forgery (XSRF) protection, for
         added security.
 
-        If XSRF protection is enabled and CORS protection is disabled at the
-        same time, Streamlit will enable them both instead.
+        This option does not enable `server.enableCORS`. Streamlit does not
+        need a valid XSRF token to open a WebSocket connection, so this option
+        does not replace `server.enableCORS`.
     """,
     default_val=True,
     type_=bool,
@@ -3002,23 +3005,37 @@ def _check_conflicts() -> None:
                 "browser.serverPort does not work when global.developmentMode is true."
             )
 
-    # XSRF conflicts
-    if get_option("server.enableXsrfProtection") and (
-        not get_option("server.enableCORS") or get_option("global.developmentMode")
+    # Tell the operator when Streamlit does not limit cross-origin access.
+    if get_option("server.enableXsrfProtection") and not get_option(
+        "server.enableCORS"
     ):
         logger.warning(
             """
-Warning: the config option 'server.enableCORS=false' is not compatible with
-'server.enableXsrfProtection=true'.
-As a result, 'server.enableCORS' is being overridden to 'true'.
+'server.enableCORS=false' tells Streamlit not to limit cross-origin access.
+Streamlit sends the header 'Access-Control-Allow-Origin: *', except on the file
+upload routes, which stay pinned to the app address and still require a valid
+XSRF token.
+Streamlit also accepts a WebSocket connection from any origin.
+Streamlit does not set 'server.enableCORS' to 'true' for you.
+'server.enableXsrfProtection=true' does not stop a cross-origin WebSocket
+connection, because Streamlit does not need a valid XSRF token to open one.
 
-More information:
-In order to protect against CSRF attacks, we send a cookie with each request.
-To do so, we must specify allowable origins, which places a restriction on
-cross-origin resource sharing.
+To limit cross-origin access, do these steps:
+  1. Set 'server.enableCORS=true'.
+  2. Put the origins that you trust in 'server.corsAllowedOrigins'.
 
-If cross origin resource sharing is required, please disable server.enableXsrfProtection.
-            """
+'server.allowedHosts' can also limit the hostnames that Streamlit accepts on a
+WebSocket connection.
+"""
+        )
+    elif get_option("global.developmentMode") and get_option("server.enableCORS"):
+        # Development mode only relaxes the header, not the WebSocket origin
+        # check, so this is a note for contributors rather than a warning.
+        logger.debug(
+            "'global.developmentMode=true' makes Streamlit send the header "
+            "'Access-Control-Allow-Origin: *', because the Vite dev server and "
+            "the Streamlit server use different ports. Streamlit still limits "
+            "the origins of WebSocket connections."
         )
 
     # Validate the XSRF cookie SameSite value. We explicitly require a string

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -41,6 +41,11 @@ SECTION_DESCRIPTIONS = copy.deepcopy(config._section_descriptions)
 CONFIG_OPTIONS = copy.deepcopy(config._config_options)
 
 
+def _warning_text(mock_logger: MagicMock) -> str:
+    """Join every `warning` call on a mock logger into one searchable string."""
+    return " ".join(str(call) for call in mock_logger.warning.call_args_list)
+
+
 class ConfigTest(unittest.TestCase):
     """Test the config system."""
 
@@ -836,12 +841,76 @@ class ConfigTest(unittest.TestCase):
             config._check_conflicts()
 
     @patch("streamlit.logger.get_logger")
-    def test_check_conflicts_server_csrf(self, get_logger):
+    def test_check_conflicts_cors_disabled_does_not_claim_an_override(self, get_logger):
+        """Disabling CORS protection must warn without claiming an override.
+
+        No code path flips server.enableCORS back to true, so the warning must
+        not say it does and _check_conflicts must not mutate the option.
+        """
         config._set_option("server.enableXsrfProtection", True, "test")
-        config._set_option("server.enableCORS", True, "test")
+        config._set_option("server.enableCORS", False, "test")
+        config._set_option("global.developmentMode", False, "test")
         mock_logger = get_logger()
         config._check_conflicts()
-        mock_logger.warning.assert_called_once()
+        assert mock_logger.warning.call_count == 1
+        warnings = _warning_text(mock_logger)
+        assert "server.enableCORS" in warnings
+        assert "overrid" not in warnings.lower()
+        assert config.get_option("server.enableCORS") is False
+
+    @patch("streamlit.logger.get_logger")
+    def test_check_conflicts_cors_disabled_warns_once_in_development_mode(
+        self, get_logger
+    ):
+        """Development mode must not add a second cross-origin warning."""
+        config._set_option("server.enableXsrfProtection", True, "test")
+        config._set_option("server.enableCORS", False, "test")
+        config._set_option("global.developmentMode", True, "test")
+        mock_logger = get_logger()
+        config._check_conflicts()
+        assert mock_logger.warning.call_count == 1
+        assert "server.enableCORS" in _warning_text(mock_logger)
+
+    @patch("streamlit.logger.get_logger")
+    def test_check_conflicts_cors_disabled_without_xsrf_is_silent(self, get_logger):
+        """Disabling both CORS and XSRF protection is a deliberate choice."""
+        config._set_option("server.enableXsrfProtection", False, "test")
+        config._set_option("server.enableCORS", False, "test")
+        config._set_option("global.developmentMode", False, "test")
+        mock_logger = get_logger()
+        config._check_conflicts()
+        mock_logger.warning.assert_not_called()
+
+    @patch("streamlit.logger.get_logger")
+    def test_check_conflicts_development_mode_logs_a_debug_note(self, get_logger):
+        """Development mode only relaxes the CORS header, so it must not warn.
+
+        Development mode is on by default in a source checkout, and it leaves
+        the WebSocket origin check in place, so this is a contributor-facing
+        note rather than an operator-facing warning.
+        """
+        config._set_option("server.enableXsrfProtection", True, "test")
+        config._set_option("server.enableCORS", True, "test")
+        config._set_option("global.developmentMode", True, "test")
+        mock_logger = get_logger()
+        config._check_conflicts()
+        mock_logger.warning.assert_not_called()
+        debug_messages = " ".join(
+            str(call) for call in mock_logger.debug.call_args_list
+        )
+        assert "global.developmentMode" in debug_messages
+
+    @patch("streamlit.logger.get_logger")
+    def test_check_conflicts_no_warning_when_xsrf_and_cors_both_enabled(
+        self, get_logger
+    ):
+        """XSRF and CORS protection both enabled is not a conflict."""
+        config._set_option("server.enableXsrfProtection", True, "test")
+        config._set_option("server.enableCORS", True, "test")
+        config._set_option("global.developmentMode", False, "test")
+        mock_logger = get_logger()
+        config._check_conflicts()
+        mock_logger.warning.assert_not_called()
 
     @parameterized.expand(["lax", "strict", "none", "Lax", "STRICT", "None"])
     def test_check_conflicts_xsrf_cookie_same_site_valid(self, value):
@@ -879,7 +948,7 @@ class ConfigTest(unittest.TestCase):
         config._set_option("server.sslCertFile", None, "test")
         mock_logger = get_logger()
         config._check_conflicts()
-        warnings = " ".join(str(call) for call in mock_logger.warning.call_args_list)
+        warnings = _warning_text(mock_logger)
         assert "xsrfCookieSameSite" in warnings
         assert "HTTPS" in warnings
 
@@ -893,7 +962,7 @@ class ConfigTest(unittest.TestCase):
         config._set_option("server.enableXsrfProtection", False, "test")
         mock_logger = get_logger()
         config._check_conflicts()
-        warnings = " ".join(str(call) for call in mock_logger.warning.call_args_list)
+        warnings = _warning_text(mock_logger)
         assert "xsrfCookieSameSite" in warnings
         assert "no effect" in warnings
 
@@ -913,7 +982,7 @@ class ConfigTest(unittest.TestCase):
         config._set_option("server.sslCertFile", None, "test")
         mock_logger = get_logger()
         config._check_conflicts()
-        warnings = " ".join(str(call) for call in mock_logger.warning.call_args_list)
+        warnings = _warning_text(mock_logger)
         assert "no effect" not in warnings
         # It should still warn about the HTTPS/Secure requirement.
         assert "HTTPS" in warnings


### PR DESCRIPTION
## Describe your changes

The startup warning for `server.enableXsrfProtection=true` + `server.enableCORS=false` claimed that `server.enableCORS` "is being overridden to 'true'". No code path has ever done that, so operators could conclude Origin checks were stricter than they are.

- **Fixed the message, not the behavior.** Actually flipping `server.enableCORS` to `true` would start rejecting WebSocket handshakes from the proxy origin and break the reverse-proxy deployments that set it deliberately. That is a breaking change and does not belong in a P3 bug fix. The wording has been wrong since `8a939704c9` (2020), so there is no regression to restore.
- The warning now states what the config does: Streamlit sends `Access-Control-Allow-Origin: *` (except on the file upload routes, which stay pinned to the app address while XSRF is on), accepts a WebSocket connection from any origin, and does not change the option for you. The XSRF claim is narrowed to what the code supports: Streamlit does not need a valid XSRF token to *open* a WebSocket, but it does compare the token on the upload routes.
- The `server.enableCORS` and `server.enableXsrfProtection` descriptions repeated the same false override claim ("Streamlit will enable them both instead"), so each has that one paragraph replaced. These feed `streamlit config show` and the published config reference. Nothing else in either description changed.
- **Behavior change worth a reviewer's attention:** the development-mode branch of this check previously logged the CORS warning even when `server.enableCORS=true`, where the text was entirely wrong. Development mode only relaxes the response header and leaves the WebSocket origin check in place (`is_url_from_allowed_origins` never reads `global.developmentMode`), so it now logs an accurate note at `debug` level. `global.developmentMode` defaults to true in a source checkout, so this also stops the warning printing on every contributor's `make debug`.

Out of scope: this does not close the underlying gap from #16386 (item 5), which is that `enableCORS=false` leaves no strict `Origin` allow-list. That needs a separate feature request.

## GitHub Issue Link (if applicable)

Closes #16390 (split from #16386)

## Testing Plan

- Unit Tests (Python): `lib/tests/streamlit/config_test.py` replaces `test_check_conflicts_server_csrf` with five targeted cases covering the CORS-disabled warning, the `xsrf=T, cors=F, dev=T` overlap (only one warning), the `xsrf=F, cors=F` silent case, the dev-mode debug note, and both-enabled silence. Includes an anti-regression assert that `_check_conflicts()` leaves `server.enableCORS` as `False`, plus a guard that the text never says "overrid".
  - Note: the old test set `enableCORS=True` and asserted one warning, which only passed because `global.developmentMode` defaults to true in a source checkout. All new cases set it explicitly.
- No E2E tests: the change is a startup log line in the Python process, which Playwright cannot observe. The unchanged origin-check behavior is already covered by `lib/tests/streamlit/web/server/starlette/starlette_websocket_test.py`.
- Manual: confirmed the rendered warning via `streamlit run --server.enableCORS=false --server.enableXsrfProtection=true --global.developmentMode=false`, and the rendered descriptions via `streamlit config show`. `make check` green; 1167 tests pass across `lib/tests/streamlit/web/` and the config suites.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and log-message changes only; server CORS/XSRF enforcement is unchanged.
> 
> **Overview**
> Fixes misleading **CORS/XSRF** messaging at startup and in `streamlit config show`: the old warning said `server.enableCORS` was being overridden to `true`, but nothing in the codebase ever did that.
> 
> **`_check_conflicts`** now warns only when `server.enableXsrfProtection=true` and `server.enableCORS=false`, with text that matches real behavior (`Access-Control-Allow-Origin: *` on most routes, permissive WebSockets, upload routes still XSRF-pinned, and steps to tighten via `corsAllowedOrigins` / `allowedHosts`). When **development mode** has CORS enabled, the former bogus warning is replaced by a **debug** note about the relaxed CORS header only.
> 
> **`server.enableCORS`** and **`server.enableXsrfProtection`** descriptions drop the false “Streamlit will enable them both instead” claim. **Tests** replace the old CSRF conflict case with five cases (no “override” wording, no config mutation, dev-mode behavior, silence when both protections are off).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abe6ac5618c7a00239fca8bfeff1abb32acb700c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->