### PR TITLE
`DateInput`: keyboard accessibility & form consistency fixes

### DIFF
--- a/e2e_playwright/st_date_input_test.py
+++ b/e2e_playwright/st_date_input_test.py
@@ -317,7 +317,7 @@ def test_range_date_calendar_picker_rendering(
     )
 
 
-def test_resets_to_default_single_value_if_calendar_closed_empty(app: Page):
+def test_single_value_reverts_to_committed_if_calendar_closed_empty(app: Page):
     """Non-clearable widget reverts to last committed value when closed empty."""
     date_input = get_date_input(app, "Single date")
     date_field = date_input.get_by_test_id("stDateInputField")

--- a/e2e_playwright/st_date_input_test.py
+++ b/e2e_playwright/st_date_input_test.py
@@ -739,8 +739,12 @@ def test_single_date_active_calendar_keyboard_navigation(app: Page):
     app.keyboard.press("Alt+ArrowDown")
     expect(calendar).to_be_visible()
 
-    # Tab to the month picker trigger and activate it
+    # Tab to the month picker trigger and activate it.
+    # Note: prev-month button is disabled (min_value=1970-01-01, showing Jan 1970),
+    # so the first focusable after the grid is the month picker trigger.
     app.keyboard.press("Tab")
+    month_trigger = calendar.get_by_role("button", name="month", exact=True)
+    expect(month_trigger).to_be_focused()
     app.keyboard.press("Enter")
     picker_popover = app.get_by_test_id("stDateInputHeaderPickerPopover")
     expect(picker_popover).to_be_visible()

--- a/e2e_playwright/st_date_input_test.py
+++ b/e2e_playwright/st_date_input_test.py
@@ -692,3 +692,113 @@ def test_date_input_query_param_out_of_range_resets(page: Page, app_base_url: st
 
     expect_prefixed_markdown(page, "Bound minmax:", "2025-06-15")
     expect(page).not_to_have_url(re.compile(r"[?&]bound_minmax_date="))
+
+
+# --- Keyboard navigation (active calendar mode) tests ---
+
+
+def test_single_date_active_calendar_keyboard_navigation(app: Page):
+    """Test keyboard navigation for single date input active calendar mode (Alt+ArrowDown).
+
+    Covers: passive mode has no dialog role, Alt+ArrowDown enters active mode,
+    Tab cycles within the calendar, nested picker Escape closes only the picker,
+    Escape returns focus to originating segment, date selection closes and returns focus.
+    """
+    date_input = get_date_input(app, "Single date")
+    date_field = date_input.get_by_test_id("stDateInputField")
+    first_segment = date_field.get_by_role("spinbutton").first
+    second_segment = date_field.get_by_role("spinbutton").nth(1)
+
+    # --- Passive mode: no dialog role ---
+    first_segment.click()
+    calendar = app.get_by_test_id("stDateInputCalendar")
+    expect(calendar).to_be_visible()
+    expect(calendar).not_to_have_attribute("role", "dialog")
+    expect(calendar).not_to_have_attribute("aria-modal", "true")
+
+    # --- Alt+ArrowDown enters active mode ---
+    app.keyboard.press("Alt+ArrowDown")
+    expect(calendar).to_have_attribute("role", "dialog")
+    expect(calendar).to_have_attribute("aria-modal", "true")
+    expect(calendar.locator(":focus")).to_have_attribute("role", "button")
+
+    # --- Tab cycles within the calendar without closing ---
+    for _ in range(6):
+        app.keyboard.press("Tab")
+        expect(calendar).to_be_visible()
+    expect(calendar.locator(":focus")).to_be_visible()
+    expect(calendar).to_have_attribute("role", "dialog")
+
+    # --- Escape closes and returns focus to originating segment ---
+    app.keyboard.press("Escape")
+    expect(calendar).not_to_be_visible()
+    expect(first_segment).to_be_focused()
+
+    # --- Nested picker Escape closes only the picker ---
+    first_segment.click()
+    app.keyboard.press("Alt+ArrowDown")
+    expect(calendar).to_be_visible()
+
+    # Tab to the month picker trigger and activate it
+    app.keyboard.press("Tab")
+    app.keyboard.press("Enter")
+    picker_popover = app.get_by_test_id("stDateInputHeaderPickerPopover")
+    expect(picker_popover).to_be_visible()
+
+    # Escape should close only the picker, not the outer calendar
+    app.keyboard.press("Escape")
+    expect(picker_popover).not_to_be_visible()
+    expect(calendar).to_be_visible()
+    expect(calendar).to_have_attribute("role", "dialog")
+
+    # Close to reset state
+    app.keyboard.press("Escape")
+    expect(calendar).not_to_be_visible()
+
+    # --- Date selection closes calendar and returns focus ---
+    second_segment.click()
+    app.keyboard.press("Alt+ArrowDown")
+    expect(calendar).to_be_visible()
+
+    # Navigate to a different date and select it with Enter
+    app.keyboard.press("ArrowRight")
+    app.keyboard.press("Enter")
+
+    expect(calendar).not_to_be_visible()
+    expect(second_segment).to_be_focused()
+    wait_for_app_run(app)
+    expect_markdown(app, "Value 1: 1970-01-02")
+
+
+def test_range_date_active_calendar_keyboard_navigation(app: Page):
+    """Test keyboard navigation for range date input active calendar mode (Alt+ArrowDown).
+
+    Covers: Alt+ArrowDown enters active mode from start field,
+    Escape returns focus to the originating segment (last segment of end field).
+    """
+    date_input = get_date_input(app, "Range, two dates")
+    date_field = date_input.get_by_test_id("stDateInputField")
+
+    # --- Alt+ArrowDown from start field enters active mode ---
+    date_field.get_by_role("spinbutton").first.click()
+    app.keyboard.press("Alt+ArrowDown")
+
+    calendar = app.get_by_test_id("stDateInputCalendar")
+    expect(calendar).to_be_visible()
+    expect(calendar).to_have_attribute("role", "dialog")
+    expect(calendar).to_have_attribute("aria-modal", "true")
+    expect(calendar.locator(":focus")).to_have_attribute("role", "button")
+
+    # Close to reset
+    app.keyboard.press("Escape")
+    expect(calendar).not_to_be_visible()
+
+    # --- Alt+ArrowDown from last segment of end field, Escape returns there ---
+    last_segment = date_field.get_by_role("spinbutton").last
+    last_segment.click()
+    app.keyboard.press("Alt+ArrowDown")
+    expect(calendar).to_be_visible()
+
+    app.keyboard.press("Escape")
+    expect(calendar).not_to_be_visible()
+    expect(last_segment).to_be_focused()

--- a/e2e_playwright/st_date_input_test.py
+++ b/e2e_playwright/st_date_input_test.py
@@ -318,12 +318,12 @@ def test_range_date_calendar_picker_rendering(
 
 
 def test_resets_to_default_single_value_if_calendar_closed_empty(app: Page):
-    """Test that single value is reset to default if calendar closed empty."""
+    """Non-clearable widget reverts to last committed value when closed empty."""
     date_input = get_date_input(app, "Single date")
     date_field = date_input.get_by_test_id("stDateInputField")
     date_field.get_by_role("spinbutton").first.click()
 
-    # Select '1970/01/02'
+    # Select '1970/01/02' — this becomes the committed value
     app.get_by_test_id("stDateInputCalendar").get_by_label(
         "Friday, January 2, 1970"
     ).click()
@@ -345,8 +345,8 @@ def test_resets_to_default_single_value_if_calendar_closed_empty(app: Page):
     # submit the cleared value
     reset_focus(app)
 
-    # Value should be reset to default
-    expect_markdown(app, "Value 1: 1970-01-01")
+    # Value reverts to last committed (1970-01-02), not the element default
+    expect_markdown(app, "Value 1: 1970-01-02")
 
 
 def test_range_is_empty_if_calendar_closed_empty(app: Page):

--- a/frontend/lib/src/components/widgets/DateInput/CalendarPopoverHeader.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/CalendarPopoverHeader.tsx
@@ -14,7 +14,13 @@
  * limitations under the License.
  */
 
-import { ReactElement, useState } from "react"
+import {
+  KeyboardEvent,
+  ReactElement,
+  useCallback,
+  useRef,
+  useState,
+} from "react"
 
 import { KeyboardArrowDown } from "@emotion-icons/material-outlined"
 import { ArrowBack, ArrowForward } from "@emotion-icons/material-rounded"
@@ -80,12 +86,24 @@ function HeaderPickerSelect({
   const selectedLabel = items.find(item => item.id === value)?.formatted ?? ""
 
   const [isOpen, setIsOpen] = useState(false)
+  const triggerRef = useRef<HTMLButtonElement | null>(null)
   const { setFloatingRef, setReferenceRef } = useOverlayDismissal({
     isOpen,
     onClose: () => setIsOpen(false),
     // No floating-ui positioning needed — the picker uses CSS absolute positioning.
     floatingSetFn: noop,
   })
+
+  const handlePickerKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLDivElement>): void => {
+      if (e.key === "Tab") {
+        e.preventDefault()
+        setIsOpen(false)
+        triggerRef.current?.focus()
+      }
+    },
+    []
+  )
 
   return (
     <StyledCalendarHeaderSelect
@@ -95,7 +113,12 @@ function HeaderPickerSelect({
       isOpen={isOpen}
       onOpenChange={setIsOpen}
     >
-      <StyledCalendarHeaderSelectTrigger ref={setReferenceRef}>
+      <StyledCalendarHeaderSelectTrigger
+        ref={(node: HTMLButtonElement | null) => {
+          triggerRef.current = node
+          setReferenceRef(node)
+        }}
+      >
         {selectedLabel}
         <StyledCalendarHeaderSelectChevron>
           <KeyboardArrowDown size={theme.iconSizes.base} />
@@ -106,9 +129,12 @@ function HeaderPickerSelect({
         isNonModal
         data-testid="stDateInputHeaderPickerPopover"
       >
-        <StyledDropdownListBox items={items}>
-          {renderPickerItem}
-        </StyledDropdownListBox>
+        {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
+        <div onKeyDown={handlePickerKeyDown}>
+          <StyledDropdownListBox items={items}>
+            {renderPickerItem}
+          </StyledDropdownListBox>
+        </div>
       </StyledDropdownPopover>
     </StyledCalendarHeaderSelect>
   )

--- a/frontend/lib/src/components/widgets/DateInput/CalendarPopoverHeader.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/CalendarPopoverHeader.tsx
@@ -98,6 +98,7 @@ function HeaderPickerSelect({
     (e: KeyboardEvent<HTMLDivElement>): void => {
       if (e.key === "Tab") {
         e.preventDefault()
+        e.stopPropagation()
         setIsOpen(false)
         triggerRef.current?.focus()
       }

--- a/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
@@ -1777,6 +1777,293 @@ describe("DateInput single-mode keyboard navigation", () => {
   })
 })
 
+describe("DateInput single-mode active calendar (Alt+ArrowDown)", () => {
+  it("Alt+ArrowDown opens calendar in active mode with focus on grid cell", async () => {
+    const user = userEvent.setup()
+    render(<DateInput {...getProps()} />)
+
+    const region = screen.getByTestId("stDateInput")
+    const { year } = getSingleDateSegments(region)
+    await user.click(year)
+    await screen.findByTestId("stDateInputCalendar")
+
+    await user.keyboard("{Alt>}{ArrowDown}{/Alt}")
+
+    await waitFor(() => {
+      const calendar = screen.getByTestId("stDateInputCalendar")
+      expect(calendar).toHaveAttribute("role", "dialog")
+      expect(calendar).toHaveAttribute("aria-modal", "true")
+      // Focus should be inside the calendar grid
+      const focused = document.activeElement
+      expect(calendar.contains(focused)).toBe(true)
+      expect(focused?.getAttribute("tabindex")).toBe("0")
+    })
+  })
+
+  it("Alt+ArrowDown opens calendar even if popover was closed", async () => {
+    const user = userEvent.setup()
+    render(<DateInput {...getProps()} />)
+
+    const region = screen.getByTestId("stDateInput")
+    const { year } = getSingleDateSegments(region)
+
+    // Focus and close the popover via Tab
+    await user.click(year)
+    await screen.findByTestId("stDateInputCalendar")
+    // Close by tabbing through all segments and out
+    await user.tab() // to month
+    await user.tab() // to day
+    await user.tab() // leaves widget, closes popover
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("stDateInputCalendar")
+      ).not.toBeInTheDocument()
+    })
+
+    // Go back to the field and press Alt+ArrowDown
+    await user.click(year)
+    await screen.findByTestId("stDateInputCalendar")
+    await user.keyboard("{Alt>}{ArrowDown}{/Alt}")
+
+    await waitFor(() => {
+      const calendar = screen.getByTestId("stDateInputCalendar")
+      expect(calendar).toHaveAttribute("role", "dialog")
+    })
+  })
+
+  it("Tab cycles within active calendar without closing", async () => {
+    const user = userEvent.setup()
+    render(
+      <DateInput
+        {...getProps({ default: ["2020-06-15"], min: "2000-01-01" })}
+      />
+    )
+
+    const region = screen.getByTestId("stDateInput")
+    const { year } = getSingleDateSegments(region)
+    await user.click(year)
+    await screen.findByTestId("stDateInputCalendar")
+
+    await user.keyboard("{Alt>}{ArrowDown}{/Alt}")
+
+    await waitFor(() => {
+      const calendar = screen.getByTestId("stDateInputCalendar")
+      expect(calendar).toHaveAttribute("role", "dialog")
+    })
+
+    // Tab should cycle within the calendar, not close it
+    await user.tab()
+    expect(screen.getByTestId("stDateInputCalendar")).toBeVisible()
+    await user.tab()
+    expect(screen.getByTestId("stDateInputCalendar")).toBeVisible()
+    await user.tab()
+    expect(screen.getByTestId("stDateInputCalendar")).toBeVisible()
+  })
+
+  it("Escape from active calendar returns focus to originating segment", async () => {
+    const user = userEvent.setup()
+    render(<DateInput {...getProps()} />)
+
+    const region = screen.getByTestId("stDateInput")
+    const { month } = getSingleDateSegments(region)
+
+    // Focus the month segment specifically
+    await user.click(month)
+    await screen.findByTestId("stDateInputCalendar")
+
+    await user.keyboard("{Alt>}{ArrowDown}{/Alt}")
+
+    await waitFor(() => {
+      const calendar = screen.getByTestId("stDateInputCalendar")
+      expect(calendar).toHaveAttribute("role", "dialog")
+    })
+
+    // Escape should close and return focus to the month segment
+    await user.keyboard("{Escape}")
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("stDateInputCalendar")
+      ).not.toBeInTheDocument()
+    })
+    expect(month).toHaveFocus()
+  })
+
+  it("selecting a date in active mode closes and returns focus to originating segment", async () => {
+    const user = userEvent.setup()
+    const props = getProps()
+    render(<DateInput {...props} />)
+
+    const region = screen.getByTestId("stDateInput")
+    const { month } = getSingleDateSegments(region)
+
+    await user.click(month)
+    const calendar = await screen.findByTestId("stDateInputCalendar")
+
+    await user.keyboard("{Alt>}{ArrowDown}{/Alt}")
+
+    await waitFor(() => {
+      expect(calendar).toHaveAttribute("role", "dialog")
+      expect(calendar.contains(document.activeElement)).toBe(true)
+    })
+
+    // Navigate to a different date and select it
+    await user.keyboard("{ArrowRight}")
+    await user.keyboard("{Enter}")
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("stDateInputCalendar")
+      ).not.toBeInTheDocument()
+    })
+    expect(month).toHaveFocus()
+  })
+
+  it("passive mode still closes on Tab from last segment (no regression)", async () => {
+    const user = userEvent.setup()
+    render(<DateInput {...getProps()} />)
+
+    const region = screen.getByTestId("stDateInput")
+    const { day } = getSingleDateSegments(region)
+
+    await user.click(day)
+    await screen.findByTestId("stDateInputCalendar")
+
+    // Calendar should NOT be in dialog mode
+    const calendar = screen.getByTestId("stDateInputCalendar")
+    expect(calendar).not.toHaveAttribute("role", "dialog")
+    expect(calendar).not.toHaveAttribute("aria-modal")
+
+    // Tab from day should close (passive behavior unchanged)
+    await user.tab()
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("stDateInputCalendar")
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  it("wrapper has aria-keyshortcuts attribute", () => {
+    render(<DateInput {...getProps()} />)
+    const wrapper = screen.getByTestId("stDateInputField")
+    expect(wrapper).toHaveAttribute("aria-keyshortcuts", "Alt+ArrowDown")
+  })
+})
+
+describe("DateInput range-mode active calendar (Alt+ArrowDown)", () => {
+  it("Alt+ArrowDown from start field segment enters active calendar", async () => {
+    const user = userEvent.setup()
+    render(
+      <DateInput
+        {...getProps({
+          isRange: true,
+          default: ["2019-07-06", "2019-07-08"],
+        })}
+      />
+    )
+
+    const region = screen.getByTestId("stDateInput")
+    const { year } = getRangeDateSegments(region, "start")
+    await user.click(year)
+    await screen.findByTestId("stDateInputCalendar")
+
+    await user.keyboard("{Alt>}{ArrowDown}{/Alt}")
+
+    await waitFor(() => {
+      const calendar = screen.getByTestId("stDateInputCalendar")
+      expect(calendar).toHaveAttribute("role", "dialog")
+      expect(calendar).toHaveAttribute("aria-modal", "true")
+    })
+  })
+
+  it("Alt+ArrowDown from end field segment enters active calendar", async () => {
+    const user = userEvent.setup()
+    render(
+      <DateInput
+        {...getProps({
+          isRange: true,
+          default: ["2019-07-06", "2019-07-08"],
+        })}
+      />
+    )
+
+    const region = screen.getByTestId("stDateInput")
+    const { day } = getRangeDateSegments(region, "end")
+    await user.click(day)
+    await screen.findByTestId("stDateInputCalendar")
+
+    await user.keyboard("{Alt>}{ArrowDown}{/Alt}")
+
+    await waitFor(() => {
+      const calendar = screen.getByTestId("stDateInputCalendar")
+      expect(calendar).toHaveAttribute("role", "dialog")
+    })
+  })
+
+  it("Tab cycles through calendar + quick select in active mode", async () => {
+    const user = userEvent.setup()
+    render(
+      <DateInput
+        {...getProps({
+          isRange: true,
+          default: ["2019-07-06", "2019-07-08"],
+        })}
+      />
+    )
+
+    const region = screen.getByTestId("stDateInput")
+    const { year } = getRangeDateSegments(region, "start")
+    await user.click(year)
+    await screen.findByTestId("stDateInputCalendar")
+
+    await user.keyboard("{Alt>}{ArrowDown}{/Alt}")
+
+    await waitFor(() => {
+      const calendar = screen.getByTestId("stDateInputCalendar")
+      expect(calendar).toHaveAttribute("role", "dialog")
+    })
+
+    // Tab multiple times — should stay within the calendar
+    for (let i = 0; i < 6; i++) {
+      await user.tab()
+      expect(screen.getByTestId("stDateInputCalendar")).toBeVisible()
+    }
+  })
+
+  it("Escape from active range calendar returns to originating segment", async () => {
+    const user = userEvent.setup()
+    render(
+      <DateInput
+        {...getProps({
+          isRange: true,
+          default: ["2019-07-06", "2019-07-08"],
+        })}
+      />
+    )
+
+    const region = screen.getByTestId("stDateInput")
+    const { month } = getRangeDateSegments(region, "end")
+    await user.click(month)
+    await screen.findByTestId("stDateInputCalendar")
+
+    await user.keyboard("{Alt>}{ArrowDown}{/Alt}")
+
+    await waitFor(() => {
+      const calendar = screen.getByTestId("stDateInputCalendar")
+      expect(calendar).toHaveAttribute("role", "dialog")
+    })
+
+    await user.keyboard("{Escape}")
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("stDateInputCalendar")
+      ).not.toBeInTheDocument()
+    })
+    expect(month).toHaveFocus()
+  })
+})
+
 describe("DateInput single-mode paste handling", () => {
   it("pasting a full date string updates the value", async () => {
     const user = userEvent.setup()

--- a/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
@@ -642,8 +642,8 @@ describe("DateInput", () => {
     const user = userEvent.setup()
     // Non-empty default makes the widget non-clearable. Clearing all
     // segments then leaving the field closes the popover; close-commit
-    // restores the last committed value and handleClose re-writes that
-    // value (formCommit is skipped while segments are still cleared).
+    // restores the last committed value locally. No backend write fires
+    // because the committed value never changed (edits were buffered).
     const props = getProps({ formId: "form" })
     props.widgetMgr.setFormSubmitBehaviors("form", true)
     vi.spyOn(props.widgetMgr, "setStringArrayValue")
@@ -659,16 +659,9 @@ describe("DateInput", () => {
     await clearSegment(user, day)
 
     await user.tab()
-    // Close-commit reverts the cleared state to the last committed value
-    // (1970-01-20). handleBlur skips formCommit for fully-cleared
-    // non-clearable widgets, avoiding a race where form submit could
-    // capture the empty intermediate state.
-    expect(props.widgetMgr.setStringArrayValue).toHaveBeenCalledWith(
-      props.element,
-      [originalDateWire],
-      { fromUi: true },
-      undefined
-    )
+    // Close-commit reverts the display locally; no setStringArrayValue
+    // should fire (avoids a spurious backend rerun with an unchanged value).
+    expect(props.widgetMgr.setStringArrayValue).not.toHaveBeenCalled()
   })
 
   describe("localization", () => {
@@ -2073,10 +2066,12 @@ describe("DateInput single-mode active calendar (Alt+ArrowDown)", () => {
     })
   })
 
-  it("wrapper has aria-keyshortcuts attribute", () => {
+  it("has aria-keyshortcuts on wrapper", () => {
     render(<DateInput {...getProps()} />)
-    const wrapper = screen.getByTestId("stDateInputField")
-    expect(wrapper).toHaveAttribute("aria-keyshortcuts", "Alt+ArrowDown")
+    expect(screen.getByTestId("stDateInputField")).toHaveAttribute(
+      "aria-keyshortcuts",
+      "Alt+ArrowDown"
+    )
   })
 })
 

--- a/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
@@ -638,13 +638,12 @@ describe("DateInput", () => {
     )
   })
 
-  it("non-clearable widget reverts to default on blur after clearing all segments", async () => {
+  it("non-clearable widget reverts to committed value on blur after clearing all segments", async () => {
     const user = userEvent.setup()
     // Non-empty default makes the widget non-clearable. Clearing all
-    // segments and blurring triggers close-commit which reverts to default,
-    // then form-blur commits that reverted value. The clearable guard was
-    // removed from handleFormCommit so the commit always fires — but the
-    // close-commit effect enforces the non-clearable constraint first.
+    // segments then leaving the field closes the popover; close-commit
+    // restores the last committed value and handleClose re-writes that
+    // value (formCommit is skipped while segments are still cleared).
     const props = getProps({ formId: "form" })
     props.widgetMgr.setFormSubmitBehaviors("form", true)
     vi.spyOn(props.widgetMgr, "setStringArrayValue")
@@ -660,9 +659,10 @@ describe("DateInput", () => {
     await clearSegment(user, day)
 
     await user.tab()
-    // Close-commit reverts the cleared state to default (1970-01-20),
-    // and form-blur-commit writes that value through without being
-    // blocked by a clearable guard.
+    // Close-commit reverts the cleared state to the last committed value
+    // (1970-01-20). handleBlur skips formCommit for fully-cleared
+    // non-clearable widgets, avoiding a race where form submit could
+    // capture the empty intermediate state.
     expect(props.widgetMgr.setStringArrayValue).toHaveBeenCalledWith(
       props.element,
       [originalDateWire],

--- a/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
@@ -602,9 +602,8 @@ describe("DateInput", () => {
     expect(props.widgetMgr.setStringArrayValue).not.toHaveBeenCalled()
   })
 
-  it("commits cleared value on blur when all segments are cleared in a clearable form widget", async () => {
+  it("commits cleared value on blur when all segments are cleared in a form widget", async () => {
     const user = userEvent.setup()
-    // default: [] makes the widget clearable
     const props = getProps({ formId: "form", default: [] })
     props.widgetMgr.setFormSubmitBehaviors("form", true)
     vi.spyOn(props.widgetMgr, "setStringArrayValue")
@@ -634,6 +633,39 @@ describe("DateInput", () => {
     expect(props.widgetMgr.setStringArrayValue).toHaveBeenCalledWith(
       props.element,
       [],
+      { fromUi: true },
+      undefined
+    )
+  })
+
+  it("non-clearable widget reverts to default on blur after clearing all segments", async () => {
+    const user = userEvent.setup()
+    // Non-empty default makes the widget non-clearable. Clearing all
+    // segments and blurring triggers close-commit which reverts to default,
+    // then form-blur commits that reverted value. The clearable guard was
+    // removed from handleFormCommit so the commit always fires — but the
+    // close-commit effect enforces the non-clearable constraint first.
+    const props = getProps({ formId: "form" })
+    props.widgetMgr.setFormSubmitBehaviors("form", true)
+    vi.spyOn(props.widgetMgr, "setStringArrayValue")
+
+    render(<DateInput {...props} />)
+    vi.mocked(props.widgetMgr.setStringArrayValue).mockClear()
+
+    const region = screen.getByTestId("stDateInput")
+    const { year, month, day } = getSingleDateSegments(region)
+
+    await clearSegment(user, year)
+    await clearSegment(user, month)
+    await clearSegment(user, day)
+
+    await user.tab()
+    // Close-commit reverts the cleared state to default (1970-01-20),
+    // and form-blur-commit writes that value through without being
+    // blocked by a clearable guard.
+    expect(props.widgetMgr.setStringArrayValue).toHaveBeenCalledWith(
+      props.element,
+      [originalDateWire],
       { fromUi: true },
       undefined
     )

--- a/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
@@ -2066,6 +2066,60 @@ describe("DateInput single-mode active calendar (Alt+ArrowDown)", () => {
     })
   })
 
+  it("clicking back into the field exits active mode", async () => {
+    const user = userEvent.setup()
+    render(<DateInput {...getProps()} />)
+    const { year, day } = getSingleDateSegments(
+      screen.getByTestId("stDateInput")
+    )
+
+    await user.click(year)
+    await screen.findByTestId("stDateInputCalendar")
+    await user.keyboard("{Alt>}{ArrowDown}{/Alt}")
+    await waitFor(() => {
+      expect(screen.getByTestId("stDateInputCalendar")).toHaveAttribute(
+        "role",
+        "dialog"
+      )
+    })
+    // Let pending rAF focus moves land before clicking.
+    for (let i = 0; i < 3; i++) {
+      await act(
+        async () => new Promise<void>(r => requestAnimationFrame(() => r()))
+      )
+    }
+
+    await user.click(day)
+    // Let any rAF re-steal attempt land.
+    for (let i = 0; i < 3; i++) {
+      await act(
+        async () => new Promise<void>(r => requestAnimationFrame(() => r()))
+      )
+    }
+    expect(day).toHaveFocus()
+    expect(screen.getByTestId("stDateInputCalendar")).not.toHaveAttribute(
+      "role",
+      "dialog"
+    )
+
+    // Close by tabbing out, then re-open by click: must stay passive.
+    await user.tab()
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("stDateInputCalendar")
+      ).not.toBeInTheDocument()
+    })
+    const refreshed = getSingleDateSegments(screen.getByTestId("stDateInput"))
+    await user.click(refreshed.day)
+    await screen.findByTestId("stDateInputCalendar")
+    for (let i = 0; i < 3; i++) {
+      await act(
+        async () => new Promise<void>(r => requestAnimationFrame(() => r()))
+      )
+    }
+    expect(refreshed.day).toHaveFocus()
+  })
+
   it("has aria-keyshortcuts on wrapper", () => {
     render(<DateInput {...getProps()} />)
     expect(screen.getByTestId("stDateInputField")).toHaveAttribute(

--- a/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
@@ -580,7 +580,7 @@ describe("DateInput", () => {
     )
   })
 
-  it("does not commit placeholder state on blur in a form (non-clearable)", async () => {
+  it("does not commit placeholder state on blur in a form (partially typed)", async () => {
     const user = userEvent.setup()
     const props = getProps({ formId: "form" })
     props.widgetMgr.setFormSubmitBehaviors("form", true)
@@ -592,13 +592,51 @@ describe("DateInput", () => {
     const region = screen.getByTestId("stDateInput")
     const { year } = getSingleDateSegments(region)
 
-    // Partially clear the year segment (leaves placeholders)
+    // Partially clear the year segment (leaves placeholders in year,
+    // but month and day remain filled — a mid-edit state)
     await clearSegment(user, year)
 
-    // Blur should NOT commit the placeholder state — form submit should
-    // read the original committed value, not an empty/cleared date.
+    // Blur should NOT commit the partially typed state — form submit
+    // should read the original committed value, not an incomplete date.
     await user.tab()
     expect(props.widgetMgr.setStringArrayValue).not.toHaveBeenCalled()
+  })
+
+  it("commits cleared value on blur when all segments are cleared in a clearable form widget", async () => {
+    const user = userEvent.setup()
+    // default: [] makes the widget clearable
+    const props = getProps({ formId: "form", default: [] })
+    props.widgetMgr.setFormSubmitBehaviors("form", true)
+    vi.spyOn(props.widgetMgr, "setStringArrayValue")
+
+    // Pre-seed widget state so the widget starts with a committed value
+    props.widgetMgr.setStringArrayValue(
+      props.element,
+      [originalDateWire],
+      { fromUi: false },
+      undefined
+    )
+
+    render(<DateInput {...props} />)
+    vi.mocked(props.widgetMgr.setStringArrayValue).mockClear()
+
+    const region = screen.getByTestId("stDateInput")
+    const { year, month, day } = getSingleDateSegments(region)
+
+    // Clear ALL segments — deliberate empty intent
+    await clearSegment(user, year)
+    await clearSegment(user, month)
+    await clearSegment(user, day)
+
+    // Blur should commit the cleared state — fully cleared is a valid
+    // user intent, distinct from partially typed (mid-edit).
+    await user.tab()
+    expect(props.widgetMgr.setStringArrayValue).toHaveBeenCalledWith(
+      props.element,
+      [],
+      { fromUi: true },
+      undefined
+    )
   })
 
   describe("localization", () => {

--- a/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
@@ -1729,7 +1729,7 @@ describe("DateInput single-mode keyboard navigation", () => {
     })
   })
 
-  it("partially cleared segments revert to default on popover close (non-clearable)", async () => {
+  it("partially cleared segments revert to committed value on popover close (non-clearable)", async () => {
     const user = userEvent.setup()
     const props = getProps()
     render(<DateInput {...props} />)
@@ -1759,10 +1759,8 @@ describe("DateInput single-mode keyboard navigation", () => {
       { timeout: 2000 }
     )
 
-    // After close, segments should revert to the default value (1970/01/20).
-    // SingleDateInput reports placeholder segments to handleClose, which
-    // reverts the value to element.default. The controlled value change causes
-    // the DateField to rebuild its segments.
+    // After close, segments revert to the last committed value (1970/01/20,
+    // which equals the default since user hasn't changed it yet).
     await waitFor(
       () => {
         const region2 = screen.getByTestId("stDateInput")
@@ -1770,6 +1768,68 @@ describe("DateInput single-mode keyboard navigation", () => {
         expect(refreshedSegments.year).toHaveTextContent("1970")
         expect(refreshedSegments.month).toHaveTextContent("01")
         expect(refreshedSegments.day).toHaveTextContent("20")
+      },
+      { timeout: 2000 }
+    )
+  })
+
+  it("cleared segments revert to last committed value (not default) after prior selection", async () => {
+    const user = userEvent.setup()
+    const props = getProps()
+    vi.spyOn(props.widgetMgr, "setStringArrayValue")
+    render(<DateInput {...props} />)
+    vi.mocked(props.widgetMgr.setStringArrayValue).mockClear()
+
+    const region = screen.getByTestId("stDateInput")
+    const { year, month, day } = getSingleDateSegments(region)
+
+    // Type a new date (1970/01/25) different from default (1970/01/20).
+    // Typing opens the calendar; the new date commits on close.
+    await typeIntoSegment(user, year, "1970")
+    await typeIntoSegment(user, month, "01")
+    await typeIntoSegment(user, day, "25")
+
+    // Close via Escape — commits the typed date (1970-01-25).
+    await user.keyboard("{Escape}")
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("stDateInputCalendar")
+      ).not.toBeInTheDocument()
+    })
+    await waitFor(() => {
+      expect(props.widgetMgr.setStringArrayValue).toHaveBeenCalledWith(
+        props.element,
+        ["1970-01-25"],
+        { fromUi: true },
+        undefined
+      )
+    })
+
+    // Now clear all segments and close again — should revert to the
+    // committed value (1970/01/25), NOT element.default (1970/01/20).
+    const refreshed1 = getSingleDateSegments(screen.getByTestId("stDateInput"))
+    await clearSegment(user, refreshed1.year)
+    await clearSegment(user, refreshed1.month)
+    await clearSegment(user, refreshed1.day)
+    await user.keyboard("{Escape}")
+
+    await waitFor(
+      () => {
+        expect(
+          screen.queryByTestId("stDateInputCalendar")
+        ).not.toBeInTheDocument()
+      },
+      { timeout: 2000 }
+    )
+
+    await waitFor(
+      () => {
+        const refreshed2 = getSingleDateSegments(
+          screen.getByTestId("stDateInput")
+        )
+        expect(refreshed2.year).toHaveTextContent("1970")
+        expect(refreshed2.month).toHaveTextContent("01")
+        expect(refreshed2.day).toHaveTextContent("25")
       },
       { timeout: 2000 }
     )

--- a/frontend/lib/src/components/widgets/DateInput/DateInput.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/DateInput.tsx
@@ -69,7 +69,6 @@ function DateInput({
   fragmentId,
 }: Props): ReactElement {
   const isInSidebar = useContext(IsSidebarContext)
-  const [isEmpty, setIsEmpty] = useState(false)
   const [error, setError] = useState<string | null>(null)
   // Incremented on form clear to signal SingleDateInput to reset its local
   // displayValue (which may have diverged from widget state due to buffering).
@@ -81,7 +80,6 @@ function DateInput({
 
   const handleFormCleared = useCallback(() => {
     resetError()
-    setIsEmpty(false)
     setFormResetKey(k => k + 1)
   }, [resetError])
 
@@ -169,7 +167,6 @@ function DateInput({
 
       if (!date) {
         setValueWithSource({ value: [], fromUi: true })
-        setIsEmpty(true)
         return
       }
 
@@ -179,7 +176,6 @@ function DateInput({
         return
       }
       setValueWithSource({ value: [calendarDateToIso(date)], fromUi: true })
-      setIsEmpty(false)
     },
     [
       buildErrorMessage,
@@ -242,17 +238,17 @@ function DateInput({
     ]
   )
 
-  // Revert to default on close when field is empty or partially cleared.
+  // Revert to last committed value on close when segments are partially
+  // cleared (incomplete date that shouldn't be committed).
   const handleClose = useCallback(
     (hasPlaceholderSegments?: boolean): void => {
-      if (!isEmpty && !hasPlaceholderSegments) {
+      if (!hasPlaceholderSegments) {
         return
       }
       resetError()
-      setValueWithSource({ value: element.default, fromUi: true })
-      setIsEmpty(element.default.length === 0)
+      setValueWithSource({ value, fromUi: true })
     },
-    [isEmpty, element.default, setValueWithSource, resetError]
+    [value, setValueWithSource, resetError]
   )
 
   // Synchronous commit for form-submit races: when inside a form, clicking

--- a/frontend/lib/src/components/widgets/DateInput/DateInput.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/DateInput.tsx
@@ -238,17 +238,19 @@ function DateInput({
     ]
   )
 
-  // Revert to last committed value on close when segments are partially
-  // cleared (incomplete date that shouldn't be committed).
+  // Revert to last committed value on close when segments still show
+  // placeholders (partially typed, or fully cleared on a non-clearable widget).
+  // The display revert is handled by SingleDateInput/RangeDateInput locally;
+  // here we only clear the validation error. No setValueWithSource needed
+  // because the committed value never changed (edits were buffered locally).
   const handleClose = useCallback(
     (hasPlaceholderSegments?: boolean): void => {
       if (!hasPlaceholderSegments) {
         return
       }
       resetError()
-      setValueWithSource({ value, fromUi: true })
     },
-    [value, setValueWithSource, resetError]
+    [resetError]
   )
 
   // Synchronous commit for form-submit races: when inside a form, clicking

--- a/frontend/lib/src/components/widgets/DateInput/DateInput.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/DateInput.tsx
@@ -262,7 +262,6 @@ function DateInput({
   const handleFormCommit = useCallback(
     (date: CalendarDate | null): void => {
       if (!inForm) return
-      if (!date && !clearable) return
       const isoValue = date ? [calendarDateToIso(date)] : []
       updateWidgetMgrState(
         element,
@@ -271,7 +270,7 @@ function DateInput({
         fragmentId
       )
     },
-    [inForm, clearable, element, widgetMgr, fragmentId]
+    [inForm, element, widgetMgr, fragmentId]
   )
 
   const handleRangeFormCommit = useCallback(

--- a/frontend/lib/src/components/widgets/DateInput/RangeDateInput.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/RangeDateInput.tsx
@@ -340,13 +340,13 @@ function RangeDateInput({
   // When entering active mode, move focus to the focused calendar cell.
   useEffect(() => {
     if (!isCalendarActive || !isOpen) return
-    const id = requestAnimationFrame(() => {
+    const rafId = requestAnimationFrame(() => {
       const cell = popoverRef.current?.querySelector<HTMLElement>(
         '[role="grid"] [tabindex="0"]'
       )
       cell?.focus()
     })
-    return () => cancelAnimationFrame(id)
+    return () => cancelAnimationFrame(rafId)
   }, [isCalendarActive, isOpen])
 
   const overlayOptions = useMemo(() => {
@@ -581,6 +581,9 @@ function RangeDateInput({
 
   // In active mode: Tab cycles focus within the popover (focus trap).
   // In passive mode: Tab moves to quick-select or closes the popover.
+  // Scoped to popoverRef only — portaled month/year pickers and the
+  // quick-select listbox self-dismiss on Tab (stopPropagation + restore
+  // trigger focus in CalendarPopoverHeader / handleQuickSelectKeyDown).
   const handlePopoverKeyDown = useCallback(
     (e: KeyboardEvent<HTMLDivElement>): void => {
       if (e.key !== "Tab") return
@@ -775,13 +778,13 @@ function RangeDateInput({
     <StyledDateFieldContainer>
       <StyledDateInputWrapper
         ref={setTriggerRef}
-        data-testid="stDateInputField"
-        data-disabled={disabled || undefined}
-        data-has-error={error ? "" : undefined}
         aria-keyshortcuts="Alt+ArrowDown"
         aria-haspopup="dialog"
         aria-expanded={isOpen}
         aria-controls={isOpen ? popoverId : undefined}
+        data-testid="stDateInputField"
+        data-disabled={disabled || undefined}
+        data-has-error={error ? "" : undefined}
         onFocus={handleFocus}
         onBlur={handleBlur}
         onClickCapture={handleClickCapture}

--- a/frontend/lib/src/components/widgets/DateInput/RangeDateInput.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/RangeDateInput.tsx
@@ -340,12 +340,13 @@ function RangeDateInput({
   // When entering active mode, move focus to the focused calendar cell.
   useEffect(() => {
     if (!isCalendarActive || !isOpen) return
-    requestAnimationFrame(() => {
+    const id = requestAnimationFrame(() => {
       const cell = popoverRef.current?.querySelector<HTMLElement>(
         '[role="grid"] [tabindex="0"]'
       )
       cell?.focus()
     })
+    return () => cancelAnimationFrame(id)
   }, [isCalendarActive, isOpen])
 
   const overlayOptions = useMemo(() => {
@@ -678,6 +679,17 @@ function RangeDateInput({
     [handleClear, handleQuickSelect]
   )
 
+  const handleQuickSelectKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLDivElement>): void => {
+      if (e.key === "Tab") {
+        e.preventDefault()
+        setIsQuickSelectOpen(false)
+        quickSelectTriggerRef.current?.focus()
+      }
+    },
+    []
+  )
+
   const makeHandlePaste = useCallback(
     (
       currentValue: CalendarDate | null,
@@ -922,23 +934,26 @@ function RangeDateInput({
                   placement="bottom end"
                   data-testid="stDateInputQuickSelectPopover"
                 >
-                  <StyledDropdownListBox
-                    aria-label="Quick select a date range"
-                    selectionMode="single"
-                    disallowEmptySelection={!clearable}
-                    selectedKeys={activePreset ? [activePreset.id] : []}
-                    onSelectionChange={handleQuickSelectSelection}
-                    autoFocus
-                  >
-                    {quickSelectPresets.map(preset => (
-                      <StyledDropdownListBoxItem
-                        key={preset.id}
-                        id={preset.id}
-                      >
-                        {preset.label}
-                      </StyledDropdownListBoxItem>
-                    ))}
-                  </StyledDropdownListBox>
+                  {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
+                  <div onKeyDown={handleQuickSelectKeyDown}>
+                    <StyledDropdownListBox
+                      aria-label="Quick select a date range"
+                      selectionMode="single"
+                      disallowEmptySelection={!clearable}
+                      selectedKeys={activePreset ? [activePreset.id] : []}
+                      onSelectionChange={handleQuickSelectSelection}
+                      autoFocus
+                    >
+                      {quickSelectPresets.map(preset => (
+                        <StyledDropdownListBoxItem
+                          key={preset.id}
+                          id={preset.id}
+                        >
+                          {preset.label}
+                        </StyledDropdownListBoxItem>
+                      ))}
+                    </StyledDropdownListBox>
+                  </div>
                 </StyledDropdownPopover>
               </StyledQuickSelectRow>
             )}

--- a/frontend/lib/src/components/widgets/DateInput/RangeDateInput.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/RangeDateInput.tsx
@@ -683,6 +683,7 @@ function RangeDateInput({
     (e: KeyboardEvent<HTMLDivElement>): void => {
       if (e.key === "Tab") {
         e.preventDefault()
+        e.stopPropagation()
         setIsQuickSelectOpen(false)
         quickSelectTriggerRef.current?.focus()
       }

--- a/frontend/lib/src/components/widgets/DateInput/RangeDateInput.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/RangeDateInput.tsx
@@ -745,6 +745,7 @@ function RangeDateInput({
     (e: FocusEvent<HTMLDivElement>): void => {
       if (e.currentTarget.contains(e.relatedTarget)) return
       if (!formCommit) return
+      if (isCalendarActiveRef.current) return
       if (hasPartiallyTypedField(triggerRef.current)) return
       const pending = compact([displayStartRef.current, displayEndRef.current])
       const committed = compact([startValue, endValue])

--- a/frontend/lib/src/components/widgets/DateInput/RangeDateInput.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/RangeDateInput.tsx
@@ -394,6 +394,18 @@ function RangeDateInput({
       onClose: () => {
         setIsOpenState(false)
         setIsCalendarActive(false)
+        // Synchronous form commit: outside-click dismiss can race form submit
+        // (the close-commit effect fires after paint). Mirrors handleBlur.
+        if (formCommit && !hasPartiallyTypedField(triggerRef.current)) {
+          const pending = compact([
+            displayStartRef.current,
+            displayEndRef.current,
+          ])
+          const committed = compact([startValue, endValue])
+          if (!rangeEqual(pending, committed)) {
+            formCommit(pending)
+          }
+        }
       },
       floatingSetFn: refs.setFloating,
       referenceSetFn: refs.setReference,

--- a/frontend/lib/src/components/widgets/DateInput/RangeDateInput.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/RangeDateInput.tsx
@@ -232,8 +232,16 @@ function RangeDateInput({
   const clearButtonRef = useRef<HTMLButtonElement | null>(null)
   const skipCloseCommitRef = useRef(false)
   // Guards against `handleFocus` reopening the popover during programmatic
-  // focus restoration (see `focusLastFieldSegment` below).
+  // focus restoration (see `restoreFocusToField` below).
   const isRestoringFocusRef = useRef(false)
+
+  // Dual-mode state: passive (visual aid) vs active (keyboard-modal).
+  const [isCalendarActive, setIsCalendarActive] = useState(false)
+  const isCalendarActiveRef = useRef(false)
+  isCalendarActiveRef.current = isCalendarActive
+  const activeOriginRef = useRef<HTMLElement | null>(null)
+  const popoverRef = useRef<HTMLDivElement | null>(null)
+
   // True while in "anchor mode": user clicked a day to start a new range
   // and the calendar is waiting for the second click to complete it.
   // The anchor VALUE is always `displayStartRef.current` — never stored
@@ -327,6 +335,17 @@ function RangeDateInput({
     wasOpenRef.current = isOpen
   }, [isOpen, startValue, endValue])
 
+  // When entering active mode, move focus to the focused calendar cell.
+  useEffect(() => {
+    if (!isCalendarActive || !isOpen) return
+    requestAnimationFrame(() => {
+      const cell = popoverRef.current?.querySelector<HTMLElement>(
+        '[role="grid"] [tabindex="0"]'
+      )
+      cell?.focus()
+    })
+  }, [isCalendarActive, isOpen])
+
   const overlayOptions = useMemo(() => {
     const base = {
       open: isOpen,
@@ -346,34 +365,50 @@ function RangeDateInput({
 
   const { refs, floatingStyles } = useFloatingOverlay(overlayOptions)
 
-  const focusLastFieldSegment = useCallback((): void => {
-    const segments = triggerRef.current?.querySelectorAll<HTMLElement>(
-      '[role="spinbutton"]'
-    )
-    const lastSegment = segments?.[segments.length - 1]
+  const restoreFocusToField = useCallback((): void => {
     isRestoringFocusRef.current = true
-    if (lastSegment) {
-      lastSegment.focus()
+    if (isCalendarActiveRef.current && activeOriginRef.current) {
+      activeOriginRef.current.focus()
     } else {
-      triggerRef.current?.focus()
+      const segments = triggerRef.current?.querySelectorAll<HTMLElement>(
+        '[role="spinbutton"]'
+      )
+      const lastSegment = segments?.[segments.length - 1]
+      if (lastSegment) {
+        lastSegment.focus()
+      } else {
+        triggerRef.current?.focus()
+      }
     }
     requestAnimationFrame(() => {
       isRestoringFocusRef.current = false
     })
   }, [])
 
-  const { setFloatingRef, setReferenceRef } = useOverlayDismissal({
-    isOpen,
-    onClose: () => setIsOpenState(false),
-    floatingSetFn: refs.setFloating,
-    referenceSetFn: refs.setReference,
-    restoreFocusFn: focusLastFieldSegment,
-    excludeSelectors: [
-      '[data-testid="stDateInputHeaderPickerPopover"]',
-      '[data-testid="stDateInputQuickSelectPopover"]',
-    ],
-    excludeEscape: true,
-  })
+  const { setFloatingRef: setDismissalFloatingRef, setReferenceRef } =
+    useOverlayDismissal({
+      isOpen,
+      onClose: () => {
+        setIsOpenState(false)
+        setIsCalendarActive(false)
+      },
+      floatingSetFn: refs.setFloating,
+      referenceSetFn: refs.setReference,
+      restoreFocusFn: restoreFocusToField,
+      excludeSelectors: [
+        '[data-testid="stDateInputHeaderPickerPopover"]',
+        '[data-testid="stDateInputQuickSelectPopover"]',
+      ],
+      excludeEscape: true,
+    })
+
+  const setFloatingRef = useCallback(
+    (node: HTMLDivElement | null): void => {
+      popoverRef.current = node
+      setDismissalFloatingRef(node)
+    },
+    [setDismissalFloatingRef]
+  )
 
   const setTriggerRef = useCallback(
     (node: HTMLDivElement | null): void => {
@@ -494,7 +529,8 @@ function RangeDateInput({
           onChange([start, end])
           skipCloseCommitRef.current = true
           setIsOpenState(false)
-          focusLastFieldSegment()
+          restoreFocusToField()
+          setIsCalendarActive(false)
           return
         }
       }
@@ -506,15 +542,24 @@ function RangeDateInput({
       onChange([range.start, range.end])
       skipCloseCommitRef.current = true
       setIsOpenState(false)
-      focusLastFieldSegment()
+      restoreFocusToField()
+      setIsCalendarActive(false)
     },
-    [onChange, focusLastFieldSegment]
+    [onChange, restoreFocusToField]
   )
 
-  // Tab from edge segments closes the popover and lets focus leave the widget
-  // naturally (keyboard users type dates directly in segments).
+  // Alt+ArrowDown enters active calendar mode; Tab from edge segments
+  // closes the passive popover and lets focus leave the widget naturally.
   const handleFieldKeyDown = useCallback(
     (e: KeyboardEvent<HTMLDivElement>): void => {
+      if (e.altKey && e.key === "ArrowDown") {
+        e.preventDefault()
+        activeOriginRef.current = e.target as HTMLElement
+        if (!isOpen) setIsOpenState(true)
+        setIsCalendarActive(true)
+        return
+      }
+
       if (e.key !== "Tab" || !isOpen) return
       const wrapper = triggerRef.current
       if (!wrapper) return
@@ -531,26 +576,57 @@ function RangeDateInput({
     [isOpen]
   )
 
+  // In active mode: Tab cycles focus within the popover (focus trap).
+  // In passive mode: Tab moves to quick-select or closes the popover.
   const handlePopoverKeyDown = useCallback(
     (e: KeyboardEvent<HTMLDivElement>): void => {
       if (e.key !== "Tab") return
-      const quickSelectBtn = quickSelectTriggerRef.current
-      // Forward-Tab inside calendar with quick-select available: move to it
-      if (
-        !e.shiftKey &&
-        quickSelectBtn &&
-        !quickSelectBtn.contains(e.target as Node)
-      ) {
+
+      if (!isCalendarActiveRef.current) {
+        // Passive mode: existing behavior
+        const quickSelectBtn = quickSelectTriggerRef.current
+        if (
+          !e.shiftKey &&
+          quickSelectBtn &&
+          !quickSelectBtn.contains(e.target as Node)
+        ) {
+          e.preventDefault()
+          quickSelectBtn.focus()
+          return
+        }
         e.preventDefault()
-        quickSelectBtn.focus()
+        setIsOpenState(false)
+        restoreFocusToField()
         return
       }
-      // Everything else (Shift+Tab, or Tab from quick-select): close
+
+      // Active mode: cycle through focusable elements within the popover
       e.preventDefault()
-      setIsOpenState(false)
-      focusLastFieldSegment()
+      const popover = popoverRef.current
+      if (!popover) return
+
+      const focusables = Array.from(
+        popover.querySelectorAll<HTMLElement>(
+          'button:not([tabindex="-1"]):not([disabled]), [tabindex="0"]'
+        )
+      )
+
+      if (focusables.length === 0) return
+
+      const currentIndex = focusables.indexOf(
+        document.activeElement as HTMLElement
+      )
+      let nextIndex: number
+      if (e.shiftKey) {
+        nextIndex =
+          currentIndex <= 0 ? focusables.length - 1 : currentIndex - 1
+      } else {
+        nextIndex =
+          currentIndex >= focusables.length - 1 ? 0 : currentIndex + 1
+      }
+      focusables[nextIndex].focus()
     },
-    [focusLastFieldSegment]
+    [restoreFocusToField]
   )
 
   // First click of a new range (from empty/partial state)
@@ -686,6 +762,7 @@ function RangeDateInput({
         data-testid="stDateInputField"
         data-disabled={disabled || undefined}
         data-has-error={error ? "" : undefined}
+        aria-keyshortcuts="Alt+ArrowDown"
         onFocus={handleFocus}
         onBlur={handleBlur}
         onClickCapture={handleClickCapture}
@@ -769,6 +846,9 @@ function RangeDateInput({
             style={floatingStyles}
             data-testid="stDateInputCalendar"
             onKeyDown={handlePopoverKeyDown}
+            role={isCalendarActive ? "dialog" : undefined}
+            aria-modal={isCalendarActive ? "true" : undefined}
+            aria-label={isCalendarActive ? "Choose date range" : undefined}
           >
             <I18nProvider locale={safeLocale}>
               <StyledRangeCalendarRoot

--- a/frontend/lib/src/components/widgets/DateInput/RangeDateInput.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/RangeDateInput.tsx
@@ -216,6 +216,8 @@ function RangeDateInput({
   const theme = useEmotionTheme()
   const id = useId()
   const errorId = `${id}-error`
+  const popoverId = `${id}-calendar`
+  const popoverDescId = `${id}-calendar-desc`
   const triggerRef = useRef<HTMLDivElement | null>(null)
   const safeLocale = useMemo(() => getSafeLocale(locale), [locale])
   // today() inside getQuickSelectPresets is intentionally not a dep — the
@@ -763,6 +765,9 @@ function RangeDateInput({
         data-disabled={disabled || undefined}
         data-has-error={error ? "" : undefined}
         aria-keyshortcuts="Alt+ArrowDown"
+        aria-haspopup="dialog"
+        aria-expanded={isOpen}
+        aria-controls={isOpen ? popoverId : undefined}
         onFocus={handleFocus}
         onBlur={handleBlur}
         onClickCapture={handleClickCapture}
@@ -842,6 +847,7 @@ function RangeDateInput({
       {isOpen && (
         <FloatingPortal id={FLOATING_OVERLAY_PORTAL_ID}>
           <StyledCalendarPopover
+            id={popoverId}
             ref={setFloatingRef}
             style={floatingStyles}
             data-testid="stDateInputCalendar"
@@ -849,7 +855,14 @@ function RangeDateInput({
             role={isCalendarActive ? "dialog" : undefined}
             aria-modal={isCalendarActive ? "true" : undefined}
             aria-label={isCalendarActive ? "Choose date range" : undefined}
+            aria-describedby={isCalendarActive ? popoverDescId : undefined}
           >
+            {isCalendarActive && (
+              <StyledVisuallyHidden id={popoverDescId}>
+                Use arrow keys to navigate dates. Enter to select. Escape to
+                close.
+              </StyledVisuallyHidden>
+            )}
             <I18nProvider locale={safeLocale}>
               <StyledRangeCalendarRoot
                 aria-label="Choose date range"

--- a/frontend/lib/src/components/widgets/DateInput/RangeDateInput.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/RangeDateInput.tsx
@@ -450,6 +450,9 @@ function RangeDateInput({
   const handleClickCapture = useCallback(
     (e: MouseEvent<HTMLDivElement>): void => {
       if (clearButtonRef.current?.contains(e.target as Node)) return
+      // Pointer-only: active mode enters via rAF, so handleFocus can't reset
+      // it without breaking Tab cycling inside the calendar.
+      setIsCalendarActive(false)
       handleFocus()
     },
     [handleFocus]

--- a/frontend/lib/src/components/widgets/DateInput/SingleDateInput.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/SingleDateInput.tsx
@@ -239,12 +239,13 @@ function SingleDateInput({
   // When entering active mode, move focus to the focused calendar cell.
   useEffect(() => {
     if (!isCalendarActive || !isOpen) return
-    requestAnimationFrame(() => {
+    const id = requestAnimationFrame(() => {
       const cell = popoverRef.current?.querySelector<HTMLElement>(
         '[role="grid"] [tabindex="0"]'
       )
       cell?.focus()
     })
+    return () => cancelAnimationFrame(id)
   }, [isCalendarActive, isOpen])
 
   // In the sidebar, flip/shift are bounded to the viewport

--- a/frontend/lib/src/components/widgets/DateInput/SingleDateInput.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/SingleDateInput.tsx
@@ -98,8 +98,9 @@ interface SingleDateInputProps {
    * committing the value to widget state. Used for real-time error
    * feedback during segment editing. */
   onValidate: (date: CalendarDate | null) => void
-  /** Called when close requires parent-level revert logic (segments left in
-   * placeholder state after an edit). Parent resets to default value. */
+  /** Called when close requires parent-level cleanup (segments left in
+   * placeholder state after an edit). Parent clears the validation error;
+   * the display revert is handled locally. */
   onClose: (hasPlaceholderSegments: boolean) => void
   /** When inside a form, writes the pending value to WidgetStateManager
    * synchronously on blur so a concurrent form submit reads the correct
@@ -364,6 +365,9 @@ function SingleDateInput({
   const handleClickCapture = useCallback(
     (e: MouseEvent<HTMLDivElement>): void => {
       if (clearButtonRef.current?.contains(e.target as Node)) return
+      // Pointer-only: active mode enters via rAF, so handleFocus can't reset
+      // it without breaking Tab cycling inside the calendar.
+      setIsCalendarActive(false)
       handleFocus()
     },
     [handleFocus]

--- a/frontend/lib/src/components/widgets/DateInput/SingleDateInput.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/SingleDateInput.tsx
@@ -199,25 +199,40 @@ function SingleDateInput({
       if (skipCloseCommitRef.current) {
         skipCloseCommitRef.current = false
       } else {
-        const pending = displayValueRef.current
-        const hasPlaceholders =
-          triggerRef.current?.querySelector('[data-placeholder="true"]') !==
-          null
+        const segments = triggerRef.current?.querySelectorAll(
+          '[role="spinbutton"]'
+        )
+        const placeholders = triggerRef.current?.querySelectorAll(
+          '[role="spinbutton"][data-placeholder="true"]'
+        )
+        const isPartiallyTyped =
+          segments &&
+          placeholders &&
+          placeholders.length > 0 &&
+          placeholders.length < segments.length
+        const allCleared =
+          segments &&
+          segments.length > 0 &&
+          placeholders?.length === segments.length
 
-        if (hasPlaceholders && !datesEqual(pending, value)) {
-          // User left segments incomplete — revert display to the committed
-          // value directly. We can't go through the parent round-trip because
-          // the widget state might already be at default (segment edits were
-          // buffered), making the parent's revert a no-op.
+        if (isPartiallyTyped || (allCleared && !clearable)) {
+          // User left segments incomplete, or fully cleared a non-clearable
+          // widget — revert display to the committed value directly. We can't
+          // go through the parent round-trip because the widget state might
+          // already be at default (segment edits were buffered), making the
+          // parent's revert a no-op.
           setDisplayValue(value)
           onCloseRef.current(true /* hasPlaceholderSegments */)
-        } else if (!datesEqual(pending, value)) {
-          onChangeRef.current(pending)
+        } else {
+          const pending = allCleared ? null : displayValueRef.current
+          if (!datesEqual(pending, value)) {
+            onChangeRef.current(pending)
+          }
         }
       }
     }
     wasOpenRef.current = isOpen
-  }, [isOpen, value])
+  }, [isOpen, value, clearable])
 
   // When entering active mode, move focus to the focused calendar cell.
   useEffect(() => {
@@ -466,9 +481,17 @@ function SingleDateInput({
     (e: FocusEvent<HTMLDivElement>): void => {
       if (e.currentTarget.contains(e.relatedTarget)) return
       if (!formCommit) return
-      const hasPlaceholders =
-        triggerRef.current?.querySelector('[data-placeholder="true"]') !== null
-      if (hasPlaceholders) return
+      const segments = triggerRef.current?.querySelectorAll(
+        '[role="spinbutton"]'
+      )
+      const placeholders = triggerRef.current?.querySelectorAll(
+        '[role="spinbutton"][data-placeholder="true"]'
+      )
+      if (segments && placeholders) {
+        const isPartiallyTyped =
+          placeholders.length > 0 && placeholders.length < segments.length
+        if (isPartiallyTyped) return
+      }
       const pending = displayValueRef.current
       if (!datesEqual(pending, value)) {
         formCommit(pending)

--- a/frontend/lib/src/components/widgets/DateInput/SingleDateInput.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/SingleDateInput.tsx
@@ -494,13 +494,15 @@ function SingleDateInput({
         const isPartiallyTyped =
           placeholders.length > 0 && placeholders.length < segments.length
         if (isPartiallyTyped) return
+        const isFullyCleared = placeholders.length === segments.length
+        if (isFullyCleared && !clearable) return
       }
       const pending = displayValueRef.current
       if (!datesEqual(pending, value)) {
         formCommit(pending)
       }
     },
-    [formCommit, value]
+    [formCommit, value, clearable]
   )
 
   return (

--- a/frontend/lib/src/components/widgets/DateInput/SingleDateInput.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/SingleDateInput.tsx
@@ -483,6 +483,7 @@ function SingleDateInput({
     (e: FocusEvent<HTMLDivElement>): void => {
       if (e.currentTarget.contains(e.relatedTarget)) return
       if (!formCommit) return
+      if (isCalendarActiveRef.current) return
       const segments = triggerRef.current?.querySelectorAll(
         '[role="spinbutton"]'
       )

--- a/frontend/lib/src/components/widgets/DateInput/SingleDateInput.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/SingleDateInput.tsx
@@ -133,6 +133,8 @@ function SingleDateInput({
   const theme = useEmotionTheme()
   const id = useId()
   const errorId = `${id}-error`
+  const popoverId = `${id}-calendar`
+  const popoverDescId = `${id}-calendar-desc`
   const triggerRef = useRef<HTMLDivElement | null>(null)
   const clearButtonRef = useRef<HTMLButtonElement | null>(null)
   const safeLocale = useMemo(() => getSafeLocale(locale), [locale])
@@ -508,6 +510,9 @@ function SingleDateInput({
         data-disabled={disabled || undefined}
         data-has-error={error ? "" : undefined}
         aria-keyshortcuts="Alt+ArrowDown"
+        aria-haspopup="dialog"
+        aria-expanded={isOpen}
+        aria-controls={isOpen ? popoverId : undefined}
         onFocus={handleFocus}
         onBlur={handleBlur}
         onClickCapture={handleClickCapture}
@@ -568,6 +573,7 @@ function SingleDateInput({
       {isOpen && (
         <FloatingPortal id={FLOATING_OVERLAY_PORTAL_ID}>
           <StyledCalendarPopover
+            id={popoverId}
             ref={setFloatingRef}
             style={floatingStyles}
             data-testid="stDateInputCalendar"
@@ -575,7 +581,14 @@ function SingleDateInput({
             role={isCalendarActive ? "dialog" : undefined}
             aria-modal={isCalendarActive ? "true" : undefined}
             aria-label={isCalendarActive ? "Choose date" : undefined}
+            aria-describedby={isCalendarActive ? popoverDescId : undefined}
           >
+            {isCalendarActive && (
+              <StyledVisuallyHidden id={popoverDescId}>
+                Use arrow keys to navigate dates. Enter to select. Escape to
+                close.
+              </StyledVisuallyHidden>
+            )}
             {/* Calendar locale is the visitor's locale (not the field's
                 fixed en-US). safeLocale guards against malformed tags. */}
             <I18nProvider locale={safeLocale}>

--- a/frontend/lib/src/components/widgets/DateInput/SingleDateInput.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/SingleDateInput.tsx
@@ -137,12 +137,20 @@ function SingleDateInput({
   const clearButtonRef = useRef<HTMLButtonElement | null>(null)
   const safeLocale = useMemo(() => getSafeLocale(locale), [locale])
   // Guards against `handleFocus` reopening the popover it's in the middle
-  // of closing — see `focusLastFieldSegment` below.
+  // of closing — see `restoreFocusToField` below.
   const isRestoringFocusRef = useRef(false)
   // When an action (calendar click, paste, clear) already committed the value
   // via onChange, the close-detection effect should skip its own commit to
   // avoid a redundant write + backend rerun.
   const skipCloseCommitRef = useRef(false)
+
+  // Dual-mode state: passive (visual aid) vs active (keyboard-modal).
+  const [isCalendarActive, setIsCalendarActive] = useState(false)
+  const isCalendarActiveRef = useRef(false)
+  isCalendarActiveRef.current = isCalendarActive
+  // Tracks which segment had focus before Alt+ArrowDown entered active mode.
+  const activeOriginRef = useRef<HTMLElement | null>(null)
+  const popoverRef = useRef<HTMLDivElement | null>(null)
 
   // --- Two-layer state (matches TimeInput/NumberInput pattern) ---
   // `displayValue` tracks what the field shows during editing.
@@ -211,6 +219,17 @@ function SingleDateInput({
     wasOpenRef.current = isOpen
   }, [isOpen, value])
 
+  // When entering active mode, move focus to the focused calendar cell.
+  useEffect(() => {
+    if (!isCalendarActive || !isOpen) return
+    requestAnimationFrame(() => {
+      const cell = popoverRef.current?.querySelector<HTMLElement>(
+        '[role="grid"] [tabindex="0"]'
+      )
+      cell?.focus()
+    })
+  }, [isCalendarActive, isOpen])
+
   // In the sidebar, flip/shift are bounded to the viewport
   // (document.documentElement) rather than the sidebar's overflow:auto
   // clipping rect. Otherwise the calendar cannot flip up when the trigger
@@ -234,36 +253,52 @@ function SingleDateInput({
 
   const { refs, floatingStyles } = useFloatingOverlay(overlayOptions)
 
-  // isRestoringFocusRef prevents handleFocus from reopening the popover
-  // in response to this programmatic focus. Reset via rAF to guarantee
-  // the synthetic focus event has been processed before re-enabling.
-  const focusLastFieldSegment = useCallback((): void => {
-    const segments = triggerRef.current?.querySelectorAll<HTMLElement>(
-      '[role="spinbutton"]'
-    )
-    const lastSegment = segments?.[segments.length - 1]
+  // Restores focus to the date field after the calendar closes.
+  // In active mode: returns to the segment that was focused before
+  // Alt+ArrowDown. In passive mode: returns to the last segment.
+  const restoreFocusToField = useCallback((): void => {
     isRestoringFocusRef.current = true
-    if (lastSegment) {
-      lastSegment.focus()
+    if (isCalendarActiveRef.current && activeOriginRef.current) {
+      activeOriginRef.current.focus()
     } else {
-      triggerRef.current?.focus()
+      const segments = triggerRef.current?.querySelectorAll<HTMLElement>(
+        '[role="spinbutton"]'
+      )
+      const lastSegment = segments?.[segments.length - 1]
+      if (lastSegment) {
+        lastSegment.focus()
+      } else {
+        triggerRef.current?.focus()
+      }
     }
     requestAnimationFrame(() => {
       isRestoringFocusRef.current = false
     })
   }, [])
 
-  const { setFloatingRef, setReferenceRef } = useOverlayDismissal({
-    isOpen,
-    onClose: () => setIsOpen(false),
-    floatingSetFn: refs.setFloating,
-    referenceSetFn: refs.setReference,
-    restoreFocusFn: focusLastFieldSegment,
-    // Exclude the month/year picker popover so Escape closes it first,
-    // not the whole calendar.
-    excludeSelectors: ['[data-testid="stDateInputHeaderPickerPopover"]'],
-    excludeEscape: true,
-  })
+  const { setFloatingRef: setDismissalFloatingRef, setReferenceRef } =
+    useOverlayDismissal({
+      isOpen,
+      onClose: () => {
+        setIsOpen(false)
+        setIsCalendarActive(false)
+      },
+      floatingSetFn: refs.setFloating,
+      referenceSetFn: refs.setReference,
+      restoreFocusFn: restoreFocusToField,
+      // Exclude the month/year picker popover so Escape closes it first,
+      // not the whole calendar.
+      excludeSelectors: ['[data-testid="stDateInputHeaderPickerPopover"]'],
+      excludeEscape: true,
+    })
+
+  const setFloatingRef = useCallback(
+    (node: HTMLDivElement | null): void => {
+      popoverRef.current = node
+      setDismissalFloatingRef(node)
+    },
+    [setDismissalFloatingRef]
+  )
 
   const setTriggerRef = useCallback(
     (node: HTMLDivElement | null): void => {
@@ -293,9 +328,10 @@ function SingleDateInput({
       onChange(date)
       skipCloseCommitRef.current = true
       setIsOpen(false)
-      focusLastFieldSegment()
+      restoreFocusToField()
+      setIsCalendarActive(false)
     },
-    [onChange, focusLastFieldSegment]
+    [onChange, restoreFocusToField]
   )
 
   // Wired to onFocus and onClickCapture: clicking an already-focused segment
@@ -354,11 +390,18 @@ function SingleDateInput({
     [disabled, format, onChange, displayValue, minDate]
   )
 
-  // Tab from edge segments closes the popover and lets focus leave the
-  // widget naturally (Ant Design pattern: calendar is a visual aid for
-  // pointer users; keyboard users type dates directly in the segments).
+  // Alt+ArrowDown enters active calendar mode; Tab from edge segments
+  // closes the passive popover and lets focus leave the widget naturally.
   const handleFieldKeyDown = useCallback(
     (e: KeyboardEvent<HTMLDivElement>): void => {
+      if (e.altKey && e.key === "ArrowDown") {
+        e.preventDefault()
+        activeOriginRef.current = e.target as HTMLElement
+        if (!isOpen) setIsOpen(true)
+        setIsCalendarActive(true)
+        return
+      }
+
       if (e.key !== "Tab" || !isOpen) return
       const wrapper = triggerRef.current
       if (!wrapper) return
@@ -375,17 +418,45 @@ function SingleDateInput({
     [isOpen]
   )
 
-  // If focus lands in the calendar (mouse click on a header control),
-  // Tab closes the popover and returns focus to the field rather than
-  // letting it escape into the page behind the overlay.
+  // In active mode: Tab cycles focus within the calendar (focus trap).
+  // In passive mode: Tab closes the popover and returns focus to the field.
   const handleCalendarKeyDown = useCallback(
     (e: KeyboardEvent<HTMLDivElement>): void => {
       if (e.key !== "Tab") return
       e.preventDefault()
-      setIsOpen(false)
-      focusLastFieldSegment()
+
+      if (!isCalendarActiveRef.current) {
+        setIsOpen(false)
+        restoreFocusToField()
+        return
+      }
+
+      // Active mode: cycle through focusable elements within the popover
+      const popover = popoverRef.current
+      if (!popover) return
+
+      const focusables = Array.from(
+        popover.querySelectorAll<HTMLElement>(
+          'button:not([tabindex="-1"]):not([disabled]), [tabindex="0"]'
+        )
+      )
+
+      if (focusables.length === 0) return
+
+      const currentIndex = focusables.indexOf(
+        document.activeElement as HTMLElement
+      )
+      let nextIndex: number
+      if (e.shiftKey) {
+        nextIndex =
+          currentIndex <= 0 ? focusables.length - 1 : currentIndex - 1
+      } else {
+        nextIndex =
+          currentIndex >= focusables.length - 1 ? 0 : currentIndex + 1
+      }
+      focusables[nextIndex].focus()
     },
-    [focusLastFieldSegment]
+    [restoreFocusToField]
   )
 
   // Synchronous commit on blur for form-submit races: clicking a form's
@@ -413,6 +484,7 @@ function SingleDateInput({
         data-testid="stDateInputField"
         data-disabled={disabled || undefined}
         data-has-error={error ? "" : undefined}
+        aria-keyshortcuts="Alt+ArrowDown"
         onFocus={handleFocus}
         onBlur={handleBlur}
         onClickCapture={handleClickCapture}
@@ -477,6 +549,9 @@ function SingleDateInput({
             style={floatingStyles}
             data-testid="stDateInputCalendar"
             onKeyDown={handleCalendarKeyDown}
+            role={isCalendarActive ? "dialog" : undefined}
+            aria-modal={isCalendarActive ? "true" : undefined}
+            aria-label={isCalendarActive ? "Choose date" : undefined}
           >
             {/* Calendar locale is the visitor's locale (not the field's
                 fixed en-US). safeLocale guards against malformed tags. */}

--- a/frontend/lib/src/components/widgets/DateInput/SingleDateInput.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/SingleDateInput.tsx
@@ -239,13 +239,13 @@ function SingleDateInput({
   // When entering active mode, move focus to the focused calendar cell.
   useEffect(() => {
     if (!isCalendarActive || !isOpen) return
-    const id = requestAnimationFrame(() => {
+    const rafId = requestAnimationFrame(() => {
       const cell = popoverRef.current?.querySelector<HTMLElement>(
         '[role="grid"] [tabindex="0"]'
       )
       cell?.focus()
     })
-    return () => cancelAnimationFrame(id)
+    return () => cancelAnimationFrame(rafId)
   }, [isCalendarActive, isOpen])
 
   // In the sidebar, flip/shift are bounded to the viewport
@@ -438,6 +438,8 @@ function SingleDateInput({
 
   // In active mode: Tab cycles focus within the calendar (focus trap).
   // In passive mode: Tab closes the popover and returns focus to the field.
+  // Scoped to popoverRef only — portaled month/year pickers self-dismiss on
+  // Tab (stopPropagation + restore trigger focus in CalendarPopoverHeader).
   const handleCalendarKeyDown = useCallback(
     (e: KeyboardEvent<HTMLDivElement>): void => {
       if (e.key !== "Tab") return
@@ -510,13 +512,13 @@ function SingleDateInput({
     <StyledDateFieldContainer>
       <StyledDateInputWrapper
         ref={setTriggerRef}
-        data-testid="stDateInputField"
-        data-disabled={disabled || undefined}
-        data-has-error={error ? "" : undefined}
         aria-keyshortcuts="Alt+ArrowDown"
         aria-haspopup="dialog"
         aria-expanded={isOpen}
         aria-controls={isOpen ? popoverId : undefined}
+        data-testid="stDateInputField"
+        data-disabled={disabled || undefined}
+        data-has-error={error ? "" : undefined}
         onFocus={handleFocus}
         onBlur={handleBlur}
         onClickCapture={handleClickCapture}

--- a/frontend/lib/src/components/widgets/DateInput/SingleDateInput.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/SingleDateInput.tsx
@@ -301,6 +301,13 @@ function SingleDateInput({
       onClose: () => {
         setIsOpen(false)
         setIsCalendarActive(false)
+        // Synchronous form commit: outside-click dismiss can race form submit
+        // (the close-commit effect fires after paint). Mirrors handleBlur.
+        if (formCommit && displayValueRef.current) {
+          if (!datesEqual(displayValueRef.current, value)) {
+            formCommit(displayValueRef.current)
+          }
+        }
       },
       floatingSetFn: refs.setFloating,
       referenceSetFn: refs.setReference,

--- a/frontend/lib/src/components/widgets/DateInput/SingleDateInput.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/SingleDateInput.tsx
@@ -303,9 +303,29 @@ function SingleDateInput({
         setIsCalendarActive(false)
         // Synchronous form commit: outside-click dismiss can race form submit
         // (the close-commit effect fires after paint). Mirrors handleBlur.
-        if (formCommit && displayValueRef.current) {
-          if (!datesEqual(displayValueRef.current, value)) {
-            formCommit(displayValueRef.current)
+        if (formCommit) {
+          const segments = triggerRef.current?.querySelectorAll(
+            '[role="spinbutton"]'
+          )
+          const placeholders = triggerRef.current?.querySelectorAll(
+            '[role="spinbutton"][data-placeholder="true"]'
+          )
+          const isPartiallyTyped =
+            segments &&
+            placeholders &&
+            placeholders.length > 0 &&
+            placeholders.length < segments.length
+          const isFullyCleared =
+            segments &&
+            segments.length > 0 &&
+            placeholders?.length === segments.length
+          if (isPartiallyTyped || (isFullyCleared && !clearable)) {
+            // Will revert on next render — don't commit stale/invalid state.
+          } else {
+            const pending = isFullyCleared ? null : displayValueRef.current
+            if (!datesEqual(pending, value)) {
+              formCommit(pending)
+            }
           }
         }
       },

--- a/frontend/lib/src/components/widgets/DateInput/styled-components.ts
+++ b/frontend/lib/src/components/widgets/DateInput/styled-components.ts
@@ -269,13 +269,14 @@ export const StyledCalendarHeaderButton = styled(Button)(({ theme }) => ({
   backgroundColor: "transparent",
   color: theme.colors.bodyText,
   cursor: "pointer",
+  outline: "none",
   "&[data-hovered]": {
     backgroundColor: theme.colors.darkenedBgMix15,
   },
   "&[data-pressed]": {
     backgroundColor: theme.colors.darkenedBgMix25,
   },
-  "&[data-focus-visible]": {
+  "&[data-focus-visible], &:focus-visible": {
     outline: `${theme.sizes.borderWidth} solid ${theme.colors.primary}`,
     outlineOffset: theme.spacing.threeXS,
   },
@@ -329,7 +330,7 @@ export const StyledQuickSelectTrigger = styled(Button, {
   "&[data-pressed]": {
     backgroundColor: theme.colors.darkenedBgMix25,
   },
-  "&[data-focus-visible]": {
+  "&[data-focus-visible], &:focus-visible": {
     boxShadow: `inset 0 0 0 ${theme.sizes.borderWidth} ${theme.colors.primary}`,
   },
 }))
@@ -392,14 +393,14 @@ export const StyledCalendarHeaderSelectTrigger = styled(Button)(
     cursor: "pointer",
     padding: `${theme.spacing.twoXS} ${theme.spacing.twoXS}`,
     maxWidth: "100%",
+    outline: "none",
     "&[data-hovered]": {
       backgroundColor: theme.colors.darkenedBgMix15,
     },
     "&[data-pressed]": {
       backgroundColor: theme.colors.darkenedBgMix25,
     },
-    "&[data-focus-visible]": {
-      outline: "none",
+    "&[data-focus-visible], &:focus-visible": {
       boxShadow: `inset 0 0 0 ${theme.sizes.borderWidth} ${theme.colors.primary}`,
     },
   })

--- a/frontend/lib/src/components/widgets/DateInput/styled-components.ts
+++ b/frontend/lib/src/components/widgets/DateInput/styled-components.ts
@@ -269,7 +269,7 @@ export const StyledCalendarHeaderButton = styled(Button)(({ theme }) => ({
   backgroundColor: "transparent",
   color: theme.colors.bodyText,
   cursor: "pointer",
-  outline: "none",
+  outline: "none", // themed ring via :focus-visible below
   "&[data-hovered]": {
     backgroundColor: theme.colors.darkenedBgMix15,
   },
@@ -393,7 +393,7 @@ export const StyledCalendarHeaderSelectTrigger = styled(Button)(
     cursor: "pointer",
     padding: `${theme.spacing.twoXS} ${theme.spacing.twoXS}`,
     maxWidth: "100%",
-    outline: "none",
+    outline: "none", // themed ring via :focus-visible below
     "&[data-hovered]": {
       backgroundColor: theme.colors.darkenedBgMix15,
     },

--- a/frontend/lib/src/components/widgets/DateInput/styled-components.ts
+++ b/frontend/lib/src/components/widgets/DateInput/styled-components.ts
@@ -533,8 +533,8 @@ export const StyledCalendarCell = styled(CalendarCell, {
         ...rangeEndpointBase,
         backgroundImage: `linear-gradient(to right, transparent 50%, ${rangeTint} 50%)`,
         "&[data-hovered]::after, &[data-focus-visible]::after": {
-          outline: `${borderWidth} solid ${primary}`,
-          outlineOffset: `-${borderWidth}`,
+          outline: `${theme.sizes.focusOutlineWidth} solid ${primary}`,
+          outlineOffset: theme.spacing.threeXS,
         },
         // Outside-month start: no indicator, no tint — just grey text
         "&[data-outside-month]": {
@@ -548,8 +548,8 @@ export const StyledCalendarCell = styled(CalendarCell, {
         ...rangeEndpointBase,
         backgroundImage: `linear-gradient(to left, transparent 50%, ${rangeTint} 50%)`,
         "&[data-hovered]::after, &[data-focus-visible]::after": {
-          outline: `${borderWidth} solid ${primary}`,
-          outlineOffset: `-${borderWidth}`,
+          outline: `${theme.sizes.focusOutlineWidth} solid ${primary}`,
+          outlineOffset: theme.spacing.threeXS,
         },
         // Outside-month end: no indicator, no tint — just grey text
         "&[data-outside-month]": {


### PR DESCRIPTION
## Describe your changes
Follow-up fixes on top of single & range date migrations. Adds keyboard accessibility for the calendar popover and fixes form integration inconsistencies between single and range modes.

- **Keyboard-accessible calendar**: Alt+ArrowDown enters active mode (WAI-ARIA dialog pattern with focus trap, Tab cycling through controls, Escape returns focus to originating segment)
- **ARIA attributes**: `aria-haspopup="dialog"`, `aria-expanded`, `aria-controls`, `aria-describedby` with usage instructions for active calendar dialog
- **Form blur consistency**: SingleDateInput handleBlur now uses "partially typed" check (aligned with RangeDateInput)
- **Close-commit alignment**: SingleDateInput three-way pattern (partially typed → revert, fully cleared + clearable → commit null, fully cleared + non-clearable → revert)
- **Remove clearable guard**: Form-blur-commit always fires with current state; close-commit enforces non-clearable semantics upstream
- **handleClose revert target**: Reverts to last committed value (not `element.default`)
- **Skip spurious form commit on active mode entry**

## Testing Plan
- [x] 101 unit tests pass (new tests for blur commit, revert-to-committed-value, active calendar mode)
- [x] 2 new e2e keyboard navigation tests (single + range active calendar scenarios)
- [x] All e2e functional tests pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches widget state commit timing, form submit races, and keyboard/focus behavior across single and range DateInput—user-visible but well covered by new tests.
> 
> **Overview**
> **DateInput** gains a **passive vs active** calendar: **Alt+ArrowDown** opens the popover as a **WAI-ARIA dialog** (`role="dialog"`, `aria-modal`, usage text), with **Tab** cycling inside the calendar, **Escape** returning focus to the segment that opened it, and nested month/year/quick-select popovers dismissing on **Tab** without closing the whole calendar. The field exposes **`aria-keyshortcuts`**, **`aria-haspopup`**, **`aria-expanded`**, and **`aria-controls`**.
> 
> **Commit and revert behavior** is tightened: closing with **partial** segments or a **fully cleared non-clearable** field **reverts the display to the last committed value** (not `element.default`) without spurious widget writes; **fully cleared clearable** fields commit empty on close/blur. **Form** blur/dismiss paths mirror the same rules (including committing cleared values and skipping commits while active calendar mode is open).
> 
> **CalendarPopoverHeader** and **styled-components** get small focus-ring fixes; **unit and Playwright** tests cover the new keyboard flows and updated revert expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c0b6d1a2ad28dd017a7c440ac3da3d0b44d4ee2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->