### PR TITLE
[refactor] Rename is_uncaught_app_exception flag

### DIFF
--- a/lib/streamlit/elements/exception.py
+++ b/lib/streamlit/elements/exception.py
@@ -98,10 +98,15 @@ def _exception(
     dg: DeltaGenerator,
     exception: BaseException,
     width: WidthWithoutContent = "stretch",
-    is_uncaught_app_exception: bool = False,
+    apply_show_error_details: bool = False,
 ) -> DeltaGenerator:
     exception_proto = ExceptionProto()
-    marshall(exception_proto, exception, width, is_uncaught_app_exception)
+    marshall(
+        exception_proto,
+        exception,
+        width,
+        apply_show_error_details=apply_show_error_details,
+    )
     return dg._enqueue("exception", exception_proto)
 
 
@@ -109,7 +114,7 @@ def marshall(
     exception_proto: ExceptionProto,
     exception: BaseException,
     width: WidthWithoutContent = "stretch",
-    is_uncaught_app_exception: bool = False,
+    apply_show_error_details: bool = False,
 ) -> None:
     """Marshalls an Exception.proto message.
 
@@ -125,8 +130,11 @@ def marshall(
         The width of the exception display. Can be either an integer (pixels) or "stretch".
         Defaults to "stretch".
 
-    is_uncaught_app_exception: bool
-        The exception originates from an uncaught error during script execution.
+    apply_show_error_details: bool
+        Redact the message, type, and stack trace of the exception as the
+        `client.showErrorDetails` config option requires. Set this for any
+        exception that Streamlit itself sends to the browser, because the
+        traceback can expose internal file paths.
     """
     validate_width(width)
 
@@ -189,7 +197,7 @@ Traceback:
             "\n".join(_get_stack_trace_str_list(str_exception)),
         )
 
-    if is_uncaught_app_exception:
+    if apply_show_error_details:
         show_error_details = config.get_option("client.showErrorDetails")
 
         show_message = (

--- a/lib/streamlit/error_util.py
+++ b/lib/streamlit/error_util.py
@@ -82,7 +82,7 @@ def _print_rich_exception(e: BaseException) -> None:
 def show_uncaught_app_exception(ex: BaseException) -> None:
     """Show the exception on the frontend."""
     main_delta_generator = get_dg_singleton_instance().main_dg
-    exception._exception(main_delta_generator, ex, is_uncaught_app_exception=True)
+    exception._exception(main_delta_generator, ex, apply_show_error_details=True)
 
 
 def _log_uncaught_app_exception(ex: BaseException) -> None:

--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -974,11 +974,11 @@ class AppSession:
     def _create_exception_message(self, e: BaseException) -> ForwardMsg:
         """Create and return an Exception ForwardMsg."""
         msg = ForwardMsg()
-        # The is_uncaught_app_exception flag applies the client.showErrorDetails
+        # The apply_show_error_details flag applies the client.showErrorDetails
         # redaction. Without this flag, the session sends the internal message,
         # type, and stack trace of the error to the browser.
         exception_utils.marshall(
-            msg.delta.new_element.exception, e, is_uncaught_app_exception=True
+            msg.delta.new_element.exception, e, apply_show_error_details=True
         )
         return msg
 

--- a/lib/tests/streamlit/elements/exception_test.py
+++ b/lib/tests/streamlit/elements/exception_test.py
@@ -58,7 +58,7 @@ SyntaxError: invalid syntax
         assert expected.strip() == _format_syntax_error_message(err)
 
     @parameterized.expand([(True,), (False,)])
-    def test_markdown_flag(self, is_uncaught_app_exception):
+    def test_markdown_flag(self, apply_show_error_details):
         """Test that ExceptionProtos for StreamlitAPIExceptions (and
         subclasses) have the "message_is_markdown" flag set.
         """
@@ -66,7 +66,7 @@ SyntaxError: invalid syntax
         exception.marshall(
             proto,
             RuntimeError("oh no!"),
-            is_uncaught_app_exception=is_uncaught_app_exception,
+            apply_show_error_details=apply_show_error_details,
         )
         assert not proto.message_is_markdown
 
@@ -74,7 +74,7 @@ SyntaxError: invalid syntax
         exception.marshall(
             proto,
             StreamlitAPIException("oh no!"),
-            is_uncaught_app_exception=is_uncaught_app_exception,
+            apply_show_error_details=apply_show_error_details,
         )
         assert proto.message_is_markdown
 
@@ -82,7 +82,7 @@ SyntaxError: invalid syntax
         exception.marshall(
             proto,
             errors.DuplicateWidgetID("oh no!"),
-            is_uncaught_app_exception=is_uncaught_app_exception,
+            apply_show_error_details=apply_show_error_details,
         )
         assert proto.message_is_markdown
 
@@ -118,9 +118,7 @@ SyntaxError: invalid syntax
 
         # Marshall it.
         proto = ExceptionProto()
-        exception.marshall(
-            proto, cast("Exception", err), is_uncaught_app_exception=True
-        )
+        exception.marshall(proto, cast("Exception", err), apply_show_error_details=True)
 
         user_module_path = os.path.join(os.path.realpath(user_module_path), "")
         assert user_module_path in proto.stack_trace[0], "Stack not stripped"
@@ -158,7 +156,7 @@ SyntaxError: invalid syntax
         # Marshall it.
         proto = ExceptionProto()
         exception.marshall(
-            proto, cast("Exception", err), is_uncaught_app_exception=False
+            proto, cast("Exception", err), apply_show_error_details=False
         )
 
         user_module_path = os.path.join(os.path.realpath(user_module_path), "")
@@ -183,7 +181,7 @@ SyntaxError: invalid syntax
 
             # Marshall it.
             proto = ExceptionProto()
-            exception.marshall(proto, err, is_uncaught_app_exception=True)
+            exception.marshall(proto, err, apply_show_error_details=True)
 
             assert proto.message == "module 'streamlit' has no attribute 'format'"
             assert len(proto.stack_trace) > 0
@@ -203,7 +201,7 @@ SyntaxError: invalid syntax
 
             # Marshall it.
             proto = ExceptionProto()
-            exception.marshall(proto, err, is_uncaught_app_exception=True)
+            exception.marshall(proto, err, apply_show_error_details=True)
 
             assert proto.message == _GENERIC_UNCAUGHT_EXCEPTION_TEXT
             assert len(proto.stack_trace) > 0
@@ -220,7 +218,7 @@ SyntaxError: invalid syntax
 
             # Marshall it.
             proto = ExceptionProto()
-            exception.marshall(proto, err, is_uncaught_app_exception=True)
+            exception.marshall(proto, err, apply_show_error_details=True)
 
             assert proto.message == _GENERIC_UNCAUGHT_EXCEPTION_TEXT
             assert len(proto.stack_trace) > 0
@@ -237,7 +235,7 @@ SyntaxError: invalid syntax
 
             # Marshall it.
             proto = ExceptionProto()
-            exception.marshall(proto, err, is_uncaught_app_exception=True)
+            exception.marshall(proto, err, apply_show_error_details=True)
 
             assert proto.message == _GENERIC_UNCAUGHT_EXCEPTION_TEXT
             assert len(proto.stack_trace) == 0
@@ -254,7 +252,7 @@ SyntaxError: invalid syntax
 
             # Marshall it.
             proto = ExceptionProto()
-            exception.marshall(proto, err, is_uncaught_app_exception=True)
+            exception.marshall(proto, err, apply_show_error_details=True)
 
             assert proto.message == _GENERIC_UNCAUGHT_EXCEPTION_TEXT
             assert len(proto.stack_trace) == 0


### PR DESCRIPTION

## Describe your changes

Follow-up to #16392, which reviewers agreed on: the `is_uncaught_app_exception` flag on `exception.marshall` names the origin of an exception, but its only effect is to apply the `client.showErrorDetails` redaction to the message, the type, and the stack trace. The old name made a correct call site read as wrong whenever the exception came from somewhere other than a script run.

`AppSession._create_exception_message` is that call site. It sets the flag to redact an error the session hits while it handles a *valid* `BackMsg`, which is not an uncaught app exception.

- Renames the flag to `apply_show_error_details` on `marshall` and `_exception`, and updates both call sites (`error_util.show_uncaught_app_exception`, `AppSession._create_exception_message`).
- Rewrites the `marshall` docstring entry to state the effect instead of the origin, and to say why callers want it: a traceback can expose internal file paths.
- `_exception` now passes the flag to `marshall` by keyword, per the "enhancing arguments" rule in `lib/AGENTS.md`.

No behavior change. Both `marshall` and `_exception` are private, so the public `st.exception` signature is untouched and nothing user-facing moves. The old name has no remaining references.

## GitHub Issue Link (if applicable)

None. This is the follow-up flagged in the #16392 review.

## Testing Plan

- No new tests. A rename with no behavior change needs no new coverage; the existing `exception_test.py` cases already pin the redaction behavior at every `client.showErrorDetails` value, and they exercise the renamed parameter directly.
- Python unit tests. `exception_test.py` updates 11 references, including the `@parameterized.expand` argument name in `test_markdown_flag`.
- Regression runs. Full suite passes (11049 passed, 66 skipped). `make python-types` is clean: mypy on 949 files and `ty`. `ruff check` and `ruff format --check` pass on all four files.


**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Rename-only refactor on private exception marshalling APIs with existing tests unchanged in behavior.
> 
> **Overview**
> Renames the private `marshall` / `_exception` flag from **`is_uncaught_app_exception`** to **`apply_show_error_details`** so call sites describe *what happens* (honor `client.showErrorDetails` redaction) instead of *where the error came from*.
> 
> The docstring now explains that flag should be set for any exception Streamlit sends to the browser, because tracebacks can leak internal paths. **`_exception`** passes the flag to **`marshall`** by keyword; **`error_util.show_uncaught_app_exception`** and **`AppSession._create_exception_message`** still pass `True`. Tests only update the parameter name.
> 
> **No behavior change**; public **`st.exception`** is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ddcbb00835d988bb0c4eddfdc264bab0d1266c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->