### PR TITLE
Add support for `50` step font weights in theme configs

### DIFF
--- a/e2e_playwright/theming/theme_font_weights_test.py
+++ b/e2e_playwright/theming/theme_font_weights_test.py
@@ -18,6 +18,7 @@ import json
 from typing import TYPE_CHECKING
 
 import pytest
+from playwright.sync_api import expect
 
 from e2e_playwright.conftest import (
     ImageCompareFunction,
@@ -39,32 +40,6 @@ if TYPE_CHECKING:
 def app_server():
     """Override to disable the default module-scoped app_server fixture."""
     return
-
-
-@pytest.fixture
-def app(
-    page: Page,
-    app_base_url: str,
-    app_port: int,
-    request: pytest.FixtureRequest,
-    theme_env: dict[str, str],
-) -> Generator[Page, None, None]:
-    """Start a fresh server with the per-test theme_env, yield the page, then stop."""
-    streamlit_proc = start_app_server(app_port, request.module, extra_env=theme_env)
-    try:
-        response = page.goto(build_app_url(app_base_url, path="/"))
-        if response is None or response.status != 200:
-            raise RuntimeError("Unable to load page")
-        wait_for_app_loaded(page)
-        yield page
-    finally:
-        streamlit_proc.terminate()
-
-
-@pytest.fixture
-def theme_env() -> dict[str, str]:
-    """Default theme env — overridden per test via indirect parametrization or override."""
-    return {}
 
 
 _CUSTOM_WEIGHTS_ENV = {
@@ -148,20 +123,15 @@ def test_50_step_font_weights_applied(fifty_step_weights_app: Page):
     """
     expect_no_skeletons(fifty_step_weights_app, timeout=25000)
 
-    h1_weight = fifty_step_weights_app.locator("h1").first.evaluate(
-        "el => getComputedStyle(el).fontWeight"
-    )
-    h2_weight = fifty_step_weights_app.locator("h2").first.evaluate(
-        "el => getComputedStyle(el).fontWeight"
-    )
+    # Scope to the main content area. The app also renders headings and markdown
+    # in the sidebar, and the sidebar theme keeps default weights, so unscoped
+    # `.first` locators could bind to sidebar elements instead of the main theme.
+    main = fifty_step_weights_app.get_by_test_id("stMain")
 
     # baseFontWeight=550 should produce normal=550, semiBold=650, bold=750, extrabold=850
     # headingFontWeights=[550, 650, ...] should produce h1=550, h2=650
-    assert h1_weight == "550", f"Expected h1 font-weight 550, got {h1_weight}"
-    assert h2_weight == "650", f"Expected h2 font-weight 650, got {h2_weight}"
+    expect(main.locator("h1").first).to_have_css("font-weight", "550")
+    expect(main.locator("h2").first).to_have_css("font-weight", "650")
 
     # Verify body text uses the 50-step base weight
-    body_weight = fifty_step_weights_app.locator(".stMarkdown p").first.evaluate(
-        "el => getComputedStyle(el).fontWeight"
-    )
-    assert body_weight == "550", f"Expected body font-weight 550, got {body_weight}"
+    expect(main.locator(".stMarkdown p").first).to_have_css("font-weight", "550")

--- a/e2e_playwright/theming/theme_font_weights_test.py
+++ b/e2e_playwright/theming/theme_font_weights_test.py
@@ -12,46 +12,156 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import json
-import os
+from typing import TYPE_CHECKING
 
 import pytest
-from playwright.sync_api import Page
 
-from e2e_playwright.conftest import ImageCompareFunction
+from e2e_playwright.conftest import (
+    ImageCompareFunction,
+    build_app_url,
+    start_app_server,
+    wait_for_app_loaded,
+)
 from e2e_playwright.shared.app_utils import expect_no_skeletons
 
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
-@pytest.fixture(scope="module")
-@pytest.mark.early
-def configure_custom_theme_font_weights():
-    """Configure custom theme."""
-    os.environ["STREAMLIT_THEME_BASE_FONT_WEIGHT"] = "200"
-    os.environ["STREAMLIT_THEME_CODE_FONT_WEIGHT"] = "600"
-    os.environ["STREAMLIT_THEME_HEADING_FONT_WEIGHTS"] = json.dumps(
-        [800, 700, 500, 400, 300, 200]
-    )
-    # Configurable separately in sidebar
-    os.environ["STREAMLIT_THEME_SIDEBAR_CODE_FONT_WEIGHT"] = "200"
-    os.environ["STREAMLIT_THEME_SIDEBAR_HEADING_FONT_WEIGHTS"] = json.dumps(
+    from playwright.sync_api import Page
+
+
+# Disable the default module-scoped app_server so each test can start its own
+# server with a different theme config via extra_env.
+@pytest.fixture(scope="module", autouse=True)
+def app_server():
+    """Override to disable the default module-scoped app_server fixture."""
+    return
+
+
+@pytest.fixture
+def app(
+    page: Page,
+    app_base_url: str,
+    app_port: int,
+    request: pytest.FixtureRequest,
+    theme_env: dict[str, str],
+) -> Generator[Page, None, None]:
+    """Start a fresh server with the per-test theme_env, yield the page, then stop."""
+    streamlit_proc = start_app_server(app_port, request.module, extra_env=theme_env)
+    try:
+        response = page.goto(build_app_url(app_base_url, path="/"))
+        if response is None or response.status != 200:
+            raise RuntimeError("Unable to load page")
+        wait_for_app_loaded(page)
+        yield page
+    finally:
+        streamlit_proc.terminate()
+
+
+@pytest.fixture
+def theme_env() -> dict[str, str]:
+    """Default theme env — overridden per test via indirect parametrization or override."""
+    return {}
+
+
+_CUSTOM_WEIGHTS_ENV = {
+    "STREAMLIT_THEME_BASE_FONT_WEIGHT": "200",
+    "STREAMLIT_THEME_CODE_FONT_WEIGHT": "600",
+    "STREAMLIT_THEME_HEADING_FONT_WEIGHTS": json.dumps([800, 700, 500, 400, 300, 200]),
+    "STREAMLIT_THEME_SIDEBAR_CODE_FONT_WEIGHT": "200",
+    "STREAMLIT_THEME_SIDEBAR_HEADING_FONT_WEIGHTS": json.dumps(
         [200, 300, 400, 500, 700, 800]
+    ),
+}
+
+_50_STEP_WEIGHTS_ENV = {
+    "STREAMLIT_THEME_BASE_FONT_WEIGHT": "550",
+    "STREAMLIT_THEME_HEADING_FONT_WEIGHTS": json.dumps([550, 650, 700, 750, 800, 850]),
+}
+
+
+@pytest.fixture
+def custom_weights_app(
+    page: Page,
+    app_base_url: str,
+    app_port: int,
+    request: pytest.FixtureRequest,
+) -> Generator[Page, None, None]:
+    streamlit_proc = start_app_server(
+        app_port, request.module, extra_env=_CUSTOM_WEIGHTS_ENV
     )
-    yield
-    del os.environ["STREAMLIT_THEME_BASE_FONT_WEIGHT"]
-    del os.environ["STREAMLIT_THEME_CODE_FONT_WEIGHT"]
-    del os.environ["STREAMLIT_THEME_HEADING_FONT_WEIGHTS"]
-    del os.environ["STREAMLIT_THEME_SIDEBAR_CODE_FONT_WEIGHT"]
-    del os.environ["STREAMLIT_THEME_SIDEBAR_HEADING_FONT_WEIGHTS"]
+    try:
+        response = page.goto(build_app_url(app_base_url, path="/"))
+        if response is None or response.status != 200:
+            raise RuntimeError("Unable to load page")
+        wait_for_app_loaded(page)
+        yield page
+    finally:
+        streamlit_proc.terminate()
 
 
-@pytest.mark.usefixtures("configure_custom_theme_font_weights")
-def test_custom_theme_font_weights(app: Page, assert_snapshot: ImageCompareFunction):
+@pytest.fixture
+def fifty_step_weights_app(
+    page: Page,
+    app_base_url: str,
+    app_port: int,
+    request: pytest.FixtureRequest,
+) -> Generator[Page, None, None]:
+    streamlit_proc = start_app_server(
+        app_port, request.module, extra_env=_50_STEP_WEIGHTS_ENV
+    )
+    try:
+        response = page.goto(build_app_url(app_base_url, path="/"))
+        if response is None or response.status != 200:
+            raise RuntimeError("Unable to load page")
+        wait_for_app_loaded(page)
+        yield page
+    finally:
+        streamlit_proc.terminate()
+
+
+def test_custom_theme_font_weights(
+    custom_weights_app: Page, assert_snapshot: ImageCompareFunction
+):
     # Set bigger viewport to better show the charts
-    app.set_viewport_size({"width": 1280, "height": 1000})
+    custom_weights_app.set_viewport_size({"width": 1280, "height": 1000})
     # Make sure that all elements are rendered and no skeletons are shown:
-    expect_no_skeletons(app, timeout=25000)
+    expect_no_skeletons(custom_weights_app, timeout=25000)
     # Add some additional timeout to ensure that fonts can load without
     # creating flakiness:
-    app.wait_for_timeout(10000)
+    custom_weights_app.wait_for_timeout(10000)
 
-    assert_snapshot(app, name="custom_weights_app", image_threshold=0.0003)
+    assert_snapshot(
+        custom_weights_app, name="custom_weights_app", image_threshold=0.0003
+    )
+
+
+def test_50_step_font_weights_applied(fifty_step_weights_app: Page):
+    """Verify that 50-step font weight values (e.g. 550, 650) are applied correctly.
+
+    These are intermediate values that are valid for variable fonts but were previously
+    blocked by the increment-of-100 validation. We check computed CSS font-weight on
+    rendered heading elements rather than using a snapshot so no baseline is needed.
+    """
+    expect_no_skeletons(fifty_step_weights_app, timeout=25000)
+
+    h1_weight = fifty_step_weights_app.locator("h1").first.evaluate(
+        "el => getComputedStyle(el).fontWeight"
+    )
+    h2_weight = fifty_step_weights_app.locator("h2").first.evaluate(
+        "el => getComputedStyle(el).fontWeight"
+    )
+
+    # baseFontWeight=550 should produce normal=550, semiBold=650, bold=750, extrabold=850
+    # headingFontWeights=[550, 650, ...] should produce h1=550, h2=650
+    assert h1_weight == "550", f"Expected h1 font-weight 550, got {h1_weight}"
+    assert h2_weight == "650", f"Expected h2 font-weight 650, got {h2_weight}"
+
+    # Verify body text uses the 50-step base weight
+    body_weight = fifty_step_weights_app.locator(".stMarkdown p").first.evaluate(
+        "el => getComputedStyle(el).fontWeight"
+    )
+    assert body_weight == "550", f"Expected body font-weight 550, got {body_weight}"

--- a/e2e_playwright/theming/theme_font_weights_test.py
+++ b/e2e_playwright/theming/theme_font_weights_test.py
@@ -58,16 +58,15 @@ _50_STEP_WEIGHTS_ENV = {
 }
 
 
-@pytest.fixture
-def custom_weights_app(
+def _app_with_theme_env(
     page: Page,
     app_base_url: str,
     app_port: int,
     request: pytest.FixtureRequest,
+    extra_env: dict[str, str],
 ) -> Generator[Page, None, None]:
-    streamlit_proc = start_app_server(
-        app_port, request.module, extra_env=_CUSTOM_WEIGHTS_ENV
-    )
+    """Start a Streamlit server with a custom theme env and yield the loaded page."""
+    streamlit_proc = start_app_server(app_port, request.module, extra_env=extra_env)
     try:
         response = page.goto(build_app_url(app_base_url, path="/"))
         if response is None or response.status != 200:
@@ -76,6 +75,18 @@ def custom_weights_app(
         yield page
     finally:
         streamlit_proc.terminate()
+
+
+@pytest.fixture
+def custom_weights_app(
+    page: Page,
+    app_base_url: str,
+    app_port: int,
+    request: pytest.FixtureRequest,
+) -> Generator[Page, None, None]:
+    yield from _app_with_theme_env(
+        page, app_base_url, app_port, request, _CUSTOM_WEIGHTS_ENV
+    )
 
 
 @pytest.fixture
@@ -85,17 +96,9 @@ def fifty_step_weights_app(
     app_port: int,
     request: pytest.FixtureRequest,
 ) -> Generator[Page, None, None]:
-    streamlit_proc = start_app_server(
-        app_port, request.module, extra_env=_50_STEP_WEIGHTS_ENV
+    yield from _app_with_theme_env(
+        page, app_base_url, app_port, request, _50_STEP_WEIGHTS_ENV
     )
-    try:
-        response = page.goto(build_app_url(app_base_url, path="/"))
-        if response is None or response.status != 200:
-            raise RuntimeError("Unable to load page")
-        wait_for_app_loaded(page)
-        yield page
-    finally:
-        streamlit_proc.terminate()
 
 
 def test_custom_theme_font_weights(

--- a/frontend/lib/src/theme/utils.test.ts
+++ b/frontend/lib/src/theme/utils.test.ts
@@ -2886,16 +2886,25 @@ describe("createEmotionTheme", () => {
   // == Theme font weight properties ==
 
   it.each([
-    // Test valid font weights
-    [100, 100, 300, 400],
-    [200, 200, 400, 500],
-    [300, 300, 500, 600],
-    [400, 400, 600, 700],
-    [500, 500, 700, 800],
-    [600, 600, 800, 900],
+    // Test valid font weights (base, normal, semiBold, bold, extrabold)
+    [100, 100, 200, 300, 400],
+    [150, 150, 250, 350, 450],
+    [200, 200, 300, 400, 500],
+    [300, 300, 400, 500, 600],
+    [350, 350, 450, 550, 650],
+    [400, 400, 500, 600, 700],
+    [500, 500, 600, 700, 800],
+    [550, 550, 650, 750, 850],
+    [600, 600, 700, 800, 900],
   ])(
     "sets the font weights based on the baseFontWeight config '%s'",
-    (baseFontWeight, expectedNormal, expectedBold, expectedExtrabold) => {
+    (
+      baseFontWeight,
+      expectedNormal,
+      expectedSemiBold,
+      expectedBold,
+      expectedExtrabold
+    ) => {
       const logWarningSpy = vi.spyOn(LOG, "warn")
       const themeInput: Partial<CustomThemeConfig> = {
         baseFontWeight,
@@ -2905,6 +2914,7 @@ describe("createEmotionTheme", () => {
 
       expect(logWarningSpy).not.toHaveBeenCalled()
       expect(theme.fontWeights.normal).toBe(expectedNormal)
+      expect(theme.fontWeights.semiBold).toBe(expectedSemiBold)
       expect(theme.fontWeights.bold).toBe(expectedBold)
       expect(theme.fontWeights.extrabold).toBe(expectedExtrabold)
     }
@@ -2912,7 +2922,8 @@ describe("createEmotionTheme", () => {
 
   it.each([
     // Test invalid font weights
-    [150, 400, 600, 700], // Not an increment of 100
+    [125, 400, 600, 700], // Not an increment of 50
+    [575, 400, 600, 700], // Not an increment of 50
     [700, 400, 600, 700], // Not between 100 and 600
     [400.5, 400, 600, 700], // Not an integer
   ])(
@@ -2926,7 +2937,7 @@ describe("createEmotionTheme", () => {
       const theme = createEmotionTheme(themeInput)
 
       expect(logWarningSpy).toHaveBeenCalledWith(
-        `Invalid baseFontWeight: ${baseFontWeight} in theme. The baseFontWeight must be an integer 100-600, and an increment of 100. Falling back to default font weight.`
+        `Invalid baseFontWeight: ${baseFontWeight} in theme. The baseFontWeight must be an integer 100-600, and an increment of 50. Falling back to default font weight.`
       )
 
       expect(theme.fontWeights.normal).toBe(expectedNormal)
@@ -2938,10 +2949,13 @@ describe("createEmotionTheme", () => {
   it.each([
     // Test valid font weights
     [100, 400, 600, 700, 100, 300, 400],
+    [150, 400, 600, 700, 150, 350, 450],
     [200, 400, 600, 700, 200, 400, 500],
     [300, 400, 600, 700, 300, 500, 600],
+    [350, 400, 600, 700, 350, 550, 650],
     [400, 400, 600, 700, 400, 600, 700],
     [500, 400, 600, 700, 500, 700, 800],
+    [550, 400, 600, 700, 550, 750, 850],
     [600, 400, 600, 700, 600, 800, 900],
   ])(
     "sets the font weights based on the codeFontWeight config '%s'",
@@ -2978,7 +2992,8 @@ describe("createEmotionTheme", () => {
     [700, 400, 600, 700, 400], // Not between 100 and 600
     [800, 400, 600, 700, 400], // Not between 100 and 600
     [900, 400, 600, 700, 400], // Not between 100 and 600
-    [150, 400, 600, 700, 400], // Not an increment of 100
+    [125, 400, 600, 700, 400], // Not an increment of 50
+    [575, 400, 600, 700, 400], // Not an increment of 50
     [1000, 400, 600, 700, 400], // Not between 100 and 900
     [400.5, 400, 600, 700, 400], // Not an integer
   ])(
@@ -2998,7 +3013,7 @@ describe("createEmotionTheme", () => {
       const theme = createEmotionTheme(themeInput)
 
       expect(logWarningSpy).toHaveBeenCalledWith(
-        `Invalid codeFontWeight: ${codeFontWeight} in theme. The codeFontWeight must be an integer 100-600, and an increment of 100. Falling back to default font weight.`
+        `Invalid codeFontWeight: ${codeFontWeight} in theme. The codeFontWeight must be an integer 100-600, and an increment of 50. Falling back to default font weight.`
       )
 
       expect(theme.fontWeights.normal).toBe(expectedNormal)
@@ -3013,13 +3028,17 @@ describe("createEmotionTheme", () => {
   it.each([
     // Test valid headingFontWeights for h1-h6
     [[100, 100, 100, 100, 100, 100]],
+    [[150, 150, 150, 150, 150, 150]],
     [[200, 200, 200, 200, 200, 200]],
     [[300, 300, 300, 300, 300, 300]],
+    [[350, 350, 350, 350, 350, 350]],
     [[400, 400, 400, 400, 400, 400]],
     [[500, 500, 500, 500, 500, 500]],
+    [[550, 550, 550, 550, 550, 550]],
     [[600, 600, 600, 600, 600, 600]],
     [[700, 700, 700, 700, 700, 700]],
     [[800, 800, 800, 800, 800, 800]],
+    [[850, 850, 850, 850, 850, 850]],
     [[900, 900, 900, 900, 900, 900]],
   ])(
     "sets the font weights based on the headingFontWeights configs '%s'",
@@ -3044,8 +3063,8 @@ describe("createEmotionTheme", () => {
   it.each([
     // Test invalid font weights for h1-h6
     {
-      headingFontWeights: [150, 200, 300, 400, 500, 600],
-      invalidFontWeight: 150,
+      headingFontWeights: [125, 200, 300, 400, 500, 600],
+      invalidFontWeight: 125,
       invalidFontWeightConfig: "h1FontWeight",
       expectedWeights: [
         baseTheme.emotion.fontWeights.h1FontWeight,
@@ -3083,8 +3102,8 @@ describe("createEmotionTheme", () => {
       ],
     },
     {
-      headingFontWeights: [200, 150, 300, 400, 500, 600],
-      invalidFontWeight: 150,
+      headingFontWeights: [200, 125, 300, 400, 500, 600],
+      invalidFontWeight: 125,
       invalidFontWeightConfig: "h2FontWeight",
       expectedWeights: [
         200,
@@ -3122,8 +3141,8 @@ describe("createEmotionTheme", () => {
       ],
     },
     {
-      headingFontWeights: [200, 300, 150, 400, 500, 600],
-      invalidFontWeight: 150,
+      headingFontWeights: [200, 300, 125, 400, 500, 600],
+      invalidFontWeight: 125,
       invalidFontWeightConfig: "h3FontWeight",
       expectedWeights: [
         200,
@@ -3161,8 +3180,8 @@ describe("createEmotionTheme", () => {
       ],
     },
     {
-      headingFontWeights: [200, 300, 400, 150, 500, 600],
-      invalidFontWeight: 150,
+      headingFontWeights: [200, 300, 400, 125, 500, 600],
+      invalidFontWeight: 125,
       invalidFontWeightConfig: "h4FontWeight",
       expectedWeights: [
         200,
@@ -3200,8 +3219,8 @@ describe("createEmotionTheme", () => {
       ],
     },
     {
-      headingFontWeights: [200, 300, 400, 500, 150, 600],
-      invalidFontWeight: 150,
+      headingFontWeights: [200, 300, 400, 500, 125, 600],
+      invalidFontWeight: 125,
       invalidFontWeightConfig: "h5FontWeight",
       expectedWeights: [
         200,
@@ -3239,8 +3258,8 @@ describe("createEmotionTheme", () => {
       ],
     },
     {
-      headingFontWeights: [200, 300, 400, 500, 600, 150],
-      invalidFontWeight: 150,
+      headingFontWeights: [200, 300, 400, 500, 600, 125],
+      invalidFontWeight: 125,
       invalidFontWeightConfig: "h6FontWeight",
       expectedWeights: [
         200,
@@ -3293,7 +3312,7 @@ describe("createEmotionTheme", () => {
       const theme = createEmotionTheme(themeInput)
 
       expect(logWarningSpy).toHaveBeenCalledWith(
-        `Invalid ${invalidFontWeightConfig} in headingFontWeights: ${invalidFontWeight} in theme. The ${invalidFontWeightConfig} in headingFontWeights must be an integer 100-900, and an increment of 100. Falling back to default font weight.`
+        `Invalid ${invalidFontWeightConfig} in headingFontWeights: ${invalidFontWeight} in theme. The ${invalidFontWeightConfig} in headingFontWeights must be an integer 100-900, and an increment of 50. Falling back to default font weight.`
       )
 
       // Check that the heading font weights are set correctly
@@ -3396,11 +3415,40 @@ describe("createEmotionTheme", () => {
       const theme = createEmotionTheme(themeInput)
 
       expect(logWarningSpy).toHaveBeenCalledWith(
-        `Invalid metricValueFontWeight: ${metricValueFontWeight}. Must be between 100 and 900.`
+        `Invalid metricValueFontWeight: ${metricValueFontWeight} in theme. The metricValueFontWeight must be an integer 100-900, and an increment of 50. Falling back to default font weight.`
       )
       expect(theme.fontWeights.metricValueFontWeight).toBe(400)
     }
   )
+
+  it.each([125, 575])(
+    "logs a warning and uses default metricValueFontWeight if value is not an increment of 50: %s",
+    metricValueFontWeight => {
+      const logWarningSpy = vi.spyOn(LOG, "warn")
+      const themeInput: Partial<CustomThemeConfig> = {
+        metricValueFontWeight,
+      }
+
+      const theme = createEmotionTheme(themeInput)
+
+      expect(logWarningSpy).toHaveBeenCalledWith(
+        `Invalid metricValueFontWeight: ${metricValueFontWeight} in theme. The metricValueFontWeight must be an integer 100-900, and an increment of 50. Falling back to default font weight.`
+      )
+      expect(theme.fontWeights.metricValueFontWeight).toBe(400)
+    }
+  )
+
+  it("accepts a 50-step metricValueFontWeight (550)", () => {
+    const logWarningSpy = vi.spyOn(LOG, "warn")
+    const themeInput: Partial<CustomThemeConfig> = {
+      metricValueFontWeight: 550,
+    }
+
+    const theme = createEmotionTheme(themeInput)
+
+    expect(logWarningSpy).not.toHaveBeenCalled()
+    expect(theme.fontWeights.metricValueFontWeight).toBe(550)
+  })
 
   // == Theme font properties ==
 

--- a/frontend/lib/src/theme/utils.ts
+++ b/frontend/lib/src/theme/utils.ts
@@ -483,7 +483,19 @@ export const parseFontSize = (
 }
 
 /**
- * Validate a font weight config
+ * Validates a font weight config value against three rules:
+ *   1. Must be an integer.
+ *   2. Must be an integer multiple of 50.
+ *   3. Must be within [`minWeight`, `maxWeight`] (inclusive).
+ *
+ * @param weightConfigName - Name of the config option, used in the warning message.
+ * @param fontWeight - The value to validate; null/undefined means "not configured".
+ * @param minWeight - Lower bound (inclusive).
+ * @param maxWeight - Upper bound (inclusive).
+ * @param inSidebar - When true, the warning message cites "theme.sidebar" instead of "theme".
+ * @returns `true` if the value is set and passes all three rules.
+ *   Returns `false` and logs a warning when the value is set but fails any rule.
+ *   Returns `false` silently when the value is null or undefined.
  */
 const isValidFontWeight = (
   weightConfigName: string,

--- a/frontend/lib/src/theme/utils.ts
+++ b/frontend/lib/src/theme/utils.ts
@@ -497,12 +497,12 @@ const isValidFontWeight = (
   // If the font weight config is set, validate it (log warning if invalid)
   if (notNullOrUndefined(fontWeight)) {
     const isInteger = Number.isInteger(fontWeight)
-    const isIncrementOf100 = fontWeight % 100 === 0
+    const isIncrementOf50 = fontWeight % 50 === 0
     const isInRange = fontWeight >= minWeight && fontWeight <= maxWeight
 
-    if (!isInteger || !isIncrementOf100 || !isInRange) {
+    if (!isInteger || !isIncrementOf50 || !isInRange) {
       LOG.warn(
-        `Invalid ${weightConfigName}: ${fontWeight} in ${themeSection}. The ${weightConfigName} must be an integer ${minWeight}-${maxWeight}, and an increment of 100. Falling back to default font weight.`
+        `Invalid ${weightConfigName}: ${fontWeight} in ${themeSection}. The ${weightConfigName} must be an integer ${minWeight}-${maxWeight}, and an increment of 50. Falling back to default font weight.`
       )
       return false
     }
@@ -1011,15 +1011,12 @@ export const createEmotionTheme = (
   )
 
   // Conditional Overrides - Metric Value Font Weight
-  if (metricValueFontWeight) {
-    if (metricValueFontWeight >= 100 && metricValueFontWeight <= 900) {
-      conditionalOverrides.fontWeights.metricValueFontWeight =
-        metricValueFontWeight
-    } else {
-      LOG.warn(
-        `Invalid metricValueFontWeight: ${metricValueFontWeight}. Must be between 100 and 900.`
-      )
-    }
+  if (
+    metricValueFontWeight &&
+    isValidFontWeight("metricValueFontWeight", metricValueFontWeight, 100, 900)
+  ) {
+    conditionalOverrides.fontWeights.metricValueFontWeight =
+      metricValueFontWeight
   }
 
   // Font Overrides

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -2103,7 +2103,11 @@ _create_theme_options(
         The root font weight for the app.
 
         This determines the overall weight of text and UI elements. This is an
-        integer multiple of 100. Values can be between 100 and 600, inclusive.
+        integer multiple of 50. Values can be between 100 and 600, inclusive.
+
+        Streamlit derives the semiBold, bold, and extrabold weights from this
+        base by adding 100, 200, and 300 respectively. The maximum is 600 so
+        that extrabold (base + 300) never exceeds 900.
 
         If this isn't set, the font weight will be set to 400 (normal weight).
     """,
@@ -2131,7 +2135,7 @@ _create_theme_options(
     description="""
         The font weight for st.metric value text.
 
-        This is an integer multiple of 100. Values can be between 100 and 900,
+        This is an integer multiple of 50. Values can be between 100 and 900,
         inclusive.
 
         If this isn't set, the font weight will inherit from the parent element.
@@ -2218,6 +2222,9 @@ _create_theme_options(
     description="""
         One or more font weights for h1-h6 headings.
 
+        Each weight must be an integer multiple of 50, between 100 and 900
+        inclusive. Invalid values are ignored and the default weight is used.
+
         If no weights are set, Streamlit will use the default weights for h1-h6
         headings. Heading font weights set in [theme] are not inherited by
         [theme.sidebar]. The following weights are used by default:
@@ -2238,7 +2245,7 @@ _create_theme_options(
 
         Setting a single value (not in an array) will set the font weight for
         all h1-h6 headings to that value:
-            headingFontWeights = 500
+            headingFontWeights = 550
     """,
 )
 
@@ -2301,8 +2308,12 @@ _create_theme_options(
         The font weight for code blocks and code text.
 
         This applies to font in inline code, code blocks, `st.json`, and
-        `st.help`. This is an integer multiple of 100. Values can be between
+        `st.help`. This is an integer multiple of 50. Values can be between
         100 and 600, inclusive.
+
+        Streamlit derives the bold and extrabold code weights from this base
+        by adding 200 and 300 respectively. The maximum is 600 so that the
+        extrabold code weight (base + 300) never exceeds 900.
 
         If this isn't set, the code font weight will be 400 (normal weight).
     """,

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -2105,9 +2105,8 @@ _create_theme_options(
         This determines the overall weight of text and UI elements. This is an
         integer multiple of 50. Values can be between 100 and 600, inclusive.
 
-        Streamlit derives the semiBold, bold, and extrabold weights from this
-        base by adding 100, 200, and 300 respectively. The maximum is 600 so
-        that extrabold (base + 300) never exceeds 900.
+        Streamlit derives heavier weights from this base (+100 / +200 / +300).
+        The maximum is 600 so the heaviest derived weight never exceeds 900.
 
         If this isn't set, the font weight will be set to 400 (normal weight).
     """,
@@ -2311,9 +2310,8 @@ _create_theme_options(
         `st.help`. This is an integer multiple of 50. Values can be between
         100 and 600, inclusive.
 
-        Streamlit derives the bold and extrabold code weights from this base
-        by adding 200 and 300 respectively. The maximum is 600 so that the
-        extrabold code weight (base + 300) never exceeds 900.
+        Streamlit derives heavier code weights from this base (+200 / +300).
+        The maximum is 600 so the heaviest derived weight never exceeds 900.
 
         If this isn't set, the code font weight will be 400 (normal weight).
     """,


### PR DESCRIPTION
## Describe your changes
Relaxes the font weight validation step from multiples of `100` to multiples of `50`, unlocking intermediate weights like `150`, `250`, etc. across all font weight config options.

Streamlit already uses variable fonts (Inter, Source Code Pro) that natively support the full 1–999 weight axis, so the 100-step restriction was a frontend validation artifact with no underlying technical basis.

- `baseFontWeight` / `codeFontWeight` — now accept 100–600 in steps of `50`; derived `semiBold` / `bold` / `extrabold` / `boldCode` / `extraboldCode` offsets (+100/+200/+300) are unchanged
- `headingFontWeights` — now accept 100–900 in steps of 50
- `metricValueFontWeight` — now accepts 100–900 in steps of 50 (also unified with the shared `isValidFontWeight` helper instead of a separate inline check)
- Config docs updated to reflect the new step size and explain why the base max is `600` (to keep derived weights ≤ `900`)

## GitHub Issue Link (if applicable)
Closes #16354 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Relaxation of theme validation with backward-compatible 100-step values; limited to typography/CSS with expanded unit and e2e coverage.
> 
> **Overview**
> **Theme font weight options now accept values in steps of 50** (e.g. 150, 550, 650) instead of only multiples of 100, so variable-font intermediate weights can be configured.
> 
> Frontend validation in `isValidFontWeight` uses `% 50 === 0` and updated warning text for **`baseFontWeight`**, **`codeFontWeight`**, **`headingFontWeights`**, and **`metricValueFontWeight`**. **`metricValueFontWeight`** is routed through the same helper instead of a separate range-only check. Derived weight offsets (+100/+200/+300) are unchanged.
> 
> **`lib/streamlit/config.py`** docs for those options now describe 50-step rules and why base/code max at 600 (derived weights stay ≤ 900).
> 
> **Tests:** `utils.test.ts` covers 50-step valid/invalid cases and **`semiBold`** expectations; Playwright **`theme_font_weights_test.py`** starts per-scenario servers via `extra_env`, keeps the snapshot test, and adds **`test_50_step_font_weights_applied`** asserting computed `font-weight` on main-content headings and body text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a15375b4309d99902f88a45e0c928fcd65083418. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->