### PR TITLE
[fix] Offload /_stcore/metrics stats computation off the event loop

### DIFF
--- a/lib/streamlit/web/server/starlette/starlette_routes.py
+++ b/lib/streamlit/web/server/starlette/starlette_routes.py
@@ -449,12 +449,16 @@ def create_script_health_routes(
 
 def create_metrics_routes(runtime: Runtime, base_url: str | None) -> list[BaseRoute]:
     """Create metrics route handlers."""
+    from starlette.concurrency import run_in_threadpool
     from starlette.responses import PlainTextResponse, Response
     from starlette.routing import Route
 
     async def _metrics_endpoint(request: Request) -> Response:
         requested_families = request.query_params.getlist("families")
-        stats = runtime.stats_mgr.get_stats(family_names=requested_families or None)
+        stats = await run_in_threadpool(
+            runtime.stats_mgr.get_stats,
+            family_names=requested_families or None,
+        )
         accept = request.headers.get("Accept", "")
         if "application/x-protobuf" in accept:
             payload = _stats_to_proto(stats).SerializeToString()

--- a/lib/tests/streamlit/web/server/starlette/starlette_app_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_app_test.py
@@ -396,17 +396,22 @@ def test_metrics_endpoint_runs_stats_off_event_loop(
     computation runs synchronously on the asyncio event loop (CWE-400),
     starving other coroutines.
     """
-    client, runtime = starlette_client
+    _, runtime = starlette_client
 
-    # The script-health endpoint runs entirely on the event loop, so it
-    # records the event-loop thread ident for comparison.
-    health_response = client.get("/_stcore/script-health-check")
-    assert health_response.status_code == 200
-    event_loop_thread_ident = runtime.event_loop_thread_ident
-    assert event_loop_thread_ident is not None
+    # The script-health-check endpoint runs entirely on the event loop, so
+    # hitting it records the event-loop thread ident for comparison. It is
+    # gated behind server.scriptHealthCheckEnabled, so enable it and rebuild
+    # the app (mirroring test_script_health_endpoint).
+    with patch_config_options({"server.scriptHealthCheckEnabled": True}):
+        app = create_starlette_app(runtime)
+        with TestClient(app) as client:
+            health_response = client.get("/_stcore/script-health-check")
+            assert health_response.status_code == 200
+            event_loop_thread_ident = runtime.event_loop_thread_ident
+            assert event_loop_thread_ident is not None
 
-    response = client.get("/_stcore/metrics")
-    assert response.status_code == 200
+            response = client.get("/_stcore/metrics")
+            assert response.status_code == 200
 
     get_stats_thread_ident = runtime.stats_mgr.get_stats_thread_ident
     assert get_stats_thread_ident is not None

--- a/lib/tests/streamlit/web/server/starlette/starlette_app_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_app_test.py
@@ -18,6 +18,7 @@ import asyncio
 import json
 import os
 import sys
+import threading
 from contextlib import asynccontextmanager
 from http import HTTPStatus
 from pathlib import Path
@@ -86,6 +87,7 @@ def _reset_main_script_path_and_config_options() -> Iterator[None]:
 
 class _DummyStatsManager:
     def __init__(self) -> None:
+        self.get_stats_thread_ident: int | None = None
         self._stats: dict[str, list[CacheStat | CounterStat | GaugeStat]] = {
             "cache_memory_bytes": [CacheStat("test_cache", "", 1)],
             "session_events": [
@@ -124,6 +126,7 @@ class _DummyStatsManager:
     def get_stats(
         self, family_names: list[str] | None = None
     ) -> dict[str, list[CacheStat | CounterStat | GaugeStat]]:
+        self.get_stats_thread_ident = threading.current_thread().ident
         if family_names is None:
             return self._stats
         return {k: self._stats.get(k, []) for k in family_names}
@@ -163,6 +166,7 @@ class _DummyRuntime:
         self.bidi_component_registry = _DummyBidiComponentRegistry()
         self.bidi_component_registry.register("comp", str(component_dir))
         self.stats_mgr = _DummyStatsManager()
+        self.event_loop_thread_ident: int | None = None
         self._active_sessions: set[str] = {"session123"}
         self.stopped = False
         self.last_backmsg = None
@@ -196,6 +200,7 @@ class _DummyRuntime:
         return fut
 
     def does_script_run_without_error(self) -> asyncio.Future[tuple[bool, str]]:
+        self.event_loop_thread_ident = threading.current_thread().ident
         loop = asyncio.get_event_loop()
         fut: asyncio.Future[tuple[bool, str]] = loop.create_future()
         fut.set_result(self.script_health)
@@ -380,6 +385,32 @@ def test_metrics_endpoint(starlette_client: tuple[TestClient, _DummyRuntime]) ->
     assert "active_sessions" in response.text
     assert "# HELP active_sessions Current number of active sessions." in response.text
     assert "# UNIT active_sessions " not in response.text
+
+
+def test_metrics_endpoint_runs_stats_off_event_loop(
+    starlette_client: tuple[TestClient, _DummyRuntime],
+) -> None:
+    """The metrics endpoint offloads get_stats off the event-loop thread.
+
+    Guards against a regression where the potentially CPU-heavy stats
+    computation runs synchronously on the asyncio event loop (CWE-400),
+    starving other coroutines.
+    """
+    client, runtime = starlette_client
+
+    # The script-health endpoint runs entirely on the event loop, so it
+    # records the event-loop thread ident for comparison.
+    health_response = client.get("/_stcore/script-health-check")
+    assert health_response.status_code == 200
+    event_loop_thread_ident = runtime.event_loop_thread_ident
+    assert event_loop_thread_ident is not None
+
+    response = client.get("/_stcore/metrics")
+    assert response.status_code == 200
+
+    get_stats_thread_ident = runtime.stats_mgr.get_stats_thread_ident
+    assert get_stats_thread_ident is not None
+    assert get_stats_thread_ident != event_loop_thread_ident
 
 
 def test_metrics_endpoint_includes_user_session_events(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Describe your changes

The unauthenticated `GET /_stcore/metrics` endpoint ran the synchronous, potentially CPU-heavy `runtime.stats_mgr.get_stats(...)` call directly on the asyncio event-loop thread. `StatsManager.get_stats()` fans out to every registered provider, several of which iterate unbounded, attacker-influenceable collections (active sessions, `st.cache_data` blobs under a lock, media files). Because the handler is `async def` but the call was inline and synchronous, it blocked the event loop, starving every other WebSocket and HTTP coroutine while it ran — an attacker could freeze the app for all connected users with back-to-back requests (CWE-400, SNOW-3688941).

- Route the `get_stats` call through `starlette.concurrency.run_in_threadpool` so it executes on a worker thread and the event loop stays responsive to other coroutines.

This change is deliberately narrow — it only moves the blocking call off the event loop. It does **not** bound the total CPU cost of the computation. The following are intentionally out of scope and left as follow-ups:

- Bounding concurrent metrics computations (concurrency limits).
- Short-TTL caching of computed stats.
- Rate-limiting and/or authentication on the endpoint.
- Making the individual stats providers cheap-by-construction.

## GitHub Issue Link (if applicable)



## Testing Plan

- Unit Tests (Python): Added `test_metrics_endpoint_runs_stats_off_event_loop`, which records the thread ident inside the stubbed stats manager's `get_stats` and inside the event-loop-only `does_script_run_without_error`, then asserts the two differ — proving the stats computation is offloaded to a worker thread. Existing metrics tests continue to assert the response output is unchanged.
- No E2E tests needed: the change is a server-internal threading concern with no user-visible behavior change.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-664839a8-cbad-4b50-993c-f15eab82be18?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-664839a8-cbad-4b50-993c-f15eab82be18&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

