### PR TITLE
[fix] Install skills where Claude Code will find them

### DIFF
--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -84,7 +84,9 @@ _LOGGER: Final = get_logger(__name__)
 # to ``""`` — ``headless`` alone fires for every deployed app and would swamp the
 # metric, and "no agent harness" / "already installed" / "user dismissed" are
 # either already measurable from the page profile or simply not interesting.
-_REPORTED_NUDGE_SUPPRESSION_REASONS: Final = frozenset({"conflict", "check_failed"})
+_REPORTED_NUDGE_SUPPRESSION_REASONS: Final = frozenset(
+    {"conflict", "check_failed", "check_unreadable"}
+)
 
 
 class AppSessionState(Enum):

--- a/lib/streamlit/runtime/backend_operation_handler.py
+++ b/lib/streamlit/runtime/backend_operation_handler.py
@@ -220,7 +220,9 @@ class InstallSkillsHandler(BackendOperationHandler):
         #   - headless mode (deployments / CI / SiS): the nudge is never shown
         #     there, so the request is a replayed/spoofed BackMsg; refuse the
         #     filesystem writes.
-        #   - no agent harness present: nothing would consume the skills.
+        #   - no agent harness present: nothing would consume the skills. Uses
+        #     the same predicate as the nudge's display gate, so a nudge we show
+        #     can never lead to a button that refuses.
         #   - the browser is not on a direct-loopback connection: the same
         #     conservative eligibility rule the nudge display uses, so a
         #     shared/deployed-ish topology (Docker/VM/reverse-proxy/SSH-tunnel)
@@ -233,11 +235,11 @@ class InstallSkillsHandler(BackendOperationHandler):
         # logging it as a failed install. Idempotent retry is the correct path.
         #
         # Check the conditions in order; the first that trips names the telemetry
-        # reason. This short-circuits, so e.g. detect_installed_agents() (which
+        # reason. This short-circuits, so e.g. agent_harness_present() (which
         # touches the filesystem) isn't called in headless mode.
         if config.get_option("server.headless"):
             gate_reason = "headless"
-        elif not skills.detect_installed_agents():
+        elif not skills.agent_harness_present():
             gate_reason = "no_agent"
         elif connection_locality(session_id) != "loopback":
             gate_reason = "non_loopback"

--- a/lib/streamlit/runtime/backend_operation_handler.py
+++ b/lib/streamlit/runtime/backend_operation_handler.py
@@ -220,9 +220,10 @@ class InstallSkillsHandler(BackendOperationHandler):
         #   - headless mode (deployments / CI / SiS): the nudge is never shown
         #     there, so the request is a replayed/spoofed BackMsg; refuse the
         #     filesystem writes.
-        #   - no agent harness present: nothing would consume the skills. Uses
-        #     the same predicate as the nudge's display gate, so a nudge we show
-        #     can never lead to a button that refuses.
+        #   - no agent harness present: nothing would consume the skills.
+        #     Shares the predicate with the nudge display gate
+        #     (agent_harness_present), so users who see the nudge always get a
+        #     working button.
         #   - the browser is not on a direct-loopback connection: the same
         #     conservative eligibility rule the nudge display uses, so a
         #     shared/deployed-ish topology (Docker/VM/reverse-proxy/SSH-tunnel)

--- a/lib/streamlit/web/skills.py
+++ b/lib/streamlit/web/skills.py
@@ -274,16 +274,35 @@ def _find_project_root(start: Path | None = None) -> Path:
     return start_dir
 
 
+def _is_claude_code_present() -> bool:
+    """Best-effort check for whether Claude Code is installed.
+
+    Claude Code only reads skills from ``.claude/skills/``, never from
+    ``.agents/skills/``, so this decides whether the installer also writes a
+    ``.claude`` target. Getting it wrong in the negative direction silently
+    costs the user the whole skill, so this checks several signals rather than
+    just ``~/.claude``: that directory is created lazily and may not exist yet
+    on a fresh install, even though the CLI is on PATH.
+    """
+    try:
+        home = Path.home()
+    except RuntimeError:
+        return False
+
+    if (home / ".claude").exists() or (home / ".claude.json").exists():
+        return True
+    return shutil.which("claude") is not None
+
+
 def _get_project_target_dirs(project_root: Path) -> list[Path]:
     """Get target directories for project skill installation.
 
     Always targets .agents/skills/. Also targets .claude/skills/
-    when ~/.claude exists (Claude Code is installed).
+    when Claude Code appears to be installed.
     """
     targets = [project_root / ".agents" / "skills"]
 
-    claude_home = Path.home() / ".claude"
-    if claude_home.exists():
+    if _is_claude_code_present():
         targets.append(project_root / ".claude" / "skills")
 
     return targets
@@ -293,14 +312,13 @@ def _get_global_target_dirs() -> list[Path]:
     """Get target directories for global skill installation.
 
     Always targets ~/.agents/skills/. Also targets ~/.claude/skills/
-    when ~/.claude exists (Claude Code is installed).
+    when Claude Code appears to be installed.
     """
     home = Path.home()
     targets = [home / ".agents" / "skills"]
 
-    claude_home = home / ".claude"
-    if claude_home.exists():
-        targets.append(claude_home / "skills")
+    if _is_claude_code_present():
+        targets.append(home / ".claude" / "skills")
 
     return targets
 
@@ -309,11 +327,15 @@ def are_skills_installed() -> bool:
     """Check whether Streamlit agent skills appear to be installed.
 
     Returns ``True`` if the bundled skill is present (as a symlink, copied
-    directory, or regular directory) in any of the project-local or global
-    target directories. This is a best-effort check used to decide whether to
-    recommend installing skills; it does not validate skill contents.
+    directory, or regular directory) in *every* target directory for the scope
+    the user installed into. A partial install counts as not installed, so the
+    nudge fires again and fills in the missing agent directory -- this matters
+    when an agent is installed after ``streamlit skills`` last ran. This is a
+    best-effort check used to decide whether to recommend installing skills; it
+    does not validate skill contents.
     """
-    candidate_dirs: list[Path] = []
+    project_dirs: list[Path] = []
+    global_dirs: list[Path] = []
     try:
         project_root = _find_project_root()
     except (OSError, RuntimeError):
@@ -322,26 +344,56 @@ def are_skills_installed() -> bool:
         pass
     else:
         try:
-            candidate_dirs.extend(_get_project_target_dirs(project_root))
+            project_dirs.extend(_get_project_target_dirs(project_root))
         except (OSError, RuntimeError):
             # Same reasoning as above; still check global dirs.
             pass
 
     try:
-        candidate_dirs.extend(_get_global_target_dirs())
+        global_dirs.extend(_get_global_target_dirs())
     except (OSError, RuntimeError):
         # Keep any project dirs already collected above instead of discarding
         # them; still a best-effort check, so just skip the global dirs.
         pass
 
-    for target_dir in candidate_dirs:
-        skill_path = target_dir / _GLOBAL_SKILL_NAME
-        try:
-            if skill_path.is_symlink() or skill_path.exists():
-                return True
-        except OSError:
+    # Project scope first: a project-local install is the more specific choice.
+    scoped_dirs = (project_dirs, global_dirs)
+
+    for scope_dirs in scoped_dirs:
+        if not scope_dirs:
             continue
+        # Directories we could not read are dropped rather than treated as
+        # missing: an unreadable path means "unknown", and reporting the skill
+        # as uninstalled because of a permissions error would nudge users who
+        # are in fact set up correctly.
+        known = [
+            present
+            for present in (_skill_present_in(target_dir) for target_dir in scope_dirs)
+            if present is not None
+        ]
+        if any(known):
+            # This scope has been installed into before, so it is the scope the
+            # user chose. Report installed only if *every* readable target dir for
+            # it has the skill. A partial install -- typically .agents/skills
+            # present but .claude/skills missing, because Claude Code was not
+            # detected the last time `streamlit skills` ran -- leaves the skill
+            # invisible to that agent. Returning True there would suppress the
+            # nudge permanently and strand the user with a skill nothing loads.
+            return all(known)
     return False
+
+
+def _skill_present_in(target_dir: Path) -> bool | None:
+    """Whether the bundled skill exists in ``target_dir``, as link or directory.
+
+    Returns ``None`` when the filesystem check itself fails, so callers can tell
+    "not there" apart from "could not look".
+    """
+    skill_path = target_dir / _GLOBAL_SKILL_NAME
+    try:
+        return skill_path.is_symlink() or skill_path.exists()
+    except OSError:
+        return None
 
 
 def _is_streamlit_owned_symlink(link_path: Path, bundled_skill_names: set[str]) -> bool:

--- a/lib/streamlit/web/skills.py
+++ b/lib/streamlit/web/skills.py
@@ -366,6 +366,30 @@ def _get_global_target_dirs() -> list[Path]:
     return targets
 
 
+def _authoritative_global_target_dir() -> Path:
+    """The one global target dir whose write decides if an install succeeded.
+
+    Claude Code is the only harness verified to read a directory we write, and it
+    reads ``.claude/skills`` while ignoring ``.agents/skills`` entirely. So when
+    Claude Code is detected, ``~/.claude/skills`` is what an install has to land,
+    and ``~/.agents/skills`` is best-effort - written for harnesses that may or may
+    not read it, and never the reason an install that already reached Claude Code
+    is reported as a failure.
+
+    With no Claude Code detected, none of our targets has a verified reader and
+    ``~/.agents/skills`` is the only one we write, so it carries authority by
+    default. That is a deliberate choice between two wrong answers: leaving no
+    target authoritative would turn every write failure into a silent success.
+
+    Always one of :func:`_get_global_target_dirs`, so exactly one target in that
+    list is load-bearing and the rest are best-effort.
+    """
+    home = Path.home()
+    if _is_claude_code_present():
+        return home / ".claude" / "skills"
+    return home / ".agents" / "skills"
+
+
 # How completely the bundled skill is installed, judged only against the
 # directories `streamlit skills` itself writes. ``partial`` is the state this
 # vocabulary exists for: it is the wedge - the skill sitting in .agents/skills
@@ -935,22 +959,32 @@ def _conflict_error(skipped: list[str]) -> InstallError:
     )
 
 
-def _write_error(result: _InstallResult) -> InstallError:
+def _write_error(
+    result: _InstallResult,
+    reasons: set[_InstallFailureReason] | None = None,
+) -> InstallError:
     """Build a "couldn't write" error for filesystem failures during copy.
 
     Distinct from :func:`_conflict_error`, which reports pre-existing files.
 
-    The reason follows what the failed targets agreed on:
+    ``reasons`` are the causes that *justify* the error - in practice those from the
+    authoritative target, whose path a detected harness reads. ``None`` means every
+    recorded cause justifies it. A best-effort failure is still named in the
+    message, since the user should see everything that did not land, but it must
+    not decide the reason: a dead-weight target cannot be allowed to mislabel a
+    failure a load-bearing one caused.
+
+    The reason follows what the justifying failures agreed on:
 
     - all agreed on one cause -> that cause
-    - they disagreed -> the generic ``write_failed``, because claiming "permission
-      denied" for a set that was half permissions and half disk-full would point
-      whoever reads the telemetry at the wrong fix
+    - they disagreed, or none was recorded -> the generic ``write_failed``, because
+      claiming "permission denied" for a set that was half permissions and half
+      disk-full would point whoever reads the telemetry at the wrong fix
     """
     joined = ", ".join(_concise_install_paths(result.errored))
-    reasons = result.write_reasons
+    justifying = result.write_reasons if reasons is None else reasons
     reason: _InstallFailureReason = (
-        next(iter(reasons)) if len(reasons) == 1 else "write_failed"
+        next(iter(justifying)) if len(justifying) == 1 else "write_failed"
     )
     return InstallError(
         f"Could not write {joined}. Check folder permissions and free disk "
@@ -1150,27 +1184,69 @@ def _install_global_skills(*, yes: bool = False) -> _InstallResult:
             reason="source_incomplete",
         )
 
-    # Install to each target directory
+    # Install to each target directory, keeping a per-target result so each
+    # target's outcome can be judged on its own. The aggregate below cannot support
+    # that: ``write_reasons`` is a set, so two targets failing the same way are
+    # indistinguishable from one, and nothing in it records WHICH target failed.
     result = _InstallResult()
     # For global install, only one skill is installed but we use a set for consistency
     bundled_skill_names = {_GLOBAL_SKILL_NAME}
+    authoritative_dir = _authoritative_global_target_dir()
+    authoritative_failed = False
+    authoritative_reasons: set[_InstallFailureReason] = set()
+    degraded_dirs: list[Path] = []
+
     for target_dir in target_dirs:
+        target_result = _InstallResult()
         _install_skill_copy(
             _GLOBAL_SKILL_NAME,
             meta_skill_dir,
             target_dir,
-            result,
+            target_result,
             bundled_skill_names,
         )
+        if target_result.errored:
+            if target_dir == authoritative_dir:
+                authoritative_failed = True
+                authoritative_reasons |= target_result.write_reasons
+            else:
+                degraded_dirs.append(target_dir)
+        result.installed += target_result.installed
+        result.up_to_date += target_result.up_to_date
+        result.skipped += target_result.skipped
+        result.errored += target_result.errored
+        result.write_reasons |= target_result.write_reasons
 
     # Report results
     _print_result(result)
 
-    # A write failure on ANY target is a hard failure, even if another target
-    # succeeded - otherwise a partial install (e.g. ~/.agents ok but ~/.claude
-    # denied) reports success and drops skillsNudgeInstallFailed:write_failed.
-    if result.errored:
+    # A write failure on the AUTHORITATIVE target is a hard failure: a detected
+    # harness reads that path, so the install reached no agent. A failure on a
+    # best-effort target is not, and used to be - telling a developer whose
+    # ~/.claude/skills was written, and whose Claude Code therefore works
+    # perfectly, that the install had failed. Worse once a partial install
+    # reopens the nudge: that developer would be nudged toward a repair that
+    # fails on the same unwritable target every time, with no way out.
+    if authoritative_failed:
+        raise _write_error(result, authoritative_reasons)
+
+    # Nothing landed anywhere. Unreachable while the authoritative dir is always
+    # one of ``target_dirs``, but a target added later must not be able to turn a
+    # total failure into a silent success.
+    if result.errored and not (result.installed or result.up_to_date):
         raise _write_error(result)
+
+    if degraded_dirs:
+        # Not swallowed. _print_result above already lists it under "Failed to
+        # write" for a CLI user; this leaves the same trace in the server log for
+        # the in-app install, which has no terminal to print to.
+        _LOGGER.warning(
+            "Skills install wrote %s but could not write best-effort target(s) %s. "
+            "Reporting success: the skill is installed where a detected agent "
+            "reads it.",
+            authoritative_dir,
+            ", ".join(str(path) for path in degraded_dirs),
+        )
 
     if result.installed or result.up_to_date:
         click.echo()

--- a/lib/streamlit/web/skills.py
+++ b/lib/streamlit/web/skills.py
@@ -315,8 +315,15 @@ def _is_claude_code_present() -> bool:
 
     Deliberately broader than the ``claude`` entry in ``_HARNESSES``, which keys
     on the home directory alone. That table answers "which harnesses exist" for
-    telemetry, where a stable definition matters more than catching a CLI
-    installed minutes ago; here a miss breaks the feature outright.
+    telemetry, where a stable definition matters more than catching a
+    just-installed CLI; here a miss breaks the feature outright.
+
+    The two only disagree in a narrow window, which is why they are left to
+    differ: ``claude --version`` creates nothing, but the first command that
+    touches config creates both ``~/.claude`` and ``~/.claude.json``, before
+    login. So the gap is "installed, never really run" - and nobody is wedged
+    there, because being wedged means having used Claude Code and found the
+    skill missing. Verified against Claude Code 2.1.235.
     """
     try:
         home = Path.home()

--- a/lib/streamlit/web/skills.py
+++ b/lib/streamlit/web/skills.py
@@ -1562,6 +1562,24 @@ _NudgeSuppressionReason = Literal[
 ]
 
 
+def agent_harness_present() -> bool:
+    """Whether an AI agent harness that would consume the skills is installed.
+
+    Either detector counts. :func:`detect_installed_agents` keys on home-dir
+    markers and defines the ``installed_agents`` telemetry vocabulary for all
+    eight harnesses; :func:`_is_claude_code_present` is the broader signal that
+    decides whether ``.claude/skills`` is an install target at all. Anyone the
+    broad one covers has a target the installer writes to, so something would
+    consume the skills - which is the question both the nudge's display gate and
+    the in-app install handler's action gate are really asking.
+
+    Shared by those two on purpose: gating the display broadly and the action
+    narrowly would offer a button that refuses, and the reverse withholds the
+    one repair from users the startup recommendation nags on every run.
+    """
+    return bool(detect_installed_agents()) or _is_claude_code_present()
+
+
 def should_show_skills_nudge(app_dir: str | None = None) -> bool:
     """Return whether the in-app "install skills" nudge should be shown.
 
@@ -1610,15 +1628,9 @@ def nudge_suppression_reason(app_dir: str | None = None) -> _NudgeSuppressionRea
         if _nudge_dismissed_marker_path().exists():
             return "dismissed"
         # An agent must be present, and our skills must not be installed yet.
-        # Either detector satisfies the first half, on purpose. Whoever
-        # _is_claude_code_present() covers has a .claude/skills target, so an
-        # .agents-only tree reports partial and the startup recommendation
-        # prints for them every run; gating on the narrower harness list alone
-        # withheld the one-click repair from exactly those users - nagged by the
-        # surface that cannot fix it, hidden from the one that can. Real
-        # population: a `claude` on PATH with no ~/.claude (shared toolchain
-        # image, leftover binary, CLAUDE_CONFIG_DIR).
-        if not detect_installed_agents() and not _is_claude_code_present():
+        # Either detector counts - see agent_harness_present(), which the in-app
+        # install handler's action gate shares so the two cannot drift.
+        if not agent_harness_present():
             return "no_agent"
         # An agent is present; recommend installing only if our skills aren't. A
         # marker found somewhere is not enough: it may sit in .agents/skills

--- a/lib/streamlit/web/skills.py
+++ b/lib/streamlit/web/skills.py
@@ -280,21 +280,24 @@ def _claude_cli_on_path() -> bool:
     found = shutil.which("claude")
     if found is None:
         return False
-    if not env_util.IS_WINDOWS:
-        return True
-    # On Windows shutil.which() searches the current directory first whatever
-    # PATH says, so a checkout that happens to contain claude.exe/.bat/.cmd
-    # would otherwise decide where we write. Nothing is executed - the cost is a
-    # stray .claude/skills/ dir - but repo contents should not be an input here,
-    # so only trust a hit that lives in a real PATH entry. A user who put "."
-    # on PATH themselves still counts; that is their choice, not the repo's.
-    found_dir = os.path.normcase(os.path.dirname(os.path.abspath(found)))
-    path_dirs = {
+    # Windows only: shutil.which() searches the current directory before PATH
+    # there, so without this a checkout shipping claude.exe/.bat/.cmd would
+    # decide where we write. Repo contents must not be an input to that.
+    return not env_util.IS_WINDOWS or _lives_in_a_path_entry(found)
+
+
+def _lives_in_a_path_entry(executable: str) -> bool:
+    """Whether ``executable`` sits in a directory ``PATH`` actually names.
+
+    A user who put "." on ``PATH`` themselves still counts - that is their
+    choice, not the repo's.
+    """
+    found_dir = os.path.normcase(os.path.dirname(os.path.abspath(executable)))
+    return found_dir in {
         os.path.normcase(os.path.abspath(entry))
         for entry in os.environ.get("PATH", "").split(os.pathsep)
         if entry
     }
-    return found_dir in path_dirs
 
 
 # Cached because this sits on the nudge show-gate, which re-evaluates on every
@@ -1572,14 +1575,15 @@ def nudge_suppression_reason(app_dir: str | None = None) -> _NudgeSuppressionRea
     """Return why the in-app "install skills" nudge is being withheld, or ``""``
     when it should be shown.
 
-    The nudge is recommended only for interactive local development where an
-    AI agent harness is present but the bundled Streamlit skills are not yet
-    installed - or are installed in only some of the agent directories the
-    installer targets - and the user has not permanently dismissed it. This
-    mirrors the gating of the CLI recommendation printed on app startup, which
-    uses the same completeness rule via :func:`are_skills_installed`. It is also
-    withheld when a one-click install would conflict at every install target, so
-    the user is never nudged toward an install that can only fail.
+    The nudge is recommended only for interactive local development where an AI
+    agent harness is present - by either detector, see the gate below - but the
+    bundled Streamlit skills are not yet installed, or are installed in only
+    some of the agent directories the installer targets, and the user has not
+    permanently dismissed it. This mirrors the gating of the CLI recommendation
+    printed on app startup, which uses the same completeness rule via
+    :func:`are_skills_installed`. It is also withheld when a one-click install
+    would conflict at every install target, so the user is never nudged toward
+    an install that can only fail.
 
     Parameters
     ----------
@@ -1605,10 +1609,16 @@ def nudge_suppression_reason(app_dir: str | None = None) -> _NudgeSuppressionRea
             return "welcome_hidden"
         if _nudge_dismissed_marker_path().exists():
             return "dismissed"
-        # Gate on the same detection the page-profile telemetry uses (both now
-        # defined here): an agent must be present, and our skills must not be
-        # installed yet.
-        if not detect_installed_agents():
+        # An agent must be present, and our skills must not be installed yet.
+        # Either detector satisfies the first half, on purpose. Whoever
+        # _is_claude_code_present() covers has a .claude/skills target, so an
+        # .agents-only tree reports partial and the startup recommendation
+        # prints for them every run; gating on the narrower harness list alone
+        # withheld the one-click repair from exactly those users - nagged by the
+        # surface that cannot fix it, hidden from the one that can. Real
+        # population: a `claude` on PATH with no ~/.claude (shared toolchain
+        # image, leftover binary, CLAUDE_CONFIG_DIR).
+        if not detect_installed_agents() and not _is_claude_code_present():
             return "no_agent"
         # An agent is present; recommend installing only if our skills aren't. A
         # marker found somewhere is not enough: it may sit in .agents/skills

--- a/lib/streamlit/web/skills.py
+++ b/lib/streamlit/web/skills.py
@@ -300,12 +300,19 @@ def _lives_in_a_path_entry(executable: str) -> bool:
     }
 
 
+# Deliberately broader than the "claude" entry in _HARNESSES, which keys on the
+# home directory alone. That table answers "which harnesses exist" for telemetry,
+# where a stable definition matters more than catching a just-installed CLI; here
+# a miss breaks the feature outright. The two only disagree for an install never
+# invoked beyond `claude --version`, which creates nothing - the first command
+# that touches config creates both ~/.claude and ~/.claude.json, before login
+# (checked against Claude Code 2.1.235). Nobody is wedged in that window, since
+# being wedged means having used Claude Code and found the skill missing.
+#
 # Cached because this sits on the nudge show-gate, which re-evaluates on every
-# script rerun, and shutil.which() walks the whole PATH (plus a PATHEXT sweep on
-# Windows) - the same reason _symlink_blocker is cached. The cost is that Claude
-# Code installed mid-session is not noticed until the server restarts, so an
-# install in that window writes .agents only. That is self-correcting rather than
-# a dead end: the next session sees a partial install and offers the repair.
+# script rerun, and shutil.which() walks the whole PATH. Claude Code installed
+# mid-session is therefore missed until the server restarts; the next session
+# sees a partial install and offers the repair.
 @lru_cache(maxsize=1)
 def _is_claude_code_present() -> bool:
     """Whether the installer should also write a ``.claude`` skills target.
@@ -315,18 +322,6 @@ def _is_claude_code_present() -> bool:
     while a false positive costs a few unused symlinks. Detection is generous to
     match that asymmetry: ``~/.claude`` is created lazily, so ``~/.claude.json``
     or a ``claude`` on ``PATH`` counts as present too.
-
-    Deliberately broader than the ``claude`` entry in ``_HARNESSES``, which keys
-    on the home directory alone. That table answers "which harnesses exist" for
-    telemetry, where a stable definition matters more than catching a
-    just-installed CLI; here a miss breaks the feature outright.
-
-    The two only disagree in a narrow window, which is why they are left to
-    differ: ``claude --version`` creates nothing, but the first command that
-    touches config creates both ``~/.claude`` and ``~/.claude.json``, before
-    login. So the gap is "installed, never really run" - and nobody is wedged
-    there, because being wedged means having used Claude Code and found the
-    skill missing. Verified against Claude Code 2.1.235.
     """
     try:
         home = Path.home()
@@ -392,13 +387,15 @@ def _install_completeness(app_dir: str | None = None) -> _InstallCompleteness:
     complete global install means every agent can load the skill, so a
     half-finished project install must not downgrade it.
 
-    Best-effort: target dirs that cannot be resolved are skipped, and target
-    dirs that cannot be read count as unknown rather than missing, so a
-    permissions error never reports a correctly-installed user as partial. When
-    no target dir in any scope can be read the whole answer is ``unknown``
-    rather than ``absent``, since "we could not look" is not evidence that the
-    skill is missing - and marker detection cannot see through those directories
-    either, so nothing else would catch it.
+    Best-effort, so a permissions error never reports a correctly-installed user
+    as partial:
+
+    - Target dirs that cannot be resolved are skipped.
+    - Target dirs that cannot be read count as unknown, not missing.
+    - When no target dir in any scope can be read, the whole answer is
+      ``unknown``: "we could not look" is not evidence the skill is missing, and
+      marker detection cannot see through those dirs either.
+
     Deliberately uncached, so repairing a partial install takes effect at once.
 
     Parameters
@@ -469,18 +466,18 @@ def _install_completeness(app_dir: str | None = None) -> _InstallCompleteness:
 
 
 def are_skills_installed() -> bool:
-    """Check whether Streamlit agent skills appear to be installed.
+    """Whether the startup recommendation should stay quiet about the skills.
 
-    Returns ``True`` only when the bundled skill is present (as a symlink,
-    copied directory, or regular directory) in *every* target directory of at
-    least one install scope, so it is reachable from every agent ``streamlit
-    skills`` writes for. A partial install counts as not installed, so the
-    startup recommendation in ``bootstrap`` prints again and the re-run fills in
-    the missing agent directory - the case that matters when an agent is
-    installed after ``streamlit skills`` last ran.
+    ``True`` when the bundled skill is present (as a symlink, copied directory,
+    or regular directory) in *every* target directory of at least one install
+    scope, so it is reachable from every agent ``streamlit skills`` writes for.
+    A partial install counts as not installed, so the startup recommendation in
+    ``bootstrap`` prints again and the re-run fills in the missing agent
+    directory - the case that matters when an agent is installed after
+    ``streamlit skills`` last ran.
 
-    An install we could not inspect at all - target dirs resolved, but every one
-    of them raised - also reports ``True``. "We could not look" is not evidence
+    Also ``True`` for an install we could not inspect at all - target dirs
+    resolved, but every one of them raised. "We could not look" is not evidence
     the skill is missing, the recommendation has no dismissal path, and the
     install it points at would hit the same error.
 
@@ -490,10 +487,11 @@ def are_skills_installed() -> bool:
 
 
 def _skill_present_in(target_dir: Path) -> bool | None:
-    """Whether the bundled skill exists in ``target_dir``, as link or directory.
+    """Whether the bundled skill path exists in ``target_dir``.
 
-    Returns ``None`` when the filesystem check itself fails, so callers can tell
-    "not there" apart from "could not look".
+    Returns ``None`` when the filesystem cannot determine this, so callers can
+    tell "not there" apart from "could not look". Dangling symlinks count as
+    present.
     """
     skill_path = target_dir / _GLOBAL_SKILL_NAME
     try:
@@ -1554,7 +1552,10 @@ _NudgeSuppressionReason = Literal[
     "dismissed",  # The user asked never to see it again.
     # Names the stage that failed, not just "error": the sibling telemetry labels
     # are install failures, so a bare "error" would read as one.
-    "check_failed",  # The check could not answer: it threw, or no target read.
+    "check_failed",  # The eligibility check raised.
+    # Split from check_failed because the fixes differ: a code-path failure is
+    # ours, an unreadable install tree is the user's permissions.
+    "check_unreadable",  # No install target could be read.
     "headless",  # Headless mode: deployments, CI, SiS.
     "installed",  # The bundled skills are already present.
     "no_agent",  # No AI agent harness on this machine.
@@ -1562,6 +1563,10 @@ _NudgeSuppressionReason = Literal[
 ]
 
 
+# Keep the nudge's display gate and the in-app installer's action gate on this
+# one predicate: gating the display broadly and the action narrowly offers a
+# button that refuses, and the reverse withholds the one repair from users the
+# startup recommendation nags on every run.
 def agent_harness_present() -> bool:
     """Whether an AI agent harness that would consume the skills is installed.
 
@@ -1570,12 +1575,7 @@ def agent_harness_present() -> bool:
     eight harnesses; :func:`_is_claude_code_present` is the broader signal that
     decides whether ``.claude/skills`` is an install target at all. Anyone the
     broad one covers has a target the installer writes to, so something would
-    consume the skills - which is the question both the nudge's display gate and
-    the in-app install handler's action gate are really asking.
-
-    Shared by those two on purpose: gating the display broadly and the action
-    narrowly would offer a button that refuses, and the reverse withholds the
-    one repair from users the startup recommendation nags on every run.
+    consume the skills - which is the question both gates are really asking.
     """
     return bool(detect_installed_agents()) or _is_claude_code_present()
 
@@ -1612,10 +1612,11 @@ def nudge_suppression_reason(app_dir: str | None = None) -> _NudgeSuppressionRea
         detection result. Falls back to the current working directory when
         ``None``.
 
-    Best-effort: returns ``"check_failed"`` whenever the check cannot answer -
-    it threw, or every install target was unreadable - so a detection failure
-    never blocks app startup or surfaces a spurious nudge. Note this is a
-    *reason*, not a falsy value — the nudge stays hidden, as before.
+    Best-effort: the nudge is withheld rather than guessed whenever the check
+    cannot answer, so a detection failure never blocks app startup or surfaces a
+    spurious nudge - ``"check_failed"`` when the check raised, and
+    ``"check_unreadable"`` when every install target was unreadable. Note these
+    are *reasons*, not falsy values — the nudge stays hidden, as before.
     """
     from streamlit import config
 
@@ -1646,10 +1647,11 @@ def nudge_suppression_reason(app_dir: str | None = None) -> _NudgeSuppressionRea
         # No marker found and nothing readable either: every target dir raised,
         # so "not installed" is a conclusion we cannot draw, and the one-click
         # install we would offer hits the same error. Withhold instead of
-        # nudging a user whose setup may be fine, reusing "check_failed" because
-        # the cause is the same - the eligibility check could not answer.
+        # nudging a user whose setup may be fine. Its own label rather than
+        # "check_failed": this is a permissions population to go and look at, not
+        # a code path of ours that broke.
         if completeness == "unknown":
-            return "check_failed"
+            return "check_unreadable"
         # No usable install found. Withhold only on a deterministic conflict at
         # every target; the other always-fail causes (missing bundled package, a
         # copy that errors on permissions/path-length) stay fail-open, since those

--- a/lib/streamlit/web/skills.py
+++ b/lib/streamlit/web/skills.py
@@ -29,6 +29,7 @@ from typing import Final, Literal
 import click
 
 import streamlit
+from streamlit import env_util
 from streamlit.logger import get_logger
 
 _LOGGER: Final = get_logger(__name__)
@@ -274,24 +275,61 @@ def _find_project_root(start: Path | None = None) -> Path:
     return start_dir
 
 
+def _claude_cli_on_path() -> bool:
+    """Whether a ``claude`` executable is reachable on the user's ``PATH``."""
+    found = shutil.which("claude")
+    if found is None:
+        return False
+    if not env_util.IS_WINDOWS:
+        return True
+    # On Windows shutil.which() searches the current directory first whatever
+    # PATH says, so a checkout that happens to contain claude.exe/.bat/.cmd
+    # would otherwise decide where we write. Nothing is executed - the cost is a
+    # stray .claude/skills/ dir - but repo contents should not be an input here,
+    # so only trust a hit that lives in a real PATH entry. A user who put "."
+    # on PATH themselves still counts; that is their choice, not the repo's.
+    found_dir = os.path.normcase(os.path.dirname(os.path.abspath(found)))
+    path_dirs = {
+        os.path.normcase(os.path.abspath(entry))
+        for entry in os.environ.get("PATH", "").split(os.pathsep)
+        if entry
+    }
+    return found_dir in path_dirs
+
+
+# Cached because this sits on the nudge show-gate, which re-evaluates on every
+# script rerun, and shutil.which() walks the whole PATH (plus a PATHEXT sweep on
+# Windows) - the same reason _symlink_blocker is cached. The cost is that Claude
+# Code installed mid-session is not noticed until the server restarts, so an
+# install in that window writes .agents only. That is self-correcting rather than
+# a dead end: the next session sees a partial install and offers the repair.
+@lru_cache(maxsize=1)
 def _is_claude_code_present() -> bool:
-    """Best-effort check for whether Claude Code is installed.
+    """Whether the installer should also write a ``.claude`` skills target.
 
     Claude Code only reads skills from ``.claude/skills/``, never from
-    ``.agents/skills/``, so this decides whether the installer also writes a
-    ``.claude`` target. Getting it wrong in the negative direction silently
-    costs the user the whole skill, so this checks several signals rather than
-    just ``~/.claude``: that directory is created lazily and may not exist yet
-    on a fresh install, even though the CLI is on PATH.
+    ``.agents/skills/``, so a missed detection costs the user the entire skill
+    while a false positive costs a few unused symlinks. Detection is generous to
+    match that asymmetry: ``~/.claude`` is created lazily, so ``~/.claude.json``
+    or a ``claude`` on ``PATH`` counts as present too.
+
+    Deliberately broader than the ``claude`` entry in ``_HARNESSES``, which keys
+    on the home directory alone. That table answers "which harnesses exist" for
+    telemetry, where a stable definition matters more than catching a CLI
+    installed minutes ago; here a miss breaks the feature outright.
     """
     try:
         home = Path.home()
     except RuntimeError:
-        return False
+        # Path.home() raises when the home directory cannot be resolved. The
+        # marker checks are impossible then, but the CLI can still be on PATH -
+        # and a project-local .claude/skills/ install needs no home directory.
+        pass
+    else:
+        if (home / ".claude").exists() or (home / ".claude.json").exists():
+            return True
 
-    if (home / ".claude").exists() or (home / ".claude.json").exists():
-        return True
-    return shutil.which("claude") is not None
+    return _claude_cli_on_path()
 
 
 def _get_project_target_dirs(project_root: Path) -> list[Path]:
@@ -323,21 +361,42 @@ def _get_global_target_dirs() -> list[Path]:
     return targets
 
 
-def are_skills_installed() -> bool:
-    """Check whether Streamlit agent skills appear to be installed.
+# How completely the bundled skill is installed, judged only against the
+# directories `streamlit skills` itself writes. ``partial`` is the state this
+# vocabulary exists for: it is the wedge - the skill sitting in .agents/skills
+# with nothing in .claude/skills, because Claude Code was not detected the last
+# time the installer ran - which leaves the skill invisible to that agent.
+_InstallCompleteness = Literal[
+    "absent",  # No target dir in either scope has the skill.
+    "complete",  # Some scope has it in every target dir we could read.
+    "partial",  # Some scope has it in some target dirs, and neither is complete.
+]
 
-    Returns ``True`` if the bundled skill is present (as a symlink, copied
-    directory, or regular directory) in *every* target directory for the scope
-    the user installed into. A partial install counts as not installed, so the
-    nudge fires again and fills in the missing agent directory -- this matters
-    when an agent is installed after ``streamlit skills`` last ran. This is a
-    best-effort check used to decide whether to recommend installing skills; it
-    does not validate skill contents.
+
+def _install_completeness(app_dir: str | None = None) -> _InstallCompleteness:
+    """How completely the bundled skill is installed, from the installer's view.
+
+    A scope counts as complete when every target dir we could read has the
+    skill, and the whole install counts as complete when *either* scope is - a
+    complete global install means every agent can load the skill, so a
+    half-finished project install must not downgrade it.
+
+    Best-effort: target dirs that cannot be resolved are skipped, and target
+    dirs that cannot be read count as unknown rather than missing, so a
+    permissions error never reports a correctly-installed user as partial.
+    Deliberately uncached, so repairing a partial install takes effect at once.
+
+    Parameters
+    ----------
+    app_dir
+        Directory of the running app's main script, used to resolve the project
+        root exactly as an install triggered from that app would. ``None`` falls
+        back to the current working directory.
     """
     project_dirs: list[Path] = []
     global_dirs: list[Path] = []
     try:
-        project_root = _find_project_root()
+        project_root = _find_project_root(Path(app_dir) if app_dir else None)
     except (OSError, RuntimeError):
         # RuntimeError can be raised by Path.home() when the home directory
         # cannot be determined. This is a best-effort check, so skip project dirs.
@@ -356,31 +415,43 @@ def are_skills_installed() -> bool:
         # them; still a best-effort check, so just skip the global dirs.
         pass
 
-    # Project scope first: a project-local install is the more specific choice.
-    scoped_dirs = (project_dirs, global_dirs)
-
-    for scope_dirs in scoped_dirs:
+    partial = False
+    # Project scope first only because a project-local install is the more
+    # specific choice; a complete scope wins wherever it is found, so the order
+    # does not change the answer.
+    for scope_dirs in (project_dirs, global_dirs):
         if not scope_dirs:
             continue
         # Directories we could not read are dropped rather than treated as
         # missing: an unreadable path means "unknown", and reporting the skill
-        # as uninstalled because of a permissions error would nudge users who
+        # as uninstalled because of a permissions error would pester users who
         # are in fact set up correctly.
         known = [
             present
             for present in (_skill_present_in(target_dir) for target_dir in scope_dirs)
             if present is not None
         ]
+        if known and all(known):
+            return "complete"
         if any(known):
-            # This scope has been installed into before, so it is the scope the
-            # user chose. Report installed only if *every* readable target dir for
-            # it has the skill. A partial install -- typically .agents/skills
-            # present but .claude/skills missing, because Claude Code was not
-            # detected the last time `streamlit skills` ran -- leaves the skill
-            # invisible to that agent. Returning True there would suppress the
-            # nudge permanently and strand the user with a skill nothing loads.
-            return all(known)
-    return False
+            partial = True
+    return "partial" if partial else "absent"
+
+
+def are_skills_installed() -> bool:
+    """Check whether Streamlit agent skills appear to be installed.
+
+    Returns ``True`` only when the bundled skill is present (as a symlink,
+    copied directory, or regular directory) in *every* target directory of at
+    least one install scope, so it is reachable from every agent ``streamlit
+    skills`` writes for. A partial install counts as not installed, so the
+    startup recommendation in ``bootstrap`` prints again and the re-run fills in
+    the missing agent directory - the case that matters when an agent is
+    installed after ``streamlit skills`` last ran.
+
+    Best-effort: it does not validate skill contents.
+    """
+    return _install_completeness() == "complete"
 
 
 def _skill_present_in(target_dir: Path) -> bool | None:
@@ -391,9 +462,20 @@ def _skill_present_in(target_dir: Path) -> bool | None:
     """
     skill_path = target_dir / _GLOBAL_SKILL_NAME
     try:
-        return skill_path.is_symlink() or skill_path.exists()
+        # lstat() rather than exists()/is_symlink(): those swallow OSError and
+        # so report an unreadable path as a missing one, which would collapse
+        # the "could not look" case this return type exists for. lstat() does
+        # not follow symlinks, so a dangling link still counts as present.
+        skill_path.lstat()
+    except (FileNotFoundError, NotADirectoryError):
+        # Nothing there, or a parent component is a file - either way the skill
+        # is genuinely absent rather than unreadable.
+        return False
     except OSError:
+        # Permissions, a dead mount, a path over the OS length limit: we could
+        # not look, which is not the same as "not installed".
         return None
+    return True
 
 
 def _is_streamlit_owned_symlink(link_path: Path, bundled_skill_names: set[str]) -> bool:
@@ -1460,10 +1542,12 @@ def nudge_suppression_reason(app_dir: str | None = None) -> _NudgeSuppressionRea
 
     The nudge is recommended only for interactive local development where an
     AI agent harness is present but the bundled Streamlit skills are not yet
-    installed, and the user has not permanently dismissed it. This mirrors the
-    gating of the CLI recommendation printed on app startup. It is also withheld
-    when a one-click install would conflict at every install target, so the user
-    is never nudged toward an install that can only fail.
+    installed - or are installed in only some of the agent directories the
+    installer targets - and the user has not permanently dismissed it. This
+    mirrors the gating of the CLI recommendation printed on app startup, which
+    uses the same completeness rule via :func:`are_skills_installed`. It is also
+    withheld when a one-click install would conflict at every install target, so
+    the user is never nudged toward an install that can only fail.
 
     Parameters
     ----------
@@ -1493,10 +1577,20 @@ def nudge_suppression_reason(app_dir: str | None = None) -> _NudgeSuppressionRea
         # installed yet.
         if not detect_installed_agents():
             return "no_agent"
-        # An agent is present; recommend installing only if our skills aren't.
-        if detect_installed_skills(app_dir):
+        # An agent is present; recommend installing only if our skills aren't. A
+        # marker found somewhere is not enough: it may sit in .agents/skills
+        # while Claude Code, which reads only .claude/skills, has nothing. Only
+        # "partial" - an install of ours that misses one of its own target dirs -
+        # keeps the nudge, since its one-click install is exactly the repair.
+        # "absent" still suppresses: the marker came from a harness we do not
+        # install for (a hand-placed .cursor/skills copy, say), and nudging that
+        # user would be noise.
+        if (
+            detect_installed_skills(app_dir)
+            and _install_completeness(app_dir) != "partial"
+        ):
             return "installed"
-        # No SKILL.md marker found. Withhold only on a deterministic conflict at
+        # No usable install found. Withhold only on a deterministic conflict at
         # every target; the other always-fail causes (missing bundled package, a
         # copy that errors on permissions/path-length) stay fail-open, since those
         # can resolve without the user removing anything.

--- a/lib/streamlit/web/skills.py
+++ b/lib/streamlit/web/skills.py
@@ -377,6 +377,7 @@ _InstallCompleteness = Literal[
     "absent",  # No target dir in either scope has the skill.
     "complete",  # Some scope has it in every target dir we could read.
     "partial",  # Some scope has it in some target dirs, and neither is complete.
+    "unknown",  # There were target dirs, but not one of them could be read.
 ]
 
 
@@ -390,7 +391,11 @@ def _install_completeness(app_dir: str | None = None) -> _InstallCompleteness:
 
     Best-effort: target dirs that cannot be resolved are skipped, and target
     dirs that cannot be read count as unknown rather than missing, so a
-    permissions error never reports a correctly-installed user as partial.
+    permissions error never reports a correctly-installed user as partial. When
+    no target dir in any scope can be read the whole answer is ``unknown``
+    rather than ``absent``, since "we could not look" is not evidence that the
+    skill is missing - and marker detection cannot see through those directories
+    either, so nothing else would catch it.
     Deliberately uncached, so repairing a partial install takes effect at once.
 
     Parameters
@@ -423,12 +428,12 @@ def _install_completeness(app_dir: str | None = None) -> _InstallCompleteness:
         pass
 
     partial = False
+    read_a_target = False
     # Project scope first only because a project-local install is the more
     # specific choice; a complete scope wins wherever it is found, so the order
     # does not change the answer.
-    for scope_dirs in (project_dirs, global_dirs):
-        if not scope_dirs:
-            continue
+    scopes = [scope_dirs for scope_dirs in (project_dirs, global_dirs) if scope_dirs]
+    for scope_dirs in scopes:
         # Directories we could not read are dropped rather than treated as
         # missing: an unreadable path means "unknown", and reporting the skill
         # as uninstalled because of a permissions error would pester users who
@@ -438,11 +443,26 @@ def _install_completeness(app_dir: str | None = None) -> _InstallCompleteness:
             for present in (_skill_present_in(target_dir) for target_dir in scope_dirs)
             if present is not None
         ]
-        if known and all(known):
+        if not known:
+            # Not one target in this scope answered, so it is evidence of
+            # nothing - neither an install nor a missing one.
+            continue
+        read_a_target = True
+        if all(known):
             return "complete"
         if any(known):
             partial = True
-    return "partial" if partial else "absent"
+
+    if partial:
+        return "partial"
+    if scopes and not read_a_target:
+        # We knew where to look and could not look anywhere: reporting "absent"
+        # here would tell both surfaces the skill is missing on the strength of
+        # a permissions error, nagging a correctly-installed user every rerun.
+        # Note this is narrower than resolving no target dirs at all, which
+        # stays "absent": there the install we recommend can still succeed.
+        return "unknown"
+    return "absent"
 
 
 def are_skills_installed() -> bool:
@@ -456,9 +476,14 @@ def are_skills_installed() -> bool:
     the missing agent directory - the case that matters when an agent is
     installed after ``streamlit skills`` last ran.
 
+    An install we could not inspect at all - target dirs resolved, but every one
+    of them raised - also reports ``True``. "We could not look" is not evidence
+    the skill is missing, the recommendation has no dismissal path, and the
+    install it points at would hit the same error.
+
     Best-effort: it does not validate skill contents.
     """
-    return _install_completeness() == "complete"
+    return _install_completeness() in {"complete", "unknown"}
 
 
 def _skill_present_in(target_dir: Path) -> bool | None:
@@ -1526,7 +1551,7 @@ _NudgeSuppressionReason = Literal[
     "dismissed",  # The user asked never to see it again.
     # Names the stage that failed, not just "error": the sibling telemetry labels
     # are install failures, so a bare "error" would read as one.
-    "check_failed",  # The eligibility check itself threw; withheld defensively.
+    "check_failed",  # The check could not answer: it threw, or no target read.
     "headless",  # Headless mode: deployments, CI, SiS.
     "installed",  # The bundled skills are already present.
     "no_agent",  # No AI agent harness on this machine.
@@ -1565,9 +1590,10 @@ def nudge_suppression_reason(app_dir: str | None = None) -> _NudgeSuppressionRea
         detection result. Falls back to the current working directory when
         ``None``.
 
-    Best-effort: returns ``"check_failed"`` on any failure so a detection failure
-    never blocks app startup or surfaces a spurious nudge. Note this is a *reason*,
-    not a falsy value — the nudge stays hidden, as before.
+    Best-effort: returns ``"check_failed"`` whenever the check cannot answer -
+    it threw, or every install target was unreadable - so a detection failure
+    never blocks app startup or surfaces a spurious nudge. Note this is a
+    *reason*, not a falsy value — the nudge stays hidden, as before.
     """
     from streamlit import config
 
@@ -1592,11 +1618,16 @@ def nudge_suppression_reason(app_dir: str | None = None) -> _NudgeSuppressionRea
         # "absent" still suppresses: the marker came from a harness we do not
         # install for (a hand-placed .cursor/skills copy, say), and nudging that
         # user would be noise.
-        if (
-            detect_installed_skills(app_dir)
-            and _install_completeness(app_dir) != "partial"
-        ):
+        completeness = _install_completeness(app_dir)
+        if detect_installed_skills(app_dir) and completeness != "partial":
             return "installed"
+        # No marker found and nothing readable either: every target dir raised,
+        # so "not installed" is a conclusion we cannot draw, and the one-click
+        # install we would offer hits the same error. Withhold instead of
+        # nudging a user whose setup may be fine, reusing "check_failed" because
+        # the cause is the same - the eligibility check could not answer.
+        if completeness == "unknown":
+            return "check_failed"
         # No usable install found. Withhold only on a deterministic conflict at
         # every target; the other always-fail causes (missing bundled package, a
         # copy that errors on permissions/path-length) stay fail-open, since those

--- a/lib/streamlit/web/skills.py
+++ b/lib/streamlit/web/skills.py
@@ -559,7 +559,7 @@ def _symlink_blocker(project_root: Path, source_path: Path) -> _FallbackReason |
     and only ``symlinks_no_privilege`` (Developer Mode off) is a cause a user can fix.
     """
     # Cached: the probe WRITES (a temp dir plus a symlink) into project_root, and
-    # the nudge show-gate calls this on every script rerun - uncached, a passive
+    # the nudge display gate calls this on every script rerun - uncached, a passive
     # eligibility check would churn the user's project directory continuously.
     # Symlink support is a property of the OS and filesystem rather than of a
     # moment in time (enabling Windows Developer Mode needs a restart anyway), so
@@ -609,7 +609,7 @@ def _symlink_target_would_conflict(target_path: Path) -> bool:
     blocking a project (symlink) install.
     """
     # Shared by _install_skill_symlink (which skips such a target) and the nudge
-    # show-gate (_one_click_install_would_be_refused) so the two cannot drift.
+    # display gate (_one_click_install_would_be_refused) so the two cannot drift.
     # Symlinks are excluded because the installer replaces any symlink named
     # after a bundled skill; a broken one has exists() == False regardless.
     return target_path.exists() and not target_path.is_symlink()
@@ -622,7 +622,7 @@ def _copy_target_would_conflict(target_path: Path) -> bool:
     # The copy counterpart to _symlink_target_would_conflict, and deliberately
     # narrower: the copy install replaces a real directory (staging to a temp dir
     # first) and unlinks a name-owned symlink, so only a real file blocks it.
-    # Shared by _install_skill_copy and the nudge show-gate, same as above.
+    # Shared by _install_skill_copy and the nudge display gate, same as above.
     return (
         target_path.exists()
         and not target_path.is_symlink()
@@ -728,7 +728,7 @@ def _install_skill_copy(
         old_target_to_remove: Path | None = None
 
         # A real (non-symlink) file is a hard conflict - skip it. Routed through the
-        # shared predicate so the nudge show-gate's preflight cannot drift from what
+        # shared predicate so the nudge display gate's preflight cannot drift from what
         # this actually skips.
         if _copy_target_would_conflict(target_path):
             result.skipped.append(f"{rel_target_path} (existing file)")
@@ -1509,7 +1509,7 @@ def clear_installed_skills_cache() -> None:
 @lru_cache(maxsize=4)
 def _log_nudge_suppressed_by_conflict(blocked_paths: tuple[str, ...]) -> None:
     """Warn that the 'install skills' nudge is being withheld, once per blocker set."""
-    # Cached purely to deduplicate: the show-gate re-evaluates on every script
+    # Cached purely to deduplicate: the display gate re-evaluates on every script
     # rerun, so an unguarded warning would repeat for as long as the blockers do.
     # Suppression is otherwise entirely silent, which leaves a developer no way to
     # find out why the nudge never appears. Absolute paths are fine here - unlike
@@ -1528,7 +1528,7 @@ def _one_click_install_would_be_refused(app_dir: str | None) -> bool:
     Fails open (returns ``False``) on any error, so a probe failure never hides
     the nudge. Deliberately uncached, so removing a blocker re-shows it.
     """
-    # Without this the show-gate and the installer disagree: a stray non-managed
+    # Without this the display gate and the installer disagree: a stray non-managed
     # ``developing-with-streamlit`` path with no SKILL.md is invisible to the
     # marker-based detection yet a hard conflict for the installer, so the nudge
     # shows, the install refuses, and the loop repeats every session. The nudge

--- a/lib/streamlit/web/skills.py
+++ b/lib/streamlit/web/skills.py
@@ -300,28 +300,24 @@ def _lives_in_a_path_entry(executable: str) -> bool:
     }
 
 
-# Deliberately broader than the "claude" entry in _HARNESSES, which keys on the
-# home directory alone. That table answers "which harnesses exist" for telemetry,
-# where a stable definition matters more than catching a just-installed CLI; here
-# a miss breaks the feature outright. The two only disagree for an install never
-# invoked beyond `claude --version`, which creates nothing - the first command
-# that touches config creates both ~/.claude and ~/.claude.json, before login
-# (checked against Claude Code 2.1.235). Nobody is wedged in that window, since
-# being wedged means having used Claude Code and found the skill missing.
+# Broader than the "claude" row in _HARNESSES, which keys on ~/.claude alone for
+# stable telemetry. Here a miss hides the skill from Claude Code, so we also
+# accept ~/.claude.json and a `claude` on PATH. In practice the two only disagree
+# for a CLI never invoked past `claude --version`: the first command that touches
+# config writes both markers, before login (checked against Claude Code 2.1.235).
 #
-# Cached because this sits on the nudge show-gate, which re-evaluates on every
-# script rerun, and shutil.which() walks the whole PATH. Claude Code installed
-# mid-session is therefore missed until the server restarts; the next session
-# sees a partial install and offers the repair.
+# Cached: the nudge display gate calls this on every script rerun, and
+# shutil.which() walks all of PATH. A Claude Code install mid-session is missed
+# until the server restarts; the next session sees a partial install and offers
+# the repair.
 @lru_cache(maxsize=1)
 def _is_claude_code_present() -> bool:
-    """Whether the installer should also write a ``.claude`` skills target.
+    """Whether Claude Code appears to be installed on this machine.
 
-    Claude Code only reads skills from ``.claude/skills/``, never from
-    ``.agents/skills/``, so a missed detection costs the user the entire skill
-    while a false positive costs a few unused symlinks. Detection is generous to
-    match that asymmetry: ``~/.claude`` is created lazily, so ``~/.claude.json``
-    or a ``claude`` on ``PATH`` counts as present too.
+    Claude Code reads only ``.claude/skills/``, never ``.agents/skills/``, so a
+    missed detection hides the skill while a false positive costs unused
+    symlinks. ``~/.claude`` is created lazily, so ``~/.claude.json`` or a
+    ``claude`` on ``PATH`` also counts.
     """
     try:
         home = Path.home()
@@ -367,22 +363,15 @@ def _get_global_target_dirs() -> list[Path]:
 
 
 def _authoritative_global_target_dir() -> Path:
-    """The one global target dir whose write decides if an install succeeded.
+    """The global target whose write failure fails the whole install.
 
-    Claude Code is the only harness verified to read a directory we write, and it
-    reads ``.claude/skills`` while ignoring ``.agents/skills`` entirely. So when
-    Claude Code is detected, ``~/.claude/skills`` is what an install has to land,
-    and ``~/.agents/skills`` is best-effort - written for harnesses that may or may
-    not read it, and never the reason an install that already reached Claude Code
-    is reported as a failure.
+    - Claude Code detected -> ``~/.claude/skills``. That is what Claude Code
+      reads; ``~/.agents/skills`` is best-effort.
+    - No Claude Code -> ``~/.agents/skills``. No target has a verified reader,
+      but leaving none authoritative would turn every write failure into silent
+      success.
 
-    With no Claude Code detected, none of our targets has a verified reader and
-    ``~/.agents/skills`` is the only one we write, so it carries authority by
-    default. That is a deliberate choice between two wrong answers: leaving no
-    target authoritative would turn every write failure into a silent success.
-
-    Always one of :func:`_get_global_target_dirs`, so exactly one target in that
-    list is load-bearing and the rest are best-effort.
+    Always one of :func:`_get_global_target_dirs`.
     """
     home = Path.home()
     if _is_claude_code_present():
@@ -390,11 +379,9 @@ def _authoritative_global_target_dir() -> Path:
     return home / ".agents" / "skills"
 
 
-# How completely the bundled skill is installed, judged only against the
-# directories `streamlit skills` itself writes. ``partial`` is the state this
-# vocabulary exists for: it is the wedge - the skill sitting in .agents/skills
-# with nothing in .claude/skills, because Claude Code was not detected the last
-# time the installer ran - which leaves the skill invisible to that agent.
+# Completeness against the directories `streamlit skills` writes. The key state
+# is ``partial``: the skill is in .agents/skills but not .claude/skills, so
+# Claude Code cannot see it.
 _InstallCompleteness = Literal[
     "absent",  # No target dir in either scope has the skill.
     "complete",  # Some scope has it in every target dir we could read.
@@ -404,15 +391,14 @@ _InstallCompleteness = Literal[
 
 
 def _install_completeness(app_dir: str | None = None) -> _InstallCompleteness:
-    """How completely the bundled skill is installed, from the installer's view.
+    """How completely the bundled skill is installed across target directories.
 
-    A scope counts as complete when every target dir we could read has the
-    skill, and the whole install counts as complete when *either* scope is - a
-    complete global install means every agent can load the skill, so a
-    half-finished project install must not downgrade it.
+    Either scope (project or global) being complete is enough - a complete global
+    install means every agent can load the skill, so a half-finished project
+    install must not downgrade it.
 
-    Best-effort, so a permissions error never reports a correctly-installed user
-    as partial:
+    Best-effort - a permissions error never reports a working install as
+    partial:
 
     - Target dirs that cannot be resolved are skipped.
     - Target dirs that cannot be read count as unknown, not missing.
@@ -453,9 +439,8 @@ def _install_completeness(app_dir: str | None = None) -> _InstallCompleteness:
 
     partial = False
     read_a_target = False
-    # Project scope first only because a project-local install is the more
-    # specific choice; a complete scope wins wherever it is found, so the order
-    # does not change the answer.
+    # Project scope first, but either scope being complete returns immediately,
+    # so the order does not affect the result.
     scopes = [scope_dirs for scope_dirs in (project_dirs, global_dirs) if scope_dirs]
     for scope_dirs in scopes:
         # Directories we could not read are dropped rather than treated as
@@ -480,30 +465,21 @@ def _install_completeness(app_dir: str | None = None) -> _InstallCompleteness:
     if partial:
         return "partial"
     if scopes and not read_a_target:
-        # We knew where to look and could not look anywhere: reporting "absent"
-        # here would tell both surfaces the skill is missing on the strength of
-        # a permissions error, nagging a correctly-installed user every rerun.
-        # Note this is narrower than resolving no target dirs at all, which
-        # stays "absent": there the install we recommend can still succeed.
+        # Targets existed but none could be read. "Absent" here would blame a
+        # permissions error for a missing install. (No targets at all stays
+        # "absent": an install can still succeed once the lookup recovers.)
         return "unknown"
     return "absent"
 
 
 def are_skills_installed() -> bool:
-    """Whether the startup recommendation should stay quiet about the skills.
+    """Whether the startup recommendation should stay quiet about missing skills.
 
-    ``True`` when the bundled skill is present (as a symlink, copied directory,
-    or regular directory) in *every* target directory of at least one install
-    scope, so it is reachable from every agent ``streamlit skills`` writes for.
-    A partial install counts as not installed, so the startup recommendation in
-    ``bootstrap`` prints again and the re-run fills in the missing agent
-    directory - the case that matters when an agent is installed after
-    ``streamlit skills`` last ran.
-
-    Also ``True`` for an install we could not inspect at all - target dirs
-    resolved, but every one of them raised. "We could not look" is not evidence
-    the skill is missing, the recommendation has no dismissal path, and the
-    install it points at would hit the same error.
+    True for ``complete`` and ``unknown``. A partial install returns False, so
+    the startup recommendation prints again and the re-run fills in the missing
+    target. ``unknown`` (every target unreadable) returns True because the
+    recommendation has no dismissal path and the install it points at would hit
+    the same error.
 
     Best-effort: it does not validate skill contents.
     """
@@ -519,10 +495,9 @@ def _skill_present_in(target_dir: Path) -> bool | None:
     """
     skill_path = target_dir / _GLOBAL_SKILL_NAME
     try:
-        # lstat() rather than exists()/is_symlink(): those swallow OSError and
-        # so report an unreadable path as a missing one, which would collapse
-        # the "could not look" case this return type exists for. lstat() does
-        # not follow symlinks, so a dangling link still counts as present.
+        # lstat() instead of exists()/is_symlink(): those swallow OSError and
+        # collapse "could not look" into "missing". lstat() raises on permission
+        # errors and does not follow symlinks.
         skill_path.lstat()
     except (FileNotFoundError, NotADirectoryError):
         # Nothing there, or a parent component is a file - either way the skill
@@ -963,23 +938,20 @@ def _write_error(
     result: _InstallResult,
     reasons: set[_InstallFailureReason] | None = None,
 ) -> InstallError:
-    """Build a "couldn't write" error for filesystem failures during copy.
+    """Build a write-failure error for the copy install path.
 
-    Distinct from :func:`_conflict_error`, which reports pre-existing files.
+    Distinct from :func:`_conflict_error` (pre-existing files).
 
-    ``reasons`` are the causes that *justify* the error - in practice those from the
-    authoritative target, whose path a detected harness reads. ``None`` means every
-    recorded cause justifies it. A best-effort failure is still named in the
-    message, since the user should see everything that did not land, but it must
-    not decide the reason: a dead-weight target cannot be allowed to mislabel a
-    failure a load-bearing one caused.
+    ``reasons`` restricts which causes set the telemetry reason - in practice,
+    those from the authoritative target. ``None`` uses every recorded cause. A
+    best-effort target's failure still appears in the user-facing message, but it
+    must not pick the telemetry reason: the dir a harness actually reads decides
+    the label.
 
-    The reason follows what the justifying failures agreed on:
-
-    - all agreed on one cause -> that cause
-    - they disagreed, or none was recorded -> the generic ``write_failed``, because
-      claiming "permission denied" for a set that was half permissions and half
-      disk-full would point whoever reads the telemetry at the wrong fix
+    - All causes agree -> that cause.
+    - They disagree, or none was recorded -> ``write_failed``, since labelling a
+      half-permissions, half-disk-full set "permission denied" would point
+      whoever reads the telemetry at the wrong fix.
     """
     joined = ", ".join(_concise_install_paths(result.errored))
     justifying = result.write_reasons if reasons is None else reasons
@@ -1184,10 +1156,9 @@ def _install_global_skills(*, yes: bool = False) -> _InstallResult:
             reason="source_incomplete",
         )
 
-    # Install to each target directory, keeping a per-target result so each
-    # target's outcome can be judged on its own. The aggregate below cannot support
-    # that: ``write_reasons`` is a set, so two targets failing the same way are
-    # indistinguishable from one, and nothing in it records WHICH target failed.
+    # Per-target results let us judge each target's outcome. The merged
+    # _InstallResult cannot: write_reasons is a set, so identical failures on
+    # different targets are indistinguishable.
     result = _InstallResult()
     # For global install, only one skill is installed but we use a set for consistency
     bundled_skill_names = {_GLOBAL_SKILL_NAME}
@@ -1220,19 +1191,16 @@ def _install_global_skills(*, yes: bool = False) -> _InstallResult:
     # Report results
     _print_result(result)
 
-    # A write failure on the AUTHORITATIVE target is a hard failure: a detected
-    # harness reads that path, so the install reached no agent. A failure on a
-    # best-effort target is not, and used to be - telling a developer whose
-    # ~/.claude/skills was written, and whose Claude Code therefore works
-    # perfectly, that the install had failed. Worse once a partial install
-    # reopens the nudge: that developer would be nudged toward a repair that
-    # fails on the same unwritable target every time, with no way out.
+    # Fail only when the authoritative target failed: a detected harness reads
+    # that path, so the install reached no agent. A best-effort miss is not a
+    # failure - it avoids nudging a developer whose Claude Code works into a
+    # repair loop on an unwritable extra dir.
     if authoritative_failed:
         raise _write_error(result, authoritative_reasons)
 
-    # Nothing landed anywhere. Unreachable while the authoritative dir is always
-    # one of ``target_dirs``, but a target added later must not be able to turn a
-    # total failure into a silent success.
+    # Backstop: nothing landed anywhere. Currently unreachable because the
+    # authoritative dir is always in target_dirs, but prevents a future extra
+    # target from turning a total failure into silent success.
     if result.errored and not (result.installed or result.up_to_date):
         raise _write_error(result)
 
@@ -1639,19 +1607,16 @@ _NudgeSuppressionReason = Literal[
 ]
 
 
-# Keep the nudge's display gate and the in-app installer's action gate on this
-# one predicate: gating the display broadly and the action narrowly offers a
-# button that refuses, and the reverse withholds the one repair from users the
-# startup recommendation nags on every run.
+# Shared by the nudge display gate and InstallSkillsHandler's action gate.
+# Different predicates would give either a nudge whose button refuses, or a
+# startup recommendation with no one-click repair to offer.
 def agent_harness_present() -> bool:
-    """Whether an AI agent harness that would consume the skills is installed.
+    """Whether some agent harness would consume the installed skills.
 
-    Either detector counts. :func:`detect_installed_agents` keys on home-dir
-    markers and defines the ``installed_agents`` telemetry vocabulary for all
-    eight harnesses; :func:`_is_claude_code_present` is the broader signal that
-    decides whether ``.claude/skills`` is an install target at all. Anyone the
-    broad one covers has a target the installer writes to, so something would
-    consume the skills - which is the question both gates are really asking.
+    True when :func:`detect_installed_agents` finds a home-dir harness *or*
+    :func:`_is_claude_code_present` reports True (so the installer writes
+    ``.claude/skills``). Both the nudge display gate and the install handler
+    share this predicate.
     """
     return bool(detect_installed_agents()) or _is_claude_code_present()
 
@@ -1669,15 +1634,14 @@ def nudge_suppression_reason(app_dir: str | None = None) -> _NudgeSuppressionRea
     """Return why the in-app "install skills" nudge is being withheld, or ``""``
     when it should be shown.
 
-    The nudge is recommended only for interactive local development where an AI
-    agent harness is present - by either detector, see the gate below - but the
-    bundled Streamlit skills are not yet installed, or are installed in only
-    some of the agent directories the installer targets, and the user has not
-    permanently dismissed it. This mirrors the gating of the CLI recommendation
-    printed on app startup, which uses the same completeness rule via
-    :func:`are_skills_installed`. It is also withheld when a one-click install
-    would conflict at every install target, so the user is never nudged toward
-    an install that can only fail.
+    The nudge is shown only for interactive local development where
+    :func:`agent_harness_present` reports True and the bundled skills are not
+    already usable: either :func:`detect_installed_skills` finds no marker, or
+    :func:`_install_completeness` reports ``partial`` - our install missing one of
+    its own target dirs. Also withheld once the user dismisses it, and when a
+    one-click install would conflict at every target, so nobody is nudged toward
+    an install that can only fail. The startup recommendation gates on the same
+    completeness rule via :func:`are_skills_installed`.
 
     Parameters
     ----------
@@ -1688,11 +1652,13 @@ def nudge_suppression_reason(app_dir: str | None = None) -> _NudgeSuppressionRea
         detection result. Falls back to the current working directory when
         ``None``.
 
+    Notes
+    -----
     Best-effort: the nudge is withheld rather than guessed whenever the check
     cannot answer, so a detection failure never blocks app startup or surfaces a
     spurious nudge - ``"check_failed"`` when the check raised, and
-    ``"check_unreadable"`` when every install target was unreadable. Note these
-    are *reasons*, not falsy values — the nudge stays hidden, as before.
+    ``"check_unreadable"`` when every install target was unreadable. These are
+    *reasons*, not falsy values: the nudge stays hidden either way.
     """
     from streamlit import config
 
@@ -1709,23 +1675,21 @@ def nudge_suppression_reason(app_dir: str | None = None) -> _NudgeSuppressionRea
         # install handler's action gate shares so the two cannot drift.
         if not agent_harness_present():
             return "no_agent"
-        # An agent is present; recommend installing only if our skills aren't. A
-        # marker found somewhere is not enough: it may sit in .agents/skills
-        # while Claude Code, which reads only .claude/skills, has nothing. Only
-        # "partial" - an install of ours that misses one of its own target dirs -
-        # keeps the nudge, since its one-click install is exactly the repair.
-        # "absent" still suppresses: the marker came from a harness we do not
-        # install for (a hand-placed .cursor/skills copy, say), and nudging that
-        # user would be noise.
+        # A found marker is not proof the agent can load the skill: it may sit
+        # in .agents/skills while Claude Code, which reads only .claude/skills,
+        # has nothing. So of the states a found marker can pair with, only
+        # ``partial`` - our install missing one of its own targets - keeps the
+        # nudge, whose one-click install is exactly that repair. A marker from a
+        # harness we do not install for (a hand-placed .cursor/skills copy, say)
+        # suppresses: that user is already set up.
         completeness = _install_completeness(app_dir)
         if detect_installed_skills(app_dir) and completeness != "partial":
             return "installed"
-        # No marker found and nothing readable either: every target dir raised,
-        # so "not installed" is a conclusion we cannot draw, and the one-click
-        # install we would offer hits the same error. Withhold instead of
-        # nudging a user whose setup may be fine. Its own label rather than
-        # "check_failed": this is a permissions population to go and look at, not
-        # a code path of ours that broke.
+        # Every target dir raised, so we cannot tell whether skills are
+        # installed. Withhold: the user's setup may be fine, and the install
+        # we'd offer would hit the same error.
+        # Own label (not check_failed): this is a permissions issue to
+        # investigate, not a code bug.
         if completeness == "unknown":
             return "check_unreadable"
         # No usable install found. Withhold only on a deterministic conflict at

--- a/lib/tests/streamlit/runtime/app_session_test.py
+++ b/lib/tests/streamlit/runtime/app_session_test.py
@@ -2530,7 +2530,7 @@ def test_create_new_session_message_suppresses_nudge_on_non_loopback() -> None:
     )
 
 
-@pytest.mark.parametrize("reason", ["conflict", "check_failed"])
+@pytest.mark.parametrize("reason", ["conflict", "check_failed", "check_unreadable"])
 def test_create_new_session_message_reports_informative_suppression(
     reason: str,
 ) -> None:

--- a/lib/tests/streamlit/runtime/backend_operation_handler_test.py
+++ b/lib/tests/streamlit/runtime/backend_operation_handler_test.py
@@ -488,8 +488,13 @@ def test_install_skills_handler_runs_real_installer(tmp_path: Path) -> None:
         patch.object(skills, "detect_installed_agents", return_value=["claude"]),
         patch.object(skills, "_get_source_skills_dir", return_value=source_dir),
         patch("pathlib.Path.cwd", return_value=project_dir),
-        # No ~/.claude, so only .agents/skills is targeted.
         patch("pathlib.Path.home", return_value=tmp_path / "home"),
+        # Pin Claude Code as absent so .agents/skills is the only target, and the
+        # detail string below stays predictable. Stated explicitly rather than
+        # left to the temp $HOME having no ~/.claude: detection also consults
+        # PATH, so on a contributor's machine with the CLI installed the real
+        # helper would add .claude/skills and this would fail there but not in CI.
+        patch.object(skills, "_is_claude_code_present", return_value=False),
         patch.object(skills, "clear_installed_skills_cache"),
     ):
         response = asyncio.run(

--- a/lib/tests/streamlit/runtime/backend_operation_handler_test.py
+++ b/lib/tests/streamlit/runtime/backend_operation_handler_test.py
@@ -364,6 +364,10 @@ def test_install_skills_handler_refuses_without_agent_harness() -> None:
     with (
         patch("streamlit.config.get_option", return_value=False),
         patch.object(skills, "detect_installed_agents", return_value=[]),
+        # Pinned, not inherited: the gate consults the broader Claude signal too,
+        # which reads PATH and so would otherwise answer differently on a
+        # contributor machine with the CLI installed than it does in CI.
+        patch.object(skills, "_is_claude_code_present", return_value=False),
         patch("streamlit.web.skills.install_skills") as mock_install,
     ):
         response = asyncio.run(
@@ -376,6 +380,34 @@ def test_install_skills_handler_refuses_without_agent_harness() -> None:
     assert response.error_msg == "Skills install is not available in this environment."
     assert response.error_reason == "refused:no_agent"
     assert not response.HasField("install_skills")
+
+
+def test_install_skills_handler_honors_a_broad_claude_signal() -> None:
+    """The action gate accepts whatever the display gate accepts.
+
+    A `claude` on PATH with no ~/.claude gets a .claude/skills target, is
+    therefore reported as partially installed, and now sees the nudge. If this
+    gate still keyed on detect_installed_agents() alone, that nudge would hand
+    the user a button that refuses - worse than the nag it replaced.
+    """
+    install_result = skills._InstallResult(installed=[".claude/skills/foo"])
+    with (
+        patch("streamlit.config.get_option", return_value=False),
+        patch.object(skills, "detect_installed_agents", return_value=[]),
+        patch.object(skills, "_is_claude_code_present", return_value=True),
+        patch(
+            "streamlit.web.skills.install_skills", return_value=install_result
+        ) as mock_install,
+    ):
+        response = asyncio.run(
+            InstallSkillsHandler(lambda: "/app/dir").handle(
+                _install_skills_request(), "session-id"
+            )
+        )
+
+    mock_install.assert_called_once()
+    assert response.error_reason == ""
+    assert response.HasField("install_skills")
 
 
 def test_install_skills_handler_refuses_non_loopback_connection() -> None:

--- a/lib/tests/streamlit/runtime/backend_operation_handler_test.py
+++ b/lib/tests/streamlit/runtime/backend_operation_handler_test.py
@@ -364,9 +364,9 @@ def test_install_skills_handler_refuses_without_agent_harness() -> None:
     with (
         patch("streamlit.config.get_option", return_value=False),
         patch.object(skills, "detect_installed_agents", return_value=[]),
-        # Pinned, not inherited: the gate consults the broader Claude signal too,
-        # which reads PATH and so would otherwise answer differently on a
-        # contributor machine with the CLI installed than it does in CI.
+        # Pinned: agent_harness_present also consults PATH, so on a contributor
+        # machine with the CLI installed the gate would let the install through,
+        # failing this test locally while it passes in CI.
         patch.object(skills, "_is_claude_code_present", return_value=False),
         patch("streamlit.web.skills.install_skills") as mock_install,
     ):
@@ -382,13 +382,11 @@ def test_install_skills_handler_refuses_without_agent_harness() -> None:
     assert not response.HasField("install_skills")
 
 
-def test_install_skills_handler_honors_a_broad_claude_signal() -> None:
-    """The action gate accepts whatever the display gate accepts.
+def test_install_skills_handler_accepts_path_only_claude_detection() -> None:
+    """Install proceeds when Claude Code is detected only via PATH (no ~/.claude).
 
-    A `claude` on PATH with no ~/.claude gets a .claude/skills target, is
-    therefore reported as partially installed, and now sees the nudge. If this
-    gate still keyed on detect_installed_agents() alone, that nudge would hand
-    the user a button that refuses - worse than the nag it replaced.
+    The nudge shows for these users (they get a .claude/skills target reported as
+    partially installed), so the handler must not refuse with no_agent.
     """
     install_result = skills._InstallResult(installed=[".claude/skills/foo"])
     with (
@@ -521,11 +519,8 @@ def test_install_skills_handler_runs_real_installer(tmp_path: Path) -> None:
         patch.object(skills, "_get_source_skills_dir", return_value=source_dir),
         patch("pathlib.Path.cwd", return_value=project_dir),
         patch("pathlib.Path.home", return_value=tmp_path / "home"),
-        # Pin Claude Code as absent so .agents/skills is the only target, and the
-        # detail string below stays predictable. Stated explicitly rather than
-        # left to the temp $HOME having no ~/.claude: detection also consults
-        # PATH, so on a contributor's machine with the CLI installed the real
-        # helper would add .claude/skills and this would fail there but not in CI.
+        # Pinned: detection also consults PATH, so a contributor machine with
+        # the CLI would add .claude/skills and break the detail-string assertion.
         patch.object(skills, "_is_claude_code_present", return_value=False),
         patch.object(skills, "clear_installed_skills_cache"),
     ):

--- a/lib/tests/streamlit/web/skills_test.py
+++ b/lib/tests/streamlit/web/skills_test.py
@@ -402,20 +402,17 @@ class TestGetProjectTargetDirs:
         assert tmp_path / ".agents" / "skills" in result
 
     @pytest.mark.parametrize(
-        ("claude_home_exists", "expected_in_result"),
+        ("claude_present", "expected_in_result"),
         [(True, True), (False, False)],
-        ids=["claude-exists", "claude-missing"],
+        ids=["claude-present", "claude-absent"],
     )
-    def test_claude_skills_conditional_on_claude_home(
-        self, tmp_path: Path, claude_home_exists: bool, expected_in_result: bool
+    def test_claude_skills_conditional_on_claude_code(
+        self, tmp_path: Path, claude_present: bool, expected_in_result: bool
     ) -> None:
-        """Includes .claude/skills/ only when ~/.claude exists."""
-        home = tmp_path / "home"
-        home.mkdir(parents=True)
-        if claude_home_exists:
-            (home / ".claude").mkdir()
-
-        with patch("pathlib.Path.home", return_value=home):
+        """Includes .claude/skills/ only when Claude Code appears installed."""
+        with patch.object(
+            skills, "_is_claude_code_present", return_value=claude_present
+        ):
             result = skills._get_project_target_dirs(tmp_path)
 
         assert (tmp_path / ".claude" / "skills" in result) == expected_in_result
@@ -435,23 +432,68 @@ class TestGetGlobalTargetDirs:
         assert home / ".agents" / "skills" in result
 
     @pytest.mark.parametrize(
-        ("claude_home_exists", "expected_in_result"),
+        ("claude_present", "expected_in_result"),
         [(True, True), (False, False)],
-        ids=["claude-exists", "claude-missing"],
+        ids=["claude-present", "claude-absent"],
     )
-    def test_claude_skills_conditional_on_claude_home(
-        self, tmp_path: Path, claude_home_exists: bool, expected_in_result: bool
+    def test_claude_skills_conditional_on_claude_code(
+        self, tmp_path: Path, claude_present: bool, expected_in_result: bool
     ) -> None:
-        """Includes ~/.claude/skills/ only when ~/.claude exists."""
+        """Includes ~/.claude/skills/ only when Claude Code appears installed."""
         home = tmp_path / "home"
         home.mkdir(parents=True)
-        if claude_home_exists:
-            (home / ".claude").mkdir()
 
-        with patch("pathlib.Path.home", return_value=home):
+        with (
+            patch("pathlib.Path.home", return_value=home),
+            patch.object(
+                skills, "_is_claude_code_present", return_value=claude_present
+            ),
+        ):
             result = skills._get_global_target_dirs()
 
         assert (home / ".claude" / "skills" in result) == expected_in_result
+
+
+class TestIsClaudeCodePresent:
+    """Tests for _is_claude_code_present."""
+
+    @pytest.mark.parametrize(
+        ("marker", "expected"),
+        [(".claude", True), (".claude.json", True), (None, False)],
+        ids=["claude-dir", "claude-json", "neither"],
+    )
+    def test_detects_home_markers(
+        self, tmp_path: Path, marker: str | None, expected: bool
+    ) -> None:
+        """~/.claude or ~/.claude.json both count as Claude Code being present."""
+        home = tmp_path / "home"
+        home.mkdir(parents=True)
+        if marker == ".claude":
+            (home / marker).mkdir()
+        elif marker:
+            (home / marker).write_text("{}")
+
+        with (
+            patch("pathlib.Path.home", return_value=home),
+            patch.object(skills.shutil, "which", return_value=None),
+        ):
+            assert skills._is_claude_code_present() is expected
+
+    def test_detects_cli_on_path_without_home_dir(self, tmp_path: Path) -> None:
+        """The CLI being on PATH counts even before ~/.claude is created.
+
+        This is the case that used to strand users: they install the skill on a
+        fresh machine where Claude Code has not yet created ~/.claude, so the
+        installer skipped .claude/skills entirely.
+        """
+        home = tmp_path / "home"
+        home.mkdir(parents=True)
+
+        with (
+            patch("pathlib.Path.home", return_value=home),
+            patch.object(skills.shutil, "which", return_value="/usr/local/bin/claude"),
+        ):
+            assert skills._is_claude_code_present() is True
 
 
 class TestAreSkillsInstalled:
@@ -470,6 +512,66 @@ class TestAreSkillsInstalled:
             patch.object(skills, "_get_global_target_dirs", return_value=[global_dir]),
         ):
             assert skills.are_skills_installed() is False
+
+    def test_partial_install_in_scope_counts_as_not_installed(
+        self, tmp_path: Path
+    ) -> None:
+        """A scope with .agents but not .claude is not installed.
+
+        This is the wedged state: the user ran `streamlit skills` before Claude
+        Code existed, so only .agents/skills was written. Once ~/.claude appears,
+        Claude Code cannot see the skill -- and if this returned True the nudge
+        would never fire again, stranding them permanently.
+        """
+        agents_dir = tmp_path / "home" / ".agents" / "skills"
+        (agents_dir / skills._GLOBAL_SKILL_NAME).mkdir(parents=True)
+        claude_dir = tmp_path / "home" / ".claude" / "skills"
+
+        with (
+            patch.object(skills, "_find_project_root", side_effect=OSError),
+            patch.object(
+                skills, "_get_global_target_dirs", return_value=[agents_dir, claude_dir]
+            ),
+        ):
+            assert skills.are_skills_installed() is False
+
+    def test_complete_install_in_scope_counts_as_installed(
+        self, tmp_path: Path
+    ) -> None:
+        """Every target dir for the scope having the skill is a complete install."""
+        agents_dir = tmp_path / "home" / ".agents" / "skills"
+        claude_dir = tmp_path / "home" / ".claude" / "skills"
+        for target in (agents_dir, claude_dir):
+            (target / skills._GLOBAL_SKILL_NAME).mkdir(parents=True)
+
+        with (
+            patch.object(skills, "_find_project_root", side_effect=OSError),
+            patch.object(
+                skills, "_get_global_target_dirs", return_value=[agents_dir, claude_dir]
+            ),
+        ):
+            assert skills.are_skills_installed() is True
+
+    def test_global_install_does_not_nudge_in_every_project(
+        self, tmp_path: Path
+    ) -> None:
+        """A deliberate global-only install is not reported as missing.
+
+        The completeness check is per scope, so someone who installed globally is
+        not nudged just because the current project has no local copy.
+        """
+        project_dir = tmp_path / "project" / ".agents" / "skills"
+        global_dir = tmp_path / "home" / ".agents" / "skills"
+        (global_dir / skills._GLOBAL_SKILL_NAME).mkdir(parents=True)
+
+        with (
+            patch.object(skills, "_find_project_root", return_value=tmp_path),
+            patch.object(
+                skills, "_get_project_target_dirs", return_value=[project_dir]
+            ),
+            patch.object(skills, "_get_global_target_dirs", return_value=[global_dir]),
+        ):
+            assert skills.are_skills_installed() is True
 
     def test_returns_true_when_installed_in_project(self, tmp_path: Path) -> None:
         """Returns True when the bundled skill exists in a project target dir."""
@@ -1197,6 +1299,9 @@ class TestInstallProjectSkillsConflicts:
             ),
             patch("pathlib.Path.cwd", return_value=project_dir),
             patch("pathlib.Path.home", return_value=tmp_path / "home"),
+            # Pin Claude Code as absent so .agents/skills is the only target and
+            # "all skills skipped" is actually what this exercises.
+            patch.object(skills, "_is_claude_code_present", return_value=False),
         ):
             result = runner.invoke(cli.main, ["skills", "--yes"])
 
@@ -1532,6 +1637,9 @@ class TestGlobalInstallationConflicts:
             patch.object(
                 skills, "_get_meta_skill_dir", return_value=mock_meta_skill_dir
             ),
+            # Pin Claude Code as absent so .agents/skills is the only target and
+            # "all targets skipped" is actually what this exercises.
+            patch.object(skills, "_is_claude_code_present", return_value=False),
         ):
             result = runner.invoke(cli.main, ["skills", "--global", "--yes"])
 

--- a/lib/tests/streamlit/web/skills_test.py
+++ b/lib/tests/streamlit/web/skills_test.py
@@ -21,6 +21,7 @@ import os
 import subprocess
 import sys
 import tempfile
+from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, get_args
 from unittest.mock import patch
@@ -49,17 +50,66 @@ def _skip_if_symlinks_not_supported(tmp_path: Path) -> None:
         )
 
 
-@pytest.fixture(autouse=True)
-def _reset_claude_detection_cache() -> Iterator[None]:
-    """Clear the cached Claude Code detection around every test.
+# POSIX-only: Windows ignores these bits, and root is exempt from them, so a
+# test that relies on a directory being unreadable proves nothing there.
+_needs_permission_bits = pytest.mark.skipif(
+    os.name == "nt" or (hasattr(os, "geteuid") and os.geteuid() == 0),
+    reason="permission bits do not gate reads on Windows or as root",
+)
 
-    ``_is_claude_code_present`` is memoized for the process, so without this a
-    test that sets up a temp HOME would inherit (or hand on) another test's
-    answer and pass or fail depending on collection order.
+
+@contextmanager
+def _unreadable(*dirs: Path) -> Iterator[None]:
+    """Make ``dirs`` impossible to stat into, restoring them on the way out.
+
+    Restoring matters even when the test fails: pytest cannot clean up a
+    ``tmp_path`` containing a 0o000 directory.
+    """
+    for target in dirs:
+        target.chmod(0o000)
+    try:
+        yield
+    finally:
+        for target in dirs:
+            target.chmod(0o700)
+
+
+@pytest.fixture
+def claude_code_present() -> bool | None:
+    """What ``_is_claude_code_present`` reports for a test.
+
+    Override with ``None`` to opt out and exercise the real detector; a test that
+    wants the other answer can pin it in place, as several below do.
+    """
+    return False
+
+
+@pytest.fixture(autouse=True)
+def _isolate_claude_detection(claude_code_present: bool | None) -> Iterator[None]:
+    """Keep Claude Code detection off the ambient environment, and uncached.
+
+    Detection consults ``PATH``, so left real it adds a ``.claude/skills`` target
+    on any contributor machine with the CLI installed while staying absent in CI -
+    a latent flake for every assertion about install targets, which this file is
+    largely made of. Pinning it here makes that hermetic by default rather than
+    leaving the next added assertion to rediscover it.
+
+    The cache is cleared around each test as well: ``_is_claude_code_present`` is
+    memoized for the process, so a test that sets up a temp HOME would otherwise
+    inherit (or hand on) another test's answer and pass or fail depending on
+    collection order.
     """
     skills._is_claude_code_present.cache_clear()
-    yield
-    skills._is_claude_code_present.cache_clear()
+    try:
+        if claude_code_present is None:
+            yield
+        else:
+            with patch.object(
+                skills, "_is_claude_code_present", return_value=claude_code_present
+            ):
+                yield
+    finally:
+        skills._is_claude_code_present.cache_clear()
 
 
 @pytest.fixture
@@ -473,6 +523,11 @@ class TestGetGlobalTargetDirs:
 class TestIsClaudeCodePresent:
     """Tests for _is_claude_code_present."""
 
+    @pytest.fixture
+    def claude_code_present(self) -> bool | None:
+        """Opt out of the file-wide pin: these tests are the detector."""
+        return None
+
     @pytest.mark.parametrize(
         ("marker", "expected"),
         [(".claude", True), (".claude.json", True), (None, False)],
@@ -835,6 +890,67 @@ class TestInstallCompleteness:
             ),
         ):
             assert skills._install_completeness() == expected
+
+    @_needs_permission_bits
+    def test_targets_we_cannot_read_at_all_are_unknown_not_absent(
+        self, tmp_path: Path
+    ) -> None:
+        """No readable target anywhere means we learned nothing, so say so.
+
+        Dropping unreadable targets is right per scope, but if *every* target is
+        unreadable the drop empties the evidence and "absent" would be an answer
+        drawn purely from a permissions error. Marker detection cannot see into
+        those directories either, so both surfaces would then pester a
+        correctly-installed user on every rerun.
+        """
+        agents_dir = tmp_path / "home" / ".agents" / "skills"
+        claude_dir = tmp_path / "home" / ".claude" / "skills"
+        for target in (agents_dir, claude_dir):
+            (target / skills._GLOBAL_SKILL_NAME).mkdir(parents=True)
+
+        with (
+            patch.object(skills, "_find_project_root", side_effect=OSError),
+            patch.object(
+                skills, "_get_global_target_dirs", return_value=[agents_dir, claude_dir]
+            ),
+            _unreadable(agents_dir, claude_dir),
+        ):
+            assert skills._install_completeness() == "unknown"
+
+    @_needs_permission_bits
+    def test_one_readable_scope_still_reports_absent(self, tmp_path: Path) -> None:
+        """An unreadable scope does not turn a genuinely empty one into unknown.
+
+        The project targets answer "no skill here", and an install into them
+        would work, so there is something to recommend - unlike the case above.
+        """
+        project_dir = tmp_path / "project" / ".agents" / "skills"
+        project_dir.mkdir(parents=True)
+        global_dir = tmp_path / "home" / ".agents" / "skills"
+        (global_dir / skills._GLOBAL_SKILL_NAME).mkdir(parents=True)
+
+        with (
+            patch.object(skills, "_find_project_root", return_value=tmp_path),
+            patch.object(
+                skills, "_get_project_target_dirs", return_value=[project_dir]
+            ),
+            patch.object(skills, "_get_global_target_dirs", return_value=[global_dir]),
+            _unreadable(global_dir),
+        ):
+            assert skills._install_completeness() == "absent"
+
+    def test_unresolvable_targets_stay_absent(self) -> None:
+        """No target dirs at all is still absent, not unknown.
+
+        Deliberately narrower than the unknown case: there we know where to look
+        and cannot, here we never got that far, and an install may well succeed
+        once whatever broke the lookup clears.
+        """
+        with (
+            patch.object(skills, "_find_project_root", side_effect=OSError),
+            patch.object(skills, "_get_global_target_dirs", return_value=[]),
+        ):
+            assert skills._install_completeness() == "absent"
 
     def test_resolves_the_project_root_from_app_dir(self, tmp_path: Path) -> None:
         """``app_dir`` picks the project root an install from that app would use.
@@ -1294,6 +1410,9 @@ class TestInstallSkillsCli:
             ),
             patch("pathlib.Path.cwd", return_value=project_dir),
             patch("pathlib.Path.home", return_value=home),
+            # ~/.claude above says Claude Code is present; pin it so the
+            # .claude target does not depend on the machine's PATH.
+            patch.object(skills, "_is_claude_code_present", return_value=True),
         ):
             result = runner.invoke(cli.main, ["skills", "--yes"])
 
@@ -1367,6 +1486,9 @@ class TestInstallSkillsCli:
             patch.object(
                 skills, "_get_meta_skill_dir", return_value=mock_meta_skill_dir
             ),
+            # ~/.claude above says Claude Code is present; pin it so the
+            # .claude target does not depend on the machine's PATH.
+            patch.object(skills, "_is_claude_code_present", return_value=True),
         ):
             result = runner.invoke(cli.main, ["skills", "-g", "-y"])
 
@@ -1914,6 +2036,9 @@ class TestGlobalInstallationConflicts:
                     OSError(errno.ENOSPC, "No space left"),
                 ],
             ),
+            # ~/.claude above says Claude Code is present; pin it so the
+            # .claude target does not depend on the machine's PATH.
+            patch.object(skills, "_is_claude_code_present", return_value=True),
             pytest.raises(skills.InstallError) as exc,
         ):
             skills._install_global_skills(yes=True)
@@ -1947,6 +2072,9 @@ class TestGlobalInstallationConflicts:
                 "copytree",
                 side_effect=[None, OSError("Permission denied")],
             ),
+            # ~/.claude above says Claude Code is present; pin it so the
+            # .claude target does not depend on the machine's PATH.
+            patch.object(skills, "_is_claude_code_present", return_value=True),
             pytest.raises(skills.InstallError) as exc,
         ):
             skills._install_global_skills(yes=True)
@@ -2029,7 +2157,14 @@ def _evaluate_nudge_reason(
     marker_exists: bool = False,
     would_be_refused: bool = False,
 ) -> str:
-    """Run ``nudge_suppression_reason`` with the given conditions patched in."""
+    """Run ``nudge_suppression_reason`` with the given conditions patched in.
+
+    ``completeness`` defaults to ``absent`` to match ``installed_skills=()``, so
+    the default world is a machine with nothing installed. Pass it whenever
+    ``installed_skills`` is non-empty: the two together decide this gate, and
+    leaving the default in place describes a marker from a harness we do not
+    write to rather than an install of ours.
+    """
     marker = tmp_path / ".skills_nudge_dismissed"
     if marker_exists:
         marker.touch()
@@ -2072,7 +2207,24 @@ def _evaluate_nudge_reason(
         ({"hide_welcome": True}, "welcome_hidden"),
         ({"marker_exists": True}, "dismissed"),
         ({"agents": ()}, "no_agent"),
-        ({"installed_skills": ("home:claude:developing-with-streamlit",)}, "installed"),
+        (
+            {
+                "installed_skills": ("home:claude:developing-with-streamlit",),
+                "completeness": "complete",
+            },
+            "installed",
+        ),
+        # A marker plus an install we could not read is still an install: the
+        # marker is the evidence, so report "installed" rather than the
+        # could-not-tell reason below.
+        (
+            {
+                "installed_skills": ("home:claude:developing-with-streamlit",),
+                "completeness": "unknown",
+            },
+            "installed",
+        ),
+        ({"completeness": "unknown"}, "check_failed"),
         (
             {
                 "installed_skills": ("home:agents:developing-with-streamlit",),
@@ -2131,11 +2283,17 @@ def test_should_show_skills_nudge_hidden_when_no_agent(tmp_path: Path) -> None:
 
 
 def test_should_show_skills_nudge_hidden_when_skills_installed(tmp_path: Path) -> None:
-    """No nudge when the bundled skills are already installed."""
+    """No nudge when the bundled skills are already installed.
+
+    ``completeness`` is passed explicitly: the helper defaults to ``absent`` so
+    its default world is coherent (nothing installed anywhere), which would make
+    this the foreign-harness branch rather than the finished install it describes.
+    """
     assert (
         _evaluate_nudge(
             tmp_path,
             installed_skills=("home:claude:developing-with-streamlit",),
+            completeness="complete",
         )
         is False
     )
@@ -2196,6 +2354,40 @@ def test_nudge_is_not_suppressed_by_a_real_partial_tree(tmp_path: Path) -> None:
         patch.object(skills, "_one_click_install_would_be_refused", return_value=False),
     ):
         assert skills.nudge_suppression_reason() == ""
+
+
+@_needs_permission_bits
+def test_nudge_is_hidden_when_no_install_target_can_be_read(tmp_path: Path) -> None:
+    """End-to-end over the real predicate: an unreadable tree does not nudge.
+
+    The tree is installed but every target dir raises, so the marker scan sees
+    nothing either. Without the ``unknown`` state both blind checks would agree
+    on "nothing installed" and nudge a correctly-installed user on every rerun -
+    with a one-click install that hits the same permissions error.
+    """
+    agents_dir = tmp_path / "project" / ".agents" / "skills"
+    (agents_dir / skills._GLOBAL_SKILL_NAME).mkdir(parents=True)
+
+    options = {"server.headless": False, "logger.hideWelcomeMessage": False}
+
+    with (
+        patch("streamlit.config.get_option", side_effect=options.__getitem__),
+        patch.object(
+            skills,
+            "_nudge_dismissed_marker_path",
+            return_value=tmp_path / ".skills_nudge_dismissed",
+        ),
+        patch.object(skills, "detect_installed_agents", return_value=["claude"]),
+        # Empty for the same reason the dirs are unreadable: the marker scan
+        # cannot see into them either.
+        patch.object(skills, "detect_installed_skills", return_value=[]),
+        patch.object(skills, "_find_project_root", return_value=tmp_path / "project"),
+        patch.object(skills, "_get_project_target_dirs", return_value=[agents_dir]),
+        patch.object(skills, "_get_global_target_dirs", return_value=[]),
+        patch.object(skills, "_one_click_install_would_be_refused", return_value=False),
+        _unreadable(agents_dir),
+    ):
+        assert skills.nudge_suppression_reason() == "check_failed"
 
 
 def test_should_show_skills_nudge_hidden_when_marker_is_from_another_harness(
@@ -2479,6 +2671,9 @@ class TestInstallDetectRoundtrip:
             patch.object(skills, "_get_source_skills_dir", return_value=source_dir),
             # Not headless / welcome message not hidden, so only detection gates.
             patch("streamlit.config.get_option", return_value=False),
+            # ~/.claude above says Claude Code is present; pin it so the
+            # .claude target does not depend on the machine's PATH.
+            patch.object(skills, "_is_claude_code_present", return_value=True),
         ):
             clear_caches()
             # Pre-install the nudge is recommended (agent present, no skills).
@@ -2893,6 +3088,9 @@ class TestNudgeSuppressedWhenInstallWouldConflict:
         with (
             patch.object(skills, "_get_source_skills_dir", return_value=source_dir),
             patch("streamlit.config.get_option", return_value=False),
+            # ~/.claude above says Claude Code is present; pin it so the
+            # .claude target does not depend on the machine's PATH.
+            patch.object(skills, "_is_claude_code_present", return_value=True),
         ):
             self._clear_caches()
             assert skills.should_show_skills_nudge(str(app_dir)) is True
@@ -3137,6 +3335,26 @@ class TestAreSkillsInstalledErrorHandling:
         ):
             assert skills.are_skills_installed() is True
 
+    @_needs_permission_bits
+    def test_install_we_cannot_inspect_does_not_print_the_recommendation(
+        self, tmp_path: Path
+    ) -> None:
+        """Every target unreadable reports installed, so the tip stays quiet.
+
+        The startup recommendation has no dismissal path, and the install it
+        points at would hit the same permissions error, so printing it on every
+        run of a possibly-fine setup is the worse error.
+        """
+        agents_dir = tmp_path / "home" / ".agents" / "skills"
+        (agents_dir / skills._GLOBAL_SKILL_NAME).mkdir(parents=True)
+
+        with (
+            patch.object(skills, "_find_project_root", side_effect=OSError),
+            patch.object(skills, "_get_global_target_dirs", return_value=[agents_dir]),
+            _unreadable(agents_dir),
+        ):
+            assert skills.are_skills_installed() is True
+
 
 class TestSkillPresentIn:
     """Tests for _skill_present_in's three-way answer."""
@@ -3163,13 +3381,7 @@ class TestSkillPresentIn:
         (target_dir / skills._GLOBAL_SKILL_NAME).symlink_to(tmp_path / "gone")
         assert skills._skill_present_in(target_dir) is True
 
-    @pytest.mark.skipif(
-        os.name == "nt", reason="POSIX permission bits do not gate reads on Windows"
-    )
-    @pytest.mark.skipif(
-        hasattr(os, "geteuid") and os.geteuid() == 0,
-        reason="root bypasses the permission bits this test relies on",
-    )
+    @_needs_permission_bits
     def test_unreadable_dir_is_unknown(self, tmp_path: Path) -> None:
         """A dir we lack permission to stat into is unknown, not absent.
 
@@ -3178,11 +3390,8 @@ class TestSkillPresentIn:
         """
         target_dir = tmp_path / "skills"
         (target_dir / skills._GLOBAL_SKILL_NAME).mkdir(parents=True)
-        target_dir.chmod(0o000)
-        try:
+        with _unreadable(target_dir):
             assert skills._skill_present_in(target_dir) is None
-        finally:
-            target_dir.chmod(0o700)
 
 
 class TestConfirmProjectInstallationEdgeCases:

--- a/lib/tests/streamlit/web/skills_test.py
+++ b/lib/tests/streamlit/web/skills_test.py
@@ -2014,13 +2014,18 @@ class TestGlobalInstallationConflicts:
 
         assert exc.value.reason == "write_denied"
 
-    def test_generalises_when_targets_fail_for_different_reasons(
+    def test_reports_the_authoritative_targets_cause_when_targets_disagree(
         self, tmp_path: Path, mock_meta_skill_dir: Path
     ) -> None:
-        """Disagreeing targets report the generic write_failed, not a guess.
+        """Targets fail differently -> the authoritative target's cause wins.
 
-        Claiming "permission denied" when one target was denied and the other was out
-        of disk would send whoever reads the telemetry after half the problem.
+        Both causes used to be pooled, so disagreement collapsed to the generic
+        write_failed. Attributing the failure to the dir a detected harness actually
+        reads is sharper: ~/.claude being out of disk is the fix to chase, while
+        ~/.agents being denied is not why this user's agent has no skill. The
+        no-guessing rule the pooled version protected still holds for the causes
+        that do justify an error - see
+        ``test_write_error_generalises_when_justifying_reasons_disagree``.
         """
         home = tmp_path / "home"
         # ~/.claude present -> _get_global_target_dirs yields two targets.
@@ -2046,7 +2051,13 @@ class TestGlobalInstallationConflicts:
         ):
             skills._install_global_skills(yes=True)
 
-        assert exc.value.reason == "write_failed"
+        # ~/.claude (authoritative) ran out of space; ~/.agents was denied.
+        assert exc.value.reason == "write_no_space"
+        # Both failures are still named for the user, even though only one of them
+        # decided the reason.
+        message = exc.value.format_message()
+        assert ".agents/skills" in message
+        assert ".claude/skills" in message
 
     def test_partial_write_failure_reports_write_failed_not_success(
         self, tmp_path: Path, mock_meta_skill_dir: Path
@@ -2057,8 +2068,12 @@ class TestGlobalInstallationConflicts:
         ``~/.agents`` copies OK (result.installed non-empty) but ``~/.claude`` raises
         OSError (result.errored), the success branch used to win over the errored
         branch - so a half-installed system reported success and emitted no
-        write_failed telemetry for exactly the locked-down cohort under study. Any
-        errored target must fail loud.
+        write_failed telemetry for exactly the locked-down cohort under study.
+
+        This is the direction that must stay hard: ``~/.claude/skills`` is the
+        authoritative target when Claude Code is detected, so failing it means the
+        install reached no agent. The mirror case is deliberately NOT a failure - see
+        ``test_best_effort_target_failure_still_reports_success``.
         """
         home = tmp_path / "home"
         # ~/.claude present -> _get_global_target_dirs yields both targets.
@@ -2083,6 +2098,98 @@ class TestGlobalInstallationConflicts:
             skills._install_global_skills(yes=True)
 
         assert exc.value.reason == "write_failed"
+
+    def test_best_effort_target_failure_still_reports_success(
+        self, tmp_path: Path, mock_meta_skill_dir: Path
+    ) -> None:
+        """~/.claude copies, ~/.agents fails -> success, not a hard failure.
+
+        The mirror of the test above, and the case it used to get wrong. Claude Code
+        reads ``.claude/skills`` and ignores ``.agents/skills`` entirely, so this
+        developer's agent has the skill and works; reporting failure told them
+        otherwise. It gets worse once a partial install reopens the nudge, because
+        the repair it offers fails on the same unwritable ~/.agents every time, with
+        no way out.
+        """
+        home = tmp_path / "home"
+        # ~/.claude present -> _get_global_target_dirs yields both targets.
+        (home / ".claude").mkdir(parents=True)
+
+        with (
+            patch("pathlib.Path.home", return_value=home),
+            patch.object(
+                skills, "_get_meta_skill_dir", return_value=mock_meta_skill_dir
+            ),
+            # Targets are ordered [.agents, .claude]: the best-effort one fails,
+            # the authoritative one copies fine.
+            patch.object(
+                skills.shutil,
+                "copytree",
+                side_effect=[OSError(errno.EACCES, "Permission denied"), None],
+            ),
+            # ~/.claude above says Claude Code is present; pin it so the
+            # .claude target does not depend on the machine's PATH.
+            patch.object(skills, "_is_claude_code_present", return_value=True),
+            patch.object(skills, "_LOGGER") as logger,
+        ):
+            result = skills._install_global_skills(yes=True)
+
+        installed = [path.replace("\\", "/") for path in result.installed]
+        errored = [path.replace("\\", "/") for path in result.errored]
+        # It landed where Claude Code reads it, so the install stands.
+        assert any(".claude/skills" in path for path in installed)
+        # Not swallowed: the CLI summary still lists the failure, and the server log
+        # records it for the in-app install, which has no terminal to print to.
+        assert any(".agents/skills" in path for path in errored)
+        assert logger.warning.called
+
+    @pytest.mark.parametrize(
+        ("claude_present", "expected_dir_name"),
+        [(True, ".claude"), (False, ".agents")],
+    )
+    def test_authoritative_target_follows_claude_detection(
+        self, tmp_path: Path, claude_present: bool, expected_dir_name: str
+    ) -> None:
+        """Authority follows the detected harness, not a fixed path.
+
+        Claude Code is the only harness verified to read a dir we write, so when it
+        is detected ``.claude/skills`` is what an install has to land. With nothing
+        detected, ``.agents/skills`` is the only dir we write, so it carries
+        authority by default - leaving none would turn every write failure into a
+        silent success.
+        """
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch.object(
+                skills, "_is_claude_code_present", return_value=claude_present
+            ),
+        ):
+            authoritative = skills._authoritative_global_target_dir()
+
+            assert authoritative == tmp_path / expected_dir_name / "skills"
+            # Whatever it names has to be a dir the installer actually writes,
+            # or an install could never satisfy it.
+            assert authoritative in skills._get_global_target_dirs()
+
+    def test_write_error_generalises_when_justifying_reasons_disagree(self) -> None:
+        """Disagreeing causes report the generic write_failed, not a guess.
+
+        Only the backstop and direct callers reach this now that one authoritative
+        target contributes at most one cause, but the rule still has to hold:
+        claiming "permission denied" for a set that was half permissions and half
+        disk-full would send whoever reads the telemetry after the wrong fix.
+        """
+        result = skills._InstallResult(
+            errored=["~/.agents/skills/developing-with-streamlit"],
+            write_reasons={"write_denied", "write_no_space"},
+        )
+
+        # Pooled and disagreeing -> generic.
+        assert skills._write_error(result).reason == "write_failed"
+        # An explicit single justifying cause wins over the pooled set.
+        assert (
+            skills._write_error(result, {"write_no_space"}).reason == "write_no_space"
+        )
 
 
 class TestInteractiveModeSelection:

--- a/lib/tests/streamlit/web/skills_test.py
+++ b/lib/tests/streamlit/web/skills_test.py
@@ -850,16 +850,17 @@ class TestAreSkillsInstalled:
 
 
 class TestInstallCompleteness:
-    """Tests for the three-state answer _install_completeness reports."""
+    """Tests for the four states _install_completeness reports."""
 
     @pytest.mark.parametrize(
         ("agents_installed", "claude_installed", "expected"),
         [
             (False, False, "absent"),
             (True, False, "partial"),
+            (False, True, "partial"),
             (True, True, "complete"),
         ],
-        ids=["absent", "partial", "complete"],
+        ids=["absent", "partial", "partial_claude_only", "complete"],
     )
     def test_reports_each_state(
         self,
@@ -872,7 +873,9 @@ class TestInstallCompleteness:
 
         The in-app nudge needs "partial" separated from "absent": only a
         half-finished install of *ours* should reopen a nudge the user has
-        already acted on.
+        already acted on. Both halves of a wedge count as partial - the common
+        one is .agents/skills with nothing in .claude/skills, and a hand-copied
+        .claude/skills with an empty .agents/skills is the mirror image.
         """
         agents_dir = tmp_path / "home" / ".agents" / "skills"
         claude_dir = tmp_path / "home" / ".claude" / "skills"
@@ -2237,7 +2240,7 @@ def _evaluate_nudge_reason(
             },
             "installed",
         ),
-        ({"completeness": "unknown"}, "check_failed"),
+        ({"completeness": "unknown"}, "check_unreadable"),
         (
             {
                 "installed_skills": ("home:agents:developing-with-streamlit",),
@@ -2423,7 +2426,7 @@ def test_nudge_is_hidden_when_no_install_target_can_be_read(tmp_path: Path) -> N
         patch.object(skills, "_one_click_install_would_be_refused", return_value=False),
         _unreadable(agents_dir),
     ):
-        assert skills.nudge_suppression_reason() == "check_failed"
+        assert skills.nudge_suppression_reason() == "check_unreadable"
 
 
 def test_should_show_skills_nudge_hidden_when_marker_is_from_another_harness(

--- a/lib/tests/streamlit/web/skills_test.py
+++ b/lib/tests/streamlit/web/skills_test.py
@@ -22,7 +22,7 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
-from typing import Any, get_args
+from typing import TYPE_CHECKING, Any, get_args
 from unittest.mock import patch
 
 import click
@@ -30,6 +30,9 @@ import pytest
 from click.testing import CliRunner
 
 from streamlit.web import cli, skills
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 
 def _skip_if_symlinks_not_supported(tmp_path: Path) -> None:
@@ -44,6 +47,19 @@ def _skip_if_symlinks_not_supported(tmp_path: Path) -> None:
         pytest.skip(
             "Symlinks not supported on this system (requires privileges on Windows)"
         )
+
+
+@pytest.fixture(autouse=True)
+def _reset_claude_detection_cache() -> Iterator[None]:
+    """Clear the cached Claude Code detection around every test.
+
+    ``_is_claude_code_present`` is memoized for the process, so without this a
+    test that sets up a temp HOME would inherit (or hand on) another test's
+    answer and pass or fail depending on collection order.
+    """
+    skills._is_claude_code_present.cache_clear()
+    yield
+    skills._is_claude_code_present.cache_clear()
 
 
 @pytest.fixture
@@ -465,7 +481,8 @@ class TestIsClaudeCodePresent:
     def test_detects_home_markers(
         self, tmp_path: Path, marker: str | None, expected: bool
     ) -> None:
-        """~/.claude or ~/.claude.json both count as Claude Code being present."""
+        """Either ~/.claude or ~/.claude.json counts as present; neither, with no
+        CLI on PATH, does not."""
         home = tmp_path / "home"
         home.mkdir(parents=True)
         if marker == ".claude":
@@ -495,6 +512,79 @@ class TestIsClaudeCodePresent:
         ):
             assert skills._is_claude_code_present() is True
 
+    def test_falls_back_to_path_when_home_cannot_be_resolved(self) -> None:
+        """An unresolvable home still leaves the PATH signal usable.
+
+        ``Path.home()`` raises when the home directory cannot be determined. The
+        marker checks are impossible then, but a project-local .claude/skills
+        install needs no home dir, so giving up here would skip it needlessly.
+        """
+        with (
+            patch("pathlib.Path.home", side_effect=RuntimeError("no home")),
+            patch.object(skills.shutil, "which", return_value="/usr/local/bin/claude"),
+        ):
+            assert skills._is_claude_code_present() is True
+
+    def test_is_cached_across_calls(self, tmp_path: Path) -> None:
+        """The PATH scan runs once per process, not once per script rerun.
+
+        This sits on the nudge show-gate, which re-evaluates on every rerun.
+        """
+        home = tmp_path / "home"
+        home.mkdir(parents=True)
+
+        with (
+            patch("pathlib.Path.home", return_value=home),
+            patch.object(skills.shutil, "which", return_value=None) as mock_which,
+        ):
+            for _ in range(3):
+                assert skills._is_claude_code_present() is False
+
+        assert mock_which.call_count == 1
+
+
+class TestClaudeCliOnPath:
+    """Tests for _claude_cli_on_path."""
+
+    def test_absent_cli_is_not_detected(self) -> None:
+        """No ``claude`` anywhere on PATH means not present."""
+        with patch.object(skills.shutil, "which", return_value=None):
+            assert skills._claude_cli_on_path() is False
+
+    def test_windows_ignores_a_hit_in_the_current_directory(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A claude.exe in the checkout must not decide where we write.
+
+        On Windows ``shutil.which`` searches the current directory before PATH
+        whatever PATH says, and returns the bare relative name for such a hit, so
+        a repo shipping claude.exe/.bat/.cmd would otherwise get a .claude/skills/
+        dir written into it.
+        """
+        (tmp_path / "claude.exe").write_text("", encoding="utf-8")
+        monkeypatch.chdir(tmp_path)
+
+        with (
+            patch.object(skills.env_util, "IS_WINDOWS", True),
+            patch.object(skills.shutil, "which", return_value="claude.exe"),
+            patch.dict(os.environ, {"PATH": str(tmp_path / "elsewhere")}),
+        ):
+            assert skills._claude_cli_on_path() is False
+
+    def test_windows_accepts_a_hit_in_a_real_path_entry(self, tmp_path: Path) -> None:
+        """A genuine PATH install is still detected on Windows."""
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+
+        with (
+            patch.object(skills.env_util, "IS_WINDOWS", True),
+            patch.object(
+                skills.shutil, "which", return_value=str(bin_dir / "claude.exe")
+            ),
+            patch.dict(os.environ, {"PATH": str(bin_dir)}),
+        ):
+            assert skills._claude_cli_on_path() is True
+
 
 class TestAreSkillsInstalled:
     """Tests for are_skills_installed."""
@@ -516,12 +606,12 @@ class TestAreSkillsInstalled:
     def test_partial_install_in_scope_counts_as_not_installed(
         self, tmp_path: Path
     ) -> None:
-        """A scope with .agents but not .claude is not installed.
+        """A scope with .agents but not .claude is not a complete install.
 
         This is the wedged state: the user ran `streamlit skills` before Claude
         Code existed, so only .agents/skills was written. Once ~/.claude appears,
-        Claude Code cannot see the skill -- and if this returned True the nudge
-        would never fire again, stranding them permanently.
+        Claude Code cannot see the skill - and if this returned True nothing
+        would ever prompt them again, stranding them permanently.
         """
         agents_dir = tmp_path / "home" / ".agents" / "skills"
         (agents_dir / skills._GLOBAL_SKILL_NAME).mkdir(parents=True)
@@ -552,13 +642,13 @@ class TestAreSkillsInstalled:
         ):
             assert skills.are_skills_installed() is True
 
-    def test_global_install_does_not_nudge_in_every_project(
+    def test_global_only_install_is_not_reported_as_partial(
         self, tmp_path: Path
     ) -> None:
         """A deliberate global-only install is not reported as missing.
 
-        The completeness check is per scope, so someone who installed globally is
-        not nudged just because the current project has no local copy.
+        Completeness is judged per scope, so someone who installed globally is
+        not prompted just because the current project has no local copy.
         """
         project_dir = tmp_path / "project" / ".agents" / "skills"
         global_dir = tmp_path / "home" / ".agents" / "skills"
@@ -570,6 +660,37 @@ class TestAreSkillsInstalled:
                 skills, "_get_project_target_dirs", return_value=[project_dir]
             ),
             patch.object(skills, "_get_global_target_dirs", return_value=[global_dir]),
+        ):
+            assert skills.are_skills_installed() is True
+
+    def test_complete_global_is_not_masked_by_a_partial_project(
+        self, tmp_path: Path
+    ) -> None:
+        """A complete scope wins even when the other scope is half-installed.
+
+        Reachable in the wild: a project install predating Claude Code (or a
+        teammate's committed .agents/skills entry) alongside a later complete
+        global one. Claude Code loads the skill from ~/.claude/skills there, so
+        the user is not wedged and must not be told to install on every run.
+        """
+        project_agents = tmp_path / "project" / ".agents" / "skills"
+        project_claude = tmp_path / "project" / ".claude" / "skills"
+        (project_agents / skills._GLOBAL_SKILL_NAME).mkdir(parents=True)
+        global_dirs = [
+            tmp_path / "home" / ".agents" / "skills",
+            tmp_path / "home" / ".claude" / "skills",
+        ]
+        for target in global_dirs:
+            (target / skills._GLOBAL_SKILL_NAME).mkdir(parents=True)
+
+        with (
+            patch.object(skills, "_find_project_root", return_value=tmp_path),
+            patch.object(
+                skills,
+                "_get_project_target_dirs",
+                return_value=[project_agents, project_claude],
+            ),
+            patch.object(skills, "_get_global_target_dirs", return_value=global_dirs),
         ):
             assert skills.are_skills_installed() is True
 
@@ -671,6 +792,69 @@ class TestAreSkillsInstalled:
             patch.object(skills, "_get_global_target_dirs", return_value=[global_dir]),
         ):
             assert skills.are_skills_installed() is True
+
+
+class TestInstallCompleteness:
+    """Tests for the three-state answer _install_completeness reports."""
+
+    @pytest.mark.parametrize(
+        ("agents_installed", "claude_installed", "expected"),
+        [
+            (False, False, "absent"),
+            (True, False, "partial"),
+            (True, True, "complete"),
+        ],
+        ids=["absent", "partial", "complete"],
+    )
+    def test_reports_each_state(
+        self,
+        tmp_path: Path,
+        agents_installed: bool,
+        claude_installed: bool,
+        expected: str,
+    ) -> None:
+        """Absent, partial, and complete are distinguished, not collapsed to a bool.
+
+        The in-app nudge needs "partial" separated from "absent": only a
+        half-finished install of *ours* should reopen a nudge the user has
+        already acted on.
+        """
+        agents_dir = tmp_path / "home" / ".agents" / "skills"
+        claude_dir = tmp_path / "home" / ".claude" / "skills"
+        for target, installed in (
+            (agents_dir, agents_installed),
+            (claude_dir, claude_installed),
+        ):
+            if installed:
+                (target / skills._GLOBAL_SKILL_NAME).mkdir(parents=True)
+
+        with (
+            patch.object(skills, "_find_project_root", side_effect=OSError),
+            patch.object(
+                skills, "_get_global_target_dirs", return_value=[agents_dir, claude_dir]
+            ),
+        ):
+            assert skills._install_completeness() == expected
+
+    def test_resolves_the_project_root_from_app_dir(self, tmp_path: Path) -> None:
+        """``app_dir`` picks the project root an install from that app would use.
+
+        The nudge passes the running app's directory, so the completeness check
+        has to look at the same tree the one-click install writes to.
+        """
+        app_dir = tmp_path / "project" / "pages"
+        app_dir.mkdir(parents=True)
+
+        with (
+            patch.object(
+                skills, "_find_project_root", return_value=tmp_path
+            ) as mock_find_root,
+            patch.object(skills, "_get_project_target_dirs", return_value=[]),
+            patch.object(skills, "_get_global_target_dirs", return_value=[]),
+        ):
+            assert skills._install_completeness(str(app_dir)) == "absent"
+
+        mock_find_root.assert_called_once_with(app_dir)
 
 
 class TestInstallSkillSymlink:
@@ -1817,6 +2001,7 @@ def _evaluate_nudge(
     hide_welcome: bool = False,
     agents: tuple[str, ...] = ("claude",),
     installed_skills: tuple[str, ...] = (),
+    completeness: str = "absent",
     marker_exists: bool = False,
     would_be_refused: bool = False,
 ) -> bool:
@@ -1827,6 +2012,7 @@ def _evaluate_nudge(
         hide_welcome=hide_welcome,
         agents=agents,
         installed_skills=installed_skills,
+        completeness=completeness,
         marker_exists=marker_exists,
         would_be_refused=would_be_refused,
     )
@@ -1839,6 +2025,7 @@ def _evaluate_nudge_reason(
     hide_welcome: bool = False,
     agents: tuple[str, ...] = ("claude",),
     installed_skills: tuple[str, ...] = (),
+    completeness: str = "absent",
     marker_exists: bool = False,
     would_be_refused: bool = False,
 ) -> str:
@@ -1860,6 +2047,12 @@ def _evaluate_nudge_reason(
             "streamlit.web.skills.detect_installed_skills",
             return_value=list(installed_skills),
         ),
+        # Patched for the same hermeticity reason as the probe below: left real,
+        # this walks the developer's own project and home dirs.
+        patch(
+            "streamlit.web.skills._install_completeness",
+            return_value=completeness,
+        ),
         # Keep the gate hermetic: otherwise the conflict-aware suppression check
         # hits the real filesystem (a dev machine's ~/.claude makes .claude/skills
         # a real target) and may run the symlink probe.
@@ -1880,6 +2073,13 @@ def _evaluate_nudge_reason(
         ({"marker_exists": True}, "dismissed"),
         ({"agents": ()}, "no_agent"),
         ({"installed_skills": ("home:claude:developing-with-streamlit",)}, "installed"),
+        (
+            {
+                "installed_skills": ("home:agents:developing-with-streamlit",),
+                "completeness": "partial",
+            },
+            "",
+        ),
         ({"would_be_refused": True}, "conflict"),
     ],
 )
@@ -1936,6 +2136,82 @@ def test_should_show_skills_nudge_hidden_when_skills_installed(tmp_path: Path) -
         _evaluate_nudge(
             tmp_path,
             installed_skills=("home:claude:developing-with-streamlit",),
+        )
+        is False
+    )
+
+
+def test_should_show_skills_nudge_when_install_is_partial(tmp_path: Path) -> None:
+    """A marker in .agents with nothing in .claude still shows the nudge.
+
+    This is the wedge the whole change is about, seen from the in-app surface: a
+    detected SKILL.md is not proof the agent can load it, and the nudge's
+    one-click install is the repair. Gating on the marker alone left these users
+    with no in-app way out.
+    """
+    assert (
+        _evaluate_nudge(
+            tmp_path,
+            installed_skills=("app:agents:developing-with-streamlit",),
+            completeness="partial",
+        )
+        is True
+    )
+
+
+def test_nudge_is_not_suppressed_by_a_real_partial_tree(tmp_path: Path) -> None:
+    """End-to-end over the real predicate: an .agents-only tree still nudges.
+
+    The mocked test above pins the branch; this one pins the wiring, so moving
+    the gate back onto ``detect_installed_skills`` alone fails here. Everything
+    but the target dirs is stubbed, since the gate would otherwise read the
+    developer's own home and project directories.
+    """
+    agents_dir = tmp_path / "project" / ".agents" / "skills"
+    claude_dir = tmp_path / "project" / ".claude" / "skills"
+    skill_dir = agents_dir / skills._GLOBAL_SKILL_NAME
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("# Skill\n", encoding="utf-8")
+
+    options = {"server.headless": False, "logger.hideWelcomeMessage": False}
+
+    with (
+        patch("streamlit.config.get_option", side_effect=options.__getitem__),
+        patch.object(
+            skills,
+            "_nudge_dismissed_marker_path",
+            return_value=tmp_path / ".skills_nudge_dismissed",
+        ),
+        patch.object(skills, "detect_installed_agents", return_value=["claude"]),
+        patch.object(
+            skills,
+            "detect_installed_skills",
+            return_value=["app:agents:developing-with-streamlit"],
+        ),
+        patch.object(skills, "_find_project_root", return_value=tmp_path / "project"),
+        patch.object(
+            skills, "_get_project_target_dirs", return_value=[agents_dir, claude_dir]
+        ),
+        patch.object(skills, "_get_global_target_dirs", return_value=[]),
+        patch.object(skills, "_one_click_install_would_be_refused", return_value=False),
+    ):
+        assert skills.nudge_suppression_reason() == ""
+
+
+def test_should_show_skills_nudge_hidden_when_marker_is_from_another_harness(
+    tmp_path: Path,
+) -> None:
+    """A marker outside our target dirs still counts as installed.
+
+    Someone who put the skill in .cursor/skills by hand has a working setup that
+    ``streamlit skills`` did not create; ``absent`` there means "we never wrote
+    here", not "the user is missing the skill", so nudging them is just noise.
+    """
+    assert (
+        _evaluate_nudge(
+            tmp_path,
+            installed_skills=("app:cursor:developing-with-streamlit",),
+            completeness="absent",
         )
         is False
     )
@@ -2828,21 +3104,26 @@ class TestGetDisplayPath:
 class TestAreSkillsInstalledErrorHandling:
     """Tests for OSError handling inside the directory-iteration loop."""
 
-    def test_continues_when_skill_path_check_errors(self, tmp_path: Path) -> None:
-        """Continues to next candidate dir when is_symlink/exists raise OSError."""
+    def test_unreadable_target_does_not_mask_an_installed_one(
+        self, tmp_path: Path
+    ) -> None:
+        """An unreadable target is unknown, not missing, so the scope stays complete.
+
+        Reporting a correctly-installed user as partially installed because one
+        target could not be read would print the startup recommendation on every
+        run with nothing for them to fix.
+        """
         first_dir = tmp_path / "first" / ".agents" / "skills"
-        second_dir = tmp_path / "second" / ".agents" / "skills"
+        second_dir = tmp_path / "second" / ".claude" / "skills"
         (second_dir / skills._GLOBAL_SKILL_NAME).mkdir(parents=True)
 
-        # Raise OSError when checking the first (nonexistent) candidate so the
-        # loop must continue to the second (existing) one. Returning False for
-        # all other paths is safe because none of them are real symlinks.
         first_skill = first_dir / skills._GLOBAL_SKILL_NAME
+        real_lstat = Path.lstat
 
-        def patched_is_symlink(self: Path) -> bool:
+        def patched_lstat(self: Path, **kwargs: Any) -> Any:
             if self == first_skill:
                 raise OSError("Simulated filesystem failure")
-            return False
+            return real_lstat(self, **kwargs)
 
         with (
             patch.object(skills, "_find_project_root", return_value=tmp_path),
@@ -2852,9 +3133,56 @@ class TestAreSkillsInstalledErrorHandling:
                 return_value=[first_dir, second_dir],
             ),
             patch.object(skills, "_get_global_target_dirs", return_value=[]),
-            patch("pathlib.Path.is_symlink", patched_is_symlink),
+            patch("pathlib.Path.lstat", patched_lstat),
         ):
             assert skills.are_skills_installed() is True
+
+
+class TestSkillPresentIn:
+    """Tests for _skill_present_in's three-way answer."""
+
+    def test_missing_dir_is_absent(self, tmp_path: Path) -> None:
+        """A target dir that does not exist reports the skill as absent."""
+        assert skills._skill_present_in(tmp_path / "nope" / "skills") is False
+
+    def test_parent_component_is_a_file_is_absent(self, tmp_path: Path) -> None:
+        """A file where a target dir should be reports absent, not unknown."""
+        not_a_dir = tmp_path / "skills"
+        not_a_dir.write_text("", encoding="utf-8")
+        assert skills._skill_present_in(not_a_dir) is False
+
+    def test_dangling_symlink_counts_as_present(self, tmp_path: Path) -> None:
+        """A broken symlink is still an install we should not overwrite silently.
+
+        ``streamlit skills`` repairs these, so they must not read as absent -
+        which is why the check uses ``lstat()`` rather than ``exists()``.
+        """
+        _skip_if_symlinks_not_supported(tmp_path)
+        target_dir = tmp_path / "skills"
+        target_dir.mkdir()
+        (target_dir / skills._GLOBAL_SKILL_NAME).symlink_to(tmp_path / "gone")
+        assert skills._skill_present_in(target_dir) is True
+
+    @pytest.mark.skipif(
+        os.name == "nt", reason="POSIX permission bits do not gate reads on Windows"
+    )
+    @pytest.mark.skipif(
+        hasattr(os, "geteuid") and os.geteuid() == 0,
+        reason="root bypasses the permission bits this test relies on",
+    )
+    def test_unreadable_dir_is_unknown(self, tmp_path: Path) -> None:
+        """A dir we lack permission to stat into is unknown, not absent.
+
+        ``exists()``/``is_symlink()`` swallow this error and answer False, which
+        is why the check stats directly.
+        """
+        target_dir = tmp_path / "skills"
+        (target_dir / skills._GLOBAL_SKILL_NAME).mkdir(parents=True)
+        target_dir.chmod(0o000)
+        try:
+            assert skills._skill_present_in(target_dir) is None
+        finally:
+            target_dir.chmod(0o700)
 
 
 class TestConfirmProjectInstallationEdgeCases:

--- a/lib/tests/streamlit/web/skills_test.py
+++ b/lib/tests/streamlit/web/skills_test.py
@@ -2128,6 +2128,7 @@ def _evaluate_nudge(
     headless: bool = False,
     hide_welcome: bool = False,
     agents: tuple[str, ...] = ("claude",),
+    claude_on_path: bool = False,
     installed_skills: tuple[str, ...] = (),
     completeness: str = "absent",
     marker_exists: bool = False,
@@ -2139,6 +2140,7 @@ def _evaluate_nudge(
         headless=headless,
         hide_welcome=hide_welcome,
         agents=agents,
+        claude_on_path=claude_on_path,
         installed_skills=installed_skills,
         completeness=completeness,
         marker_exists=marker_exists,
@@ -2152,12 +2154,17 @@ def _evaluate_nudge_reason(
     headless: bool = False,
     hide_welcome: bool = False,
     agents: tuple[str, ...] = ("claude",),
+    claude_on_path: bool = False,
     installed_skills: tuple[str, ...] = (),
     completeness: str = "absent",
     marker_exists: bool = False,
     would_be_refused: bool = False,
 ) -> str:
     """Run ``nudge_suppression_reason`` with the given conditions patched in.
+
+    ``agents`` is the harness list ``detect_installed_agents()`` reports;
+    ``claude_on_path`` is the broader Claude signal. The agent gate consults
+    both, so they vary independently here.
 
     ``completeness`` defaults to ``absent`` to match ``installed_skills=()``, so
     the default world is a machine with nothing installed. Pass it whenever
@@ -2178,6 +2185,7 @@ def _evaluate_nudge_reason(
             "streamlit.web.skills.detect_installed_agents",
             return_value=list(agents),
         ),
+        patch.object(skills, "_is_claude_code_present", return_value=claude_on_path),
         patch(
             "streamlit.web.skills.detect_installed_skills",
             return_value=list(installed_skills),
@@ -2206,7 +2214,12 @@ def _evaluate_nudge_reason(
         ({"headless": True}, "headless"),
         ({"hide_welcome": True}, "welcome_hidden"),
         ({"marker_exists": True}, "dismissed"),
-        ({"agents": ()}, "no_agent"),
+        ({"agents": (), "claude_on_path": False}, "no_agent"),
+        # The broad Claude signal alone is enough: that user gets a
+        # .claude/skills target and so a "partial" install, which means the
+        # startup recommendation prints for them. Withholding the one-click
+        # repair here is what left them nagged with nothing to click.
+        ({"agents": (), "claude_on_path": True, "completeness": "partial"}, ""),
         (
             {
                 "installed_skills": ("home:claude:developing-with-streamlit",),
@@ -2279,7 +2292,30 @@ def test_should_show_skills_nudge_hidden_when_marker_exists(tmp_path: Path) -> N
 
 def test_should_show_skills_nudge_hidden_when_no_agent(tmp_path: Path) -> None:
     """No nudge when no agent harness is detected on the system."""
-    assert _evaluate_nudge(tmp_path, agents=()) is False
+    assert _evaluate_nudge(tmp_path, agents=(), claude_on_path=False) is False
+
+
+def test_nudge_is_shown_when_only_the_broad_claude_signal_fires(
+    tmp_path: Path,
+) -> None:
+    """A `claude` on PATH with no ~/.claude still gets the one-click repair.
+
+    ``detect_installed_agents()`` keys on ~/.claude, so gating on it alone hid
+    the nudge from exactly the users the broader signal had already decided to
+    give a .claude/skills target - and who therefore see the startup
+    recommendation on every run. Nagged by the surface that cannot fix it,
+    hidden from the one that can.
+    """
+    assert (
+        _evaluate_nudge(
+            tmp_path,
+            agents=(),
+            claude_on_path=True,
+            installed_skills=("app:agents:developing-with-streamlit",),
+            completeness="partial",
+        )
+        is True
+    )
 
 
 def test_should_show_skills_nudge_hidden_when_skills_installed(tmp_path: Path) -> None:

--- a/lib/tests/streamlit/web/skills_test.py
+++ b/lib/tests/streamlit/web/skills_test.py
@@ -60,10 +60,9 @@ _needs_permission_bits = pytest.mark.skipif(
 
 @contextmanager
 def _unreadable(*dirs: Path) -> Iterator[None]:
-    """Make ``dirs`` impossible to stat into, restoring them on the way out.
+    """Set ``dirs`` to mode 0o000 so ``lstat()`` fails, then restore 0o700.
 
-    Restoring matters even when the test fails: pytest cannot clean up a
-    ``tmp_path`` containing a 0o000 directory.
+    Restores even on test failure: pytest cannot clean up a 0o000 ``tmp_path``.
     """
     for target in dirs:
         target.chmod(0o000)
@@ -76,28 +75,21 @@ def _unreadable(*dirs: Path) -> Iterator[None]:
 
 @pytest.fixture
 def claude_code_present() -> bool | None:
-    """What ``_is_claude_code_present`` reports for a test.
+    """Pinned return value for ``_is_claude_code_present``.
 
-    Override with ``None`` to opt out and exercise the real detector; a test that
-    wants the other answer can pin it in place, as several below do.
+    Default ``False`` so tests are hermetic. Override to ``True`` to simulate
+    Claude Code, or ``None`` to exercise the real detector.
     """
     return False
 
 
 @pytest.fixture(autouse=True)
 def _isolate_claude_detection(claude_code_present: bool | None) -> Iterator[None]:
-    """Keep Claude Code detection off the ambient environment, and uncached.
+    """Pin Claude Code detection and clear its process-lifetime cache per test.
 
-    Detection consults ``PATH``, so left real it adds a ``.claude/skills`` target
-    on any contributor machine with the CLI installed while staying absent in CI -
-    a latent flake for every assertion about install targets, which this file is
-    largely made of. Pinning it here makes that hermetic by default rather than
-    leaving the next added assertion to rediscover it.
-
-    The cache is cleared around each test as well: ``_is_claude_code_present`` is
-    memoized for the process, so a test that sets up a temp HOME would otherwise
-    inherit (or hand on) another test's answer and pass or fail depending on
-    collection order.
+    The real detector reads ``PATH``, so a local ``claude`` CLI would add a
+    ``.claude/skills`` target in local runs but not in CI - a latent flake. The
+    cache is cleared so tests do not inherit stale answers.
     """
     skills._is_claude_code_present.cache_clear()
     try:
@@ -525,7 +517,7 @@ class TestIsClaudeCodePresent:
 
     @pytest.fixture
     def claude_code_present(self) -> bool | None:
-        """Opt out of the file-wide pin: these tests are the detector."""
+        """Use the real detector: this class tests it directly."""
         return None
 
     @pytest.mark.parametrize(
@@ -552,11 +544,10 @@ class TestIsClaudeCodePresent:
             assert skills._is_claude_code_present() is expected
 
     def test_detects_cli_on_path_without_home_dir(self, tmp_path: Path) -> None:
-        """The CLI being on PATH counts even before ~/.claude is created.
+        """A CLI on PATH counts even when ~/.claude does not exist yet.
 
-        This is the case that used to strand users: they install the skill on a
-        fresh machine where Claude Code has not yet created ~/.claude, so the
-        installer skipped .claude/skills entirely.
+        Claude Code is present but has not created ~/.claude, so the installer
+        must still write .claude/skills.
         """
         home = tmp_path / "home"
         home.mkdir(parents=True)
@@ -581,9 +572,9 @@ class TestIsClaudeCodePresent:
             assert skills._is_claude_code_present() is True
 
     def test_is_cached_across_calls(self, tmp_path: Path) -> None:
-        """The PATH scan runs once per process, not once per script rerun.
+        """The result is cached: repeated calls do not re-walk PATH.
 
-        This sits on the nudge show-gate, which re-evaluates on every rerun.
+        The nudge display gate calls this on every rerun, so caching matters.
         """
         home = tmp_path / "home"
         home.mkdir(parents=True)
@@ -663,10 +654,10 @@ class TestAreSkillsInstalled:
     ) -> None:
         """A scope with .agents but not .claude is not a complete install.
 
-        This is the wedged state: the user ran `streamlit skills` before Claude
-        Code existed, so only .agents/skills was written. Once ~/.claude appears,
-        Claude Code cannot see the skill - and if this returned True nothing
-        would ever prompt them again, stranding them permanently.
+        The user ran `streamlit skills` before Claude Code existed, so only
+        .agents/skills was written. Once ~/.claude appears, Claude Code cannot see
+        the skill - and returning True here would stop anything from ever
+        prompting them again.
         """
         agents_dir = tmp_path / "home" / ".agents" / "skills"
         (agents_dir / skills._GLOBAL_SKILL_NAME).mkdir(parents=True)
@@ -726,7 +717,7 @@ class TestAreSkillsInstalled:
         Reachable in the wild: a project install predating Claude Code (or a
         teammate's committed .agents/skills entry) alongside a later complete
         global one. Claude Code loads the skill from ~/.claude/skills there, so
-        the user is not wedged and must not be told to install on every run.
+        the skill loads and the user must not be told to install every run.
         """
         project_agents = tmp_path / "project" / ".agents" / "skills"
         project_claude = tmp_path / "project" / ".claude" / "skills"
@@ -862,20 +853,18 @@ class TestInstallCompleteness:
         ],
         ids=["absent", "partial", "partial_claude_only", "complete"],
     )
-    def test_reports_each_state(
+    def test_completeness_from_agents_and_claude_combinations(
         self,
         tmp_path: Path,
         agents_installed: bool,
         claude_installed: bool,
         expected: str,
     ) -> None:
-        """Absent, partial, and complete are distinguished, not collapsed to a bool.
+        """Absent, partial, and complete are distinguished, not collapsed to bool.
 
-        The in-app nudge needs "partial" separated from "absent": only a
-        half-finished install of *ours* should reopen a nudge the user has
-        already acted on. Both halves of a wedge count as partial - the common
-        one is .agents/skills with nothing in .claude/skills, and a hand-copied
-        .claude/skills with an empty .agents/skills is the mirror image.
+        Only ``partial`` (our install missing one of its own targets) should
+        reopen the nudge. Either half missing counts: .agents without .claude is
+        the common case, and the reverse is the mirror image.
         """
         agents_dir = tmp_path / "home" / ".agents" / "skills"
         claude_dir = tmp_path / "home" / ".claude" / "skills"
@@ -2272,15 +2261,14 @@ def _evaluate_nudge_reason(
 ) -> str:
     """Run ``nudge_suppression_reason`` with the given conditions patched in.
 
-    ``agents`` is the harness list ``detect_installed_agents()`` reports;
-    ``claude_on_path`` is the broader Claude signal. The agent gate consults
-    both, so they vary independently here.
+    ``agents`` is the harness list from ``detect_installed_agents()``;
+    ``claude_on_path`` pins ``_is_claude_code_present()``. The agent gate
+    consults both, so they vary independently here.
 
-    ``completeness`` defaults to ``absent`` to match ``installed_skills=()``, so
-    the default world is a machine with nothing installed. Pass it whenever
-    ``installed_skills`` is non-empty: the two together decide this gate, and
-    leaving the default in place describes a marker from a harness we do not
-    write to rather than an install of ours.
+    ``completeness`` defaults to ``absent`` to match ``installed_skills=()``.
+    Pass it whenever ``installed_skills`` is non-empty: the two together decide
+    the gate, and leaving the default describes a foreign-harness marker rather
+    than an install of ours.
     """
     marker = tmp_path / ".skills_nudge_dismissed"
     if marker_exists:
@@ -2325,10 +2313,9 @@ def _evaluate_nudge_reason(
         ({"hide_welcome": True}, "welcome_hidden"),
         ({"marker_exists": True}, "dismissed"),
         ({"agents": (), "claude_on_path": False}, "no_agent"),
-        # The broad Claude signal alone is enough: that user gets a
-        # .claude/skills target and so a "partial" install, which means the
-        # startup recommendation prints for them. Withholding the one-click
-        # repair here is what left them nagged with nothing to click.
+        # Claude on PATH alone is enough: that user gets a .claude/skills
+        # target, so a "partial" install. Withholding the nudge here would leave
+        # them nagged by the startup recommendation with no one-click repair.
         ({"agents": (), "claude_on_path": True, "completeness": "partial"}, ""),
         (
             {
@@ -2405,16 +2392,12 @@ def test_should_show_skills_nudge_hidden_when_no_agent(tmp_path: Path) -> None:
     assert _evaluate_nudge(tmp_path, agents=(), claude_on_path=False) is False
 
 
-def test_nudge_is_shown_when_only_the_broad_claude_signal_fires(
-    tmp_path: Path,
-) -> None:
-    """A `claude` on PATH with no ~/.claude still gets the one-click repair.
+def test_nudge_is_shown_when_claude_is_only_on_path(tmp_path: Path) -> None:
+    """A ``claude`` on PATH with no ~/.claude still gets the one-click repair.
 
-    ``detect_installed_agents()`` keys on ~/.claude, so gating on it alone hid
-    the nudge from exactly the users the broader signal had already decided to
-    give a .claude/skills target - and who therefore see the startup
-    recommendation on every run. Nagged by the surface that cannot fix it,
-    hidden from the one that can.
+    ``detect_installed_agents()`` keys on ~/.claude, so gating on it alone hides
+    the nudge from the exact users who see the startup recommendation (because
+    ``_is_claude_code_present`` adds a .claude/skills target they do not have).
     """
     assert (
         _evaluate_nudge(
@@ -2448,10 +2431,8 @@ def test_should_show_skills_nudge_hidden_when_skills_installed(tmp_path: Path) -
 def test_should_show_skills_nudge_when_install_is_partial(tmp_path: Path) -> None:
     """A marker in .agents with nothing in .claude still shows the nudge.
 
-    This is the wedge the whole change is about, seen from the in-app surface: a
-    detected SKILL.md is not proof the agent can load it, and the nudge's
-    one-click install is the repair. Gating on the marker alone left these users
-    with no in-app way out.
+    A detected SKILL.md is not proof the agent can load it. The nudge's
+    one-click install fills the missing target.
     """
     assert (
         _evaluate_nudge(
@@ -2464,12 +2445,12 @@ def test_should_show_skills_nudge_when_install_is_partial(tmp_path: Path) -> Non
 
 
 def test_nudge_is_not_suppressed_by_a_real_partial_tree(tmp_path: Path) -> None:
-    """End-to-end over the real predicate: an .agents-only tree still nudges.
+    """End-to-end: a real .agents-only tree still triggers the nudge.
 
-    The mocked test above pins the branch; this one pins the wiring, so moving
-    the gate back onto ``detect_installed_skills`` alone fails here. Everything
-    but the target dirs is stubbed, since the gate would otherwise read the
-    developer's own home and project directories.
+    Unlike the mocked test above, this runs the real ``_install_completeness``
+    against real directories, so a change that re-gates on
+    ``detect_installed_skills`` alone would fail here. Only the target dirs are
+    real - the rest is stubbed, or the gate would read the developer's own home.
     """
     agents_dir = tmp_path / "project" / ".agents" / "skills"
     claude_dir = tmp_path / "project" / ".claude" / "skills"
@@ -2504,12 +2485,12 @@ def test_nudge_is_not_suppressed_by_a_real_partial_tree(tmp_path: Path) -> None:
 
 @_needs_permission_bits
 def test_nudge_is_hidden_when_no_install_target_can_be_read(tmp_path: Path) -> None:
-    """End-to-end over the real predicate: an unreadable tree does not nudge.
+    """End-to-end: an unreadable install tree does not trigger the nudge.
 
-    The tree is installed but every target dir raises, so the marker scan sees
-    nothing either. Without the ``unknown`` state both blind checks would agree
-    on "nothing installed" and nudge a correctly-installed user on every rerun -
-    with a one-click install that hits the same permissions error.
+    The skill is installed but every target dir raises, so
+    ``detect_installed_skills`` and ``_install_completeness`` both see nothing.
+    Without the ``unknown`` state they would agree on "not installed" and nudge a
+    correctly-installed user on every rerun.
     """
     agents_dir = tmp_path / "project" / ".agents" / "skills"
     (agents_dir / skills._GLOBAL_SKILL_NAME).mkdir(parents=True)

--- a/lib/tests/streamlit/web/skills_test.py
+++ b/lib/tests/streamlit/web/skills_test.py
@@ -2943,7 +2943,7 @@ class TestOneClickInstallWouldBeRefused:
     returns True only when the mode the installer would actually use is fully
     blocked — every project symlink target by a real file/dir, or, when symlinks
     are unsupported, every global copy target by a real file. It reuses the
-    installer's own resolvers so the show-gate cannot drift from the install."""
+    installer's own resolvers so the display gate cannot drift from the install."""
 
     @staticmethod
     def _run(
@@ -3125,7 +3125,7 @@ class TestOneClickInstallWouldBeRefused:
 class TestNudgeSuppressedWhenInstallWouldConflict:
     """End-to-end: when a non-managed file/dir occupies every install target the
     marker-based detection can't see it (no SKILL.md), but the installer refuses
-    with a conflict error. The show-gate must suppress the nudge so the user is
+    with a conflict error. The display gate must suppress the nudge so the user is
     not stuck in an unbreakable nudge -> install -> conflict loop. Ties the gate's
     suppression to the installer's refusal on identical filesystem state.
     """
@@ -3271,7 +3271,7 @@ class TestNudgeSuppressedWhenInstallWouldConflict:
 
 
 class TestNudgeGateSideEffects:
-    """The show-gate is re-evaluated on every script rerun, so its cost and its
+    """The display gate is re-evaluated on every script rerun, so its cost and its
     side effects on the user's project matter as much as its answer."""
 
     @staticmethod

--- a/lib/tests/streamlit/web/skills_test.py
+++ b/lib/tests/streamlit/web/skills_test.py
@@ -33,7 +33,7 @@ from click.testing import CliRunner
 from streamlit.web import cli, skills
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Callable, Iterator
 
 
 def _skip_if_symlinks_not_supported(tmp_path: Path) -> None:
@@ -71,6 +71,24 @@ def _unreadable(*dirs: Path) -> Iterator[None]:
     finally:
         for target in dirs:
             target.chmod(0o700)
+
+
+def _copytree_failing_at(errors: dict[str, OSError]) -> Callable[..., None]:
+    """A ``shutil.copytree`` side effect keyed on the destination path.
+
+    ``errors`` maps a path fragment (``".claude/skills"``) to the error that
+    destination raises; anything unnamed copies. Keyed on the destination rather
+    than on call order, so a test still asserts what it means to if
+    ``_get_global_target_dirs`` ever reorders its targets.
+    """
+
+    def side_effect(source: Path, destination: Path, *args: Any, **kwargs: Any) -> None:
+        target = str(destination).replace("\\", "/")
+        for fragment, error in errors.items():
+            if fragment in target:
+                raise error
+
+    return side_effect
 
 
 @pytest.fixture
@@ -631,6 +649,24 @@ class TestClaudeCliOnPath:
         ):
             assert skills._claude_cli_on_path() is True
 
+    def test_windows_accepts_cwd_when_dot_is_on_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A user who put "." on PATH gets the cwd hit the checkout does not.
+
+        The cwd filter above targets a claude.exe the repo happens to ship, not a
+        directory the user asked to be searched, so "." on PATH must still count.
+        """
+        (tmp_path / "claude.exe").write_text("", encoding="utf-8")
+        monkeypatch.chdir(tmp_path)
+
+        with (
+            patch.object(skills.env_util, "IS_WINDOWS", True),
+            patch.object(skills.shutil, "which", return_value="claude.exe"),
+            patch.dict(os.environ, {"PATH": "."}),
+        ):
+            assert skills._claude_cli_on_path() is True
+
 
 class TestAreSkillsInstalled:
     """Tests for are_skills_installed."""
@@ -882,6 +918,42 @@ class TestInstallCompleteness:
             ),
         ):
             assert skills._install_completeness() == expected
+
+    def test_complete_project_is_not_masked_by_a_partial_global(
+        self, tmp_path: Path
+    ) -> None:
+        """Either scope being complete is enough, not both.
+
+        The mirror of ``test_complete_global_is_not_masked_by_a_partial_project``,
+        which only covers this through ``are_skills_installed``. Pinned here too,
+        so a change requiring *both* scopes is caught at the function that decides
+        it rather than one layer up.
+        """
+        project_agents = tmp_path / "project" / ".agents" / "skills"
+        project_claude = tmp_path / "project" / ".claude" / "skills"
+        for target in (project_agents, project_claude):
+            (target / skills._GLOBAL_SKILL_NAME).mkdir(parents=True)
+        # Global scope is half-installed, so on its own it would report partial.
+        global_agents = tmp_path / "home" / ".agents" / "skills"
+        (global_agents / skills._GLOBAL_SKILL_NAME).mkdir(parents=True)
+        global_claude = tmp_path / "home" / ".claude" / "skills"
+
+        with (
+            patch.object(
+                skills, "_find_project_root", return_value=tmp_path / "project"
+            ),
+            patch.object(
+                skills,
+                "_get_project_target_dirs",
+                return_value=[project_agents, project_claude],
+            ),
+            patch.object(
+                skills,
+                "_get_global_target_dirs",
+                return_value=[global_agents, global_claude],
+            ),
+        ):
+            assert skills._install_completeness() == "complete"
 
     @_needs_permission_bits
     def test_targets_we_cannot_read_at_all_are_unknown_not_absent(
@@ -2028,10 +2100,12 @@ class TestGlobalInstallationConflicts:
             patch.object(
                 skills.shutil,
                 "copytree",
-                side_effect=[
-                    OSError(errno.EACCES, "Permission denied"),
-                    OSError(errno.ENOSPC, "No space left"),
-                ],
+                side_effect=_copytree_failing_at(
+                    {
+                        ".agents/skills": OSError(errno.EACCES, "Permission denied"),
+                        ".claude/skills": OSError(errno.ENOSPC, "No space left"),
+                    }
+                ),
             ),
             # ~/.claude above says Claude Code is present; pin it so the
             # .claude target does not depend on the machine's PATH.
@@ -2073,11 +2147,13 @@ class TestGlobalInstallationConflicts:
             patch.object(
                 skills, "_get_meta_skill_dir", return_value=mock_meta_skill_dir
             ),
-            # First target (~/.agents) copies fine; second (~/.claude) fails.
+            # ~/.agents copies fine; ~/.claude (the authoritative target) fails.
             patch.object(
                 skills.shutil,
                 "copytree",
-                side_effect=[None, OSError("Permission denied")],
+                side_effect=_copytree_failing_at(
+                    {".claude/skills": OSError("Permission denied")}
+                ),
             ),
             # ~/.claude above says Claude Code is present; pin it so the
             # .claude target does not depend on the machine's PATH.
@@ -2087,6 +2163,12 @@ class TestGlobalInstallationConflicts:
             skills._install_global_skills(yes=True)
 
         assert exc.value.reason == "write_failed"
+        # The message names only what failed, so this pins ~/.claude as the target
+        # that did - it cannot pass by failing the best-effort dir instead, which
+        # is the mirror case and must not raise at all.
+        message = exc.value.format_message()
+        assert ".claude/skills" in message
+        assert ".agents/skills" not in message
 
     def test_best_effort_target_failure_still_reports_success(
         self, tmp_path: Path, mock_meta_skill_dir: Path
@@ -2219,6 +2301,36 @@ class TestIsStreamlitOwnedSymlinkErrorPaths:
 
         # Should return True based on name check
         assert skills._is_streamlit_owned_symlink(link, {"developing-with-streamlit"})
+
+
+class TestAgentHarnessPresent:
+    """Tests for the predicate the nudge gate and the install handler share."""
+
+    @pytest.mark.parametrize(
+        ("agents", "claude_present", "expected"),
+        [
+            (["claude"], False, True),
+            ([], True, True),
+            (["cursor"], True, True),
+            ([], False, False),
+        ],
+        ids=["home-dir-harness", "path-only-claude", "both", "neither"],
+    )
+    def test_either_detector_is_enough(
+        self, agents: list[str], claude_present: bool, expected: bool
+    ) -> None:
+        """Either detector alone answers yes; only both saying no is a no.
+
+        Covered indirectly by the nudge and handler gates, but pinned here so a
+        change to the ``or`` fails at the function that owns it.
+        """
+        with (
+            patch.object(skills, "detect_installed_agents", return_value=agents),
+            patch.object(
+                skills, "_is_claude_code_present", return_value=claude_present
+            ),
+        ):
+            assert skills.agent_harness_present() is expected
 
 
 def _evaluate_nudge(
@@ -2550,6 +2662,16 @@ def test_should_show_skills_nudge_returns_false_on_error() -> None:
     """A detection failure suppresses the nudge rather than raising."""
     with patch("streamlit.config.get_option", side_effect=RuntimeError("boom")):
         assert skills.should_show_skills_nudge() is False
+
+
+def test_nudge_suppression_reason_is_check_failed_on_error() -> None:
+    """A detection failure reports ``check_failed``, not just a falsy answer.
+
+    The boolean wrapper above cannot tell ``check_failed`` from any other
+    suppression reason, and the reason is what reaches telemetry.
+    """
+    with patch("streamlit.config.get_option", side_effect=RuntimeError("boom")):
+        assert skills.nudge_suppression_reason() == "check_failed"
 
 
 def test_write_nudge_dismissed_marker_creates_file(tmp_path: Path) -> None:

--- a/proto/streamlit/proto/NewSession.proto
+++ b/proto/streamlit/proto/NewSession.proto
@@ -107,6 +107,12 @@ message Initialize {
   //                            loopback gate excludes.
   //   "check_failed"         - the eligibility check itself threw, so the
   //                            nudge was withheld defensively.
+  //   "check_unreadable"     - no install target could be read (e.g.
+  //                            permissions), so whether the skills are
+  //                            installed is unknown and the nudge was withheld.
+  //                            Split from "check_failed" because the two point
+  //                            at different fixes: ours vs. the user's
+  //                            filesystem.
   // The high-volume uninteresting cases (headless, no agent harness, skills
   // already installed, user dismissed) are deliberately NOT reported.
   //

--- a/specs/2026-05-11-streamlit-skills-cli/product-spec.md
+++ b/specs/2026-05-11-streamlit-skills-cli/product-spec.md
@@ -188,21 +188,24 @@ breaking changes roll out to users.
   so a missed detection costs the user the whole skill while a false positive
   costs a few unused symlinks. `~/.claude` alone is not sufficient: it is
   created lazily, so a freshly installed CLI has none yet. False positives
-  (a leftover dir after uninstall) and false negatives (a custom `CLAUDE_HOME`
-  with the CLI off `PATH`) are still accepted to keep detection simple.
+  (a leftover dir after uninstall) and false negatives (a `CLAUDE_CONFIG_DIR`
+  pointing elsewhere with the CLI off `PATH`) are still accepted to keep
+  detection simple.
 - **Install completeness:** A skill present in only some of a scope's target
   directories counts as *not* installed, so the startup recommendation and the
   in-app nudge both prompt again and the re-run fills in the missing agent
   directory. Completeness is judged per scope and either scope satisfying it is
   enough, so a deliberate global-only install is not flagged in every project. An
   install that cannot be inspected at all - every target directory raises, e.g.
-  on permissions - counts as installed rather than missing: neither surface can
-  tell, and the install they would recommend hits the same error.
+  on permissions - does not prompt: neither surface can tell, and the install
+  they would recommend hits the same error. The startup recommendation reaches
+  that by treating it as installed; the in-app nudge withholds under its own
+  `check_unreadable` reason, so the two stay distinguishable in telemetry.
 - **Who gets prompted:** The in-app nudge requires an agent harness to be
   present, judged by *either* detector - the home-directory harness list or the
   broader Claude Code detection above. Either is enough on purpose: a user
-  detected broadly enough to be given a `.claude/skills` target is also reported
-  as partially installed, so the startup recommendation prints for them. Gating
+  detected broadly enough to be given a `.claude/skills` target is not reported
+  as fully installed, so the startup recommendation prints for them. Gating
   the nudge on the narrower signal left that user nagged by the surface that
   cannot fix it and hidden from the one-click repair that can.
 - **Idempotent:** Safe to run multiple times; reports "up to date" for existing

--- a/specs/2026-05-11-streamlit-skills-cli/product-spec.md
+++ b/specs/2026-05-11-streamlit-skills-cli/product-spec.md
@@ -15,7 +15,7 @@ Two installation modes are supported:
 - **Global:** Fetches the `developing-with-streamlit` meta skill from the
   [`streamlit/agent-skills`](https://github.com/streamlit/agent-skills) GitHub
   repository and installs it to the user's global agent skills directories
-  (`~/.agents/skills/` and `~/.claude/skills/` if `~/.claude` exists).
+  (`~/.agents/skills/`, and `~/.claude/skills/` when Claude Code is detected).
   This meta skill includes a discovery script that dynamically locates
   project-specific bundled skills at runtime.
 
@@ -124,7 +124,7 @@ active Streamlit installation, ensuring version-matched guidance.
 
 **Targets:**
 - `<project>/.agents/skills/developing-with-streamlit/` (always)
-- `<project>/.claude/skills/developing-with-streamlit/` (when `~/.claude` exists)
+- `<project>/.claude/skills/developing-with-streamlit/` (when Claude Code is detected)
 
 **Project root detection:** Existing `.agents/` or `.claude/` dir → git root → cwd.
 
@@ -153,7 +153,7 @@ locates each project's bundled skills at runtime.
 
 **Targets:**
 - `~/.agents/skills/developing-with-streamlit/` (always)
-- `~/.claude/skills/developing-with-streamlit/` (when `~/.claude` exists)
+- `~/.claude/skills/developing-with-streamlit/` (when Claude Code is detected)
 
 **What gets installed:**
 ```
@@ -181,11 +181,20 @@ breaking changes roll out to users.
 
 ### Common Behavior
 
-- **Claude Code detection:** The presence of `~/.claude` in the user's home
-  directory is used to determine whether to install to `.claude/skills/`
-  directories (both project-local and global). This simple heuristic may
-  produce false positives (leftover dir after uninstall) or false negatives
-  (custom `CLAUDE_HOME`), but keeps the implementation straightforward.
+- **Claude Code detection:** Whether to install to `.claude/skills/` (both
+  project-local and global) is decided by any of three signals: `~/.claude`,
+  `~/.claude.json`, or a `claude` executable on `PATH`. Any one is enough,
+  because the failure is asymmetric - Claude Code never reads `.agents/skills/`,
+  so a missed detection costs the user the whole skill while a false positive
+  costs a few unused symlinks. `~/.claude` alone is not sufficient: it is
+  created lazily, so a freshly installed CLI has none yet. False positives
+  (a leftover dir after uninstall) and false negatives (a custom `CLAUDE_HOME`
+  with the CLI off `PATH`) are still accepted to keep detection simple.
+- **Install completeness:** A skill present in only some of a scope's target
+  directories counts as *not* installed, so the startup recommendation and the
+  in-app nudge both prompt again and the re-run fills in the missing agent
+  directory. Completeness is judged per scope and either scope satisfying it is
+  enough, so a deliberate global-only install is not flagged in every project.
 - **Idempotent:** Safe to run multiple times; reports "up to date" for existing
   installs, repairs broken links, skips user-managed files with conflict warning,
   and updates global skill if the versioned tag has changed on GitHub

--- a/specs/2026-05-11-streamlit-skills-cli/product-spec.md
+++ b/specs/2026-05-11-streamlit-skills-cli/product-spec.md
@@ -198,6 +198,13 @@ breaking changes roll out to users.
   install that cannot be inspected at all - every target directory raises, e.g.
   on permissions - counts as installed rather than missing: neither surface can
   tell, and the install they would recommend hits the same error.
+- **Who gets prompted:** The in-app nudge requires an agent harness to be
+  present, judged by *either* detector - the home-directory harness list or the
+  broader Claude Code detection above. Either is enough on purpose: a user
+  detected broadly enough to be given a `.claude/skills` target is also reported
+  as partially installed, so the startup recommendation prints for them. Gating
+  the nudge on the narrower signal left that user nagged by the surface that
+  cannot fix it and hidden from the one-click repair that can.
 - **Idempotent:** Safe to run multiple times; reports "up to date" for existing
   installs, repairs broken links, skips user-managed files with conflict warning,
   and updates global skill if the versioned tag has changed on GitHub

--- a/specs/2026-05-11-streamlit-skills-cli/product-spec.md
+++ b/specs/2026-05-11-streamlit-skills-cli/product-spec.md
@@ -194,7 +194,10 @@ breaking changes roll out to users.
   directories counts as *not* installed, so the startup recommendation and the
   in-app nudge both prompt again and the re-run fills in the missing agent
   directory. Completeness is judged per scope and either scope satisfying it is
-  enough, so a deliberate global-only install is not flagged in every project.
+  enough, so a deliberate global-only install is not flagged in every project. An
+  install that cannot be inspected at all - every target directory raises, e.g.
+  on permissions - counts as installed rather than missing: neither surface can
+  tell, and the install they would recommend hits the same error.
 - **Idempotent:** Safe to run multiple times; reports "up to date" for existing
   installs, repairs broken links, skips user-managed files with conflict warning,
   and updates global skill if the versioned tag has changed on GitHub


### PR DESCRIPTION
## TL;DR (for humans)

Install the Streamlit agent skills before Claude Code is set up and they land in a directory Claude Code never reads. Everything reports success. Nothing prompts again, so the agent quietly goes without them. Now a half-finished install counts as not installed, so the startup message and the in-app prompt both come back and a re-run fills in the gap. The prompt also stops hiding from the people that startup message was already nagging: if you are told your install is incomplete, you now get the button that fixes it. And an install that reached Claude Code no longer reports failure just because a second directory nothing verifiably reads was denied — that told developers whose setup works perfectly that it was broken, and it would now send them round a repair loop with no exit.

---

## Full context (for agents)

### Background

#### Why

`streamlit skills` could leave a Claude Code user permanently unable to use the skill they just installed, while telling them everything was fine:

1. Run `streamlit skills` before Claude Code is set up. `~/.claude` doesn't exist, so `_get_*_target_dirs()` writes only `.agents/skills/`.
2. Install Claude Code later. It reads `.claude/skills/`, never `.agents/`, so it can't see the skill.
3. Nothing prompts again: the startup recommendation was gated on `are_skills_installed()`, which returned `True` as soon as *any* target dir had the skill, and the in-app nudge was gated on `detect_installed_skills()`, which counts a `SKILL.md` marker anywhere.

A later audit of this PR found the mirror image of the same problem, introduced by the fix itself. The two recommendation surfaces disagreed about what counts as "an agent is here", and the wrong way round: the startup recommendation follows `are_skills_installed()`, and so the broad Claude detection below, while the in-app nudge was gated on `detect_installed_agents()`, which keys on `~/.claude` alone. Anyone the broad signal covered but the narrow one didn't — a `claude` on `PATH` with no `~/.claude`, meaning a shared toolchain image, a leftover binary, or `CLAUDE_CONFIG_DIR` pointing elsewhere — had their `.agents`-only install reported as partial, printed the startup recommendation on every run with no dismissal path, and had the one-click repair withheld. Nagged by the surface that cannot fix it, hidden from the one that can. Before this PR they were quiet, so it was a regression in the making.

Fixing that display gate alone then produced a worse bug, which is worth recording because it is the same shape one level up. The in-app install *action* has its own gate in `backend_operation_handler.py`, deliberately separate from the nudge's display predicate ("gate the ACTION on install safety"), and it keyed on `detect_installed_agents()` alone. Widening only the display gate meant the very user it was meant to help saw the nudge, clicked it, and got `refused:no_agent` — "Skills install is not available in this environment." A button that refuses is worse than the nag it replaced, and it is exactly what `_one_click_install_would_be_refused()` exists to prevent. Two definitions of "would anything consume these skills" was the cause, so there is now one.

No issue link. Found while analysing skill-adoption telemetry: Claude Code users whose skill sits only in `.agents` follow skill-advocated practices measurably less often than those with it in `.claude`. That gap is plumbing rather than guidance, which is what prompted this.

#### What

A handful of private helpers in `lib/streamlit/web/skills.py` and the two gates that consume them — the nudge's display gate there, and the in-app install handler's action gate in `lib/streamlit/runtime/backend_operation_handler.py` — plus the merged skills-CLI spec and unit tests. No public `st.*` API, CLI flag, config option, protobuf, or dependency changes. Observable behaviour changes only for incomplete installs, for who gets offered the in-app repair, and for whether a partly-written global install reports failure.

#### How

Detection is generous because the failure is asymmetric: Claude Code never reads `.agents/skills/`, so a missed detection costs the whole skill while a false positive costs a few unused symlinks. Completeness is judged only against the directories `streamlit skills` itself writes, so a skill hand-placed under a harness we don't install for is neither evidence of a partial install nor a reason to prompt. Either scope satisfying completeness is enough, because a complete global install means every agent can load the skill. Unreadable is unknown rather than missing, and when nothing at all can be read the answer is `unknown` rather than `absent`, so neither surface acts on a permissions error. And "an agent is here" is now one predicate, `agent_harness_present()`, accepting either detector and shared by the nudge's display gate and the installer's action gate, which closes the gap described above without touching the telemetry vocabulary.

The same asymmetry decides the install *verdict*, which is the one place the fix had to cut the other way. A write failure on any global target used to fail the whole install, so `~/.agents/skills` being denied reported failure to a developer whose `~/.claude/skills` was written and whose Claude Code therefore works. Only the *authoritative* target — the dir a detected harness actually reads, via the same `_is_claude_code_present()` — can fail an install now; the other is best-effort, and its failure is printed and logged rather than fatal. With no harness detected, `.agents/skills` carries authority by default, since leaving none would turn every write failure into a silent success. This mattered more once a partial install reopens the nudge: that developer would otherwise be nudged toward a repair that fails on the same unwritable target every time, and `_one_click_install_would_be_refused()` cannot catch it, because that guard tests for conflicts rather than permissions.

Two things were deliberately left out. The startup recommendation still has no dedicated dismissal path: letting the nudge's dismissal silence it too would mean dismissing the toast also silences the only other signal a wedged user gets, recreating this bug in a quieter form. And `_HARNESSES` still keys on `~/.claude` alone, because that table defines the `installed_agents` telemetry labels for all eight harnesses; widening it is a product decision, not a bugfix.

### Changes

- Add `_is_claude_code_present()` behind both target-dir functions, checking `~/.claude`, `~/.claude.json`, and a `claude` on `PATH` rather than `~/.claude` alone — that directory is created lazily, so on a fresh machine the CLI can be present while the directory isn't. Cached with `@lru_cache(maxsize=1)` because it sits on a gate that re-evaluates every rerun.
- Add `_claude_cli_on_path()` and `_lives_in_a_path_entry()`. On Windows `shutil.which()` searches the current directory before `PATH`, so a hit is trusted only when it lives in a directory `PATH` actually names; a user who put `.` on `PATH` themselves still counts.
- Replace the boolean install check with `_install_completeness()` returning `absent` / `partial` / `complete` / `unknown`, judged per scope against the installer's own target dirs.
- Rewrite `_skill_present_in()` to use `lstat()` instead of `exists()` / `is_symlink()`, which swallow `OSError` and so report an unreadable path as a missing one. `FileNotFoundError` / `NotADirectoryError` mean absent, any other `OSError` means unknown, and a dangling symlink still counts as present.
- `are_skills_installed()` is now true for `complete` or `unknown`, so the startup recommendation prints for a partial install and stays quiet when nothing could be inspected.
- `nudge_suppression_reason()` no longer lets a detected marker suppress on its own — only `partial` reopens the nudge, whose one-click install is exactly the repair — and returns `check_failed` when no install target could be read.
- Add `_authoritative_global_target_dir()`: `~/.claude/skills` when Claude Code is detected, else `~/.agents/skills`. Always one of `_get_global_target_dirs()`, so exactly one global target is load-bearing and the rest are best-effort.
- Give `_install_global_skills()` a per-target `_InstallResult`, merged into the aggregate. The shared result cannot support a per-target verdict: `write_reasons` is a set, so two targets failing the same way are indistinguishable from one, and nothing in it records *which* target failed.
- Only an authoritative failure raises. A best-effort failure still appears in the CLI summary's "Failed to write" list and now also logs a warning, so the in-app install — which has no terminal — leaves a trace. A backstop still raises if nothing landed anywhere; unreachable while the authoritative dir is always a target, but a target added later must not be able to turn a total failure into a silent success.
- `_write_error()` takes the reasons that *justify* the error, so a dead-weight target cannot mislabel a failure a load-bearing one caused. Both failures are still named in the message.
- Add `agent_harness_present()`, which is true when either detector finds a harness, and route both the nudge's `no_agent` gate and `InstallSkillsHandler`'s `refused:no_agent` gate through it so a nudge we show can never hand the user a button that refuses.
- Update `specs/2026-05-11-streamlit-skills-cli/product-spec.md`: the three detection signals and why, the completeness rule including the uninspectable case, and who gets prompted.

### Test plan

- [x] Unit tests in `lib/tests/streamlit/web/skills_test.py`, 220 → 247 cases. Detection: each signal independently, including `test_detects_cli_on_path_without_home_dir` (the case that stranded people) and `test_falls_back_to_path_when_home_cannot_be_resolved`; `TestClaudeCliOnPath` covers `test_windows_ignores_a_hit_in_the_current_directory` and `test_windows_accepts_a_hit_in_a_real_path_entry`.
- [x] Completeness: `test_reports_each_state`, `test_partial_install_in_scope_counts_as_not_installed` (the regression), `test_complete_global_is_not_masked_by_a_partial_project` and `test_global_only_install_is_not_reported_as_partial` (the over-fire guards), `test_targets_we_cannot_read_at_all_are_unknown_not_absent` with `test_one_readable_scope_still_reports_absent` and `test_unresolvable_targets_stay_absent` bounding it on both sides, and `TestSkillPresentIn` against a real `chmod 000` dir and a real dangling symlink.
- [x] Nudge: `test_should_show_skills_nudge_when_install_is_partial` pins the branch and `test_nudge_is_not_suppressed_by_a_real_partial_tree` pins the wiring over a real `.agents`-only tree; `test_nudge_is_hidden_when_no_install_target_can_be_read` does the same for `unknown` over a real unreadable tree; `test_nudge_is_shown_when_only_the_broad_claude_signal_fires` covers the agent gate; `test_should_show_skills_nudge_hidden_when_marker_is_from_another_harness` is the over-fire guard.
- [x] Install verdict: `test_best_effort_target_failure_still_reports_success` is the case this fixes (`~/.claude` copies, `~/.agents` denied → success, failure still reported and logged); `test_partial_write_failure_reports_write_failed_not_success` pins the direction that must stay hard (`~/.claude` denied → fails); `test_authoritative_target_follows_claude_detection` covers both authority branches and asserts the authoritative dir is always one the installer writes; `test_write_error_generalises_when_justifying_reasons_disagree` keeps the no-guessing rule covered now that the pooled path is only reachable from the backstop.
- [x] `test_generalises_when_targets_fail_for_different_reasons` became `test_reports_the_authoritative_targets_cause_when_targets_disagree`: two targets failing differently now report the authoritative target's actual cause (`write_no_space`) instead of collapsing to the generic `write_failed`, which is sharper telemetry, not a lost guarantee.
- [x] Existing tests touched. `skills_test.py` no longer lets the ambient `PATH` decide install targets: an autouse fixture pins `_is_claude_code_present` to `False`, overridable per test, and still clears its cache per test. Six tests that set up a temp `~/.claude` and relied on detection noticing it now pin it `True` beside that setup — two of them, `test_partial_conflict_still_nudges` and `TestInstallDetectRoundtrip`, need *two* project targets for their scenario to exist at all, so they were green in CI and green on a dev machine for opposite reasons. `backend_operation_handler_test.py::test_install_skills_handler_runs_real_installer` keeps its own pin; it asserts the install detail is exactly `"Installed to .agents/skills."` and was a latent flake on any machine with the `claude` CLI on `PATH`.
- [x] `skills_test.py` 247 passed and `runtime/backend_operation_handler_test.py` 34 passed, including `test_install_skills_handler_honors_a_broad_claude_signal` for the population the action gate now lets through. That test file has no autouse fixture, so its `no_agent` test now pins `_is_claude_code_present` explicitly rather than reading the ambient `PATH`. Also ran `bootstrap_test.py`, `runtime/app_session_test.py` and `runtime/metrics_util_test.py` — the other callers of the predicates involved.
- [x] `ruff format` and `ruff check` clean at the pinned 0.16.1; `mypy` on `skills.py` reports no issues.
- [x] No E2E needed. `e2e_playwright/skills_nudge.py` exercises the nudge with no skills installed anywhere, which this doesn't change; only the predicates feeding it moved.
- [ ] **A real Windows run is the one thing still unverified.** The `shutil.which` current-directory filtering is unit-tested with `env_util.IS_WINDOWS` patched, which exercises the logic but not the platform behaviour it compensates for. A reviewer on Windows confirming a normal `claude` install is still detected would close it.

Every behaviour claim below was staged on disk in an isolated `$HOME` and project, running the *same* on-disk state against each revision.

The original wedge, with a stub `claude` on `PATH` standing in for "Claude Code installed later":

| revision | `are_skills_installed()` | nudge reason | in-app nudge |
|---|---|---|---|
| `b6bc0557` pre-PR `develop` | `True` — wrong | `installed` | hidden |
| `691093a1` before the review fixes | `False` | `installed` — wrong | hidden |
| `2583e4b7` | `False` | `''` | **shown** |

Re-running the installer then wrote `.claude/skills` only (`.agents` already up to date) and both surfaces went quiet. A complete global install alongside a partial project one reports `complete` and stays silent. Details in [this comment](https://github.com/streamlit/streamlit/pull/16394#issuecomment-5399016018).

Round 2's finding — a complete global install with every agent dir `chmod 000`, so nothing readable in either scope:

| revision | completeness | `are_skills_installed()` | nudge reason | in-app nudge |
|---|---|---|---|---|
| `2583e4b7` before the fix | `absent` | `False` | `''` | **shown** — wrong |
| `0c5c0e45` | `unknown` | `True` | `check_failed` | hidden |

Round 3's finding — a `claude` on `PATH`, no `~/.claude`, `.agents`-only install:

| revision | startup recommendation | in-app nudge |
|---|---|---|
| `b6bc0557` pre-PR `develop` | silent | `no_agent` |
| `0c5c0e45` before the fix | **prints every run** | `no_agent` — wrong |
| `a42e4201` | prints, and now actionable | **shown**; one click writes `.claude/skills`, then both go quiet |

Round 4's finding, driving the real `InstallSkillsHandler` rather than `install_skills()` — same staged tree, a `claude` on `PATH` with no `~/.claude`:

| revision | nudge | handler `error_reason` | outcome |
|---|---|---|---|
| `a42e4201` before the fix | shown | `refused:no_agent` | nothing written — wrong |
| `04e70a04` | shown | `''` | `Installed to .claude/skills.` |

A fresh `$HOME` with Claude Code and nothing installed still reports `absent` and still nudges, and a machine with no agent at all is still suppressed with `no_agent`, so neither new behaviour leaks into the cases the PR exists to fix. Every nudge-loop candidate I could construct terminates: a partial install with a conflict at the skill path resolves on the next install, one with an unwritable target fails the symlink and falls back to the global copy (staged), and a fully blocked tree is caught by `_one_click_install_would_be_refused()`.

### Telemetry

No proto, schema, or label-vocabulary changes: no member was added to `_NudgeSuppressionReason` or `_InstallFailureReason`, and no proto or frontend file is touched, so no dashboard query orphans. Three label *distributions* shift on the release that ships this, which is the intended signal rather than a regression:

| label | before | after |
|---|---|---|
| `installed` | a marker exists anywhere | a marker exists *and* the install is not partial |
| `no_agent` | the home-dir harness list is empty | *both* detectors are quiet |
| `check_unreadable` | — | new: no install target could be read (split out of `check_failed`) |
| `""` (nudge shown) | — | grows, absorbing the three above |

On the failure path, `skillsNudgeInstallFailed:write_*` **steps down**: installs that reached the authoritative target and failed only a best-effort one now emit the success label instead. That cohort becomes unattributed rather than mislabelled — there is no new field carrying it, so the only trace is the server-log warning. If we want that rate countable, it needs its own field on the success payload, and it cannot be backfilled; called out as a follow-up rather than smuggled in here.

`refused:no_agent` on `BackendOperationResponse.error_reason` fires less often for the same reason. `installed_skills` and `installed_agents` keep their exact meaning — `detect_installed_skills()` is still a pure `SKILL.md` scanner and `detect_installed_agents()` still keys on the eight home dirs — though both will show more `claude` tokens as installs actually reach `.claude/skills`.

### Review feedback addressed

| Feedback | Resolution |
| --- | --- |
| Bugbot (high) / QA Issue 1 / inline `skills.py:332` — the in-app nudge still treats partial installs as done | Fixed rather than deferred. The nudge is the only one-click recovery path, so leaving it meant the wedge stayed unfixed for anyone who doesn't read the terminal. `detect_installed_skills()` stays a pure telemetry scanner; `_install_completeness()` is what gates. |
| Inline `skills.py:374` / QA E3 — a complete global install can be masked by a partial project install | Fixed. Either scope being complete is enough. That user isn't wedged, and the startup recommendation has no dismissal path, so nagging them every run was the worse error. |
| QA Issue 2 — unreadable dirs were missing, not unknown | Fixed. `exists()` / `is_symlink()` swallow `OSError`, so the documented policy only held under a mock. `_skill_present_in()` now uses `lstat()`, which raises; `FileNotFoundError` / `NotADirectoryError` ⇒ absent, other `OSError` ⇒ unknown. `lstat()` also keeps dangling symlinks counting as present. |
| Inline `skills.py:294` — Windows `shutil.which` resolves the cwd before `PATH` | Closed rather than documented. Repo contents shouldn't decide where we write, even when the blast radius is a stray symlink dir. A hit is trusted only if it lives in a real `PATH` entry; a user who put `.` on `PATH` themselves still counts. |
| Inline `skills.py:277` — cache `_is_claude_code_present()` | Done, `@lru_cache(maxsize=1)`, with the mid-session tradeoff in a comment. It's self-correcting rather than a dead end: the next session sees a partial install and offers the repair. |
| Inline `skills.py:290` — untested `except RuntimeError`, and should it still consult `PATH`? | Both. It now falls through to the `PATH` check (a project-local `.claude/skills/` install needs no home dir), with a test. |
| Inline `skills.py:395` — `OSError` → `None` uncovered | Covered, against a real `chmod 000` dir rather than a mock. |
| **Round 2** — greptile (P1) `skills.py:442` — unknown targets collapse to `absent`, so a correctly-installed user whose dirs cannot be read is nudged repeatedly | Fixed. `_install_completeness()` gained `unknown` for "no scope produced a readable answer"; both gates treat it as nothing to act on. Deliberately narrower than the report: one scope answering "no skill here" while the other is unreadable stays `absent`, since the install we then recommend lands in the readable scope and succeeds. Staged on disk, before/after above. |
| **Round 2** — `skills_test.py:60` — the autouse fixture should pin detection off by default | Done, via an overridable `claude_code_present` fixture. It was latent rather than theoretical: six tests depended on ambient detection noticing a temp `~/.claude`, two of them for a second install target their scenario needs. |
| **Round 2** — `skills_test.py:2028` — default the nudge helper's `completeness` to `"complete"` | Half taken. The two sites that mean a finished install now pass it explicitly; the default stays `absent` to match `installed_skills=()`, so the helper's default world stays coherent. Reasoning in the helper's docstring. |
| Recommendation 1 — the merged skills-CLI spec still documents the `~/.claude`-only heuristic | Updated `specs/2026-05-11-streamlit-skills-cli/product-spec.md`: the three detection signals and why, plus the completeness rule — including, after round 2, that an install nothing can inspect counts as installed. |
| Recommendation 4 — `_HARNESSES` / `detect_installed_agents()` still key on `~/.claude` alone | The table is unchanged, so the `installed_agents` telemetry vocabulary for all eight harnesses still means exactly what it did. Round 3 stopped the *nudge gate* from depending on it alone (see below); the detector itself was left alone deliberately, and the divergence is documented in `_is_claude_code_present()` so nobody "fixes" it later. Verified why it cannot bite (Claude Code 2.1.235, empty `$HOME`): `claude --version` creates nothing, but the first config-touching command creates both `~/.claude` and `~/.claude.json`, before login. So the detectors disagree only for an install never invoked beyond `--version` — where nobody can be wedged, since that requires having used Claude Code and found the skill missing. |
| Readability — "nudge" vs "startup recommendation", test names, docstrings, PR title/description | Reworded throughout; `test_global_install_does_not_nudge_in_every_project` → `test_global_only_install_is_not_reported_as_partial`. The `nudge_suppression_reason()` docstring now says it shares the completeness rule, because it does. |
| Readability — the "3.9pp less adherence" figure | Dropped the number. Fair point that this repo has no means of collecting practice-adherence data; it came from internal telemetry analysis that can't be linked here. Kept the qualitative provenance. |
| **Round 3** — inline `skills.py:283` (mine) — "can you explain why this is needed with a comment? feels sort of out of place to check os in this func" | Audited the diff rather than answering in place, because the smell was real. The `PATH`-entry filtering moved into `_lives_in_a_path_entry()`, so the Windows branch is one expression with a three-line rationale instead of a paragraph mid-function. |
| **Round 3** — the audit's own finding: the two surfaces used *different* definitions of "an agent is here", the wrong way round | Fixed. The startup recommendation follows the broad signal, while the nudge was gated on the narrow one, so a `claude` on `PATH` with no `~/.claude` was told their install was incomplete on every run and had the one-click repair withheld. Either detector now satisfies the agent gate. Staged both populations, table above. |
| **Round 3** — considered and deferred: no dismissal path for the startup recommendation | Still the residual nag, still out of scope here. It is new product behaviour, and after the gate fix the population needing it is narrow: someone who sees the nudge, dismisses it because they do *not* want the skill in Claude, and still gets the terminal line. |
| **Round 3** — noted, not acted on: six of the eight harnesses have this wedge permanently | `.cursor/skills`, `.codex/skills` and friends are never written, so those users are wedged by design — deferred to v2 in the spec. Worth knowing the Claude-specific detector does not generalise; driving targets off `_HARNESSES` would. |
| **Round 4** — found while answering "does this PR change any telemetry?": the action gate still keyed on the narrow detector | Fixed in `04e70a04`. `a42e4201` showed the nudge to PATH-only users while `InstallSkillsHandler` refused their install with `refused:no_agent`. Both gates now share `agent_harness_present()`. My round-3 check missed it by calling `install_skills()` directly instead of driving the handler; the table above drives the handler. |

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes filesystem install targets, nudge/install gating, and success vs failure semantics for multi-target global installs; mistakes could mis-prompt users or skip needed `.claude/skills` writes, though behavior is heavily unit-tested.
> 
> **Overview**
> Fixes agent-skill installs that **look successful but Claude Code never reads** (e.g. skill only under `.agents/skills` while Claude uses `.claude/skills`), and aligns nudge, startup messaging, and in-app install so users who are told to repair actually get a working button.
> 
> **Detection & targets:** Claude Code presence no longer hinges on `~/.claude` alone. New `_is_claude_code_present()` (cached) also checks `~/.claude.json` and a `claude` on `PATH`, with Windows filtering so a repo-local `claude.exe` does not drive install paths. Project/global installs add `.claude/skills` when that detector fires.
> 
> **“Installed” vs nudge:** `_install_completeness()` replaces a simple any-dir-exists check with `absent` / `partial` / `complete` / `unknown` (per scope, using `lstat()` so unreadable dirs are not “missing”). Partial installs prompt again via startup text and the in-app nudge; fully unreadable trees suppress the nudge as `check_unreadable` (telemetry now reports this reason). **`agent_harness_present()`** unifies the nudge gate and `InstallSkillsHandler` so PATH-only Claude users are not shown a nudge whose install returns `refused:no_agent`.
> 
> **Global copy installs:** Failures on the **authoritative** target (`~/.claude/skills` when Claude is detected, else `~/.agents/skills`) still fail the operation; best-effort target write errors log a warning but can still succeed when the harness-readable path was written.
> 
> Specs and tests updated for the new detection, completeness, nudge, and install-outcome behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 200f01299bf1f55c83dbe0913d887507c7d0ba14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->






