### PR TITLE
[fix] Name the class and frame of unclassified install failures

### DIFF
--- a/frontend/app/src/components/SkillsNudgeToast/skillsNudge.ts
+++ b/frontend/app/src/components/SkillsNudgeToast/skillsNudge.ts
@@ -195,8 +195,10 @@ const REFUSED_REASON_PREFIX = "refused:"
  * refusals get their own event so they never inflate the genuine failure rate.
  * Either way the server's machine-readable reason becomes a label suffix,
  * mirroring `skillsNudgeSuppressedNonLocal:<locality>`, so outcomes split by cause
- * (e.g. `skillsNudgeInstallFailed:write_denied`). Reasons are a fixed server-side
- * vocabulary, never user input, so they are safe to emit verbatim.
+ * (e.g. `skillsNudgeInstallFailed:write_denied`). Reasons come from a fixed
+ * server-side vocabulary, plus `unexpected_<ExceptionClass>` when no vocabulary
+ * entry covers the failure — a code identifier the server bounds and sanitizes,
+ * never user input, so either form is safe to emit verbatim.
  *
  * Callers must check {@link isSkillsNudgeDroppedConnection} first — a dropped
  * connection is neither outcome and is counted separately.

--- a/frontend/app/src/components/SkillsNudgeToast/skillsNudge.ts
+++ b/frontend/app/src/components/SkillsNudgeToast/skillsNudge.ts
@@ -196,9 +196,10 @@ const REFUSED_REASON_PREFIX = "refused:"
  * Either way the server's machine-readable reason becomes a label suffix,
  * mirroring `skillsNudgeSuppressedNonLocal:<locality>`, so outcomes split by cause
  * (e.g. `skillsNudgeInstallFailed:write_denied`). Reasons come from a fixed
- * server-side vocabulary, plus `unexpected_<ExceptionClass>` when no vocabulary
- * entry covers the failure — a code identifier the server bounds and sanitizes,
- * never user input, so either form is safe to emit verbatim.
+ * server-side vocabulary, plus `unexpected_<Class>_in_<function>` when no entry
+ * covers the failure — code identifiers from Streamlit's own source that the
+ * server bounds and sanitizes, never user input and never a frame from the
+ * user's app, so either form is safe to emit verbatim.
  *
  * Callers must check {@link isSkillsNudgeDroppedConnection} first — a dropped
  * connection is neither outcome and is counted separately.

--- a/lib/streamlit/runtime/backend_operation_handler.py
+++ b/lib/streamlit/runtime/backend_operation_handler.py
@@ -50,8 +50,9 @@ _LOGGER: Final = get_logger(__name__)
 _REFUSED_REASON_PREFIX: Final[str] = "refused:"
 
 # Prefixes marking an ``error_reason`` as an *unclassified* exception: the reason
-# vocabulary did not cover it, so the suffix is the exception's class name instead of
-# a vocabulary member. Two prefixes because the distinction is diagnostic:
+# vocabulary did not cover it, so the suffix names the exception's class and the
+# Streamlit function it was raised from (``unexpected_ValueError_in_install_skills``)
+# instead of a vocabulary member. Two prefixes because the distinction is diagnostic:
 #   - ``unexpected_`` — the operation ran and raised. The handler's own vocabulary
 #     (``InstallError.reason``, errno classification) did not apply.
 #   - ``unhandled_``  — the exception escaped the handler entirely and was caught by
@@ -65,23 +66,58 @@ _REFUSED_REASON_PREFIX: Final[str] = "refused:"
 _UNEXPECTED_REASON_PREFIX: Final[str] = "unexpected_"
 _UNHANDLED_REASON_PREFIX: Final[str] = "unhandled_"
 
-# Cap on the class-name portion of the reasons above. Exception class names are Python
-# identifiers in practice, but a dynamically built class can carry anything, and the
-# reason becomes a telemetry label - so bound the length and strip everything outside
-# ASCII alphanumerics rather than trusting ``__name__``.
-_MAX_EXCEPTION_NAME_LEN: Final[int] = 40
+# Cap on each identifier in the reasons above (exception class, function name).
+# Both are Python identifiers in practice, but a dynamically built class can carry
+# anything and the reason becomes a telemetry label - so bound the length and keep only
+# identifier characters rather than trusting ``__name__``. Dropping ``:`` is the
+# load-bearing part: downstream reads the reason with ``split_part(label, ':', 2)``.
+_MAX_REASON_IDENT_LEN: Final[int] = 40
+
+
+def _reason_ident(value: str, fallback: str) -> str:
+    """Bound one identifier destined for a telemetry label."""
+    kept = "".join(c for c in value if c.isascii() and (c.isalnum() or c == "_"))
+    return kept[:_MAX_REASON_IDENT_LEN] or fallback
+
+
+def _raising_streamlit_function(ex: BaseException) -> str | None:
+    """Name the deepest frame in Streamlit's own code, or ``None`` if there is none.
+
+    The traceback is the only thing in an ``except`` block that says *where* a failure
+    happened, and it is logged but never leaves the machine - so without this an
+    unclassified failure reports its type and nothing about its location.
+
+    The deepest *Streamlit* frame is the right granularity. If the raise came from
+    inside a stdlib call, this names the Streamlit function that made the call, which
+    is the actionable part. It also means a frame in the user's own app code can never
+    be named here: only modules under the ``streamlit`` package qualify.
+
+    The line number is deliberately excluded. It moves with every edit to the file,
+    which would scatter one bug across several labels as releases go out.
+    """
+    name: str | None = None
+    tb = ex.__traceback__
+    while tb is not None:
+        module = tb.tb_frame.f_globals.get("__name__", "")
+        if isinstance(module, str) and (
+            module == "streamlit" or module.startswith("streamlit.")
+        ):
+            name = tb.tb_frame.f_code.co_name
+        tb = tb.tb_next
+    return name
 
 
 def _exception_reason(prefix: str, ex: BaseException) -> str:
-    """Build a bounded ``error_reason`` naming the exception's class.
+    """Build a bounded ``error_reason`` naming the exception's class and origin.
 
-    The class name is the whole point: without it every unclassified failure
-    collapses into one opaque bucket that no query can take apart. It is a code
-    identifier, not user data, so it carries no paths and no PII - unlike the
-    exception's *message*, which is why that is never used here.
+    Both halves are code identifiers, not user data, so neither carries a path nor
+    any PII - unlike the exception's *message*, which is why that is never used here.
+    The class name stays directly after the prefix so a ``unexpected_ValueError%``
+    prefix match keeps working whether or not a function was resolved.
     """
-    name = "".join(c for c in type(ex).__name__ if c.isascii() and c.isalnum())
-    return f"{prefix}{name[:_MAX_EXCEPTION_NAME_LEN] or 'Exception'}"
+    reason = f"{prefix}{_reason_ident(type(ex).__name__, 'Exception')}"
+    func = _raising_streamlit_function(ex)
+    return f"{reason}_in_{_reason_ident(func, 'unknown')}" if func else reason
 
 
 def connection_locality(session_id: str) -> str:

--- a/lib/streamlit/runtime/backend_operation_handler.py
+++ b/lib/streamlit/runtime/backend_operation_handler.py
@@ -49,6 +49,40 @@ _LOGGER: Final = get_logger(__name__)
 # components/SkillsNudgeToast/skillsNudge.ts.
 _REFUSED_REASON_PREFIX: Final[str] = "refused:"
 
+# Prefixes marking an ``error_reason`` as an *unclassified* exception: the reason
+# vocabulary did not cover it, so the suffix is the exception's class name instead of
+# a vocabulary member. Two prefixes because the distinction is diagnostic:
+#   - ``unexpected_`` — the operation ran and raised. The handler's own vocabulary
+#     (``InstallError.reason``, errno classification) did not apply.
+#   - ``unhandled_``  — the exception escaped the handler entirely and was caught by
+#     the dispatcher, so the operation may never have started. For skills-install
+#     that means the safety gate itself threw, which is a different bug than an
+#     install that ran and failed.
+# Both use ``_`` rather than ``:`` as the separator: the client turns a reason into a
+# telemetry label suffix (``skillsNudgeInstallFailed:<reason>``) and the downstream
+# queries read the reason with ``split_part(label, ':', 2)``, which a second colon
+# would truncate.
+_UNEXPECTED_REASON_PREFIX: Final[str] = "unexpected_"
+_UNHANDLED_REASON_PREFIX: Final[str] = "unhandled_"
+
+# Cap on the class-name portion of the reasons above. Exception class names are Python
+# identifiers in practice, but a dynamically built class can carry anything, and the
+# reason becomes a telemetry label - so bound the length and strip everything outside
+# ASCII alphanumerics rather than trusting ``__name__``.
+_MAX_EXCEPTION_NAME_LEN: Final[int] = 40
+
+
+def _exception_reason(prefix: str, ex: BaseException) -> str:
+    """Build a bounded ``error_reason`` naming the exception's class.
+
+    The class name is the whole point: without it every unclassified failure
+    collapses into one opaque bucket that no query can take apart. It is a code
+    identifier, not user data, so it carries no paths and no PII - unlike the
+    exception's *message*, which is why that is never used here.
+    """
+    name = "".join(c for c in type(ex).__name__ if c.isascii() and c.isalnum())
+    return f"{prefix}{name[:_MAX_EXCEPTION_NAME_LEN] or 'Exception'}"
+
 
 def connection_locality(session_id: str) -> str:
     """Classify the WebSocket peer of ``session_id`` for the skills nudge.
@@ -143,7 +177,7 @@ class BackendOperationDispatcher:
 
         try:
             return await handler.handle(request, session_id)
-        except Exception:
+        except Exception as ex:
             _LOGGER.exception(
                 "Error handling backend operation request %s (type: %s)",
                 request.request_id,
@@ -152,6 +186,12 @@ class BackendOperationDispatcher:
             return BackendOperationResponse(
                 request_id=request.request_id,
                 error_msg="Failed to process backend operation",
+                # Name the exception class. A handler that raises past its own
+                # try/except lands here, and without a reason the client emits a
+                # bare failure label - indistinguishable from an old client that
+                # predates reasons, and silent about the fact that the operation
+                # may never have run at all.
+                error_reason=_exception_reason(_UNHANDLED_REASON_PREFIX, ex),
             )
 
 
@@ -280,14 +320,19 @@ class InstallSkillsHandler(BackendOperationHandler):
             # UnicodeDecodeError.reason) would emit an unbounded label and break the
             # fixed vocabulary. A bare ``OSError`` that escaped the installer gets the
             # same errno classification, so it lands in a specific write_* bucket
-            # rather than being flattened to "unknown".
+            # rather than in the unclassified bucket below.
             reason: str
             if isinstance(ex, skills.InstallError):
                 reason = ex.reason
             elif isinstance(ex, OSError):
                 reason = skills.classify_write_error(ex)
             else:
-                reason = "unknown"
+                # Anything else is a bug or an unforeseen library error, so no
+                # vocabulary entry can describe it. Name the exception class instead
+                # of flattening to a single ``unknown``: the traceback is logged
+                # above but never leaves the server, so the class name is the only
+                # part of the cause that reaches telemetry at all.
+                reason = _exception_reason(_UNEXPECTED_REASON_PREFIX, ex)
             return BackendOperationResponse(
                 request_id=request.request_id,
                 error_msg=detail or "Failed to install skills.",

--- a/lib/tests/streamlit/runtime/backend_operation_handler_test.py
+++ b/lib/tests/streamlit/runtime/backend_operation_handler_test.py
@@ -27,10 +27,12 @@ from streamlit.proto.ForwardMsg_pb2 import (
     DeferredFileResponsePayload,
 )
 from streamlit.runtime.backend_operation_handler import (
+    _UNEXPECTED_REASON_PREFIX,
     BackendOperationDispatcher,
     DeferredFileHandler,
     DismissSkillsNudgeHandler,
     InstallSkillsHandler,
+    _exception_reason,
     connection_locality,
 )
 from streamlit.web import skills
@@ -141,8 +143,9 @@ def test_dispatch_returns_error_when_handler_fails() -> None:
     # The dispatcher's catch-all used to return no reason at all, so a handler that
     # raised past its own try/except produced a bare telemetry label -
     # indistinguishable from a pre-1.61 client and silent about the operation
-    # possibly never having run.
-    assert response.error_reason == "unhandled_RuntimeError"
+    # possibly never having run. ``dispatch`` is the deepest Streamlit frame here:
+    # the handler that raised lives in this test module, which is correctly skipped.
+    assert response.error_reason == "unhandled_RuntimeError_in_dispatch"
     assert not response.HasField("deferred_file")
 
 
@@ -273,8 +276,8 @@ def test_install_skills_handler_reports_failure() -> None:
 
     assert response.error_msg == "No skills found"
     # A ``ClickException`` that is not an ``InstallError`` carries no vocabulary
-    # reason, so the reason names its class rather than collapsing to "unknown".
-    assert response.error_reason == "unexpected_ClickException"
+    # reason, so the reason names its class and origin rather than "unknown".
+    assert response.error_reason == "unexpected_ClickException_in_handle"
     assert not response.HasField("install_skills")
 
 
@@ -360,17 +363,18 @@ def test_install_skills_handler_ignores_foreign_reason_attribute() -> None:
             )
         )
 
-    assert response.error_reason == "unexpected_ValueError"
+    assert response.error_reason == "unexpected_ValueError_in_handle"
     assert "some-unbounded-string" not in response.error_reason
 
 
 def test_install_skills_handler_names_unclassified_exception_class() -> None:
-    """An exception no vocabulary entry covers is reported by its class name.
+    """An exception no vocabulary entry covers is reported by class and origin.
 
     Every such failure used to collapse into one ``unknown`` bucket, which made the
     largest share of install failures undiagnosable from telemetry - the traceback is
-    logged server-side but never leaves the machine. The class name is a code
-    identifier, so it splits the bucket without carrying a path or any user data.
+    logged server-side but never leaves the machine. Class name and raising function
+    are code identifiers, so they split the bucket without carrying a path or any
+    user data.
     """
     with (
         patch("streamlit.config.get_option", return_value=False),
@@ -386,10 +390,64 @@ def test_install_skills_handler_names_unclassified_exception_class() -> None:
             )
         )
 
-    assert response.error_reason == "unexpected_RuntimeError"
-    # The class name is safe; the *message* is not, and is never part of the reason.
+    assert response.error_reason == "unexpected_RuntimeError_in_handle"
+    # The identifiers are safe; the *message* is not, and is never part of the reason.
     assert "/absolute/server/path" not in response.error_reason
     assert response.error_msg == "Failed to install skills."
+
+
+def test_install_skills_handler_names_deepest_streamlit_frame() -> None:
+    """The reason names the *deepest* Streamlit frame, not the outermost one.
+
+    Naming ``handle`` for every failure would be barely better than ``unknown`` - the
+    point is to localize the bug. Here the real installer runs and its innermost step
+    raises, so the reason must name ``_install_project_skills`` (the Streamlit function
+    that made the failing call) rather than the handler that started it all.
+    """
+    with (
+        patch("streamlit.config.get_option", return_value=False),
+        patch.object(skills, "detect_installed_agents", return_value=["claude"]),
+        patch.object(
+            skills, "_get_source_skills_dir", side_effect=RuntimeError("boom")
+        ),
+    ):
+        response = asyncio.run(
+            InstallSkillsHandler(lambda: "/app/dir").handle(
+                _install_skills_request(), "session-id"
+            )
+        )
+
+    assert response.error_reason == "unexpected_RuntimeError_in__install_project_skills"
+
+
+def test_exception_reason_falls_back_to_class_without_traceback() -> None:
+    """An exception that was never raised has no traceback, so only the class is named.
+
+    The prefix and class stay in the same position either way, so a
+    ``unexpected_ValueError%`` prefix match works whether or not a frame resolved.
+    """
+    reason = _exception_reason(_UNEXPECTED_REASON_PREFIX, ValueError("never raised"))
+
+    assert reason == "unexpected_ValueError"
+
+
+def test_exception_reason_skips_non_streamlit_frames() -> None:
+    """Only frames inside the ``streamlit`` package may be named.
+
+    This is what keeps a function from the *user's own app* out of the label: their
+    module never sits under ``streamlit``, so a traceback made up entirely of
+    third-party and user frames resolves to no function at all.
+    """
+
+    def _raise_outside_streamlit() -> None:
+        raise ValueError("from a test module, not streamlit")
+
+    try:
+        _raise_outside_streamlit()
+    except ValueError as ex:
+        reason = _exception_reason(_UNEXPECTED_REASON_PREFIX, ex)
+
+    assert reason == "unexpected_ValueError"
 
 
 def test_install_skills_handler_bounds_hostile_exception_class_name() -> None:
@@ -397,7 +455,7 @@ def test_install_skills_handler_bounds_hostile_exception_class_name() -> None:
 
     Class names are Python identifiers in practice, but a dynamically built class can
     carry arbitrary text, and this value ends up as a telemetry label suffix. Anything
-    outside ASCII alphanumerics is dropped - including the ``:`` that downstream
+    outside identifier characters is dropped - including the ``:`` that downstream
     ``split_part(label, ':', 2)`` queries would otherwise truncate on.
     """
     hostile = type("Bad: name\nwith 💥 junk" + "X" * 80, (Exception,), {})
@@ -413,11 +471,11 @@ def test_install_skills_handler_bounds_hostile_exception_class_name() -> None:
         )
 
     reason = response.error_reason
-    assert reason.startswith("unexpected_")
-    suffix = reason.removeprefix("unexpected_")
-    assert suffix == "BadnamewithjunkXXXXXXXXXXXXXXXXXXXXXXXXX"
-    assert len(suffix) == 40
+    assert reason == "unexpected_BadnamewithjunkXXXXXXXXXXXXXXXXXXXXXXXXX_in_handle"
+    # The class portion is capped at 40 chars, independent of the frame suffix.
+    assert len(reason.removeprefix("unexpected_").removesuffix("_in_handle")) == 40
     assert ":" not in reason
+    assert "\n" not in reason
 
 
 def test_install_skills_handler_refuses_without_agent_harness() -> None:

--- a/lib/tests/streamlit/runtime/backend_operation_handler_test.py
+++ b/lib/tests/streamlit/runtime/backend_operation_handler_test.py
@@ -138,6 +138,11 @@ def test_dispatch_returns_error_when_handler_fails() -> None:
 
     assert response.request_id == "request-id"
     assert response.error_msg == "Failed to process backend operation"
+    # The dispatcher's catch-all used to return no reason at all, so a handler that
+    # raised past its own try/except produced a bare telemetry label -
+    # indistinguishable from a pre-1.61 client and silent about the operation
+    # possibly never having run.
+    assert response.error_reason == "unhandled_RuntimeError"
     assert not response.HasField("deferred_file")
 
 
@@ -267,7 +272,9 @@ def test_install_skills_handler_reports_failure() -> None:
         )
 
     assert response.error_msg == "No skills found"
-    assert response.error_reason == "unknown"
+    # A ``ClickException`` that is not an ``InstallError`` carries no vocabulary
+    # reason, so the reason names its class rather than collapsing to "unknown".
+    assert response.error_reason == "unexpected_ClickException"
     assert not response.HasField("install_skills")
 
 
@@ -338,7 +345,7 @@ def test_install_skills_handler_ignores_foreign_reason_attribute() -> None:
     exception carrying a free-form str ``.reason`` (``UnicodeDecodeError`` and
     several stdlib errors do) would emit an unbounded telemetry label and break the
     fixed vocabulary. The reason is now trusted ONLY from skills.InstallError; a
-    non-OSError foreign exception is classified ``unknown``.
+    non-OSError foreign exception is named by its class instead.
     """
     foreign = ValueError("boom")
     foreign.reason = "some-unbounded-string"  # type: ignore[attr-defined]
@@ -353,7 +360,64 @@ def test_install_skills_handler_ignores_foreign_reason_attribute() -> None:
             )
         )
 
-    assert response.error_reason == "unknown"
+    assert response.error_reason == "unexpected_ValueError"
+    assert "some-unbounded-string" not in response.error_reason
+
+
+def test_install_skills_handler_names_unclassified_exception_class() -> None:
+    """An exception no vocabulary entry covers is reported by its class name.
+
+    Every such failure used to collapse into one ``unknown`` bucket, which made the
+    largest share of install failures undiagnosable from telemetry - the traceback is
+    logged server-side but never leaves the machine. The class name is a code
+    identifier, so it splits the bucket without carrying a path or any user data.
+    """
+    with (
+        patch("streamlit.config.get_option", return_value=False),
+        patch.object(skills, "detect_installed_agents", return_value=["claude"]),
+        patch(
+            "streamlit.web.skills.install_skills",
+            side_effect=RuntimeError("/absolute/server/path exploded"),
+        ),
+    ):
+        response = asyncio.run(
+            InstallSkillsHandler(lambda: "/app/dir").handle(
+                _install_skills_request(), "session-id"
+            )
+        )
+
+    assert response.error_reason == "unexpected_RuntimeError"
+    # The class name is safe; the *message* is not, and is never part of the reason.
+    assert "/absolute/server/path" not in response.error_reason
+    assert response.error_msg == "Failed to install skills."
+
+
+def test_install_skills_handler_bounds_hostile_exception_class_name() -> None:
+    """The class name is sanitized and length-capped before becoming a label.
+
+    Class names are Python identifiers in practice, but a dynamically built class can
+    carry arbitrary text, and this value ends up as a telemetry label suffix. Anything
+    outside ASCII alphanumerics is dropped - including the ``:`` that downstream
+    ``split_part(label, ':', 2)`` queries would otherwise truncate on.
+    """
+    hostile = type("Bad: name\nwith 💥 junk" + "X" * 80, (Exception,), {})
+    with (
+        patch("streamlit.config.get_option", return_value=False),
+        patch.object(skills, "detect_installed_agents", return_value=["claude"]),
+        patch("streamlit.web.skills.install_skills", side_effect=hostile("boom")),
+    ):
+        response = asyncio.run(
+            InstallSkillsHandler(lambda: "/app/dir").handle(
+                _install_skills_request(), "session-id"
+            )
+        )
+
+    reason = response.error_reason
+    assert reason.startswith("unexpected_")
+    suffix = reason.removeprefix("unexpected_")
+    assert suffix == "BadnamewithjunkXXXXXXXXXXXXXXXXXXXXXXXXX"
+    assert len(suffix) == 40
+    assert ":" not in reason
 
 
 def test_install_skills_handler_refuses_without_agent_harness() -> None:


### PR DESCRIPTION
## Describe your changes

1.61 shipped a bounded failure reason on the skills-install nudge ([#16279](https://github.com/streamlit/streamlit/pull/16279)) so install outcomes would split by cause. Six days of 1.61 data (2026-08-04 → 08-09) say they don't — of **663** failing developers, **641 (96.7%)** carry nothing a query can act on:

| Reason | Devs | Share |
| --- | --- | --- |
| `unknown` | 494 | 74.5% |
| *(no reason at all)* | 147 | 22.2% |
| real reasons (`write_denied` 7, `conflict` 5, `no_skills` 4, `source_missing` 3, `write_failed` 3) | 22 | 3.3% |

Two separate holes, both closed here:

- **`reason = "unknown"`** discarded everything it knew. The classifier reads `InstallError.reason` and errno, so every *other* exception — a bug, an unforeseen library error, a plain `ClickException` — collapsed into one bucket. The reason now names the exception class **and the Streamlit function it was raised from**: `unexpected_ValueError_in__install_project_skills`.
- **`BackendOperationDispatcher.dispatch()` returned no `error_reason`**, so anything thrown past a handler's own `try` produced a *bare* label, indistinguishable from a pre-1.61 client that predates reasons. That gets its own `unhandled_` prefix, because for skills-install it means the safety gate itself threw — the operation may never have started, which is a different bug than an install that ran and failed.

The two prefixes aren't speculative: the buckets have different platform signatures, so they are not the same failure.

| Bucket | Windows | macOS | Linux |
| --- | --- | --- | --- |
| `unknown` | 494 | 0 | 0 |
| *(no reason)* | 112 | 26 | 9 |

### Why the function name and not just the class

A class alone often won't close the question — a `ValueError` could come from source discovery, project-root resolution, the symlink probe, the global fallback, or the copy. Each round trip to find out costs a release plus its adoption ramp. The traceback is already in the `except` block, so the deepest **Streamlit** frame comes for free and localizes the bug instead of hinting at it.

Deliberate choices there:

- **Deepest Streamlit frame, not deepest frame.** If the raise came from inside a stdlib call, this names the Streamlit function that made it — the actionable part. It also means a frame from the **user's own app can never be named**, since their module never sits under `streamlit`.
- **No line number.** It moves with every edit to the file, which would scatter one bug across several labels as releases go out.
- **Class stays directly after the prefix**, so an `unexpected_ValueError%` prefix match works whether or not a frame resolved (an exception that was never raised has no traceback).

Both halves are code identifiers, so neither carries a path nor any PII — unlike the exception's *message*, which is still never used. They're sanitized to identifier characters and capped at 40 anyway, since a dynamically built class can be named anything. Dropping `:` is the load-bearing part: downstream reads the reason with `split_part(label, ':', 2)`, which a second colon would truncate — hence `_` as the separator in both prefixes.

Scope note: `DismissSkillsNudgeHandler` is deliberately left alone. It has no failure telemetry consuming a reason, so adding one would be noise.

**What this does not do:** it won't retro-explain the 494. It makes the next cohort diagnosable. Worth knowing while waiting — they are **100% Windows** and deterministic: only 54 of 637 ever succeeded, and 203 (31.9%) permanently opted out via "Don't show again."

Dashboard note: `skillsNudgeInstallFailed:unknown` stops growing, replaced by `skillsNudgeInstallFailed:unexpected_*`; bare `skillsNudgeInstallFailed` from 1.62+ clients becomes `unhandled_*`. Prefix matching on the reason (not equality with `unknown`) keeps working across the transition.

## GitHub Issue Link (if applicable)

Follow-up to [#16279](https://github.com/streamlit/streamlit/pull/16279). Related: [#15966](https://github.com/streamlit/streamlit/pull/15966).

## Testing Plan

- Unit Tests (Python) — `lib/tests/streamlit/runtime/backend_operation_handler_test.py`
  - the reason names the **deepest** Streamlit frame (`_install_project_skills`), not the outermost handler — the assertion that makes this better than a bare class name
  - frames outside the `streamlit` package resolve to no function, so a user's app is never named
  - an exception with no traceback falls back to class-only, keeping the prefix stable
  - a hostile class name (colon, newline, emoji, 80 chars) is sanitized and capped at 40
  - the dispatcher's catch-all now carries `unhandled_RuntimeError_in_dispatch` instead of nothing
  - existing `InstallError` / `OSError` classification is unchanged
- No E2E: no user-visible behavior changes — the toast copy and error states are identical. This only alters the telemetry label suffix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry-only `error_reason` shaping with no user-visible UI changes; known `InstallError`/`OSError` reasons are unchanged.
> 
> **Overview**
> **Replaces the `unknown` / missing `error_reason` buckets** for skills-install backend failures so telemetry can split failures by exception type and location inside Streamlit.
> 
> When `InstallError` / `OSError` classification does not apply, the install handler now emits bounded reasons like `unexpected_ValueError_in__install_project_skills` (deepest `streamlit.*` frame only; exception messages and user app frames are never included). The dispatcher catch-all now sets `error_reason` too, using the `unhandled_` prefix when a handler raises past its own `try/except` (e.g. `unhandled_RuntimeError_in_dispatch`).
> 
> Identifiers are sanitized (ASCII alnum/`_`, 40-char cap, no `:`) so label suffixes stay safe for `split_part(label, ':', 2)` queries. **Frontend change is documentation only** in `skillsNudgeInstallFailureLabel` — existing label plumbing already forwards `error_reason` verbatim.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bce3d9645146238f64f1cb6c1fd127830b50f7eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->