### PR TITLE
[fix] Handle Matplotlib non-raster savefig formats in `st.pyplot` (#16429)

### DIFF
--- a/lib/streamlit/elements/pyplot.py
+++ b/lib/streamlit/elements/pyplot.py
@@ -46,18 +46,18 @@ _UNSUPPORTED_VECTOR_MAGIC: Final = {
 
 
 def _svg_markup_or_none(payload: bytes) -> str | None:
-    r"""Return ``payload`` decoded as SVG markup, or ``None`` if it is not SVG.
+    r"""Return SVG markup from ``payload``, or ``None`` if it is not SVG.
 
-    Also handles svgz, which Matplotlib writes for ``format="svgz"`` and which is
-    just gzipped SVG -- inflating it reaches the same SVG path rather than the
-    PNG/PIL path, which cannot parse it.
+    Handles svgz (gzipped SVG) by inflating first, so it reaches the existing SVG
+    path rather than PIL, which cannot parse it.
 
-    Sniffs the buffer rather than reading ``kwargs["format"]``: Matplotlib resolves
-    the format itself, so ``format=None`` with ``rcParams["savefig.format"] = "svg"``
-    still produces SVG. No raster format collides with these prefixes (PNG starts
-    with ``b"\x89PNG"``, JPEG with ``b"\xff\xd8"``). An ``<?xml`` prolog alone is
-    not enough because ``image_to_url`` also requires an ``<svg`` tag, and the search
-    is bounded since Matplotlib emits ``<svg`` within the first few hundred bytes.
+    Sniffs the buffer rather than reading ``kwargs["format"]``, because Matplotlib
+    resolves the format itself -- ``format=None`` with
+    ``rcParams["savefig.format"] = "svg"`` still yields SVG. No raster format shares
+    these prefixes (PNG starts with ``b"\x89PNG"``, JPEG with ``b"\xff\xd8"``). An
+    ``<svg`` tag is required rather than an ``<?xml`` prolog alone, since
+    ``image_to_url`` needs the tag too, and the search is bounded because Matplotlib
+    emits ``<svg`` within the first few hundred bytes.
     """
     if payload[:2] == b"\x1f\x8b":  # gzip magic, i.e. svgz
         try:

--- a/lib/streamlit/elements/pyplot.py
+++ b/lib/streamlit/elements/pyplot.py
@@ -16,8 +16,9 @@
 
 from __future__ import annotations
 
+import gzip
 import io
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Final, cast
 
 from streamlit.deprecation_util import (
     make_deprecated_name_warning,
@@ -25,6 +26,7 @@ from streamlit.deprecation_util import (
 )
 from streamlit.elements.lib.image_utils import marshall_images
 from streamlit.elements.lib.layout_utils import create_layout_config
+from streamlit.errors import StreamlitAPIException
 from streamlit.proto.Image_pb2 import ImageList as ImageListProto
 from streamlit.runtime.metrics_util import gather_metrics
 
@@ -33,6 +35,58 @@ if TYPE_CHECKING:
 
     from streamlit.delta_generator import DeltaGenerator
     from streamlit.elements.lib.layout_utils import LayoutConfig, Width
+
+# Vector output that cannot be turned into an image without an external
+# rasteriser (Ghostscript for PostScript, Poppler for PDF), neither of which
+# Streamlit depends on. Keyed by the magic bytes Matplotlib writes.
+_UNSUPPORTED_VECTOR_MAGIC: Final = {
+    b"%PDF": "PDF",
+    b"%!PS": "PostScript",
+}
+
+
+def _svg_markup_or_none(payload: bytes) -> str | None:
+    r"""Return ``payload`` decoded as SVG markup, or ``None`` if it is not SVG.
+
+    Also handles svgz, which Matplotlib writes for ``format="svgz"`` and which is
+    just gzipped SVG -- inflating it reaches the same SVG path rather than the
+    PNG/PIL path, which cannot parse it.
+
+    Sniffs the buffer rather than reading ``kwargs["format"]``: Matplotlib resolves
+    the format itself, so ``format=None`` with ``rcParams["savefig.format"] = "svg"``
+    still produces SVG. No raster format collides with these prefixes (PNG starts
+    with ``b"\x89PNG"``, JPEG with ``b"\xff\xd8"``). An ``<?xml`` prolog alone is
+    not enough because ``image_to_url`` also requires an ``<svg`` tag, and the search
+    is bounded since Matplotlib emits ``<svg`` within the first few hundred bytes.
+    """
+    if payload[:2] == b"\x1f\x8b":  # gzip magic, i.e. svgz
+        try:
+            payload = gzip.decompress(payload)
+        except (OSError, EOFError):
+            return None
+
+    stripped = payload.lstrip()
+    is_svg = stripped.startswith(b"<svg") or (
+        stripped.startswith(b"<?xml") and b"<svg" in stripped[:2048]
+    )
+    return payload.decode("utf-8") if is_svg else None
+
+
+def _raise_for_unsupported_vector_format(payload: bytes) -> None:
+    """Reject vector output that the image path cannot render.
+
+    Without this, the bytes reach PIL and fail several frames deeper with an
+    opaque ``UnidentifiedImageError`` or ``OSError`` that names neither the
+    format nor a way forward.
+    """
+    for magic, label in _UNSUPPORTED_VECTOR_MAGIC.items():
+        if payload.startswith(magic):
+            raise StreamlitAPIException(
+                f"`st.pyplot` cannot display {label} output, since rendering it "
+                "requires an external tool that Streamlit does not bundle. Use "
+                '`format="png"` (the default) for a raster image, or '
+                '`format="svg"` to keep the output as scalable vector graphics.'
+            )
 
 
 class PyplotMixin:
@@ -224,22 +278,14 @@ def marshall(
     image = io.BytesIO()
     fig.savefig(image, **kwargs)
 
-    # SVG is text, not raster bytes, so decode it to a string and let
-    # image_to_url take its SVG path instead of the PNG/PIL path, which cannot
-    # parse SVG and crashes.
-    #
-    # Sniff the buffer rather than reading kwargs["format"]: Matplotlib resolves
-    # the format itself, so format=None with rcParams["savefig.format"] = "svg"
-    # still produces SVG. No raster format collides with these prefixes (PNG
-    # starts with b"\x89PNG", JPEG with b"\xff\xd8"). An `<?xml` prolog alone is
-    # not enough because image_to_url also requires a `<svg` tag, and the search
-    # is bounded since Matplotlib emits `<svg` within the first few hundred bytes.
+    # SVG is text, not raster bytes, so it goes to image_to_url's SVG path rather
+    # than the PNG/PIL path, which cannot parse it and crashes. Anything else
+    # vector is rejected up front so the failure names the format.
     payload = image.getvalue()
-    stripped = payload.lstrip()
-    is_svg = stripped.startswith(b"<svg") or (
-        stripped.startswith(b"<?xml") and b"<svg" in stripped[:2048]
-    )
-    image_for_proto: str | io.BytesIO = payload.decode("utf-8") if is_svg else image
+    svg_markup = _svg_markup_or_none(payload)
+    if svg_markup is None:
+        _raise_for_unsupported_vector_format(payload)
+    image_for_proto: str | io.BytesIO = image if svg_markup is None else svg_markup
 
     marshall_images(
         coordinates=coordinates,

--- a/lib/streamlit/elements/pyplot.py
+++ b/lib/streamlit/elements/pyplot.py
@@ -63,6 +63,9 @@ def _svg_markup_or_none(payload: bytes) -> str | None:
         try:
             payload = gzip.decompress(payload)
         except (OSError, EOFError):
+            # Report "not SVG" rather than raising, so a truncated or corrupt
+            # buffer continues to the raster/rejection path and is reported
+            # there, instead of failing with a gzip error from this helper.
             return None
 
     stripped = payload.lstrip()
@@ -283,9 +286,12 @@ def marshall(
     # vector is rejected up front so the failure names the format.
     payload = image.getvalue()
     svg_markup = _svg_markup_or_none(payload)
-    if svg_markup is None:
+    if svg_markup is not None:
+        image_for_proto: str | io.BytesIO = svg_markup
+    else:
+        # Not SVG, so it is either raster (fine) or vector we cannot render.
         _raise_for_unsupported_vector_format(payload)
-    image_for_proto: str | io.BytesIO = image if svg_markup is None else svg_markup
+        image_for_proto = image
 
     marshall_images(
         coordinates=coordinates,

--- a/lib/tests/streamlit/elements/pyplot_test.py
+++ b/lib/tests/streamlit/elements/pyplot_test.py
@@ -253,6 +253,25 @@ class PyplotTest(DeltaGeneratorTestCase):
         decoded = base64.b64decode(url.split(",", 1)[1]).decode("utf-8")
         assert "<svg" in decoded
 
+    def test_st_pyplot_svgz_via_rcparams(self):
+        """svgz resolved from rcParams is also detected, not just from `format=`.
+
+        Mirrors the plain-SVG rcParams case: Matplotlib resolves the format itself,
+        so `format=None` with an rcParams default of "svgz" produces gzipped SVG that
+        the `format` kwarg alone would not reveal. This is what the buffer sniff buys.
+        """
+        fig, ax = plt.subplots()
+        ax.plot([1, 2, 3], [1, 2, 3])
+
+        with mpl.rc_context({"savefig.format": "svgz"}):
+            st.pyplot(fig, format=None)
+
+        el = self.get_delta_from_queue().new_element
+        url = el.imgs.imgs[0].url
+        assert url.startswith("data:image/svg+xml;base64,")
+        decoded = base64.b64decode(url.split(",", 1)[1]).decode("utf-8")
+        assert "<svg" in decoded
+
     @parameterized.expand(
         [
             ("pdf", "pdf", "PDF"),

--- a/lib/tests/streamlit/elements/pyplot_test.py
+++ b/lib/tests/streamlit/elements/pyplot_test.py
@@ -234,6 +234,62 @@ class PyplotTest(DeltaGeneratorTestCase):
         decoded = base64.b64decode(url.split(",", 1)[1]).decode("utf-8")
         assert "<svg" in decoded
 
+    @parameterized.expand([("lowercase", "svgz"), ("uppercase", "SVGZ")])
+    def test_st_pyplot_svgz_format(self, _, fmt: str):
+        """svgz is gzipped SVG, so it must be inflated onto the SVG path.
+
+        Without inflation the gzip magic bytes reach PIL, which cannot identify
+        them, so this crashed the same way plain SVG used to.
+        """
+        fig, ax = plt.subplots()
+        ax.plot([1, 2, 3], [1, 2, 3])
+
+        st.pyplot(fig, format=fmt)
+
+        el = self.get_delta_from_queue().new_element
+        url = el.imgs.imgs[0].url
+        assert url.startswith("data:image/svg+xml;base64,")
+        # Decode so a gzip blob mislabelled as SVG cannot pass on MIME alone.
+        decoded = base64.b64decode(url.split(",", 1)[1]).decode("utf-8")
+        assert "<svg" in decoded
+
+    @parameterized.expand(
+        [
+            ("pdf", "pdf", "PDF"),
+            ("eps", "eps", "PostScript"),
+            ("ps", "ps", "PostScript"),
+        ]
+    )
+    def test_st_pyplot_rejects_unrenderable_vector_format(
+        self, _, fmt: str, expected_label: str
+    ):
+        """PDF/PostScript must fail with a message naming the format and a way out.
+
+        These need an external rasteriser that Streamlit does not bundle. Left
+        alone they reach PIL and surface an opaque ``UnidentifiedImageError`` /
+        ``OSError`` from several frames deeper, naming neither the format nor a fix.
+        """
+        fig, ax = plt.subplots()
+        ax.plot([1, 2, 3], [1, 2, 3])
+
+        with pytest.raises(StreamlitAPIException) as exc_info:
+            st.pyplot(fig, format=fmt)
+
+        message = str(exc_info.value)
+        assert expected_label in message, "the error must name the offending format"
+        assert 'format="png"' in message, "the error must offer a working alternative"
+        assert 'format="svg"' in message
+
+    def test_st_pyplot_png_is_unaffected_by_vector_guard(self):
+        """The default raster path must still render, not trip the new guard."""
+        fig, ax = plt.subplots()
+        ax.plot([1, 2, 3], [1, 2, 3])
+
+        st.pyplot(fig)
+
+        el = self.get_delta_from_queue().new_element
+        assert el.imgs.imgs[0].url.startswith(MEDIA_ENDPOINT)
+
     @parameterized.expand(
         [
             (


### PR DESCRIPTION
## Describe your changes

`st.pyplot` forwards `**kwargs` to `savefig`, so `format=` accepts every format Matplotlib supports — but only raster output survives the image path. #16283 fixed `format="svg"`; the remaining vector formats still reached PIL and failed there.

Sniffing the buffer the way the existing SVG check does shows two distinct problems behind one symptom:

```
format  first bytes                        detected as SVG?  PIL result
png     b'\x89PNG\r\n\x1a\n\x00\x00\x00\r'  False            OK
svg     b'<?xml versio'                     True             (bypasses PIL)
pdf     b'%PDF-1.4\n%\xac\xdc'              False            UnidentifiedImageError
eps     b'%!PS-Adobe-3'                     False            OSError
ps      b'%!PS-Adobe-3'                     False            OSError
svgz    b'\x1f\x8b\x08\x00p\xf0xj\x02\xff'  False            UnidentifiedImageError
```

**`svgz` is renderable** — it is just gzipped SVG. Its gzip magic meant the `<svg` / `<?xml` sniff could not see the markup inside, so it went to PIL. Inflating it first puts it on the SVG path that already works, so `format="svgz"` now displays.

**`pdf` / `eps` / `ps` are not renderable in-process.** Rasterising them needs Ghostscript or Poppler, and Streamlit bundles neither. They now raise `StreamlitAPIException` naming the format and pointing at a working alternative:

> `st.pyplot` cannot display PDF output, since rendering it requires an external tool that Streamlit does not bundle. Use `format="png"` (the default) for a raster image, or `format="svg"` to keep the output as scalable vector graphics.

This is not a behaviour regression — those formats already failed, just unhelpfully, several frames deep in PIL with nothing identifying the cause. It follows the "never silent, never cryptic" half of principle 23 in `specs/AGENTS.md`.

Two details worth surfacing for review:

- **`eps` and `ps` share the `%!PS-Adobe-3` prefix**, so they cannot be told apart by magic bytes. Both are reported as "PostScript" rather than guessed at.
- **The sniff stays on the buffer rather than reading `kwargs["format"]`**, keeping #16283's rationale intact: Matplotlib resolves the format itself, so `format=None` with `rcParams["savefig.format"] = "svgz"` produces svgz that the kwarg alone would not reveal.

I did consider rasterising PDF/PS instead of rejecting them, and dropped it — it would mean a hard dependency on an external binary for a rarely-used code path, which is a bad trade against a one-line `format="png"` fix on the user's side.

## GitHub Issue Link (if applicable)

Closes #16429

## Testing Plan

- **Unit tests** in `pyplot_test.py`: `svgz` renders as an SVG data URI (lowercase and uppercase); `pdf`/`eps`/`ps` each raise with the format named and both alternatives offered; and the default PNG path still renders, so the new guard cannot over-trigger.
- **Mutation-verified independently.** Removing the gzip inflation fails exactly the 2 svgz cases; removing the rejection call fails exactly the 3 PDF/PostScript cases. The PNG test passes under both mutations, which is correct — it guards against over-triggering rather than under-triggering.
- **Full suite:** `11120 passed, 76 skipped`. `make python-format`, `make python-lint`, `uv run ty check`, `uv run mypy` all clean.
- **No E2E test.** The behaviour is entirely server-side — one path produces an SVG data URI already covered by #16283's e2e, the other raises before any element is created.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to st.pyplot post-savefig handling and error messaging; default PNG rendering is unchanged and covered by tests.
> 
> **Overview**
> **`st.pyplot`** now classifies Matplotlib `savefig` output by **buffer sniffing** (not only `format=`), so behavior stays correct when Matplotlib picks the format via `rcParams`.
> 
> **`svgz`** is treated as SVG by **gunzipping** first, then reusing the existing SVG display path instead of sending gzip bytes to PIL.
> 
> **PDF, EPS, and PS** are **rejected early** with a **`StreamlitAPIException`** that names the format and suggests `format="png"` or `format="svg"`, instead of opaque PIL errors deeper in the stack.
> 
> SVG detection is moved into **`_svg_markup_or_none`**; unsupported vector magic bytes are handled by **`_raise_for_unsupported_vector_format`**. The default **PNG** raster path is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 925345ab71658d12e87fd88461b2c15f3323f4b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->