### PR TITLE
[chore] Include package updates in lock PRs

### DIFF
--- a/.github/workflows/update-python-lock.yml
+++ b/.github/workflows/update-python-lock.yml
@@ -55,9 +55,12 @@ jobs:
             # Use a unique delimiter so a bare "EOF" line in uv's log cannot
             # close the multiline GITHUB_OUTPUT block early.
             echo "upgrade_log<<EOF_UPGRADE_LOG"
-            # Emit as a markdown bullet list for the PR body / summary.
+            # Emit Update/Add/Remove lines as markdown bullets for the PR
+            # body / summary; skip resolution chatter like "Resolved N packages".
             while IFS= read -r line || [[ -n "$line" ]]; do
               [[ -z "$line" ]] && continue
+              # Match Updated/Added/Removed (and Update/Add/Remove) prefixes.
+              [[ "$line" =~ ^(Update|Add|Remove) ]] || continue
               echo "- ${line}"
             done < "$upgrade_log"
             echo "EOF_UPGRADE_LOG"

--- a/.github/workflows/update-python-lock.yml
+++ b/.github/workflows/update-python-lock.yml
@@ -42,7 +42,24 @@ jobs:
           enable-cache: true
 
       - name: Upgrade Python lock
-        run: uv lock --upgrade
+        id: upgrade-lock
+        run: |
+          set -euo pipefail
+
+          upgrade_log="${RUNNER_TEMP}/uv-lock-upgrade.log"
+
+          # uv prints Update/Add/Remove lines on stderr; capture both streams.
+          uv lock --upgrade 2>&1 | tee "$upgrade_log"
+
+          {
+            echo "upgrade_log<<EOF"
+            # Emit as a markdown bullet list for the PR body / summary.
+            while IFS= read -r line || [[ -n "$line" ]]; do
+              [[ -z "$line" ]] && continue
+              echo "- ${line}"
+            done < "$upgrade_log"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Check whether uv.lock changed
         id: check-lock
@@ -122,9 +139,17 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           BRANCH_NAME: ${{ steps.create-branch.outputs.branch_name }}
+          UPGRADE_LOG: ${{ steps.upgrade-lock.outputs.upgrade_log }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            const upgradeLog = (process.env.UPGRADE_LOG || '').trim();
+            const packageUpdatesSection = [
+              '## Package updates',
+              '',
+              upgradeLog || '- No package updates reported by uv.',
+            ].join('\n');
+
             const created = await github.rest.pulls.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -135,6 +160,8 @@ jobs:
                 'Automated weekly refresh of all direct and transitive Python dependencies in `uv.lock`.',
                 '',
                 'The project-level 24-hour package cooldown remains in effect.',
+                '',
+                packageUpdatesSection,
               ].join('\n'),
               draft: false,
             });
@@ -152,6 +179,7 @@ jobs:
           DRY_RUN: ${{ inputs.dry_run }}
           LOCK_CHANGED: ${{ steps.check-lock.outputs.lock_changed }}
           PR_URL: ${{ steps.create-pr.outputs.pr_url }}
+          UPGRADE_LOG: ${{ steps.upgrade-lock.outputs.upgrade_log }}
         run: |
           {
             echo "## Python lock update summary"
@@ -163,4 +191,8 @@ jobs:
             else
               echo "- No compatible updates found; no PR created"
             fi
+            echo
+            echo "### Package updates"
+            echo
+            echo "${UPGRADE_LOG:-- No package updates reported by uv.}"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/update-python-lock.yml
+++ b/.github/workflows/update-python-lock.yml
@@ -52,13 +52,15 @@ jobs:
           uv lock --upgrade 2>&1 | tee "$upgrade_log"
 
           {
-            echo "upgrade_log<<EOF"
+            # Use a unique delimiter so a bare "EOF" line in uv's log cannot
+            # close the multiline GITHUB_OUTPUT block early.
+            echo "upgrade_log<<EOF_UPGRADE_LOG"
             # Emit as a markdown bullet list for the PR body / summary.
             while IFS= read -r line || [[ -n "$line" ]]; do
               [[ -z "$line" ]] && continue
               echo "- ${line}"
             done < "$upgrade_log"
-            echo "EOF"
+            echo "EOF_UPGRADE_LOG"
           } >> "$GITHUB_OUTPUT"
 
       - name: Check whether uv.lock changed


### PR DESCRIPTION
## Describe your changes

Includes the `uv lock --upgrade` output as a bullet list in automated Python lock-update PRs (and the workflow summary), so reviewers can see which packages changed without opening the lockfile diff.

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- Workflow-only change; no runtime behavior. Verified locally that `uv lock --upgrade` emits `Update`/`Add`/`Remove` lines on stderr and that prefixing each line with `- ` renders as a markdown bullet list.
- [ ] Unit Tests (JS and/or Python)
- [ ] E2E Tests
- [ ] Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

Made with [Cursor](https://cursor.com)