### PR TITLE
[spec] Fix `st.context.theme.type` correctness

### DIFF
--- a/specs/2026-08-08-st-context-theme-type/product-spec.md
+++ b/specs/2026-08-08-st-context-theme-type/product-spec.md
@@ -207,5 +207,5 @@ These need explicit reviewer sign-off before (or as) the implementation PR:
    appearance can both be queried?
 3. **System + OS change:** When selection is System and the OS theme flips, should that always trigger an auto-rerun
    (proposed: yes, as an allowlisted source)?
-4. **SiS / embedded hosts:** Any host-specific constraints on sending preference or auto-rerunning on `SET_THEME` /
-   theme messages beyond the hostframe E2E?
+4. **SiS / embedded hosts:** Any host-specific constraints on sending preference or auto-rerunning on
+   `SET_CUSTOM_THEME_CONFIG` / theme messages beyond the hostframe E2E?

--- a/specs/2026-08-08-st-context-theme-type/product-spec.md
+++ b/specs/2026-08-08-st-context-theme-type/product-spec.md
@@ -15,6 +15,11 @@ This product spec owns the decision of **what `type` means** now that appearance
 are separate. See the [tech spec](./tech-spec.md) for protocol, backend resolution, and the MPA-safe auto-rerun
 design.
 
+> **Status: proposed, not scheduled.** The semantics below (Option C) are the decision this spec asks for. The
+> *implementation* is not vetted — see [What is not settled](./tech-spec.md#what-is-not-settled) in the tech spec,
+> which records the open approach decision, the residual first-run gaps, and why the auto-rerun mechanism is the
+> risky part. Whether the fix is worth building at ~0.6% adoption is an open question, not a settled yes.
+
 ## Problem
 
 ### Motivation / demand

--- a/specs/2026-08-08-st-context-theme-type/product-spec.md
+++ b/specs/2026-08-08-st-context-theme-type/product-spec.md
@@ -145,16 +145,22 @@ docstring wording change.
 | Single `[theme]` with non-hex bg, no `base`          | `"light"`            | `"light"` (fallback)         |
 | `[theme.light]` + `[theme.dark]`, both well-authored | `"dark"`             | `"dark"` (from dark section) |
 | `[theme.dark]` with light hex bg (pathological)      | `"dark"`             | `"light"` (what is painted)  |
+| Host dark theme (SiS/Cloud) overriding config        | `"dark"` (host)      | `"dark"` (host wins)         |
 
 ### User-facing behavior (reliability)
 
 Independent of A/B/C, once fixed:
 
 1. **First script run** — `type` is correct for that run (including `[theme]` / `[theme.light]` / `[theme.dark]`).
+   - *Caveat:* Host-provided themes (SiS/Cloud) that arrive after the FE's first BackMsg may have a one-run
+     delay corrected by immediate auto-rerun. In practice this race is rare (hosts send theme during iframe init).
 2. **Appearance change** (menu System/Light/Dark, host theme message, OS change while on System) — app reruns and
    `type` updates without a manual rerun.
 3. **MPA deep links** — non-default page + `[theme]` still lands on that page (no #11797 regression).
 4. **CSS overrides** — injected CSS backgrounds remain out of scope for `type`.
+5. **Host theme vs config.toml** — runtime host themes (`SET_CUSTOM_THEME_CONFIG`) replace config.toml on the
+   FE (no merge, last-write-wins). Pre-load host customizations (`LIGHT_THEME`/`DARK_THEME`) merge into
+   presets only but do not propagate into config.toml custom themes. `type` always reflects what is painted.
 
 ### API surface
 

--- a/specs/2026-08-08-st-context-theme-type/product-spec.md
+++ b/specs/2026-08-08-st-context-theme-type/product-spec.md
@@ -7,26 +7,24 @@ created: 2026-08-08
 
 ## Summary
 
-`st.context.theme.type` should reliably return `"light"` or `"dark"` on the first script
-run of a session and whenever appearance changes (menu, host, or OS) — without
-regressing multipage deep links ([#11920](https://github.com/streamlit/streamlit/issues/11920)).
+`st.context.theme.type` should reliably return `"light"` or `"dark"` on the first script run of a session and
+whenever appearance changes (menu, host, or OS) — without regressing multipage deep links
+([#11920](https://github.com/streamlit/streamlit/issues/11920)).
 
-This product spec owns the decision of **what `type` means** now that appearance
-preference and application theme are separate. See the [tech spec](./tech-spec.md) for
-protocol, backend resolution, and the MPA-safe auto-rerun design.
+This product spec owns the decision of **what `type` means** now that appearance preference and application theme
+are separate. See the [tech spec](./tech-spec.md) for protocol, backend resolution, and the MPA-safe auto-rerun
+design.
 
 ## Problem
 
 ### Motivation / demand
 
-[#11920](https://github.com/streamlit/streamlit/issues/11920) is currently the
-**highest-upvoted open theming issue** on the Streamlit tracker (21 👍 as of this
-writing — ahead of other open `feature:theming` issues). Fixing it also
-**unblocks** [#11536](https://github.com/streamlit/streamlit/issues/11536) (expose all
-theming config options in `st.context.theme`, also highly upvoted): that expansion
-reuses the same frontend→backend theme sync path, so shipping more fields on a
-still-stale `st.context.theme` would inherit the same first-run and appearance-change
-bugs. Correctness first, then richer theme context.
+[#11920](https://github.com/streamlit/streamlit/issues/11920) is currently the **highest-upvoted open theming
+issue** on the Streamlit tracker (21 👍 as of this writing — ahead of other open `feature:theming` issues). Fixing
+it also **unblocks** [#11536](https://github.com/streamlit/streamlit/issues/11536) (expose all theming config
+options in `st.context.theme`, also highly upvoted): that expansion reuses the same frontend→backend theme sync
+path, so shipping more fields on a still-stale `st.context.theme` would inherit the same first-run and
+appearance-change bugs. Correctness first, then richer theme context.
 
 ### Use cases
 
@@ -38,7 +36,9 @@ logo = "logo-on-dark.svg" if st.context.theme.type == "dark" else "logo-on-light
 st.image(logo)
 
 # 2. Chart / Plotly color schemes that match the app
-fig.update_layout(template="plotly_dark" if st.context.theme.type == "dark" else "plotly_white")
+fig.update_layout(
+    template="plotly_dark" if st.context.theme.type == "dark" else "plotly_white"
+)
 
 # 3. Custom Markdown / HTML styling
 bg = "#0e1117" if st.context.theme.type == "dark" else "#ffffff"
@@ -48,50 +48,46 @@ st.markdown(f'<div style="background:{bg}">…</div>', unsafe_allow_html=True)
 # (also relevant for future st.iframe inject_theme; see st-iframe product spec)
 ```
 
-A secondary ask (seen in forum/issue comments) is matching the **user’s** light/dark
-intent elsewhere. That may be preference, not painted appearance — which is why the
-semantics choice below matters.
+A secondary ask (seen in forum/issue comments) is matching the **user's** light/dark intent elsewhere. That may be
+preference, not painted appearance — which is why the semantics choice below matters.
 
 ### Where it fails today
 
-After [#10972](https://github.com/streamlit/streamlit/pull/10972) shipped `type`, an
-automatic theme-change rerun broke multipage deep links when `[theme]` was set
-([#11797](https://github.com/streamlit/streamlit/issues/11797)). [#11870](https://github.com/streamlit/streamlit/pull/11870)
-removed that rerun to fix MPA. Documented tradeoff → [#11920](https://github.com/streamlit/streamlit/issues/11920):
+After [#10972](https://github.com/streamlit/streamlit/pull/10972) shipped `type`, an automatic theme-change rerun
+broke multipage deep links when `[theme]` was set ([#11797](https://github.com/streamlit/streamlit/issues/11797)).
+[#11870](https://github.com/streamlit/streamlit/pull/11870) removed that rerun to fix MPA. Documented tradeoff →
+[#11920](https://github.com/streamlit/streamlit/issues/11920):
 
-1. **First run with a custom theme** — `type` can reflect a cached/preset theme, not the
-   custom theme that paints after `NewSession`.
-2. **Settings / main-menu / host appearance change** — UI updates immediately; `type`
-   stays stale until a later unrelated rerun
-   ([#15287](https://github.com/streamlit/streamlit/issues/15287)).
+1. **First run with a custom theme** — `type` can reflect a cached/preset theme, not the custom theme that paints
+   after `NewSession`.
+2. **Settings / main-menu / host appearance change** — UI updates immediately; `type` stays stale until a later
+   unrelated rerun ([#15287](https://github.com/streamlit/streamlit/issues/15287)).
 
 ### Why the meaning of `type` is newly ambiguous
 
-The main menu separates **appearance preference** (System / Light / Dark) from
-**application theme** (defaults vs custom vs custom light/dark). Before that split,
-preference and theme were effectively tied. Now `type` can mean three different things
-(current docs describe **C** — “inferred from the background color”):
+The main menu separates **appearance preference** (System / Light / Dark) from **application theme** (defaults vs
+custom vs custom light/dark). Before that split, preference and theme were effectively tied. Now `type` can mean
+three different things (current docs describe **C** — "inferred from the background color"):
 
-| Meaning | What it answers | Source of truth |
-|---------|-----------------|-----------------|
-| A. User preference | "What did the user/system ask for?" | Menu selection / OS `prefers-color-scheme` |
-| B. Active variant | "Which theme branch is active?" | Which section (`[theme.light]` vs `[theme.dark]`) was selected |
-| C. Visual appearance | "Does the app look light or dark?" | `base` / luminance of the rendered background |
+| Meaning                    | What it answers                     | Source of truth                                                                         |
+| -------------------------- | ----------------------------------- | --------------------------------------------------------------------------------------- |
+| A. User/browser preference | "What did the user/system ask for?" | Menu selection / OS `prefers-color-scheme`                                              |
+| B. Theme identity          | "Which application theme is active?" | The theme name/variant: Default Light, Default Dark, Custom, Custom Light, Custom Dark  |
+| C. Visual appearance       | "Does the app look light or dark?"  | `base` / luminance of the rendered background                                           |
 
-Where they diverge in practice (see behavior matrix below): A/B/C agree for
-presets and well-authored dual themes; they disagree for a single custom theme
-whose appearance differs from OS preference, and for pathological section
+Where they diverge in practice (see behavior matrix above): A/B/C agree for presets and well-authored dual themes;
+they disagree for a single custom theme whose appearance differs from OS preference, and for pathological section
 colors.
 
 ### Related issues
 
-| Issue | Role |
-|-------|------|
+| Issue                                                         | Role                                                                                 |
+| ------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
 | [#11920](https://github.com/streamlit/streamlit/issues/11920) | Umbrella: make `type` correct in all situations (highest-upvoted open theming issue) |
-| [#11797](https://github.com/streamlit/streamlit/issues/11797) | MPA deep-link regression (closed by #11870) |
-| [#15287](https://github.com/streamlit/streamlit/issues/15287) | No auto-update on settings theme change (dup of #11920) |
-| [#11536](https://github.com/streamlit/streamlit/issues/11536) | Expose all theming config options — unblocked by this work; still out of scope here |
-| [#5009](https://github.com/streamlit/streamlit/issues/5009) | Original light/dark detection request (closed by #10972) |
+| [#11797](https://github.com/streamlit/streamlit/issues/11797) | MPA deep-link regression (closed by #11870)                                          |
+| [#15287](https://github.com/streamlit/streamlit/issues/15287) | No auto-update on settings theme change (dup of #11920)                              |
+| [#11536](https://github.com/streamlit/streamlit/issues/11536) | Expose all theming config options — unblocked by this work; still out of scope here  |
+| [#5009](https://github.com/streamlit/streamlit/issues/5009)   | Original light/dark detection request (closed by #10972)                             |
 
 ## Proposal
 
@@ -99,61 +95,62 @@ colors.
 
 **Option C: Visual appearance of the active theme** ✅ PREFERRED
 
-`type` answers “does the app look light or dark?” Resolve from the active theme/section:
+`type` answers "does the app look light or dark?" Resolve from the active theme/section:
 
 1. Prefer `base` if set.
 2. Else infer from 6-digit hex `backgroundColor` luminance.
 3. Else fall back to resolved appearance preference.
 
-- Pros: Matches today’s docs; matches the primary “contrast my content” use case; single
-  dark custom theme correctly reports `"dark"` even if OS preference is light.
-- Cons: Pathological misauthored sections (dark section, light bg) report what is *seen*,
-  not what the section is *named*; preference alone is not exposed on `st.context.theme`.
+- Pros: Matches today's docs; matches the primary "contrast my content" use case; single dark custom theme
+  correctly reports `"dark"` even if OS preference is light.
+- Cons: Pathological misauthored sections (dark section, light bg) report what is _seen_, not what the section is
+  _named_; preference alone is not exposed on `st.context.theme`.
 
 **Option A: User preference**
 
 `type` ≈ menu/OS selection (`"light"` / `"dark"`; System resolved to OS).
 
 - Pros: Simplest implementation (little/no config branching on the backend).
-- Cons: Wrong for the primary use case when a single custom theme’s appearance disagrees
-  with OS preference; contradicts current docs; “auto” intent is lost unless we expand
-  the type.
+- Cons: Wrong for the primary use case when a single custom theme's appearance disagrees with OS preference;
+  contradicts current docs; "auto" intent is lost unless we expand the type.
 
-**Option B: Active variant**
+**Option B: Theme identity**
 
-`type` follows which branch is selected (`[theme.light]` vs `[theme.dark]` / preset name),
-independent of that section’s actual background.
+`type` returns a descriptive identifier of the active application theme — not a binary light/dark classification
+but the theme itself. Possible values could include `"Default Light"`, `"Default Dark"`, `"Custom"`,
+`"Custom Light"`, `"Custom Dark"`, etc.
 
-- Pros: Stable even if luminance edge cases misclassify colors.
-- Cons: Undefined for a single custom theme with no light/dark sections; diverges from
-  painted UI in the pathological case; still needs preference as an *input* to pick the
-  section.
+- Pros: Most expressive; developers can distinguish custom themes from presets and branch on specific theme
+  variants; no ambiguity from luminance thresholds; future-proof if theme types grow beyond light/dark.
+- Cons: Breaks the existing `Literal["light", "dark"]` return type contract; forces developers to handle an
+  open-ended set of values instead of a simple binary check; doesn't directly answer the primary use case ("should
+  I use light or dark contrast for my chart/logo?"); theme identity strings may change across Streamlit versions or
+  when users rename their config sections; developers still need to know whether a given theme identity implies
+  light or dark appearance, so a luminance/base classification is needed _in addition_ to identity.
 
-**Review ask:** Accept Option C (preferred), or choose A/B and adjust the tech resolver
-accordingly. Implementation of correctness (first run + appearance-change rerun) proceeds
-either way; only resolution rules and docstring wording change.
+**Review ask:** Accept Option C (preferred), or choose A/B and adjust the tech resolver accordingly.
+Implementation of correctness (first run + appearance-change rerun) proceeds either way; only resolution rules and
+docstring wording change.
 
 ### Expected `type` under Option C (behavior matrix)
 
-| Config | Preference sent | Expected `type` |
-|--------|-----------------|-----------------|
-| Presets only | `"light"` / `"dark"` | Same as preference |
-| Single `[theme]` with `base = "dark"` | `"light"` | `"dark"` |
-| Single `[theme]` with `#121212` bg, no `base` | `"light"` | `"dark"` (hex luminance) |
-| Single `[theme]` with non-hex bg, no `base` | `"light"` | `"light"` (fallback) |
-| `[theme.light]` + `[theme.dark]`, both well-authored | `"dark"` | `"dark"` (from dark section) |
-| `[theme.dark]` with light hex bg (pathological) | `"dark"` | `"light"` (what is painted) |
+| Config                                               | Preference sent      | Expected `type`              |
+| ---------------------------------------------------- | -------------------- | ---------------------------- |
+| Presets only                                         | `"light"` / `"dark"` | Same as preference           |
+| Single `[theme]` with `base = "dark"`                | `"light"`            | `"dark"`                     |
+| Single `[theme]` with `#121212` bg, no `base`        | `"light"`            | `"dark"` (hex luminance)     |
+| Single `[theme]` with non-hex bg, no `base`          | `"light"`            | `"light"` (fallback)         |
+| `[theme.light]` + `[theme.dark]`, both well-authored | `"dark"`             | `"dark"` (from dark section) |
+| `[theme.dark]` with light hex bg (pathological)      | `"dark"`             | `"light"` (what is painted)  |
 
 ### User-facing behavior (reliability)
 
 Independent of A/B/C, once fixed:
 
-1. **First script run** — `type` is correct for that run (including `[theme]` /
-   `[theme.light]` / `[theme.dark]`).
-2. **Appearance change** (menu System/Light/Dark, host theme message, OS change while on
-   System) — app reruns and `type` updates without a manual rerun.
-3. **MPA deep links** — non-default page + `[theme]` still lands on that page (no #11797
-   regression).
+1. **First script run** — `type` is correct for that run (including `[theme]` / `[theme.light]` / `[theme.dark]`).
+2. **Appearance change** (menu System/Light/Dark, host theme message, OS change while on System) — app reruns and
+   `type` updates without a manual rerun.
+3. **MPA deep links** — non-default page + `[theme]` still lands on that page (no #11797 regression).
 4. **CSS overrides** — injected CSS backgrounds remain out of scope for `type`.
 
 ### API surface
@@ -164,44 +161,42 @@ No new public parameters or commands:
 st.context.theme.type → Literal["light", "dark"] | None
 ```
 
-`None` is only expected when there is no script-run context (e.g. imported helper
-code outside a run). In a normal app script after connect, `type` should be
-`"light"` or `"dark"` — including on the first run once this fix lands. Prefer
-guarding with `if st.context.theme.type == "dark":` rather than treating `None`
-as a third theme mode.
+`None` is only expected when there is no script-run context (e.g. imported helper code outside a run). In a normal
+app script after connect, `type` should be `"light"` or `"dark"` — including on the first run once this fix lands.
+Prefer guarding with `if st.context.theme.type == "dark":` rather than treating `None` as a third theme mode.
 
-A separate public preference field (e.g. `st.context.theme.preference` →
-`"light"` | `"dark"` | `"auto"`) would let A and C coexist. That is **out of scope** for
-#11920 and belongs with [#11536](https://github.com/streamlit/streamlit/issues/11536).
+A separate public preference field (e.g. `st.context.theme.preference` → `"light"` | `"dark"` | `"auto"`) would
+let A and C coexist. That is **out of scope** for #11920 and belongs with
+[#11536](https://github.com/streamlit/streamlit/issues/11536).
 
 ## Out of scope
 
 - Exposing all theming config options on `st.context.theme`
-  ([#11536](https://github.com/streamlit/streamlit/issues/11536)) — intentionally deferred
-  until this correctness path is solid; this work is a prerequisite, not a substitute.
+  ([#11536](https://github.com/streamlit/streamlit/issues/11536)) — intentionally deferred until this correctness
+  path is solid; this work is a prerequisite, not a substitute.
 - Public `st.context.theme.preference` (or equivalent).
 - Making CSS-injected backgrounds affect `type`.
 - Programmatic theme setters at runtime ([#14172](https://github.com/streamlit/streamlit/issues/14172)).
 
 ## Checklist
 
-| Item | ✅ or comment |
-|------|---------------|
-| Works on SiS, Cloud, etc? | Yes — host theme messages must update `type` (re-enable skipped hostframe E2E) |
-| No breaking API changes | Attribute name/shape unchanged; semantics clarified and made reliable |
-| No new dependencies | Expected |
-| Metrics collected | Existing `context.theme` metrics remain; no new public API |
-| Any security/legal impact? | No |
-| Any docs changes needed? | Yes — docstring/docs must match the chosen A/B/C meaning and drop stale first-load / settings caveats |
+| Item                       | ✅ or comment                                                                                         |
+| -------------------------- | ----------------------------------------------------------------------------------------------------- |
+| Works on SiS, Cloud, etc?  | Yes — host theme messages must update `type` (re-enable skipped hostframe E2E)                        |
+| No breaking API changes    | Attribute name/shape unchanged; semantics clarified and made reliable                                 |
+| No new dependencies        | Expected                                                                                              |
+| Metrics collected          | Existing `context.theme` metrics remain; no new public API                                            |
+| Any security/legal impact? | No                                                                                                    |
+| Any docs changes needed?   | Yes — docstring/docs must match the chosen A/B/C meaning and drop stale first-load / settings caveats |
 
 ## Open questions
 
 These need explicit reviewer sign-off before (or as) the implementation PR:
 
 1. **Semantics:** Confirm Option C (preferred), or choose A or B?
-2. **Public preference later?** Should #11536 (or a follow-up) add
-   `st.context.theme.preference` so preference and appearance can both be queried?
-3. **System + OS change:** When selection is System and the OS theme flips, should that
-   always trigger an auto-rerun (proposed: yes, as an allowlisted source)?
-4. **SiS / embedded hosts:** Any host-specific constraints on sending preference or
-   auto-rerunning on `SET_THEME` / theme messages beyond the hostframe E2E?
+2. **Public preference later?** Should #11536 (or a follow-up) add `st.context.theme.preference` so preference and
+   appearance can both be queried?
+3. **System + OS change:** When selection is System and the OS theme flips, should that always trigger an auto-rerun
+   (proposed: yes, as an allowlisted source)?
+4. **SiS / embedded hosts:** Any host-specific constraints on sending preference or auto-rerunning on `SET_THEME` /
+   theme messages beyond the hostframe E2E?

--- a/specs/2026-08-08-st-context-theme-type/product-spec.md
+++ b/specs/2026-08-08-st-context-theme-type/product-spec.md
@@ -100,9 +100,10 @@ colors.
 
 1. If `backgroundColor` is a 6-digit hex → use luminance (authoritative: what is painted).
 2. Else if `base` is `"light"` or `"dark"` → use it (determines which preset bg fills in).
-3. Else inferred default: `"light"` for single `[theme]` (FE default when base is unspecified), or the
-   section variant name for dual themes (e.g. `"dark"` for `[theme.dark]` — mirrors the FE injecting
-   `base` from the section name via `handleSectionInheritance`).
+   For dual themes, `base` is always present — the FE forces it from the section variant
+   name via `handleSectionInheritance` (e.g. `"dark"` for `[theme.dark]`), so step 2
+   always applies unless a hex `backgroundColor` is set (step 1).
+3. Else `"light"` (the frontend default for single `[theme]` when `base` is unspecified).
 
 - Pros: Matches today's docs; matches the primary "contrast my content" use case; single dark custom theme
   correctly reports `"dark"` even if OS preference is light.
@@ -143,7 +144,7 @@ docstring wording change.
 | Single `[theme]` with `base = "dark"`                | `"light"`            | `"dark"`                     |
 | Single `[theme]` with `#121212` bg, no `base`        | `"light"`            | `"dark"` (hex luminance)     |
 | Single `[theme]` with non-hex bg, no `base`          | `"light"`            | `"light"` (fallback)         |
-| `[theme.light]` + `[theme.dark]`, both well-authored | `"dark"`             | `"dark"` (from dark section) |
+| `[theme.light]` + `[theme.dark]`, both well-authored | `"dark"`             | `"dark"` (section bg or forced variant base) |
 | `[theme.dark]` with light hex bg (pathological)      | `"dark"`             | `"light"` (what is painted)  |
 | Host dark theme (SiS/Cloud) overriding config        | `"dark"` (host)      | `"dark"` (host wins)         |
 

--- a/specs/2026-08-08-st-context-theme-type/product-spec.md
+++ b/specs/2026-08-08-st-context-theme-type/product-spec.md
@@ -96,9 +96,11 @@ differs from OS preference, and for pathological section colors — see the beha
 
 `type` answers "does the app look light or dark?" Resolve from the active theme/section:
 
-1. If `backgroundColor` is a valid hex color (`#rgb`, `#rgba`, `#rrggbb`, or `#rrggbbaa`)
-   → use luminance (authoritative: what is painted). Short forms are expanded before
-   computing luminance (e.g. `#fff` → `#ffffff`); alpha channels are ignored.
+1. If `backgroundColor` is a color the backend can parse — hex in 3, 4, 6, or 8 digits
+   (with or without the leading `#`), a CSS named color, `rgb()`, or `hsl()` → use its
+   luminance, since that is what gets painted. Alpha channels are ignored, matching the
+   frontend. A value in a syntax the backend cannot parse falls through to step 2, and the
+   frontend corrects it (see the [tech spec](./tech-spec.md) §4).
 2. Else if `base` is `"light"` or `"dark"` → use it (it determines which preset background
    fills in):
    - **Single `[theme]`:** `base` is whatever the user set, if anything.
@@ -156,7 +158,7 @@ docstring wording change.
 | Single `[theme]` with `base = "dark"`                | `"light"`            | `"dark"`                     |
 | Single `[theme]` with `#121212` bg, no `base`        | `"light"`            | `"dark"` (hex luminance)     |
 | Single `[theme]` with `#fff` bg, no `base`           | `"light"`            | `"light"` (short hex → luminance) |
-| Single `[theme]` with non-hex bg, no `base`          | `"light"`            | `"light"` (fallback) — ⚠️ **wrong when the color is dark**, e.g. `backgroundColor = "black"` paints dark but reports `"light"`. Theme colors are not hex-validated, so this is reachable; see open question 5 |
+| Single `[theme]` with non-hex bg, no `base`          | `"light"`            | `"dark"` for `backgroundColor = "black"` — the painted value. Named colours, `rgb()` and `hsl()` are parsed on the backend, so this is correct on the first run with no extra rerun |
 | `[theme.light]` + `[theme.dark]`, both well-authored | `"dark"`             | `"dark"` (section bg or forced variant base) |
 | `[theme.dark]` with light hex bg (pathological)      | `"dark"`             | `"light"` (what is painted)  |
 | Only `[theme.sidebar]` set (no main-area config)     | `"dark"`             | `"light"` (main area = lightTheme) |
@@ -167,10 +169,12 @@ docstring wording change.
 Independent of A/B/C, once fixed:
 
 1. **First script run** — `type` is correct for that run (including `[theme]` / `[theme.light]` / `[theme.dark]`).
-   - *Caveat:* With an embedding host (SiS/Cloud) that pushes its own theme, the first run may resolve from the
-     other source — host theme vs `config.toml` — depending on whether the host's theme arrives before or after
-     the app's first message to the server. Both orderings are corrected by an immediate auto-rerun; see the
-     ordering table in the [tech spec](./tech-spec.md).
+   - *Caveat:* In the few cases where the backend cannot determine the appearance itself — an embedding host
+     (SiS/Cloud) that pushes its own theme after the app connects, or a `backgroundColor` in a CSS syntax the
+     backend cannot parse — the first run may briefly hold the other value. The backend reports what the script
+     saw, the client notices the disagreement, and one immediate auto-rerun corrects it; see the
+     [tech spec](./tech-spec.md) §4. Apps that only render from `type` see a flicker at worst; apps with side
+     effects on their first run would perform them with the earlier value.
 2. **Appearance change** (menu System/Light/Dark, host theme message, OS change while on System) — app reruns and
    `type` updates without a manual rerun.
 3. **MPA deep links** — non-default page + `[theme]` still lands on that page (no #11797 regression).
@@ -209,9 +213,9 @@ let A and C coexist. That is **out of scope** for #11920 and belongs with
 
 | Item                       | ✅ or comment                                                                                         |
 | -------------------------- | ----------------------------------------------------------------------------------------------------- |
-| Works on SiS, Cloud, etc?  | Yes — host theme messages must update `type` (re-enable skipped hostframe E2E)                        |
+| Works on SiS, Cloud, etc?  | Yes — host theme messages update `type`; re-enables the hostframe E2E skipped since #11870 |
 | No breaking API changes    | Attribute name/shape unchanged; semantics clarified and made reliable                                 |
-| No new dependencies        | Expected                                                                                              |
+| No new dependencies        | Yes — backend color parsing uses `PIL.ImageColor`, already a runtime dependency               |
 | Metrics collected          | Existing `context.theme` metrics remain; no new public API                                            |
 | Any security/legal impact? | No                                                                                                    |
 | Any docs changes needed?   | Yes — docstring/docs must match the chosen A/B/C meaning and drop stale first-load / settings caveats |
@@ -220,16 +224,10 @@ let A and C coexist. That is **out of scope** for #11920 and belongs with
 
 These need explicit reviewer sign-off before (or as) the implementation PR:
 
-1. **Semantics:** Confirm Option C (preferred), or choose A or B?
-2. **Public preference later?** Should #11536 (or a follow-up) add `st.context.theme.preference` so preference and
+1. **Public preference later?** Should #11536 (or a follow-up) add `st.context.theme.preference` so preference and
    appearance can both be queried?
-3. **System + OS change:** When selection is System and the OS theme flips, should that always trigger an auto-rerun
-   (proposed: yes, as an allowlisted source)?
-4. **SiS / embedded hosts:** Any host-specific constraints on sending preference or auto-rerunning on
-   `SET_CUSTOM_THEME_CONFIG` / theme messages beyond the hostframe E2E?
-5. **Non-hex `backgroundColor`:** Theme color options are not validated as hex today, so
-   `backgroundColor = "black"` (or `rgb()` / `hsl()`) is accepted and paints dark, while the backend
-   resolver can only read hex and would report `"light"`. Which way do we go — accept and document the
-   wrong value, teach the resolver named colors and `rgb()`/`hsl()`, or start validating theme colors as
-   hex in config (a breaking change for configs that work today)? See the limitation in the
-   [tech spec](./tech-spec.md) §2.
+2. **System + OS change:** When the selection is System and the OS flips light↔dark, the app reruns so `type`
+   keeps up. Is an automatic rerun on an OS-level change what we want, given the script re-executes without
+   the user touching anything?
+3. **SiS / embedded hosts:** Any host-specific constraints on sending preference, or on auto-rerunning in
+   response to `SET_CUSTOM_THEME_CONFIG`, beyond what the hostframe E2E covers?

--- a/specs/2026-08-08-st-context-theme-type/product-spec.md
+++ b/specs/2026-08-08-st-context-theme-type/product-spec.md
@@ -75,7 +75,8 @@ three different things (current docs describe **C** — "inferred from the backg
 | B. Theme identity          | "Which application theme is active?" | The theme name/variant: Default Light, Default Dark, Custom, Custom Light, Custom Dark  |
 | C. Visual appearance       | "Does the app look light or dark?"  | `base` / luminance of the rendered background                                           |
 
-Where they diverge in practice (see behavior matrix above): A/B/C agree for presets and well-authored dual themes;
+Where they diverge in practice (see the "Expected `type` under Option C" behavior matrix in the Proposal section
+below): A/B/C agree for presets and well-authored dual themes;
 they disagree for a single custom theme whose appearance differs from OS preference, and for pathological section
 colors.
 

--- a/specs/2026-08-08-st-context-theme-type/product-spec.md
+++ b/specs/2026-08-08-st-context-theme-type/product-spec.md
@@ -98,12 +98,23 @@ colors.
 
 `type` answers "does the app look light or dark?" Resolve from the active theme/section:
 
-1. If `backgroundColor` is a 6-digit hex → use luminance (authoritative: what is painted).
+1. If `backgroundColor` is a valid hex color (`#rgb`, `#rgba`, `#rrggbb`, or `#rrggbbaa`)
+   → use luminance (authoritative: what is painted). Short forms are expanded before
+   computing luminance (e.g. `#fff` → `#ffffff`); alpha channels are ignored.
 2. Else if `base` is `"light"` or `"dark"` → use it (determines which preset bg fills in).
    For dual themes, `base` is always present — the FE forces it from the section variant
    name via `handleSectionInheritance` (e.g. `"dark"` for `[theme.dark]`), so step 2
    always applies unless a hex `backgroundColor` is set (step 1).
 3. Else `"light"` (the frontend default for single `[theme]` when `base` is unspecified).
+
+**Sidebar-only configs:** Setting only `[theme.sidebar]` (without any main-area keys in
+`[theme]`, `[theme.light]`, or `[theme.dark]`) still creates a custom theme on the FE —
+the main area inherits from `lightTheme` and always paints light. The resolver detects
+sidebar sections and enters the single-custom-theme path (returning `"light"` via the
+fallback), which matches what is painted. Similarly, `[theme.light.sidebar]` or
+`[theme.dark.sidebar]` trigger dual-theme mode on the FE (the FE's `hasThemeSectionConfigs`
+recursively checks nested objects); the resolver mirrors this by entering the dual-theme
+path when sidebar subsections are present.
 
 - Pros: Matches today's docs; matches the primary "contrast my content" use case; single dark custom theme
   correctly reports `"dark"` even if OS preference is light.
@@ -143,9 +154,11 @@ docstring wording change.
 | Presets only                                         | `"light"` / `"dark"` | Same as preference           |
 | Single `[theme]` with `base = "dark"`                | `"light"`            | `"dark"`                     |
 | Single `[theme]` with `#121212` bg, no `base`        | `"light"`            | `"dark"` (hex luminance)     |
+| Single `[theme]` with `#fff` bg, no `base`           | `"light"`            | `"light"` (short hex → luminance) |
 | Single `[theme]` with non-hex bg, no `base`          | `"light"`            | `"light"` (fallback)         |
 | `[theme.light]` + `[theme.dark]`, both well-authored | `"dark"`             | `"dark"` (section bg or forced variant base) |
 | `[theme.dark]` with light hex bg (pathological)      | `"dark"`             | `"light"` (what is painted)  |
+| Only `[theme.sidebar]` set (no main-area config)     | `"dark"`             | `"light"` (main area = lightTheme) |
 | Host dark theme (SiS/Cloud) overriding config        | `"dark"` (host)      | `"dark"` (host wins)         |
 
 ### User-facing behavior (reliability)

--- a/specs/2026-08-08-st-context-theme-type/product-spec.md
+++ b/specs/2026-08-08-st-context-theme-type/product-spec.md
@@ -1,0 +1,207 @@
+---
+author: mayagbarnes
+created: 2026-08-08
+---
+
+# Make `st.context.theme.type` correct in all situations
+
+## Summary
+
+`st.context.theme.type` should reliably return `"light"` or `"dark"` on the first script
+run of a session and whenever appearance changes (menu, host, or OS) — without
+regressing multipage deep links ([#11920](https://github.com/streamlit/streamlit/issues/11920)).
+
+This product spec owns the decision of **what `type` means** now that appearance
+preference and application theme are separate. See the [tech spec](./tech-spec.md) for
+protocol, backend resolution, and the MPA-safe auto-rerun design.
+
+## Problem
+
+### Motivation / demand
+
+[#11920](https://github.com/streamlit/streamlit/issues/11920) is currently the
+**highest-upvoted open theming issue** on the Streamlit tracker (21 👍 as of this
+writing — ahead of other open `feature:theming` issues). Fixing it also
+**unblocks** [#11536](https://github.com/streamlit/streamlit/issues/11536) (expose all
+theming config options in `st.context.theme`, also highly upvoted): that expansion
+reuses the same frontend→backend theme sync path, so shipping more fields on a
+still-stale `st.context.theme` would inherit the same first-run and appearance-change
+bugs. Correctness first, then richer theme context.
+
+### Use cases
+
+Developers use `st.context.theme.type` to adapt app content to the active theme:
+
+```python
+# 1. Contrast-aware assets (logos, hero images)
+logo = "logo-on-dark.svg" if st.context.theme.type == "dark" else "logo-on-light.svg"
+st.image(logo)
+
+# 2. Chart / Plotly color schemes that match the app
+fig.update_layout(template="plotly_dark" if st.context.theme.type == "dark" else "plotly_white")
+
+# 3. Custom Markdown / HTML styling
+bg = "#0e1117" if st.context.theme.type == "dark" else "#ffffff"
+st.markdown(f'<div style="background:{bg}">…</div>', unsafe_allow_html=True)
+
+# 4. Custom components / iframes that need to match Streamlit chrome
+# (also relevant for future st.iframe inject_theme; see st-iframe product spec)
+```
+
+A secondary ask (seen in forum/issue comments) is matching the **user’s** light/dark
+intent elsewhere. That may be preference, not painted appearance — which is why the
+semantics choice below matters.
+
+### Where it fails today
+
+After [#10972](https://github.com/streamlit/streamlit/pull/10972) shipped `type`, an
+automatic theme-change rerun broke multipage deep links when `[theme]` was set
+([#11797](https://github.com/streamlit/streamlit/issues/11797)). [#11870](https://github.com/streamlit/streamlit/pull/11870)
+removed that rerun to fix MPA. Documented tradeoff → [#11920](https://github.com/streamlit/streamlit/issues/11920):
+
+1. **First run with a custom theme** — `type` can reflect a cached/preset theme, not the
+   custom theme that paints after `NewSession`.
+2. **Settings / main-menu / host appearance change** — UI updates immediately; `type`
+   stays stale until a later unrelated rerun
+   ([#15287](https://github.com/streamlit/streamlit/issues/15287)).
+
+### Why the meaning of `type` is newly ambiguous
+
+The main menu separates **appearance preference** (System / Light / Dark) from
+**application theme** (defaults vs custom vs custom light/dark). Before that split,
+preference and theme were effectively tied. Now `type` can mean three different things
+(current docs describe **C** — “inferred from the background color”):
+
+| Meaning | What it answers | Source of truth |
+|---------|-----------------|-----------------|
+| A. User preference | "What did the user/system ask for?" | Menu selection / OS `prefers-color-scheme` |
+| B. Active variant | "Which theme branch is active?" | Which section (`[theme.light]` vs `[theme.dark]`) was selected |
+| C. Visual appearance | "Does the app look light or dark?" | `base` / luminance of the rendered background |
+
+Where they diverge in practice (see behavior matrix below): A/B/C agree for
+presets and well-authored dual themes; they disagree for a single custom theme
+whose appearance differs from OS preference, and for pathological section
+colors.
+
+### Related issues
+
+| Issue | Role |
+|-------|------|
+| [#11920](https://github.com/streamlit/streamlit/issues/11920) | Umbrella: make `type` correct in all situations (highest-upvoted open theming issue) |
+| [#11797](https://github.com/streamlit/streamlit/issues/11797) | MPA deep-link regression (closed by #11870) |
+| [#15287](https://github.com/streamlit/streamlit/issues/15287) | No auto-update on settings theme change (dup of #11920) |
+| [#11536](https://github.com/streamlit/streamlit/issues/11536) | Expose all theming config options — unblocked by this work; still out of scope here |
+| [#5009](https://github.com/streamlit/streamlit/issues/5009) | Original light/dark detection request (closed by #10972) |
+
+## Proposal
+
+### What `type` means — options for review
+
+**Option C: Visual appearance of the active theme** ✅ PREFERRED
+
+`type` answers “does the app look light or dark?” Resolve from the active theme/section:
+
+1. Prefer `base` if set.
+2. Else infer from 6-digit hex `backgroundColor` luminance.
+3. Else fall back to resolved appearance preference.
+
+- Pros: Matches today’s docs; matches the primary “contrast my content” use case; single
+  dark custom theme correctly reports `"dark"` even if OS preference is light.
+- Cons: Pathological misauthored sections (dark section, light bg) report what is *seen*,
+  not what the section is *named*; preference alone is not exposed on `st.context.theme`.
+
+**Option A: User preference**
+
+`type` ≈ menu/OS selection (`"light"` / `"dark"`; System resolved to OS).
+
+- Pros: Simplest implementation (little/no config branching on the backend).
+- Cons: Wrong for the primary use case when a single custom theme’s appearance disagrees
+  with OS preference; contradicts current docs; “auto” intent is lost unless we expand
+  the type.
+
+**Option B: Active variant**
+
+`type` follows which branch is selected (`[theme.light]` vs `[theme.dark]` / preset name),
+independent of that section’s actual background.
+
+- Pros: Stable even if luminance edge cases misclassify colors.
+- Cons: Undefined for a single custom theme with no light/dark sections; diverges from
+  painted UI in the pathological case; still needs preference as an *input* to pick the
+  section.
+
+**Review ask:** Accept Option C (preferred), or choose A/B and adjust the tech resolver
+accordingly. Implementation of correctness (first run + appearance-change rerun) proceeds
+either way; only resolution rules and docstring wording change.
+
+### Expected `type` under Option C (behavior matrix)
+
+| Config | Preference sent | Expected `type` |
+|--------|-----------------|-----------------|
+| Presets only | `"light"` / `"dark"` | Same as preference |
+| Single `[theme]` with `base = "dark"` | `"light"` | `"dark"` |
+| Single `[theme]` with `#121212` bg, no `base` | `"light"` | `"dark"` (hex luminance) |
+| Single `[theme]` with non-hex bg, no `base` | `"light"` | `"light"` (fallback) |
+| `[theme.light]` + `[theme.dark]`, both well-authored | `"dark"` | `"dark"` (from dark section) |
+| `[theme.dark]` with light hex bg (pathological) | `"dark"` | `"light"` (what is painted) |
+
+### User-facing behavior (reliability)
+
+Independent of A/B/C, once fixed:
+
+1. **First script run** — `type` is correct for that run (including `[theme]` /
+   `[theme.light]` / `[theme.dark]`).
+2. **Appearance change** (menu System/Light/Dark, host theme message, OS change while on
+   System) — app reruns and `type` updates without a manual rerun.
+3. **MPA deep links** — non-default page + `[theme]` still lands on that page (no #11797
+   regression).
+4. **CSS overrides** — injected CSS backgrounds remain out of scope for `type`.
+
+### API surface
+
+No new public parameters or commands:
+
+```text
+st.context.theme.type → Literal["light", "dark"] | None
+```
+
+`None` is only expected when there is no script-run context (e.g. imported helper
+code outside a run). In a normal app script after connect, `type` should be
+`"light"` or `"dark"` — including on the first run once this fix lands. Prefer
+guarding with `if st.context.theme.type == "dark":` rather than treating `None`
+as a third theme mode.
+
+A separate public preference field (e.g. `st.context.theme.preference` →
+`"light"` | `"dark"` | `"auto"`) would let A and C coexist. That is **out of scope** for
+#11920 and belongs with [#11536](https://github.com/streamlit/streamlit/issues/11536).
+
+## Out of scope
+
+- Exposing all theming config options on `st.context.theme`
+  ([#11536](https://github.com/streamlit/streamlit/issues/11536)) — intentionally deferred
+  until this correctness path is solid; this work is a prerequisite, not a substitute.
+- Public `st.context.theme.preference` (or equivalent).
+- Making CSS-injected backgrounds affect `type`.
+- Programmatic theme setters at runtime ([#14172](https://github.com/streamlit/streamlit/issues/14172)).
+
+## Checklist
+
+| Item | ✅ or comment |
+|------|---------------|
+| Works on SiS, Cloud, etc? | Yes — host theme messages must update `type` (re-enable skipped hostframe E2E) |
+| No breaking API changes | Attribute name/shape unchanged; semantics clarified and made reliable |
+| No new dependencies | Expected |
+| Metrics collected | Existing `context.theme` metrics remain; no new public API |
+| Any security/legal impact? | No |
+| Any docs changes needed? | Yes — docstring/docs must match the chosen A/B/C meaning and drop stale first-load / settings caveats |
+
+## Open questions
+
+These need explicit reviewer sign-off before (or as) the implementation PR:
+
+1. **Semantics:** Confirm Option C (preferred), or choose A or B?
+2. **Public preference later?** Should #11536 (or a follow-up) add
+   `st.context.theme.preference` so preference and appearance can both be queried?
+3. **System + OS change:** When selection is System and the OS theme flips, should that
+   always trigger an auto-rerun (proposed: yes, as an allowlisted source)?
+4. **SiS / embedded hosts:** Any host-specific constraints on sending preference or
+   auto-rerunning on `SET_THEME` / theme messages beyond the hostframe E2E?

--- a/specs/2026-08-08-st-context-theme-type/product-spec.md
+++ b/specs/2026-08-08-st-context-theme-type/product-spec.md
@@ -20,11 +20,14 @@ design.
 ### Motivation / demand
 
 [#11920](https://github.com/streamlit/streamlit/issues/11920) is currently the **highest-upvoted open theming
-issue** on the Streamlit tracker (21 👍 as of this writing — ahead of other open `feature:theming` issues). Fixing
-it also **unblocks** [#11536](https://github.com/streamlit/streamlit/issues/11536) (expose all theming config
-options in `st.context.theme`, also highly upvoted): that expansion reuses the same frontend→backend theme sync
-path, so shipping more fields on a still-stale `st.context.theme` would inherit the same first-run and
-appearance-change bugs. Correctness first, then richer theme context.
+issue** on the Streamlit tracker (21 👍 as of this writing — ahead of other open `feature:theming` issues).
+
+Correctness here is also a prerequisite for any future expansion of `st.context.theme`
+([#11536](https://github.com/streamlit/streamlit/issues/11536)): more fields on a still-stale object would
+inherit the same first-run and appearance-change bugs. Note that #11536's direction is itself contested —
+exposing the whole theme means attaching many properties to every rerun, and CSS variables on the frontend
+([#4198](https://github.com/streamlit/streamlit/issues/4198)) are arguably the better answer for the underlying
+use case of styling custom HTML. This spec takes no position on that; it only fixes what exists.
 
 ### Use cases
 
@@ -85,7 +88,7 @@ differs from OS preference, and for pathological section colors — see the beha
 | [#11920](https://github.com/streamlit/streamlit/issues/11920) | Umbrella: make `type` correct in all situations (highest-upvoted open theming issue) |
 | [#11797](https://github.com/streamlit/streamlit/issues/11797) | MPA deep-link regression (closed by #11870)                                          |
 | [#15287](https://github.com/streamlit/streamlit/issues/15287) | No auto-update on settings theme change (dup of #11920)                              |
-| [#11536](https://github.com/streamlit/streamlit/issues/11536) | Expose all theming config options — unblocked by this work; still out of scope here  |
+| [#11536](https://github.com/streamlit/streamlit/issues/11536) | Expose all theming config options — out of scope, and its direction is contested (see #4198)  |
 | [#5009](https://github.com/streamlit/streamlit/issues/5009)   | Original light/dark detection request (closed by #10972)                             |
 
 ## Proposal
@@ -175,8 +178,11 @@ Independent of A/B/C, once fixed:
      saw, the client notices the disagreement, and one immediate auto-rerun corrects it; see the
      [tech spec](./tech-spec.md) §4. Apps that only render from `type` see a flicker at worst; apps with side
      effects on their first run would perform them with the earlier value.
-2. **Appearance change** (menu System/Light/Dark, host theme message, OS change while on System) — app reruns and
-   `type` updates without a manual rerun.
+2. **Appearance change** (menu System/Light/Dark, host theme message, OS change while on System) — for apps that
+   read `st.context.theme`, the app reruns and `type` updates without a manual rerun. Apps that never read it are
+   **not** rerun: `type` is read by roughly 0.6% of apps, so the correction is gated on actual use rather than
+   charged to everyone. Such an app pays at most one correction per session — see the
+   [tech spec](./tech-spec.md) access gate.
 3. **MPA deep links** — non-default page + `[theme]` still lands on that page (no #11797 regression).
 4. **CSS overrides** — injected CSS backgrounds remain out of scope for `type`.
 5. **Host theme vs config.toml** — runtime host themes (`SET_CUSTOM_THEME_CONFIG`) replace config.toml on the
@@ -224,10 +230,14 @@ let A and C coexist. That is **out of scope** for #11920 and belongs with
 
 These need explicit reviewer sign-off before (or as) the implementation PR:
 
-1. **Public preference later?** Should #11536 (or a follow-up) add `st.context.theme.preference` so preference and
-   appearance can both be queried?
-2. **System + OS change:** When the selection is System and the OS flips light↔dark, the app reruns so `type`
+1. **Adoption vs. cost.** `st.context.theme.type` is read by roughly **0.6% of apps**. The tech spec's access
+   gate keeps the other 99.4% free of extra reruns, and its scope decision offers a lighter variant that drops
+   the backend resolver at the price of a visibly wrong first paint. Which variant do we want?
+2. **Public preference later?** Should a follow-up add `st.context.theme.preference` so preference and
+   appearance can both be queried? (Reviewer feedback so far: preference and theme identity are not useful on
+   the backend, so probably not.)
+3. **System + OS change:** When the selection is System and the OS flips light↔dark, the app reruns so `type`
    keeps up. Is an automatic rerun on an OS-level change what we want, given the script re-executes without
    the user touching anything?
-3. **SiS / embedded hosts:** Any host-specific constraints on sending preference, or on auto-rerunning in
+4. **SiS / embedded hosts:** Any host-specific constraints on sending preference, or on auto-rerunning in
    response to `SET_CUSTOM_THEME_CONFIG`, beyond what the hostframe E2E covers?

--- a/specs/2026-08-08-st-context-theme-type/product-spec.md
+++ b/specs/2026-08-08-st-context-theme-type/product-spec.md
@@ -180,8 +180,10 @@ Independent of A/B/C, once fixed:
      effects on their first run would perform them with the earlier value.
 2. **Appearance change** (menu System/Light/Dark, host theme message, OS change while on System) — for apps that
    read `st.context.theme`, the app reruns and `type` updates without a manual rerun. Apps that never read it are
-   **not** rerun: `type` is read by roughly 0.6% of apps, so the correction is gated on actual use rather than
-   charged to everyone. Such an app pays at most one correction per session — see the
+   **not charged per theme change**: `type` is read by roughly 0.6% of apps, so the correction is gated on actual
+   use rather than charged to everyone. Precisely, a no-read app pays **at most one** correction per session — on
+   the first appearance change after load, and only if no other rerun happened first — then none thereafter. Not
+   zero, because the first `NewSession` is sent before any user code can declare a read; see the
    [tech spec](./tech-spec.md) access gate.
 3. **MPA deep links** — non-default page + `[theme]` still lands on that page (no #11797 regression).
 4. **CSS overrides** — injected CSS backgrounds remain out of scope for `type`.
@@ -228,7 +230,9 @@ let A and C coexist. That is **out of scope** for #11920 and belongs with
 
 ## Open questions
 
-These need explicit reviewer sign-off before (or as) the implementation PR:
+These are sign-off gates on the **implementation** PR, not blockers for agreeing the direction
+here. Merging this spec settles the meaning of `type` (Option C) and the preferred approach;
+these four still need an explicit answer before the implementation lands:
 
 1. **Adoption vs. cost.** `st.context.theme.type` is read by roughly **0.6% of apps**. The tech spec's access
    gate keeps the other 99.4% free of extra reruns, and its scope decision offers a lighter variant that drops

--- a/specs/2026-08-08-st-context-theme-type/product-spec.md
+++ b/specs/2026-08-08-st-context-theme-type/product-spec.md
@@ -75,10 +75,8 @@ three different things (current docs describe **C** — "inferred from the backg
 | B. Theme identity          | "Which application theme is active?" | The theme name/variant: Default Light, Default Dark, Custom, Custom Light, Custom Dark  |
 | C. Visual appearance       | "Does the app look light or dark?"  | `base` / luminance of the rendered background                                           |
 
-Where they diverge in practice (see the "Expected `type` under Option C" behavior matrix in the Proposal section
-below): A/B/C agree for presets and well-authored dual themes;
-they disagree for a single custom theme whose appearance differs from OS preference, and for pathological section
-colors.
+A/B/C agree for presets and well-authored dual themes. They diverge for a single custom theme whose appearance
+differs from OS preference, and for pathological section colors — see the behavior matrix below.
 
 ### Related issues
 
@@ -101,10 +99,13 @@ colors.
 1. If `backgroundColor` is a valid hex color (`#rgb`, `#rgba`, `#rrggbb`, or `#rrggbbaa`)
    → use luminance (authoritative: what is painted). Short forms are expanded before
    computing luminance (e.g. `#fff` → `#ffffff`); alpha channels are ignored.
-2. Else if `base` is `"light"` or `"dark"` → use it (determines which preset bg fills in).
-   For dual themes, `base` is always present — the FE forces it from the section variant
-   name via `handleSectionInheritance` (e.g. `"dark"` for `[theme.dark]`), so step 2
-   always applies unless a hex `backgroundColor` is set (step 1).
+2. Else if `base` is `"light"` or `"dark"` → use it (it determines which preset background
+   fills in):
+   - **Single `[theme]`:** `base` is whatever the user set, if anything.
+   - **Dual themes:** `base` is always present, because the frontend forces it from the
+     section variant via `handleSectionInheritance` (e.g. `"dark"` for `[theme.dark]`) — so
+     step 2 always applies unless a hex `backgroundColor` is set. Note that `base` is not a
+     valid key inside `[theme.light]` / `[theme.dark]`; only `[theme]` accepts it.
 3. Else `"light"` (the frontend default for single `[theme]` when `base` is unspecified).
 
 **Sidebar-only configs:** Setting only `[theme.sidebar]` (without any main-area keys in
@@ -155,7 +156,7 @@ docstring wording change.
 | Single `[theme]` with `base = "dark"`                | `"light"`            | `"dark"`                     |
 | Single `[theme]` with `#121212` bg, no `base`        | `"light"`            | `"dark"` (hex luminance)     |
 | Single `[theme]` with `#fff` bg, no `base`           | `"light"`            | `"light"` (short hex → luminance) |
-| Single `[theme]` with non-hex bg, no `base`          | `"light"`            | `"light"` (fallback)         |
+| Single `[theme]` with non-hex bg, no `base`          | `"light"`            | `"light"` (fallback) — ⚠️ **wrong when the color is dark**, e.g. `backgroundColor = "black"` paints dark but reports `"light"`. Theme colors are not hex-validated, so this is reachable; see open question 5 |
 | `[theme.light]` + `[theme.dark]`, both well-authored | `"dark"`             | `"dark"` (section bg or forced variant base) |
 | `[theme.dark]` with light hex bg (pathological)      | `"dark"`             | `"light"` (what is painted)  |
 | Only `[theme.sidebar]` set (no main-area config)     | `"dark"`             | `"light"` (main area = lightTheme) |
@@ -166,15 +167,18 @@ docstring wording change.
 Independent of A/B/C, once fixed:
 
 1. **First script run** — `type` is correct for that run (including `[theme]` / `[theme.light]` / `[theme.dark]`).
-   - *Caveat:* Host-provided themes (SiS/Cloud) that arrive after the FE's first BackMsg may have a one-run
-     delay corrected by immediate auto-rerun. In practice this race is rare (hosts send theme during iframe init).
+   - *Caveat:* With an embedding host (SiS/Cloud) that pushes its own theme, the first run may resolve from the
+     other source — host theme vs `config.toml` — depending on whether the host's theme arrives before or after
+     the app's first message to the server. Both orderings are corrected by an immediate auto-rerun; see the
+     ordering table in the [tech spec](./tech-spec.md).
 2. **Appearance change** (menu System/Light/Dark, host theme message, OS change while on System) — app reruns and
    `type` updates without a manual rerun.
 3. **MPA deep links** — non-default page + `[theme]` still lands on that page (no #11797 regression).
 4. **CSS overrides** — injected CSS backgrounds remain out of scope for `type`.
 5. **Host theme vs config.toml** — runtime host themes (`SET_CUSTOM_THEME_CONFIG`) replace config.toml on the
-   FE (no merge, last-write-wins). Pre-load host customizations (`LIGHT_THEME`/`DARK_THEME`) merge into
-   presets only but do not propagate into config.toml custom themes. `type` always reflects what is painted.
+   frontend (no merge, last-write-wins). Pre-load host customizations (`LIGHT_THEME`/`DARK_THEME`) merge into
+   presets only but do not propagate into config.toml custom themes. `type` always reflects what is painted —
+   including after the user switches between a host theme and a config.toml theme in the settings menu.
 
 ### API surface
 
@@ -223,3 +227,9 @@ These need explicit reviewer sign-off before (or as) the implementation PR:
    (proposed: yes, as an allowlisted source)?
 4. **SiS / embedded hosts:** Any host-specific constraints on sending preference or auto-rerunning on
    `SET_CUSTOM_THEME_CONFIG` / theme messages beyond the hostframe E2E?
+5. **Non-hex `backgroundColor`:** Theme color options are not validated as hex today, so
+   `backgroundColor = "black"` (or `rgb()` / `hsl()`) is accepted and paints dark, while the backend
+   resolver can only read hex and would report `"light"`. Which way do we go — accept and document the
+   wrong value, teach the resolver named colors and `rgb()`/`hsl()`, or start validating theme colors as
+   hex in config (a breaking change for configs that work today)? See the limitation in the
+   [tech spec](./tech-spec.md) §2.

--- a/specs/2026-08-08-st-context-theme-type/product-spec.md
+++ b/specs/2026-08-08-st-context-theme-type/product-spec.md
@@ -98,9 +98,11 @@ colors.
 
 `type` answers "does the app look light or dark?" Resolve from the active theme/section:
 
-1. Prefer `base` if set.
-2. Else infer from 6-digit hex `backgroundColor` luminance.
-3. Else fall back to resolved appearance preference.
+1. If `backgroundColor` is a 6-digit hex → use luminance (authoritative: what is painted).
+2. Else if `base` is `"light"` or `"dark"` → use it (determines which preset bg fills in).
+3. Else inferred default: `"light"` for single `[theme]` (FE default when base is unspecified), or the
+   section variant name for dual themes (e.g. `"dark"` for `[theme.dark]` — mirrors the FE injecting
+   `base` from the section name via `handleSectionInheritance`).
 
 - Pros: Matches today's docs; matches the primary "contrast my content" use case; single dark custom theme
   correctly reports `"dark"` even if OS preference is light.

--- a/specs/2026-08-08-st-context-theme-type/tech-spec.md
+++ b/specs/2026-08-08-st-context-theme-type/tech-spec.md
@@ -91,11 +91,18 @@ In [`ClientState.proto`](../../proto/streamlit/proto/ClientState.proto), add to
 // Resolved appearance from the client: "light" or "dark".
 // System menu selection must be resolved to OS preference before send.
 optional string theme_preference = 7;
+
+// True when a host-provided custom theme (SET_CUSTOM_THEME_CONFIG) is active.
+// When set, the backend skips config.toml resolution and uses theme_preference
+// directly — the host theme overrides config and only the FE knows its appearance.
+optional bool host_theme_active = 8;
 ```
 
 Keep `color_scheme` as what Python exposes via `st.context.theme.type`. When
 `theme_preference` is present, the backend overwrites `color_scheme` before the script
-run. **Old clients without field 7 keep working:** the backend leaves `color_scheme` as
+run. When `host_theme_active` is true, the backend returns `theme_preference` directly
+(config.toml is irrelevant — the FE is painting the host theme, not the config theme).
+**Old clients without fields 7-8 keep working:** the backend leaves `color_scheme` as
 sent, so existing deployed frontends against a new backend do not regress.
 
 ### 2. Backend resolver
@@ -143,8 +150,12 @@ def _merge_for_dual_theme(parent: dict, section: dict) -> dict:
       dropped → bg luminance → "light" (what is painted). Correct.
     - [theme.dark] base="dark" → section's explicit base is kept. Correct.
     """
-    merged = {**parent, **section}
-    if "base" not in section:
+    # Filter None values — get_options_for_section includes all registered keys
+    # even when unset. Only non-None values represent user-provided config.
+    parent_set = {k: v for k, v in parent.items() if v is not None}
+    section_set = {k: v for k, v in section.items() if v is not None}
+    merged = {**parent_set, **section_set}
+    if "base" not in section_set:
         merged.pop("base", None)
     return merged
 
@@ -159,10 +170,19 @@ def _type_from_bg_or_base(opts: dict, *, fallback: str) -> str:
     return fallback
 ```
 
-**`_has_section_content`** returns True when the section has at least one option key
-(e.g. `primaryColor`, `base`, `backgroundColor`). A TOML header with no keys (bare
-`[theme.dark]` with nothing underneath) is not detected as a section — this matches
-the FE's behavior, which also requires at least one key to trigger dual-theme mode.
+**`_has_section_content`** returns True when the section has at least one option with a
+non-None value. `get_options_for_section` returns all registered option keys for the
+section (even when the user didn't write that TOML header), so checking truthiness of
+the dict is insufficient — filter None values:
+
+```python
+def _has_section_content(section: dict) -> bool:
+    return any(v is not None for v in section.values())
+```
+
+A bare `[theme.dark]` header with no keys underneath has all-None values → returns
+False. This matches the FE's behavior, which also requires at least one key to trigger
+dual-theme mode.
 
 | Config shape | How to get `type` (Option C) |
 |--------------|------------------------------|
@@ -178,11 +198,21 @@ resolved value:
 ```python
 if client_state.HasField("context_info"):
     self._client_state.context_info.CopyFrom(client_state.context_info)
-    if self._client_state.context_info.HasField("theme_preference"):
-        self._client_state.context_info.color_scheme = resolve_theme_type(
-            self._client_state.context_info.theme_preference
-        )
+    ctx = self._client_state.context_info
+    if ctx.HasField("theme_preference"):
+        if ctx.host_theme_active:
+            # Host theme overrides config.toml — FE already resolved appearance.
+            ctx.color_scheme = ctx.theme_preference
+        else:
+            ctx.color_scheme = resolve_theme_type(ctx.theme_preference)
 ```
+
+**Critical:** `RerunData.context_info` must be sourced from `self._client_state` (the
+resolved copy), not from the incoming `client_state` parameter. After the snippet above,
+all downstream code that builds `RerunData` reads from `self._client_state.context_info`
+which now has the correct `color_scheme`. Verify that the existing `_create_rerun_data`
+helper (or equivalent) already uses `self._client_state` — if it reads the raw parameter
+instead, the resolved value never reaches the script.
 
 Applies to **full-script and fragment** reruns alike.
 
@@ -198,6 +228,7 @@ In [`App.sendRerunBackMsg`](../../frontend/app/src/App.tsx) / `contextInfo`:
 
 ```ts
 themePreference: this.getResolvedThemePreference(), // "light" | "dark"
+hostThemeActive: this.hostThemePreference != null && !this.hasEmbedThemeOverride(),
 ```
 
 **Source of truth** (do not reverse-engineer from active custom theme name after
@@ -226,6 +257,30 @@ back-compat if useful; BE overwrites when `theme_preference` is present.
 `color_scheme` untouched — existing deployed clients do not regress. New frontend +
 old backend ignores the unknown field until both sides are upgraded; once both are
 new, BE overwrites `color_scheme` from preference + config.
+
+**Host theme vs config.toml precedence:** Two distinct host mechanisms exist:
+
+1. **Pre-load** (`window.__streamlit.LIGHT_THEME` / `DARK_THEME`): merges host colors
+   into the preset Light/Dark themes via `getMergedLightTheme()`. These merged presets
+   appear in the theme picker. However, `createTheme` for config.toml custom themes
+   inherits from the **static** `lightTheme`/`darkTheme` (never the merged ones), so
+   pre-load host colors do NOT propagate into config.toml custom themes. When no custom
+   `[theme]` is configured (presets only), the resolver returns `preference` — correct,
+   since hosts customize within the same dark/light family.
+
+2. **Runtime** (`SET_CUSTOM_THEME_CONFIG` postMessage): creates a standalone custom
+   theme via `setImportedTheme` → `createTheme(name, proto)`. No merge with config.toml
+   — last-write-wins. In practice the host theme arrives after `NewSession` so it
+   replaces config.toml entirely. When `host_theme_active` is true, config.toml colors
+   are not painted — BE must not resolve from them.
+
+**Known limitation — host theme first-run race:** If the host sends its theme *after*
+the FE's first BackMsg (rare — hosts typically send during iframe init handshake before
+WebSocket connects), the first script run resolves from config.toml (potentially wrong).
+The auto-rerun in §4 corrects this within milliseconds once the host theme arrives and
+luminance changes. This is acceptable because: (a) the race is uncommon in practice, (b)
+the correction is immediate and invisible to users, and (c) solving it fully would
+require a new protocol where the host pushes theme to the server, not just the iframe.
 
 ### 4. MPA-safe auto-rerun on appearance change
 
@@ -406,6 +461,9 @@ chosen product meaning. Drop stale first-load / settings caveats; keep CSS-overr
 - Resolver matrix matching the product behavior table (presets; single custom `base` /
   hex / non-hex; light+dark sections; section-wins inheritance merge; parent `base`
   does not override section; missing colors → preference).
+- `host_theme_active = true` → resolver returns `preference` directly, ignoring
+  config.toml (even if config has conflicting `[theme] base="light"`).
+- `_has_section_content` returns False for all-None dicts (registered but unset).
 - `request_rerun` resolves on `_client_state` (not the incoming `client_state`) for
   full and fragment paths; verify server-initiated reruns also use resolved value.
 

--- a/specs/2026-08-08-st-context-theme-type/tech-spec.md
+++ b/specs/2026-08-08-st-context-theme-type/tech-spec.md
@@ -99,9 +99,11 @@ comparison in §3-§4, and the access gate in §5. The three approaches differ *
 the first script run gets its value**.
 
 These are approaches to *implementation*. They are unrelated to the product spec's Options
-A/B/C, which decide what `type` should *mean*; that decision is **proposed** as Option C
-(visual appearance) and still open for sign-off on the product spec. All three approaches
-below implement whichever meaning is chosen.
+A/B/C, which decide what `type` should *mean*. That decision is **Option C** (visual
+appearance), owned by the [product spec](./product-spec.md) and settled by merging it. All
+three approaches below implement that meaning; see
+[Alternatives considered](#if-the-product-spec-picks-meaning-a-or-b-instead-of-c) for what
+changes if it lands differently.
 
 | | **A — lightweight** | **B — robust** (proposed) | **C — push theme ahead** |
 |---|---|---|---|
@@ -286,8 +288,12 @@ is painted:
   `> 0.5`, identical to color2k's `getLuminance`. Pin the boundary in tests at **`#bbbbbb`
   (0.4969, dark) / `#bcbcbc` (0.5029, light)** — that is the real crossing. Mid-gray sits at
   ~0.21 and would pass any implementation, proving nothing.
-- **Still best-effort.** CSS's space-separated syntax (`rgb(0 0 0)`, `hsl(0 0% 10%)`) and
-  `transparent` remain unparsed and fall through to the fallback. The resolver deliberately
+- **Still best-effort, and the gap is wider than it looks.** Unparsed: CSS's space-separated
+  syntax (`rgb(0 0 0)`, `hsl(0 0% 10%)`), `transparent`, and the modern colour functions
+  `oklch()`, `oklab()`, `lab()`, `lch()`, `hwb()`. Those five are not hypothetical —
+  `frontend/lib/src/theme/utils.test.ts` pins them as accepted `backgroundColor` values, so
+  each is a working config whose first run the backend gets wrong. All fall through to the
+  fallback. The resolver deliberately
   does not grow a full CSS parser: the echo covers them at the cost of one rerun, which is
   what lets the resolver stay small as frontend theme logic evolves. Pin that gap in a test
   so it stays visible.
@@ -325,11 +331,15 @@ must come back untouched — then `CopyFrom` the result into a fresh `ContextInf
 `RerunData`. A test that only asserts the incoming BackMsg is untouched will not catch the
 aliasing; assert the *outgoing* snapshot is stable across a second request.
 
-Note what this does **not** buy: a server-initiated rerun (file watcher, `st.rerun` from the
-server side) takes the `RerunData()` branch with `context_info=None`, and nothing falls back
-to `_client_state`, so `st.context.theme.type` is `None` for that run. That is today's
-behaviour and this design does not change it — but it is why the echo must stay unset there
-rather than reporting the last known value, which the script did not see.
+Resolving onto the cache is also what carries the value across reruns the client did not
+ask for. **These are not a special case, and it is worth being precise, because assuming
+they were would invent one:** `run_on_save` calls `request_rerun(self._client_state)`, and
+`st.rerun()` / `st.switch_page()` pass `context_info=ctx.context_info` into `RerunData`
+([`execution_control.py`](../../lib/streamlit/commands/execution_control.py)) — all of them
+reuse the last client context, so the echo should report whatever that run actually saw, as
+usual. The only path with `context_info=None` is `request_rerun(None)`, used by
+`Runtime.does_script_run_without_error` (the app-warmup check) and by tests, where there is
+no browser: `type` is `None` for that run and the echo correctly stays unset.
 
 ```python
 def _resolve_color_scheme(context_info: ContextInfo) -> None:
@@ -350,8 +360,8 @@ def _resolve_color_scheme(context_info: ContextInfo) -> None:
 
 `_create_new_session_message` sends the echo — **subject to the
 [access gate](#5-the-access-gate)**, and left unset when there is
-no value yet (e.g. a server-initiated first run), which the client treats as "nothing to
-compare" rather than a mismatch:
+no value yet (e.g. the `request_rerun(None)` warmup path), which the client treats as
+"nothing to compare" rather than a mismatch:
 
 ```python
 # `color_scheme_this_run` arrives on the SCRIPT_STARTED event, NOT from
@@ -432,11 +442,16 @@ and sends that never reach the server.
 
 Four hooks:
 
-**1. `handleNewSession`** records the echo *before* `processThemeInput`, so the
-`componentDidUpdate` that follows the theme application can compare the two. An absent or
-unrecognized echo must be recorded as `null` — **not** skipped, leaving the previous value
-in place, which is the infinite-loop failure mode described in §5. Any `NewSession` is also
-the observed event that clears the in-flight flag:
+**1. `handleNewSession`** records the echo near the **top** of the method — after the
+version-reload return, and **above the `if (!fragmentIdsThisRun.length)` branch**. Do not
+put it next to `processThemeInput`: that call lives inside the full-app branch, so fragment
+reruns skip it, and tying the recording to it would make every fragment `NewSession` skip
+both the echo and the flag clear. The only ordering the comparison needs is "before the
+`componentDidUpdate` that follows", which holds anywhere in this method; applying the theme
+is unrelated. An absent or unrecognized echo must be recorded as `null` — **not** skipped,
+leaving the previous value in place, which is the infinite-loop failure mode described in
+§5. Any `NewSession`, fragment or not, is also the observed event that clears the in-flight
+flag:
 
 ```tsx
 const resolved = newSessionProto.resolvedColorScheme
@@ -490,6 +505,20 @@ private readonly maybeRerunForThemeChange = (): void => {
 }
 ```
 
+**4. `handleConnectionStateChanged`** is the other half of that flag's lifecycle, and the
+reason a dropped send is not lost forever. It is easy to omit, because nothing fails visibly
+without it — the correction is simply never retried:
+
+```tsx
+// Leaving CONNECTED: the in-flight send may have been discarded, since
+// ConnectionManager.sendMessage drops messages and returns normally when
+// disconnected. Forget the in-flight assumption so the disagreement -- still
+// recorded in backendColorScheme -- is retried on the reconnect re-render.
+if (this.state.connectionState === ConnectionState.CONNECTED) {
+  this.themeCorrectionInFlight = false
+}
+```
+
 Four constraints on this, each of which is easy to get wrong:
 
 **Use a local flag, not `scriptRunState`.** Marking the app `RERUN_REQUESTED` is tempting —
@@ -537,7 +566,7 @@ differs from what the client paints.** The echo then corrects it in one rerun. K
 
 | Case | Why the guess differs |
 |------|----------------------|
-| `backgroundColor` in a CSS syntax Pillow cannot parse — `rgb(0 0 0)`, `hsl(0 0% 10%)`, `transparent` | The frontend's parser accepts more syntax than Pillow's. Named colours, `rgb()`, `rgb(%)` and `hsl()` **are** handled and are correct on the first run |
+| `backgroundColor` in a CSS syntax Pillow cannot parse — space-separated `rgb()`/`hsl()`, `transparent`, and `oklch()`/`oklab()`/`lab()`/`lch()`/`hwb()` | The frontend's parser accepts more syntax than Pillow's. Named colours, `rgb()`, `rgb(%)` and `hsl()` **are** handled and are correct on the first run |
 | Host theme applied around or after the first `BackMsg` | The guess comes from `config.toml`, but a host theme is what gets painted |
 | A mirror divergence not yet found | The resolver re-implements three frontend rules; any could drift |
 
@@ -614,7 +643,9 @@ the CSS-override note, which remains true.
   being ignored.
 - **Colour parsing.** Hex in all four lengths, named colours, `rgb()`, `rgb(%)`, `hsl()`;
   and rejection of genuine garbage. Also pin the syntax that is *not* parsed
-  (`rgb(0 0 0)`, `transparent`) so the remaining gap stays visible rather than silent.
+  (space-separated `rgb()`/`hsl()`, `transparent`, and `oklch()`/`oklab()`/`lab()`/`lch()`/
+  `hwb()`) so the size of the gap stays visible rather than silent — and so that Pillow
+  learning one of them shows up as a test change instead of a behaviour change.
 - **The resolver matrix**, one case per row of the product spec's behavior table: presets
   follow preference; single custom `base`; hex and non-hex backgrounds; background winning
   over `base`; no-`base`-no-background falling to light; sidebar-only; dual themes following
@@ -646,9 +677,19 @@ harmless (which is how `AppTest` runs).
 existing `sendRerunBackMsg` assertions, plus dedicated coverage for the parts E2E reaches
 awkwardly: `isThemeApplied` across the startup window and after a host theme;
 `getResolvedThemePreference` for each source; `maybeRerunForThemeChange` deferring while
-`RUNNING` or disconnected and draining once idle; and **that the client stops correcting once
-the echo stops arriving** — the test that catches the infinite-loop failure mode described in
-the access gate.
+`RUNNING` or disconnected and draining once idle; a dropped send being retried after a
+reconnect (the hook-4 clear); **that the client stops correcting once the echo stops
+arriving** — the test that catches the infinite-loop failure mode described in the access
+gate; and **that a fragment rerun's `NewSession` records the echo**, which is what pins the
+recording above the full-app branch.
+
+Two warnings on that last one, both learned the hard way. Assert the **positive** — a
+fragment echo that disagrees *does* produce a correction. The tempting negative form ("an
+unechoed fragment `NewSession` causes no further correction") passes even with the recording
+inside the full-app branch, because the uncleared in-flight flag suppresses the send by
+itself. And do not reach for a disconnect to clear that flag: on reconnect the app requests
+its own rerun when the last run was a fragment, so the rerun count stops measuring
+corrections.
 
 **Mutation-test every guard.** Each of these tests should be verified by removing the
 protection it covers and confirming it goes red. A guard test that cannot fail is worse than
@@ -717,12 +758,16 @@ surrounding code, and each one will cost time if it is discovered late.
   normalizes it to `"light"`/`"dark"` before options are read, so
   `_type_from_bg_or_base` can treat `base` as a plain variant name. Do not make it resolve
   paths.
-- **Fragment reruns emit a `NewSession` too**, so they run the echo path. `SCRIPT_STARTED`
-  builds and enqueues the message unconditionally, with `fragment_ids_this_run` set. This is
-  benign but worth knowing: by the time fragments run, `theme_applied` is true, so the echo
-  is the client's own `color_scheme` and the comparison agrees — no correction fires. It does
-  mean a fragment's `NewSession` clears `themeCorrectionInFlight`; the `NOT_RUNNING` condition
-  in the trigger is what keeps that from turning into a duplicate send.
+- **Fragment reruns emit a `NewSession` too**, on both sides. The backend builds and enqueues
+  it unconditionally at `SCRIPT_STARTED` with `fragment_ids_this_run` set; on the client,
+  `handleNewSession` runs for it but **skips the `if (!fragmentIdsThisRun.length)` branch**
+  that applies the theme. That asymmetry is why §4 puts the echo recording above that branch
+  — see the note there. Recording a fragment's echo is benign in itself: `theme_applied` is
+  true by then, so it is the client's own `color_scheme` and the comparison agrees. A
+  fragment `NewSession` therefore also clears `themeCorrectionInFlight`, and the trigger's
+  `NOT_RUNNING` condition is what keeps that from becoming a duplicate send — fragment runs
+  do flip `scriptRunState` to `RUNNING`, since the backend enters `APP_IS_RUNNING` for them
+  and emits `session_status_changed`.
 - **Non-hex `backgroundColor` is deliberately supported by the frontend.** `parseColor` in
   `frontend/lib/src/theme/utils.ts` runs the value through the browser's CSS parser,
   retries with a `#` prefix, and warns only on real failure. So `"black"` is a valid,

--- a/specs/2026-08-08-st-context-theme-type/tech-spec.md
+++ b/specs/2026-08-08-st-context-theme-type/tech-spec.md
@@ -116,11 +116,24 @@ def resolve_theme_type(
     theme = config.get_options_for_section("theme")
     light = config.get_options_for_section("theme.light")
     dark = config.get_options_for_section("theme.dark")
+    sidebar = config.get_options_for_section("theme.sidebar")
+    light_sidebar = config.get_options_for_section("theme.light.sidebar")
+    dark_sidebar = config.get_options_for_section("theme.dark.sidebar")
 
-    if not _has_any_theme_config(theme, light, dark):
+    if not _has_any_theme_config(
+        theme, light, dark, sidebar, light_sidebar, dark_sidebar
+    ):
         return preference  # presets only
 
-    if _has_section_content(light) or _has_section_content(dark):
+    # FE enters dual-theme mode when theme.light / theme.dark have content OR
+    # when their nested sidebar subsections do (hasThemeSectionConfigs checks
+    # one level deep into nested objects).
+    if (
+        _has_section_content(light)
+        or _has_section_content(dark)
+        or _has_section_content(light_sidebar)
+        or _has_section_content(dark_sidebar)
+    ):
         section = dark if preference == "dark" else light
         merged = _merge_for_dual_theme(theme, section, variant=preference)
         # fallback = preference (which equals the section variant name, e.g.
@@ -129,7 +142,10 @@ def resolve_theme_type(
         return _type_from_bg_or_base(merged, fallback=preference)
 
     # Single custom theme — if neither bg nor base is set, FE defaults to
-    # light preset (no base → inherits from lightTheme).
+    # light preset (no base → inherits from lightTheme). This also covers
+    # sidebar-only configs ([theme.sidebar] without main-area keys): the FE
+    # creates a single custom theme inheriting from lightTheme, so the main
+    # area always paints light.
     return _type_from_bg_or_base(theme, fallback="light")
 
 
@@ -166,20 +182,55 @@ def _merge_for_dual_theme(parent: dict, section: dict, *, variant: str) -> dict:
 
 def _type_from_bg_or_base(opts: dict, *, fallback: str) -> str:
     bg = opts.get("backgroundColor")
-    if _is_six_digit_hex(bg):
+    if _is_hex_color(bg):
         return "light" if _hex_luminance(bg) > 0.5 else "dark"
     base = opts.get("base")
     if base in ("light", "dark"):
         return base
     return fallback
+
+
+def _is_hex_color(value: object) -> bool:
+    """Accept all valid hex color forms: #rgb, #rgba, #rrggbb, #rrggbbaa.
+
+    Stricter than config validation's is_hex_color_like (which uses isalnum
+    and would accept non-hex chars like 'g'/'z'). We need actual hex digits
+    since _hex_luminance parses them with int(..., 16).
+    """
+    if not isinstance(value, str) or not value.startswith("#"):
+        return False
+    h = value[1:]
+    if len(h) not in (3, 4, 6, 8):
+        return False
+    return all(c in "0123456789abcdefABCDEF" for c in h)
 ```
 
-**`_hex_luminance` must match the frontend formula exactly:** Use WCAG relative luminance
-(sRGB linearization + BT.709 coefficients) with threshold `> 0.5`, identical to the
-frontend's `hasLightBackgroundColor` / color2k `getLuminance`. A divergent Python
-implementation would disagree with painted appearance for near-threshold hex backgrounds.
-Add a cross-check unit test comparing Python `_hex_luminance` against known FE outputs
-for boundary colors (e.g. `#7f7f7f`, `#808080`).
+**`_hex_luminance` must normalize short forms and ignore alpha:** Expand `#rgb` →
+`#rrggbb` (double each digit), `#rgba` → `#rrggbbaa` (double each, then discard alpha),
+`#rrggbbaa` → use first 6 hex digits only. Then compute WCAG relative luminance (sRGB
+linearization + BT.709 coefficients) with threshold `> 0.5`, identical to the frontend's
+`hasLightBackgroundColor` / color2k `getLuminance`.
+
+```python
+def _hex_luminance(hex_color: str) -> float:
+    """WCAG relative luminance from any valid hex color string."""
+    h = hex_color.lstrip("#")
+    if len(h) in (3, 4):
+        # Expand short form: #rgb → rrggbb, #rgba → rrggbbaa
+        h = "".join(c * 2 for c in h)
+    # Use only first 6 chars (ignore alpha if present)
+    r, g, b = int(h[0:2], 16) / 255, int(h[2:4], 16) / 255, int(h[4:6], 16) / 255
+    # sRGB linearization
+    r = r / 12.92 if r <= 0.04045 else ((r + 0.055) / 1.055) ** 2.4
+    g = g / 12.92 if g <= 0.04045 else ((g + 0.055) / 1.055) ** 2.4
+    b = b / 12.92 if b <= 0.04045 else ((b + 0.055) / 1.055) ** 2.4
+    return 0.2126 * r + 0.7152 * g + 0.0722 * b
+```
+
+A divergent Python implementation would disagree with painted appearance for
+near-threshold hex backgrounds. Add a cross-check unit test comparing Python
+`_hex_luminance` against known FE outputs for boundary colors (e.g. `#7f7f7f`,
+`#808080`, `#fff`, `#000`).
 
 **`_has_section_content`** returns True when the section has at least one option with a
 non-None value. `get_options_for_section` returns all registered option keys for the
@@ -195,22 +246,45 @@ A bare `[theme.dark]` header with no keys underneath has all-None values → ret
 False. This matches the FE's behavior, which also requires at least one key to trigger
 dual-theme mode.
 
-**`_has_any_theme_config`** is a simple OR over the three sections:
+**`_has_any_theme_config`** is a simple OR over all six sections (main-area and sidebar):
 
 ```python
-def _has_any_theme_config(theme: dict, light: dict, dark: dict) -> bool:
+def _has_any_theme_config(
+    theme: dict,
+    light: dict,
+    dark: dict,
+    sidebar: dict,
+    light_sidebar: dict,
+    dark_sidebar: dict,
+) -> bool:
     return (
         _has_section_content(theme)
         or _has_section_content(light)
         or _has_section_content(dark)
+        or _has_section_content(sidebar)
+        or _has_section_content(light_sidebar)
+        or _has_section_content(dark_sidebar)
     )
 ```
+
+**Why sidebar sections matter:** The FE creates a custom theme whenever `custom_theme` is
+present in `NewSession` — even if only sidebar fields are set. A bare `[theme.sidebar]`
+(no main-area keys) produces a single custom theme inheriting from `lightTheme`; the main
+area always paints light regardless of OS preference. Without detecting sidebar sections,
+the resolver would return `preference` (wrong when OS = dark).
+
+`[theme.light.sidebar]` or `[theme.dark.sidebar]` trigger dual-theme mode on the FE
+because `hasThemeSectionConfigs` recursively checks one level of nested objects. The
+resolver mirrors this by including `light_sidebar` / `dark_sidebar` in the dual-theme
+condition.
 
 | Config shape | How to get `type` (Option C) |
 |--------------|------------------------------|
 | No custom theme (presets) | Return `preference` |
 | Single `[theme]` only | `_type_from_bg_or_base` with `fallback="light"` (FE default) |
+| Only `[theme.sidebar]` (no main-area keys) | Same as single `[theme]`: falls to `fallback="light"` (main area inherits lightTheme) |
 | `[theme.light]` and/or `[theme.dark]` | Pick section from `preference`, force `base=variant` (matching FE), then `_type_from_bg_or_base` with `fallback=preference` (= section variant name) |
+| `[theme.light.sidebar]` or `[theme.dark.sidebar]` (no main-area keys in .light/.dark) | Dual-theme path: merged section has only forced `base=variant` → returns `preference` (main area follows preset for each variant) |
 
 Wire in [`app_session.request_rerun`](../../lib/streamlit/runtime/app_session.py) after
 copying client `context_info` into `RerunData`. **Resolution targets the cached
@@ -545,6 +619,12 @@ chosen product meaning. Drop stale first-load / settings caveats; keep CSS-overr
   hex / non-hex; light+dark sections; dual-theme forced variant `base` overrides
   explicit section `base` (matching FE `handleSectionInheritance`); missing colors →
   preference).
+- Short hex forms: `#fff` → "light", `#000` → "dark", `#rgba` forms handled correctly.
+- `_is_hex_color` accepts lengths {4, 5, 7, 9} with valid hex digits; rejects
+  non-hex alphanumeric (e.g. `#ghijkl`) — stricter than config validation.
+- `_hex_luminance` expands short forms correctly (e.g. `#abc` → `#aabbcc`).
+- Sidebar-only configs: `[theme.sidebar]` alone → "light" (regardless of preference);
+  `[theme.light.sidebar]` alone → enters dual-theme path → returns preference.
 - `host_theme_active = true` → resolver returns `preference` directly, ignoring
   config.toml (even if config has conflicting `[theme] base="light"`).
 - `_has_section_content` returns False for all-None dicts (registered but unset).
@@ -621,7 +701,7 @@ BE work.
 | Risk | Mitigation |
 |------|------------|
 | Auto-rerun reintroduces #11797 | `skipNextThemeUpdate` suppresses `processThemeInput` renders; appearance-diff (not name); `sendUpdateWidgetsMessage` preserves page context; MPA E2E required |
-| BE luminance disagrees with FE | Use identical WCAG formula (sRGB linearization + BT.709, threshold `> 0.5`); cross-check unit test against FE boundary values; hex-only; fall back to `base`/preference |
+| BE luminance disagrees with FE | Use identical WCAG formula (sRGB linearization + BT.709, threshold `> 0.5`); normalize all hex forms (#rgb/#rgba/#rrggbb/#rrggbbaa); cross-check unit test against FE boundary values; fall back to `base`/preference for non-hex |
 | Preference tracking drifts after `processThemeInput` | Track explicit `ThemeSelection`, never reverse from theme name |
 | Host/SiS theme messages ignored | Explicit `handleThemeMessage` path; re-enable hostframe E2E |
 | Option A/B chosen late | §2 is the only major rewrite; proto + auto-rerun stay |
@@ -631,7 +711,8 @@ BE work.
 - Full theme config on `st.context.theme` ([#11536](https://github.com/streamlit/streamlit/issues/11536)).
 - Programmatic theme setters at runtime ([#14172](https://github.com/streamlit/streamlit/issues/14172)).
 - Full Emotion theme build on the backend.
-- Non-hex CSS color parsing for luminance.
+- Non-hex CSS color parsing for luminance (named colors like `"red"`, `hsl()`, etc. —
+  only hex forms accepted by config validation are handled).
 - CSS-injected backgrounds affecting `type`.
 
 ## Checklist

--- a/specs/2026-08-08-st-context-theme-type/tech-spec.md
+++ b/specs/2026-08-08-st-context-theme-type/tech-spec.md
@@ -321,10 +321,15 @@ private pendingThemeRerun: boolean = false
 
 ```tsx
 this.skipNextThemeUpdate = true
+this.hostThemePreference = null  // config.toml theme replaces host theme
 ```
 
-Only set when the theme actually changes (hash differs), so it will not stick around
-to suppress a later legitimate change.
+`skipNextThemeUpdate` only set when the theme actually changes (hash differs), so it
+will not stick around to suppress a later legitimate change. Clearing
+`hostThemePreference` ensures `hostThemeActive` goes false on the next BackMsg — the BE
+resumes config.toml resolution since the FE is now painting the config theme, not the
+host theme. If the host later sends another `SET_CUSTOM_THEME_CONFIG`, `handleThemeMessage`
+re-sets `hostThemePreference` and the flag flips back to true.
 
 **3. In `componentDidUpdate`, appended after the existing `scriptRunState` handling:**
 

--- a/specs/2026-08-08-st-context-theme-type/tech-spec.md
+++ b/specs/2026-08-08-st-context-theme-type/tech-spec.md
@@ -99,8 +99,9 @@ comparison in §3-§4, and the access gate in §5. The three approaches differ *
 the first script run gets its value**.
 
 These are approaches to *implementation*. They are unrelated to the product spec's Options
-A/B/C, which decide what `type` should *mean*; that decision is settled as Option C
-(visual appearance) and all three approaches below implement it.
+A/B/C, which decide what `type` should *mean*; that decision is **proposed** as Option C
+(visual appearance) and still open for sign-off on the product spec. All three approaches
+below implement whichever meaning is chosen.
 
 | | **A — lightweight** | **B — robust** (proposed) | **C — push theme ahead** |
 |---|---|---|---|
@@ -253,9 +254,15 @@ Dual-theme detection must include the nested `.sidebar` subsections, because the
 nor an empty list — empty lists are discounted because the frontend's
 `hasThemeSectionConfigs` treats them as "no config" too.
 `get_options_for_section` returns every registered key even when the user never wrote the
-TOML header, so the *values* are the signal. This is the same determination
-`_populate_theme_msg` makes before sending a theme to the client, and the two must agree —
-otherwise the backend resolves against config the frontend was never told about.
+TOML header, so the *values* are the signal.
+
+**Mirror `hasThemeSectionConfigs`, not `_populate_theme_msg`.** The nearby backend check is
+the tempting model and it is the wrong one: `_populate_theme_msg` early-returns only on
+`all(val is None ...)`, so it counts `chartCategoricalColors = []` as content, while the
+frontend discounts empty lists. Copying the backend check would put the resolver on the
+dual-theme path for a `[theme.light]` holding only an empty colour list, while the client
+builds a single custom theme — the two would then disagree about which theme is even active.
+The frontend is the authority here, because what it paints is what `type` must report.
 
 `_merge_for_dual_theme` lets section values win over `[theme]`, then forces
 `base = variant`, mirroring the FE merging `{ base }` last. (`base` is only registered on
@@ -312,10 +319,17 @@ but the session's `context_info` is long-lived and every later rerun request ove
 in place, while `ScriptRunContext` holds whatever object it was given and `st.context` reads
 it lazily at property-access time. Passing the live object lets an incoming request change
 what an *already-running* script sees — for `theme.type` and equally for `timezone`,
-`locale`, `url`, and `is_embedded`. Resolve onto `_client_state` (so server-initiated reruns
-keep the value), then `CopyFrom` it into a fresh `ContextInfo` for `RerunData`. A test that
-only asserts the incoming BackMsg is untouched will not catch this; assert the *outgoing*
-snapshot is stable across a second request.
+`locale`, `url`, and `is_embedded`. Copy the incoming context into the session cache and
+resolve *there* — never on the `client_state` parameter, which is the caller's message and
+must come back untouched — then `CopyFrom` the result into a fresh `ContextInfo` for
+`RerunData`. A test that only asserts the incoming BackMsg is untouched will not catch the
+aliasing; assert the *outgoing* snapshot is stable across a second request.
+
+Note what this does **not** buy: a server-initiated rerun (file watcher, `st.rerun` from the
+server side) takes the `RerunData()` branch with `context_info=None`, and nothing falls back
+to `_client_state`, so `st.context.theme.type` is `None` for that run. That is today's
+behaviour and this design does not change it — but it is why the echo must stay unset there
+rather than reporting the last known value, which the script did not see.
 
 ```python
 def _resolve_color_scheme(context_info: ContextInfo) -> None:
@@ -340,11 +354,32 @@ no value yet (e.g. a server-initiated first run), which the client treats as "no
 compare" rather than a mismatch:
 
 ```python
+# `color_scheme_this_run` arrives on the SCRIPT_STARTED event, NOT from
+# `self._client_state` -- see below.
 correction_can_matter = not self._has_sent_new_session or self._context_theme_was_read
-if correction_can_matter and self._client_state.context_info.color_scheme:
-    msg.new_session.resolved_color_scheme = self._client_state.context_info.color_scheme
+if correction_can_matter and color_scheme_this_run:
+    msg.new_session.resolved_color_scheme = color_scheme_this_run
 self._has_sent_new_session = True
 ```
+
+**The echo must come from the run's own snapshot, not `_client_state`.** This is the same
+aliasing hazard as `RerunData` above, on the reporting side, and it is easy to miss because
+the buggy version reads naturally. `ScriptRunner` emits `SCRIPT_STARTED` from the **script
+thread**, and `_on_scriptrunner_event` hands it to the event loop via
+`call_soon_threadsafe`; `_create_new_session_message` therefore runs *later* than the
+moment the run began. A `BackMsg` arriving in that gap runs `request_rerun` on the loop
+first, overwriting `_client_state.context_info` in place, so an echo read from there can
+report a value **this run never saw**.
+
+The consequence is worse than a spurious rerun: if the stale echo happens to match what the
+client paints, the client sees agreement, the real disagreement is never corrected, and
+`type` stays wrong for the rest of the session — silently, and precisely the bug #11920 is
+about. Carry the run's value on the event instead. `SCRIPT_STARTED` already passes per-run
+data (`page_script_hash`, `fragment_ids_this_run`, `pages`), and at the emission site
+`rerun_data.context_info` is in scope — the very object just handed to `ctx.reset()`, so it
+is by construction what the script sees. Note that stashing the snapshot on the session at
+`request_rerun` time does **not** work: a second request would overwrite that field before
+the first `SCRIPT_STARTED` is processed, reproducing the same race one level down.
 
 ### 3. Frontend: what it sends
 
@@ -398,16 +433,16 @@ and sends that never reach the server.
 Four hooks:
 
 **1. `handleNewSession`** records the echo *before* `processThemeInput`, so the
-`componentDidUpdate` that follows the theme application can compare the two. Anything
-other than `"light"`/`"dark"` (including unset) is ignored:
+`componentDidUpdate` that follows the theme application can compare the two. An absent or
+unrecognized echo must be recorded as `null` — **not** skipped, leaving the previous value
+in place, which is the infinite-loop failure mode described in §5. Any `NewSession` is also
+the observed event that clears the in-flight flag:
 
 ```tsx
-if (
-  newSessionProto.resolvedColorScheme === "light" ||
-  newSessionProto.resolvedColorScheme === "dark"
-) {
-  this.backendColorScheme = newSessionProto.resolvedColorScheme
-}
+const resolved = newSessionProto.resolvedColorScheme
+this.backendColorScheme =
+  resolved === "light" || resolved === "dark" ? resolved : null
+this.themeCorrectionInFlight = false
 ```
 
 **`sendRerunBackMsg` must NOT record what Python will believe.** The echo is the only
@@ -596,6 +631,10 @@ In `app_session_test.py`, four cases around the wiring:
 - A client sending no `theme_preference` passes straight through, covering old frontends.
 - `_create_new_session_message` populates the echo, and leaves it unset when there is no
   value to send.
+- **The echo reports the run's own value, not a later one.** Deliver `SCRIPT_STARTED` for a
+  run carrying `"light"`, then apply a second `request_rerun` carrying `"dark"` *before*
+  building the message, and assert the echo is still `"light"`. Without this, the aliasing
+  bug is invisible: every single-request test passes either way.
 
 **Python unit, the gate** — three cases on `_create_new_session_message`: the first
 `NewSession` echoes; a later one does **not** when no run has read the theme; a later one
@@ -631,6 +670,20 @@ or not the guard exists.
 Also unskip [`hostframe_app_test.py::test_st_context_theme_respects_dark_theme_message`](../../e2e_playwright/hostframe_app_test.py),
 skipped since #11870. No new CI infrastructure — the hostframe suite already exists.
 
+**External-host coverage is a separate question from that unskip**, and the split is not
+uniform across these tests. `@pytest.mark.external_test` runs a test against an externally
+hosted app or an embedding host page (`--external-app-url` / `--external-host-url`); per
+`e2e_playwright/AGENTS.md` the marker is a manual, per-test decision.
+
+- The config-driven tests (first-run correctness, non-hex background) are **not** candidates.
+  They depend on a module-scoped `@pytest.mark.early` config fixture applied before the local
+  server boots — exactly the local-harness coupling the marker excludes.
+- The **host-theme** path is the strongest candidate, since it needs no `config.toml` and is
+  the SiS case: `SET_CUSTOM_THEME_CONFIG` across a real iframe boundary, plus the
+  `localStorage` theme cache in a third-party frame, are what a local hostframe approximates
+  rather than reproduces. `hostframe_app_test.py` carries no `external_test` marker today, so
+  this is a decision for the implementation PR — the unskip does not deliver it.
+
 Run the theme E2Es on Firefox and WebKit as well as Chromium: the trigger depends on React
 lifecycle timing, which is the kind of thing that differs between engines.
 
@@ -664,6 +717,12 @@ surrounding code, and each one will cost time if it is discovered late.
   normalizes it to `"light"`/`"dark"` before options are read, so
   `_type_from_bg_or_base` can treat `base` as a plain variant name. Do not make it resolve
   paths.
+- **Fragment reruns emit a `NewSession` too**, so they run the echo path. `SCRIPT_STARTED`
+  builds and enqueues the message unconditionally, with `fragment_ids_this_run` set. This is
+  benign but worth knowing: by the time fragments run, `theme_applied` is true, so the echo
+  is the client's own `color_scheme` and the comparison agrees — no correction fires. It does
+  mean a fragment's `NewSession` clears `themeCorrectionInFlight`; the `NOT_RUNNING` condition
+  in the trigger is what keeps that from turning into a duplicate send.
 - **Non-hex `backgroundColor` is deliberately supported by the frontend.** `parseColor` in
   `frontend/lib/src/theme/utils.ts` runs the value through the browser's CSS parser,
   retries with a `#` prefix, and warns only on real failure. So `"black"` is a valid,

--- a/specs/2026-08-08-st-context-theme-type/tech-spec.md
+++ b/specs/2026-08-08-st-context-theme-type/tech-spec.md
@@ -1,0 +1,331 @@
+---
+author: mayagbarnes
+created: 2026-08-08
+---
+
+# Make `st.context.theme.type` correct — tech design
+
+## Summary
+
+Fix `st.context.theme.type` by having the client send a resolved appearance preference
+(`"light"` | `"dark"`) on every rerun, and having the backend resolve the effective type
+from that preference plus `config.toml` **before** the script runs — plus an MPA-safe
+auto-rerun when appearance changes via menu, host, or OS.
+
+See the [product spec](./product-spec.md) for the A/B/C semantics decision and
+user-facing behavior. This tech spec is written against **Option C** (visual appearance);
+if product picks A or B, adjust §2 only.
+
+## Problem
+
+### Current data path
+
+```text
+FE getThemeColorScheme()  →  ContextInfo.color_scheme  →  st.context.theme.type
+```
+
+`color_scheme` is inferred from the active frontend theme’s background luminance
+([`App.getThemeColorScheme`](../../frontend/app/src/App.tsx)) and sent inside
+`BackMsg.rerun_script`. Custom theme config arrives later in `NewSession.custom_theme`
+via [`_populate_theme_msg`](../../lib/streamlit/runtime/app_session.py). There is no
+backend resolution of `type` today.
+
+### Chicken-and-egg on first run
+
+1. Client sends first `BackMsg` with `color_scheme` from a cached/preset theme.
+2. Server runs the script (Python already has that `color_scheme`).
+3. Server sends `NewSession` with custom theme from `config.toml`.
+4. FE applies custom theme via `processThemeInput` → UI is correct; Python is stale.
+
+The only entity that has **both** preference **and** `config.toml` at first-run time is
+the backend. True first-execution correctness requires backend resolution (or a slower
+pre-session handshake — rejected below).
+
+### Why the old auto-rerun broke MPA
+
+[#10972](https://github.com/streamlit/streamlit/pull/10972) added:
+
+```tsx
+if (prevProps.theme.activeTheme.name !== this.props.theme.activeTheme.name) {
+  this.sendRerunBackMsg()
+}
+```
+
+Theme **name** changes for system-internal reasons — page navigation / connect /
+reconnect → `NewSession` → `processThemeInput` remaps `"Light"` → `"Custom Theme"` →
+extra `rerun_script` → page context not preserved → deep link bounces to the default
+page ([#11797](https://github.com/streamlit/streamlit/issues/11797)). [#11870](https://github.com/streamlit/streamlit/pull/11870)
+removed that path. **Do not restore** name-based `componentDidUpdate` reruns.
+
+## Proposal
+
+### High-level flow
+
+```mermaid
+sequenceDiagram
+    participant FE as Frontend
+    participant BE as Backend
+
+    FE->>FE: Resolve System to OS light/dark
+    FE->>BE: BackMsg.rerun with theme_preference
+    BE->>BE: resolve_theme_type(preference, config.toml)
+    BE->>BE: Set context_info.color_scheme before ScriptRunner
+    BE->>BE: Script runs; st.context.theme.type is correct
+    BE->>FE: NewSession.custom_theme for UI paint
+```
+
+Preference selects which theme **branch/section** is active. Under Option C, `type` is
+then derived from that theme’s `base` / background (preference `"light"` + single dark
+custom theme → `type` `"dark"`).
+
+**Implementation order:** proto → backend resolver (+ unit tests) → FE preference on
+every BackMsg → FE auto-rerun hooks. Do not start auto-rerun work until the BE resolver
+is tested in isolation.
+
+### 1. Proto
+
+In [`ClientState.proto`](../../proto/streamlit/proto/ClientState.proto), add to
+`ContextInfo`:
+
+```protobuf
+// Resolved appearance from the client: "light" or "dark".
+// System menu selection must be resolved to OS preference before send.
+optional string theme_preference = 7;
+```
+
+Keep `color_scheme` as what Python exposes via `st.context.theme.type`. When
+`theme_preference` is present, the backend overwrites `color_scheme` before the script
+run. **Old clients without field 7 keep working:** the backend leaves `color_scheme` as
+sent, so existing deployed frontends against a new backend do not regress.
+
+### 2. Backend resolver
+
+Add `lib/streamlit/runtime/theme_type.py` (sketch under Option C):
+
+```python
+def resolve_theme_type(preference: Literal["light", "dark"]) -> Literal["light", "dark"]:
+    theme = config.get_options_for_section("theme")
+    light = config.get_options_for_section("theme.light")
+    dark = config.get_options_for_section("theme.dark")
+
+    if not _has_any_theme_config(theme, light, dark):
+        return preference  # presets only
+
+    if _has_section_content(light) or _has_section_content(dark):
+        section = dark if preference == "dark" else light
+        # Merge [theme] inheritance for base / backgroundColor only
+        return _type_from_base_or_bg(_merge_theme(theme, section), fallback=preference)
+
+    # Single custom theme — preference does not override appearance
+    return _type_from_base_or_bg(theme, fallback=preference)
+
+
+def _type_from_base_or_bg(opts: dict, *, fallback: str) -> str:
+    base = opts.get("base")
+    if base in ("light", "dark"):
+        return base
+    bg = opts.get("backgroundColor")
+    if _is_six_digit_hex(bg):
+        return "light" if _hex_luminance(bg) > 0.5 else "dark"
+    return fallback
+```
+
+| Config shape | How to get `type` (Option C) |
+|--------------|------------------------------|
+| No custom theme (presets) | Return `preference` |
+| Single `[theme]` only | `_type_from_base_or_bg` (ignore preference for the value except as fallback) |
+| `[theme.light]` and/or `[theme.dark]` | Pick section from `preference`, merge inheritance, then `_type_from_base_or_bg` |
+
+Wire in [`app_session.request_rerun`](../../lib/streamlit/runtime/app_session.py) after
+copying client `context_info` into `RerunData`:
+
+```python
+if client_state.HasField("context_info"):
+    self._client_state.context_info.CopyFrom(client_state.context_info)
+    if client_state.context_info.HasField("theme_preference"):
+        client_state.context_info.color_scheme = resolve_theme_type(
+            client_state.context_info.theme_preference
+        )
+```
+
+Applies to **full-script and fragment** reruns alike.
+
+If product picks **Option A**, this collapses to
+`color_scheme = theme_preference`. If **Option B**, return the selected section’s
+nominal variant without luminance.
+
+### 3. Frontend: send preference on every rerun
+
+In [`App.sendRerunBackMsg`](../../frontend/app/src/App.tsx) / `contextInfo`:
+
+```ts
+themePreference: this.getResolvedThemePreference(), // "light" | "dark"
+```
+
+**Source of truth** (do not reverse-engineer from active custom theme name after
+`processThemeInput`):
+
+1. Existing embed query options `embed_options=light_theme` /
+   `embed_options=dark_theme` (already used by host embedding — not a new protocol)
+   if present.
+2. Else tracked `ThemeSelection` (`Light` / `Dark` / `System`), with
+   `System` → `getSystemThemePreference()`.
+3. `getCachedThemeSelection()` only for initial hydrate.
+
+Maintain `lastSentThemePreference` on the App instance; update it whenever a BackMsg
+with that preference is actually sent. Keep sending `colorScheme` for back-compat if
+useful; BE overwrites when `theme_preference` is present.
+
+**Backward compatibility:** New backend + old frontend (no `theme_preference`) leaves
+`color_scheme` untouched — existing deployed clients do not regress. New frontend +
+old backend ignores the unknown field until both sides are upgraded; once both are
+new, BE overwrites `color_scheme` from preference + config.
+
+### 4. MPA-safe auto-rerun on appearance change
+
+#### Hard invariant (source allowlist + preference ref)
+
+```text
+Auto-rerun fires ONLY when BOTH:
+  (a) resolved theme_preference !== lastSentThemePreference, AND
+  (b) trigger source is an intentional appearance action:
+        - main menu / settings Light|Dark|System toggle
+        - handleThemeMessage (host)
+        - OS matchMedia change while selection is System
+      NEVER as a side-effect of processThemeInput, handleNewSession,
+      or any setAndSendTheme call initiated from those paths.
+```
+
+Sketch:
+
+```ts
+maybeRerunForThemePreference = (source: "menu" | "host" | "os"): void => {
+  if (this.suppressThemeRerun) return // belt-and-suspenders during NewSession
+  const next = this.getResolvedThemePreference()
+  if (next === this.lastSentThemePreference) return
+  this.sendRerunBackMsg(
+    this.state.widgetStates,
+    undefined, // fragmentId — full script
+    this.state.currentPageScriptHash,
+    /* pageName / query from current URL state */
+  )
+}
+
+// Allowlisted call sites only — NOT the end of setAndSendTheme:
+// - menu/settings handler after updating tracked ThemeSelection
+// - handleThemeMessage after mapping host light/dark → selection
+// - matchMedia listener when selection === "System"
+```
+
+#### Why preference-diff alone is not enough
+
+`processThemeInput` calls `setAndSendTheme` on every NewSession. An ungated hook inside
+`setAndSendTheme` would fire on connect/nav/reconnect.
+
+- **NewSession / first connect:** preference already sent; BE resolved `type`; preference
+  unchanged after paint → **no** second rerun (avoids #11797).
+- **Intentional toggle on MPA Page B:** preference changes → auto-rerun must send
+  current `pageScriptHash` / page name / query from live App state **synchronously**
+  (no debounce that can observe stale page state).
+
+#### Implementation commitments
+
+1. Compare **preference only**, never theme name / FE luminance.
+2. **Do not** put an ungated auto-rerun at the end of `setAndSendTheme`. Prefer
+   allowlisted call sites, or an explicit `rerunOnPreferenceChange` flag that NewSession
+   never sets.
+3. `suppressThemeRerun` around `handleNewSession` / `processThemeInput` is a backstop,
+   not the sole defense.
+4. Update [`handleThemeMessage`](../../frontend/app/src/App.tsx) — today visual-only.
+5. **Do not restore** name-based `componentDidUpdate` reruns.
+
+### 5. Docs
+
+Update [`context.py`](../../lib/streamlit/runtime/context.py) docstring to match the
+chosen product meaning. Drop stale first-load / settings caveats; keep CSS-override note.
+
+### 6. Testing
+
+**Python unit**
+
+- Resolver matrix matching the product behavior table (presets; single custom `base` /
+  hex / non-hex; light+dark sections; inheritance; missing colors → preference).
+- `request_rerun` sets `color_scheme` for full and fragment paths.
+
+**Frontend unit**
+
+- Preference serialization (System→OS, Light, Dark, host query); not from remapped
+  custom theme name.
+- `maybeRerunForThemePreference`: allowlisted sources only; no-op when preference
+  unchanged; **no** rerun from `processThemeInput` / `handleNewSession`; page hash /
+  name / query from current state.
+- Regression: theme **name** change alone must not call `sendRerunBackMsg`.
+
+**E2E** (`make run-e2e-test`)
+
+- Custom `[theme]` `base = "dark"` + light OS/cache preference → first output
+  `type: dark`.
+- MPA deep link + `[theme]` lands on target page (#11797).
+- Main-menu Light↔Dark updates `type` without manual rerun.
+- Re-enable
+  [`test_st_context_theme_respects_dark_theme_message`](../../e2e_playwright/hostframe_app_test.py)
+  (skipped since #11870). No new CI host environment — this is an existing Playwright
+  hostframe suite; unskip only.
+## Alternatives considered
+
+### A. Fix the auto-rerun MPA-safely (no new proto field)
+
+Double-run on first load: wrong `type` → FE applies custom theme → corrected rerun.
+
+- Simpler; worse UX; first script execution still wrong.
+
+**Rejected** for first-run correctness.
+
+### B. Backend uses config `base` / `backgroundColor` only (no preference)
+
+- Fixes common single-custom-with-`base` quickly.
+- Fails for dual light/dark sections and preset-only Dark menu selection.
+- Still needs auto-rerun for mid-session changes.
+
+**Rejected** as sole fix and as throwaway milestone (`theme_preference` is needed
+eventually).
+
+### C. Pre-session theme config before first script run
+
+Extra RTT every connection; protocol reordering; comparable complexity, worse latency.
+
+**Rejected.**
+
+### D. Ship first-run and auto-rerun as separate PRs
+
+Separable for blast radius. **This spec still does both in one pass**, with hard order
+(resolver tested before auto-rerun) so auto-rerun can be reverted without undoing proto /
+BE work.
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Auto-rerun reintroduces #11797 | Source allowlist + preference-diff + sync page hash; MPA E2E required |
+| BE luminance disagrees with FE | Prefer `base`; hex-only luminance; fall back to preference |
+| Preference tracking drifts after `processThemeInput` | Track explicit `ThemeSelection`, never reverse from theme name |
+| Host/SiS theme messages ignored | Explicit `handleThemeMessage` path; re-enable hostframe E2E |
+| Option A/B chosen late | §2 is the only major rewrite; proto + auto-rerun stay |
+
+## Out of scope
+
+- Full theme config on `st.context.theme` ([#11536](https://github.com/streamlit/streamlit/issues/11536)).
+- Full Emotion theme build on the backend.
+- Non-hex CSS color parsing for luminance.
+- CSS-injected backgrounds affecting `type`.
+
+## Checklist
+
+| Item | ✅ or comment |
+|------|---------------|
+| Works on SiS, Cloud, etc? | Host theme path required; unskip existing hostframe E2E (no new CI infra) |
+| No breaking API changes | Additive proto field; `type` shape unchanged. Old FE + new BE: `color_scheme` left as client-sent (no regression) |
+| No new dependencies | Hex luminance only — no color-parsing library |
+| Metrics collected | Existing `context.theme` metrics sufficient |
+| Any security/legal impact? | No |
+| Any docs changes needed? | Docstring + API reference once semantics are signed off |

--- a/specs/2026-08-08-st-context-theme-type/tech-spec.md
+++ b/specs/2026-08-08-st-context-theme-type/tech-spec.md
@@ -442,23 +442,36 @@ and sends that never reach the server.
 
 Four hooks:
 
-**1. `handleNewSession`** records the echo near the **top** of the method — after the
-version-reload return, and **above the `if (!fragmentIdsThisRun.length)` branch**. Do not
-put it next to `processThemeInput`: that call lives inside the full-app branch, so fragment
-reruns skip it, and tying the recording to it would make every fragment `NewSession` skip
-both the echo and the flag clear. The only ordering the comparison needs is "before the
-`componentDidUpdate` that follows", which holds anywhere in this method; applying the theme
-is unrelated. An absent or unrecognized echo must be recorded as `null` — **not** skipped,
-leaving the previous value in place, which is the infinite-loop failure mode described in
-§5. Any `NewSession`, fragment or not, is also the observed event that clears the in-flight
-flag:
+**1. `handleNewSession`** does two things that **must not be placed together**, which is the
+single most error-prone detail in this design:
 
 ```tsx
+// Above the fragment branch: EVERY NewSession records the echo.
 const resolved = newSessionProto.resolvedColorScheme
 this.backendColorScheme =
   resolved === "light" || resolved === "dark" ? resolved : null
-this.themeCorrectionInFlight = false
+
+if (!fragmentIdsThisRun.length) {
+  // Inside it: only a full-app NewSession answers a correction.
+  this.themeCorrectionInFlight = false
+  ...
+}
 ```
+
+**Recording goes above the `if (!fragmentIdsThisRun.length)` branch.** Do not put it next to
+`processThemeInput`, which lives inside that branch: fragment reruns skip it, and the
+"absent echo means stop comparing" rule of §5 has to hold for every `NewSession` or a stale
+value survives. An absent or unrecognized echo must be recorded as `null`, **not** skipped —
+skipping is the infinite-loop mode described in §5. The only ordering the comparison needs is
+"before the `componentDidUpdate` that follows", which holds anywhere in this method;
+applying the theme is unrelated.
+
+**Clearing the in-flight flag stays inside the full-app branch.** A correction is always a
+full-app rerun, so only a full-app `NewSession` can answer one. Clearing on a fragment's
+`NewSession` releases the guard while the disagreement is still unresolved, and the next
+render sends a **second, redundant full-app correction** — one theme change, two app runs.
+Moving both statements together looks like the tidy refactor and is a defect; there is a
+regression test for it in §7.
 
 **`sendRerunBackMsg` must NOT record what Python will believe.** The echo is the only
 writer of `backendColorScheme`. Predicting it at send time is unsound, because
@@ -680,16 +693,20 @@ awkwardly: `isThemeApplied` across the startup window and after a host theme;
 `RUNNING` or disconnected and draining once idle; a dropped send being retried after a
 reconnect (the hook-4 clear); **that the client stops correcting once the echo stops
 arriving** — the test that catches the infinite-loop failure mode described in the access
-gate; and **that a fragment rerun's `NewSession` records the echo**, which is what pins the
-recording above the full-app branch.
+gate; and **two tests for the split in §4's hook 1**, which pin it from both sides:
 
-Two warnings on that last one, both learned the hard way. Assert the **positive** — a
-fragment echo that disagrees *does* produce a correction. The tempting negative form ("an
-unechoed fragment `NewSession` causes no further correction") passes even with the recording
-inside the full-app branch, because the uncleared in-flight flag suppresses the send by
-itself. And do not reach for a disconnect to clear that flag: on reconnect the app requests
-its own rerun when the last run was a fragment, so the rerun count stops measuring
-corrections.
+- *A fragment `NewSession` records the echo* — pins the recording above the full-app branch.
+  Assert the **positive**: a fragment echo that disagrees *does* produce a correction. The
+  tempting negative form ("an unechoed fragment `NewSession` causes no further correction")
+  passes even with the recording inside the branch, because the uncleared in-flight flag
+  suppresses the send by itself. And do not reach for a disconnect to clear that flag: on
+  reconnect the app requests its own rerun when the last run was a fragment, so the rerun
+  count stops measuring corrections.
+- *A fragment `NewSession` does not reopen an unresolved correction* — pins the flag clear
+  inside the branch. Send a correction, then deliver a fragment `NewSession` still echoing
+  the stale value, and assert the rerun count is **unchanged**. Without this, moving both
+  statements above the branch — which reads as the obvious cleanup — silently doubles the
+  reruns for a single theme change.
 
 **Mutation-test every guard.** Each of these tests should be verified by removing the
 protection it covers and confirming it goes red. A guard test that cannot fail is worse than
@@ -762,12 +779,12 @@ surrounding code, and each one will cost time if it is discovered late.
   it unconditionally at `SCRIPT_STARTED` with `fragment_ids_this_run` set; on the client,
   `handleNewSession` runs for it but **skips the `if (!fragmentIdsThisRun.length)` branch**
   that applies the theme. That asymmetry is why §4 puts the echo recording above that branch
-  — see the note there. Recording a fragment's echo is benign in itself: `theme_applied` is
-  true by then, so it is the client's own `color_scheme` and the comparison agrees. A
-  fragment `NewSession` therefore also clears `themeCorrectionInFlight`, and the trigger's
-  `NOT_RUNNING` condition is what keeps that from becoming a duplicate send — fragment runs
-  do flip `scriptRunState` to `RUNNING`, since the backend enters `APP_IS_RUNNING` for them
-  and emits `session_status_changed`.
+  — while the flag clear stays inside it. A fragment `NewSession` must **not** clear
+  `themeCorrectionInFlight`. Do not expect the trigger's `NOT_RUNNING` condition to save you
+  here: fragment runs do flip `scriptRunState` to `RUNNING` (the backend enters
+  `APP_IS_RUNNING` and emits `session_status_changed`), but that message is enqueued *after*
+  the `NewSession`, so the client can act on the echo while it still believes nothing is
+  running.
 - **Non-hex `backgroundColor` is deliberately supported by the frontend.** `parseColor` in
   `frontend/lib/src/theme/utils.ts` runs the value through the browser's CSS parser,
   retries with a `#` prefix, and warns only on real failure. So `"black"` is a valid,

--- a/specs/2026-08-08-st-context-theme-type/tech-spec.md
+++ b/specs/2026-08-08-st-context-theme-type/tech-spec.md
@@ -16,6 +16,15 @@ Fix `st.context.theme.type` with a two-way exchange:
    **before** the script runs. Otherwise it trusts the client's own `color_scheme`.
 3. The backend **echoes** whatever the script saw back in `NewSession`. The client reruns
    once whenever what it paints disagrees with that echo.
+4. The echo is **gated**: it is sent only on the first `NewSession` of a session, or once a
+   run has actually read `st.context.theme`. With no echo there is nothing to compare, so
+   the client does not rerun.
+
+Point 4 matters as much as the rest. `st.context.theme.type` is read by roughly **0.6% of
+apps**, so a correction mechanism that fired for everyone would charge the other 99.4% for a
+value they never read. See [the access gate](#the-access-gate-required-by-either-approach)
+for what it costs them (one correction per session, not zero) and for the client-side
+condition that makes gating safe rather than harmful.
 
 The echo is what makes the system self-correcting. The backend resolver is deliberately
 best-effort — it parses most CSS colours but not every syntax — and any disagreement, from
@@ -29,16 +38,14 @@ this design depends on, and that are easy to get wrong.
 
 ### Terms
 
+Four terms this design leans on, which are easy to conflate:
+
 | Term | Meaning |
 |------|---------|
-| **Frontend** / **FE**, **Backend** / **BE** | The React app in `frontend/` and the Python runtime in `lib/`, respectively |
 | **Appearance preference** | What the user or their OS asked for: menu `Light` / `Dark` / `System`, with `System` resolved against `prefers-color-scheme`. Sent as `theme_preference` |
 | **Painted appearance** | Whether the app actually renders light or dark, from the active theme's background luminance (`getThemeColorScheme`). What Option C defines `type` to mean |
 | **Theme applied** | Whether the client is painting its *final* theme for this session, which makes its own `color_scheme` authoritative. Sent as `theme_applied` |
 | **Echo** | `NewSession.resolved_color_scheme` — the value the script actually saw, sent back so the client can detect a disagreement |
-| **Dual theme** | A `config.toml` with `[theme.light]` and/or `[theme.dark]` sections, which makes the FE build separate light and dark custom themes |
-| **Section variant** | Which half of a dual theme is active — `"light"` or `"dark"`. The FE forces the theme's `base` from it |
-| **Host theme** | A theme pushed by an embedding host at runtime via the `SET_CUSTOM_THEME_CONFIG` postMessage, which replaces `config.toml` on the FE |
 
 ## Problem
 
@@ -63,8 +70,10 @@ with.
 4. FE applies custom theme via `processThemeInput` → UI is correct; Python is stale.
 
 The only entity that has **both** preference **and** `config.toml` at first-run time is
-the backend. True first-execution correctness requires backend resolution (or a slower
-pre-session handshake — rejected below).
+the backend. So getting the *first* run right means either resolving it there, or reordering
+the handshake so the client has the theme before it asks for a run — which is what
+[the design space](#the-design-space-three-approaches) weighs. Everything after the first run
+is correctable without either.
 
 ### Why the old auto-rerun broke MPA
 
@@ -84,21 +93,6 @@ page ([#11797](https://github.com/streamlit/streamlit/issues/11797)).
 restore** name-based `componentDidUpdate` reruns.
 
 ## Proposal
-
-### High-level flow
-
-```mermaid
-sequenceDiagram
-    participant FE as Frontend
-    participant BE as Backend
-
-    FE->>BE: BackMsg.rerun (theme_preference, theme_applied=false, color_scheme)
-    BE->>BE: theme_applied false → resolve from preference + config.toml
-    BE->>BE: Script runs; st.context.theme.type is the resolved value
-    BE->>FE: NewSession (custom_theme, resolved_color_scheme)
-    FE->>FE: Apply custom theme, compare paint against resolved_color_scheme
-    FE->>BE: One rerun, only if they disagree (theme_applied=true from here on)
-```
 
 ### 1. Proto
 
@@ -133,6 +127,11 @@ optional string resolved_color_scheme = 12;
 `color_scheme` remains what Python exposes via `st.context.theme.type`; the backend
 overwrites it only in the `theme_applied=false` window.
 
+`resolved_color_scheme` is **conditionally** populated — see
+[the access gate](#the-access-gate-required-by-either-approach). Its absence is meaningful
+rather than merely empty: it tells the client there is nothing to keep truthful, and the
+client must clear its copy rather than retain the last value.
+
 **Backward compatibility.** Old FE + new BE: no `theme_preference`, so `color_scheme` is
 left exactly as sent — no regression. New FE + old BE: no `resolved_color_scheme`, so the
 client never sees a disagreement and behaves as it does today.
@@ -149,38 +148,11 @@ theming calculations belong on the frontend, and this is the one window where th
 cannot know the answer. It also points at `handleSectionInheritance` /
 `createCustomThemes` in `frontend/lib/src/theme/utils.ts` as the rules being mirrored.
 
-```python
-def resolve_theme_type(preference: ThemeType) -> ThemeType:
-    theme = config.get_options_for_section("theme")
-    light = config.get_options_for_section("theme.light")
-    dark = config.get_options_for_section("theme.dark")
-    sidebar = config.get_options_for_section("theme.sidebar")
-    light_sidebar = config.get_options_for_section("theme.light.sidebar")
-    dark_sidebar = config.get_options_for_section("theme.dark.sidebar")
-
-    if not any(
-        _has_section_content(section)
-        for section in (theme, light, dark, sidebar, light_sidebar, dark_sidebar)
-    ):
-        # Presets only: the frontend paints whatever was preferred.
-        return preference
-
-    # The frontend enters dual-theme mode when [theme.light] / [theme.dark] have
-    # content, or when their nested sidebar subsections do (hasThemeSectionConfigs
-    # checks one level into nested objects).
-    if any(
-        _has_section_content(section)
-        for section in (light, dark, light_sidebar, dark_sidebar)
-    ):
-        section = dark if preference == "dark" else light
-        merged = _merge_for_dual_theme(theme, section, variant=preference)
-        return _type_from_bg_or_base(merged, fallback=preference)
-
-    # A single custom theme. With neither background nor base set the frontend
-    # inherits from lightTheme, so it paints light. This also covers sidebar-only
-    # configs, where the main area always follows lightTheme.
-    return _type_from_bg_or_base(theme, fallback="light")
-```
+It reads all six theme sections (`theme`, `theme.light`, `theme.dark`, and their `.sidebar`
+subsections) and branches in this order: **no theme config at all** → return the preference;
+**any light/dark section has content** → dual-theme path; **otherwise** → single custom theme.
+Dual-theme detection must include the nested `.sidebar` subsections, because the frontend's
+`hasThemeSectionConfigs` looks one level into nested objects.
 
 | Config shape | Resolved `type` |
 |--------------|-----------------|
@@ -207,43 +179,30 @@ base is an explicit section `backgroundColor`.
 fallback. It assumes `base` is already `"light"`/`"dark"`;
 `config_util.process_theme_inheritance` guarantees that.
 
-`_parse_color` handles the CSS colour space rather than hex alone, using
-`PIL.ImageColor.getrgb` — **no new dependency**, since `pillow>=7.1.0,<13` is already a
-runtime dependency of the library. That covers hex in 3/4/6/8 digits, all 148 CSS named
-colours, `rgb()` with numbers or percentages, and `hsl()`; alpha is dropped, matching the
-frontend. It is imported lazily because the resolver runs at most once per session and the
-runtime should not pay for Pillow at startup.
+**Colour handling** must match the frontend, because a mismatch reports the inverse of what
+is painted:
 
-`_luminance` computes WCAG relative luminance (sRGB linearization + BT.709) with threshold
-`> 0.5` — identical to color2k's `getLuminance`, which the FE uses via
-`hasLightBackgroundColor`. Pin these boundary values in the tests, measured against the
-vendored color2k:
-
-| Color | `getLuminance` | Classified |
-|-------|---------------|------------|
-| `#7f7f7f` | 0.2122 | dark |
-| `#808080` | 0.2159 | dark |
-| `#bbbbbb` | 0.4969 | **dark** — just below |
-| `#bcbcbc` | 0.5029 | **light** — just above |
-
-`#bbbbbb`/`#bcbcbc` is the real crossing. Mid-gray sits at ~0.21 and would pass any
-implementation, proving nothing.
-
-`_parse_color` must also retry with a `#` prefix, because the frontend's `parseColor` does
-— which makes a bare `backgroundColor = "121212"` a working config that the backend would
-otherwise misread.
-
-**Still best-effort, but the gap is narrow.** What remains unparsed is CSS's
-space-separated syntax (`rgb(0 0 0)`, `hsl(0 0% 10%)`) and the `transparent` keyword. Those
-fall through to the fallback and can be the inverse of what is painted. The resolver
-deliberately does **not** grow a full CSS parser to chase them — the echo covers them at
-the cost of one extra rerun on that load, which is also what lets the resolver stay small
-as frontend theme logic evolves. Pin the remaining gap in a test so it stays visible.
+- `_parse_color` uses `PIL.ImageColor.getrgb` — **no new dependency**, `pillow>=7.1.0,<13`
+  is already required — covering hex in 3/4/6/8 digits, the 148 CSS named colours, `rgb()`
+  with numbers or percentages, and `hsl()`. Alpha is dropped, matching the frontend. Import
+  it lazily: the resolver runs at most once per session.
+- It must **retry with a `#` prefix**, because the frontend's `parseColor` does — otherwise a
+  bare `backgroundColor = "121212"` is a working config the backend misreads.
+- `_luminance` is WCAG relative luminance (sRGB linearization + BT.709) with threshold
+  `> 0.5`, identical to color2k's `getLuminance`. Pin the boundary in tests at **`#bbbbbb`
+  (0.4969, dark) / `#bcbcbc` (0.5029, light)** — that is the real crossing. Mid-gray sits at
+  ~0.21 and would pass any implementation, proving nothing.
+- **Still best-effort.** CSS's space-separated syntax (`rgb(0 0 0)`, `hsl(0 0% 10%)`) and
+  `transparent` remain unparsed and fall through to the fallback. The resolver deliberately
+  does not grow a full CSS parser: the echo covers them at the cost of one rerun, which is
+  what lets the resolver stay small as frontend theme logic evolves. Pin that gap in a test
+  so it stays visible.
 
 #### Wiring in `app_session.py`
 
-`request_rerun` resolves onto the session's **cached** `_client_state`, and `RerunData`
-then reads from that copy — the incoming `client_state` is a different object:
+`request_rerun` resolves onto the session's **cached** `_client_state` — the incoming
+`client_state` is a different object, so resolving on the parameter would never reach the
+script — and then hands `RerunData` a fresh snapshot of the result:
 
 ```python
 if client_state.HasField("context_info"):
@@ -253,15 +212,20 @@ if client_state.HasField("context_info"):
 query_string = sanitize_query_string(client_state.query_string)
 rerun_data = RerunData(
     ...
-    # Read from the cached copy, not the incoming parameter: the
-    # resolution above only applies to _client_state, and for a client
-    # BackMsg these are distinct objects.
-    context_info=self._client_state.context_info,
+    # A snapshot, NOT the session's own object -- see below.
+    context_info=context_info,
 )
 ```
 
-Resolving on the cached copy also means server-initiated reruns (run-on-save, fragment
-reruns) use the resolved value.
+**Hand `RerunData` a copy, not `_client_state.context_info`.** `RerunData` is a snapshot,
+but the session's `context_info` is long-lived and every later rerun request overwrites it
+in place, while `ScriptRunContext` holds whatever object it was given and `st.context` reads
+it lazily at property-access time. Passing the live object lets an incoming request change
+what an *already-running* script sees — for `theme.type` and equally for `timezone`,
+`locale`, `url`, and `is_embedded`. Resolve onto `_client_state` (so server-initiated reruns
+keep the value), then `CopyFrom` it into a fresh `ContextInfo` for `RerunData`. A test that
+only asserts the incoming BackMsg is untouched will not catch this; assert the *outgoing*
+snapshot is stable across a second request.
 
 ```python
 def _resolve_color_scheme(context_info: ContextInfo) -> None:
@@ -280,14 +244,16 @@ def _resolve_color_scheme(context_info: ContextInfo) -> None:
     context_info.color_scheme = theme_type.resolve_theme_type(preference)
 ```
 
-`_create_new_session_message` sends the echo, left unset when there is no value yet (e.g.
-a server-initiated first run) so the client treats it as "unknown" rather than a mismatch:
+`_create_new_session_message` sends the echo — **subject to the
+[access gate](#the-access-gate-required-by-either-approach)**, and left unset when there is
+no value yet (e.g. a server-initiated first run), which the client treats as "nothing to
+compare" rather than a mismatch:
 
 ```python
-if self._client_state.context_info.color_scheme:
-    msg.new_session.resolved_color_scheme = (
-        self._client_state.context_info.color_scheme
-    )
+correction_can_matter = not self._has_sent_new_session or self._context_theme_was_read
+if correction_can_matter and self._client_state.context_info.color_scheme:
+    msg.new_session.resolved_color_scheme = self._client_state.context_info.color_scheme
+self._has_sent_new_session = True
 ```
 
 ### 3. Frontend: what it sends
@@ -317,11 +283,8 @@ getResolvedThemePreference = (): "light" | "dark" => {
 
 `state.themeHash` is `""` **exactly** during the pre-`processThemeInput` window — a
 session with no custom theme still gets a non-empty sentinel hash — so it is a reliable
-"has the final theme been applied" test. `hostThemeApplied` is a monotonic flag set **inside** each of
-`handleThemeMessage`'s three branches, never after the chain: a host message that matches no
-branch paints nothing, so it must not claim the client's `colorScheme` is authoritative.
-Once a branch does paint, the flag stays set for the session, which is why it needs no
-clearing.
+"has the final theme been applied" test. `hostThemeApplied` covers the other way the window
+can close; see §4 for how it is set.
 
 Because `theme_preference` is consulted **only** inside that startup window — before any
 in-session interaction — the cached selection and the OS preference are the whole story.
@@ -335,8 +298,12 @@ Three instance fields on `App`:
 | Field | Meaning |
 |-------|---------|
 | `backendColorScheme: "light" \| "dark" \| null` | What Python currently believes `type` is. `null` means we have not been told yet, which is **not** a disagreement |
-| `hostThemeApplied: boolean` | A host has pushed a theme. Monotonic — never cleared, so there is no stale-flag failure mode |
-| `pendingThemeRerun: boolean` | A theme rerun that could not be sent because we were busy or offline |
+| `hostThemeApplied: boolean` | A host has pushed a theme. Set **inside** each `handleThemeMessage` branch, never after the chain — a message matching no branch paints nothing and must not claim authority. Monotonic thereafter |
+| `themeCorrectionInFlight: boolean` | A correction was sent and the server has not answered. Cleared only on observed events (see below) |
+
+There is deliberately **no** "pending rerun" flag. The disagreement between what we paint
+and `backendColorScheme` *is* the pending state, and unlike a flag it survives disconnects
+and sends that never reach the server.
 
 Four hooks:
 
@@ -353,71 +320,76 @@ if (
 }
 ```
 
-**2. `sendRerunBackMsg`**, after the message is sent, records what Python will now believe:
+**`sendRerunBackMsg` must NOT record what Python will believe.** The echo is the only
+writer of `backendColorScheme`. Predicting it at send time is unsound, because
+`ConnectionManager.sendMessage` logs an error and returns `void` when disconnected — the
+caller cannot tell whether the message went out. A predicted update after a discarded send
+would leave the client believing Python holds a value it never received, with no
+disagreement left to detect.
+
+**2. `componentDidUpdate`**, appended after the existing `scriptRunState` handling — one
+unconditional re-evaluation:
 
 ```tsx
-this.backendColorScheme = contextInfo.themeApplied
-  ? (contextInfo.colorScheme as "light" | "dark")
-  : null
-this.pendingThemeRerun = false
+this.maybeRerunForThemeChange()
 ```
 
-When we claimed our theme was applied, Python gets exactly the `colorScheme` we sent.
-Otherwise the backend is resolving and we learn the value from the echo.
-
-**3. `componentDidUpdate`**, appended after the existing `scriptRunState` handling:
-
-```tsx
-// Rerun when what we paint disagrees with what Python holds. `null` means we
-// have not been told yet, which is not a disagreement.
-if (
-  this.backendColorScheme !== null &&
-  this.getThemeColorScheme() !== this.backendColorScheme
-) {
-  this.maybeRerunForThemeChange()
-}
-
-if (this.pendingThemeRerun) {
-  this.maybeRerunForThemeChange()
-}
-```
-
-**4. `maybeRerunForThemeChange`** re-checks, defers, or sends:
+**3. `maybeRerunForThemeChange`** compares, and either sends or does nothing:
 
 ```tsx
 private maybeRerunForThemeChange = (): void => {
-  // Same predicate as the caller: null means we have not been told what Python
-  // holds, which is not a disagreement to correct.
+  // `null` means we have not been told what Python holds, so there is nothing
+  // to correct yet.
   if (
     this.backendColorScheme === null ||
     this.getThemeColorScheme() === this.backendColorScheme
   ) {
-    this.pendingThemeRerun = false
     return
   }
+
   if (
     !this.isServerConnected() ||
     this.state.scriptRunState !== ScriptRunState.NOT_RUNNING
   ) {
-    this.pendingThemeRerun = true
+    // Cannot send right now. Nothing to remember: the disagreement persists, and
+    // reconnecting or the script finishing both re-render and re-check.
     return
   }
-  // Left set until the BackMsg is actually sent, so a send that silently
-  // fails (e.g. the socket dropped underneath us) is retried rather than lost.
+
   this.widgetMgr.sendUpdateWidgetsMessage(undefined)
+
+  // Suppress duplicate sends until the server answers.
+  this.themeCorrectionInFlight = true
 }
 ```
 
-**Why this preserves the current page.** The `undefined` argument to
-`sendUpdateWidgetsMessage` is the *fragment id*, which makes this a full-app rerun. The page
-hash matters separately: `WidgetStateManager.sendUpdateWidgetsMessage` always calls
-`sendRerunBackMsg` with `pageScriptHash` as `undefined`, and `sendRerunBackMsg` then falls
-through to `this.state.currentPageScriptHash`. So the rerun cannot carry a stale or empty
-page, which is what broke deep links in #11797.
+Four constraints on this, each of which is easy to get wrong:
 
-**Loop safety.** Every send refreshes `backendColorScheme`, and the `NewSession` echo
-reports what the script actually saw, so once the two agree the comparison short-circuits.
-The menu E2E should assert a run counter, proving exactly one rerun per toggle (Principle 34).
+**Use a local flag, not `scriptRunState`.** Marking the app `RERUN_REQUESTED` is tempting —
+it would block a second send and let the reconnect path retry a dropped one — but that state
+makes `isElementStale` return `true` for *every* element and shows a running indicator, so a
+theme change would grey out the whole app. `sendUpdateWidgetsMessage` avoids it for the same
+reason (see the `ChatInput` comment).
+
+**Clear the flag only on observed events**, never on the assumption a send succeeded:
+`ConnectionManager.sendMessage` discards messages and returns `void` when disconnected. Clear
+it when a `NewSession` arrives, and when the connection drops — the latter is what retries a
+discarded send, since the disagreement is still recorded and reconnecting re-renders.
+
+**The echo is the only writer of `backendColorScheme`.** Do not also set it at send time from
+the value just sent: that is predicting the server's answer, and a discarded send would leave
+the client believing Python holds a value it never received, with no disagreement left to
+detect. Loop safety then follows — once the echo and the paint agree, the comparison
+short-circuits.
+
+**Corrections land one script completion later.** The echo rides on `NewSession`, which
+carries `sessionStatus.scriptIsRunning = true`, so the client learns Python's value while the
+script is running and the correction waits for that run to finish. Never same-run.
+
+The rerun preserves the current page, which is what #11797 turned on: `undefined` here is the
+*fragment id*, making this a full-app rerun, while `WidgetStateManager` separately passes
+`pageScriptHash` as `undefined`, so `sendRerunBackMsg` falls through to
+`this.state.currentPageScriptHash` and cannot carry a stale or empty page.
 
 **Why this does not regress MPA:**
 
@@ -427,7 +399,7 @@ The menu E2E should assert a run counter, proving exactly one rerun per toggle (
 | Fired on page navigation / reconnection | Same — a new `NewSession` re-applies the same theme and echoes the same value |
 | Used theme NAME comparison | Nothing reads theme names; the comparison is `getThemeColorScheme()` vs. the echo |
 | `sendRerunBackMsg()` without page context lost current page | The rerun goes through `sendUpdateWidgetsMessage`, so `sendRerunBackMsg` falls through to `this.state.currentPageScriptHash` |
-| Theme change while script running was silently dropped | `pendingThemeRerun`, drained by `componentDidUpdate` once connected and `NOT_RUNNING` |
+| Theme change while script running was silently dropped | Nothing to drop: the disagreement persists in state, and the script finishing re-renders and re-checks |
 
 **Invariant the trigger depends on:** it only fires when React renders. `App` is a
 `PureComponent` but re-renders on every `ThemedApp` render because `useThemeManager`
@@ -443,27 +415,20 @@ differs from what the client paints.** The echo then corrects it in one rerun. K
 |------|----------------------|
 | `backgroundColor` in a CSS syntax Pillow cannot parse — `rgb(0 0 0)`, `hsl(0 0% 10%)`, `transparent` | The frontend's parser accepts more syntax than Pillow's. Named colours, `rgb()`, `rgb(%)` and `hsl()` **are** handled and are correct on the first run |
 | Host theme applied around or after the first `BackMsg` | The guess comes from `config.toml`, but a host theme is what gets painted |
-| A mirror divergence not yet found | The resolver re-implements five frontend rules; any of them could drift |
+| A mirror divergence not yet found | The resolver re-implements three frontend rules; any could drift |
 
-Two properties worth stating explicitly, because they bound how much this matters:
+**No case is silently wrong** — if the client's luminance agrees with the guess then `type`
+equals the painted appearance by definition, so every divergence is detectable and produces
+exactly one corrective rerun. **But the correction is not free:** run 1 *executed* with the
+wrong value, and the output is visible before it settles. A light logo on a dark background
+is not a subliminal flicker, and a script with side effects on that run — a log, an API call,
+a counter — performed them with the wrong `type`. That residue is the strongest argument for
+approach C, and why approach A is not simply a cheaper B.
 
-**No silently-wrong case remains.** If the client's luminance agrees with the guess, then
-`type` equals the painted appearance, which is correct by definition. So every divergence
-is detectable, and every detectable divergence produces exactly one corrective rerun.
-
-**But "corrected in milliseconds" is not free.** The first run *executed* with the wrong
-value. For pure rendering the output flashes and settles, invisibly. For a script with
-side effects on that run — logging, an API call, a counter, an email — the work was done
-with the wrong `type`. This is the inherent cost of any resolver-based approach and the
-strongest argument for alternative C.
-
-By contrast, `config.toml` precedence is **not** a source of first-run error. The resolver
-reads through `get_options_for_section` *after* all merging has happened — global and
-project `config.toml`, environment variables, CLI flags, and `theme.base` file inheritance
-(`config_util.process_theme_inheritance` clears and re-applies every `theme.*` option,
-sections included). We read the merged answer rather than re-deriving it, so multi-config
-precedence cannot drift. Only the section→appearance mapping is mirrored, and that is what
-the echo guards.
+Note that `config.toml` **precedence** is not a source of error: the resolver reads
+`get_options_for_section` *after* all merging — global and project config, env vars, CLI
+flags, and `theme.base` file inheritance — so it reads the merged answer rather than
+re-deriving it. Only the section→appearance mapping is mirrored.
 
 ### 5. Docs
 
@@ -498,11 +463,25 @@ In `app_session_test.py`, four cases around the wiring:
 - `_create_new_session_message` populates the echo, and leaves it unset when there is no
   value to send.
 
+**Python unit, the gate** — three cases on `_create_new_session_message`: the first
+`NewSession` echoes; a later one does **not** when no run has read the theme; a later one
+does once a run has. Plus, on the notification path: reading `st.context.theme` sets the
+flag, reading a sibling like `st.context.timezone` does **not**, and a `None` handler is
+harmless (which is how `AppTest` runs).
+
 **Frontend unit** — `App.test.tsx` needs the two new `contextInfo` fields added to the three
 existing `sendRerunBackMsg` assertions, plus dedicated coverage for the parts E2E reaches
 awkwardly: `isThemeApplied` across the startup window and after a host theme;
-`getResolvedThemePreference` for each source; and `maybeRerunForThemeChange` deferring while
-`RUNNING` or disconnected and draining once idle.
+`getResolvedThemePreference` for each source; `maybeRerunForThemeChange` deferring while
+`RUNNING` or disconnected and draining once idle; and **that the client stops correcting once
+the echo stops arriving** — the test that catches the infinite-loop failure mode described in
+the access gate.
+
+**Mutation-test every guard.** Each of these tests should be verified by removing the
+protection it covers and confirming it goes red. A guard test that cannot fail is worse than
+no test, because it manufactures confidence. The failure mode is specific and easy to hit
+here: a guard test can be satisfied by a rerun from an unrelated code path and pass whether
+or not the guard exists.
 
 **E2E** — one module per theme configuration, since a module can only apply one (see
 [Implementation notes](#implementation-notes)):
@@ -512,7 +491,8 @@ awkwardly: `isThemeApplied` across the startup window and after a host theme;
 | First-run correctness — the core of #11920 | `base=dark` + a dark `backgroundColor`, light OS preference | `type` is `"dark"` with no interaction, and stays `"dark"` across a rerun (covering the handoff to the client's own value) |
 | Non-hex background | `backgroundColor="black"`, light OS preference | the computed background really is `rgb(0, 0, 0)`, and `type` is `"dark"` on the first run |
 | Menu appearance change — #15287 | none (presets) | Light→Dark→Light from the settings menu updates `type` with no manual rerun, and a run counter proves exactly one rerun per toggle |
-| MPA deep link — the #11797 guard | `[theme]` set | entering a non-default page by direct URL still lands on that page. **No such test exists today:** `mpa_v2_custom_theme_test.py` configures a theme but navigates by clicking, and `mpa_basics_test.py` deep-links with no theme — so the regression this design must not reintroduce is currently unguarded |
+| MPA deep link — the #11797 guard | `[theme]` set | entering a non-default page by direct URL still lands on that page. Belongs in `mpa_v2_custom_theme_test.py`, which already configures a theme; verify it by reintroducing #10972's name-diff rerun and checking the test fails |
+| **An app that never reads `st.context.theme`** | presets | count the reruns across several menu toggles. Assert the *number*, not the absence of a correction — an absence assertion passes even when the gate is broken. This is the only test that measures the cost to the 99.4% |
 
 Also unskip [`hostframe_app_test.py::test_st_context_theme_respects_dark_theme_message`](../../e2e_playwright/hostframe_app_test.py),
 skipped since #11870. No new CI infrastructure — the hostframe suite already exists.
@@ -555,68 +535,142 @@ surrounding code, and each one will cost time if it is discovered late.
   retries with a `#` prefix, and warns only on real failure. So `"black"` is a valid,
   working config that must not be rejected — which is precisely why the echo exists.
 
+## The design space: three approaches
+
+Everything else in this spec is shared: the echo (`resolved_color_scheme`), the client
+comparison in §3-§4, and the access gate below. The three approaches differ **only in how
+the first script run gets its value**.
+
+These are approaches to *implementation*. They are unrelated to the product spec's Options
+A/B/C, which decide what `type` should *mean*; that decision is settled as Option C
+(visual appearance) and all three approaches below implement it.
+
+| | **A — lightweight** | **B — robust** (proposed) | **C — push theme ahead** |
+|---|---|---|---|
+| How run 1 gets its value | the client's provisional value; corrected on run 2 | the backend resolves from `config.toml` before the run | the backend sends the theme *before* the client's first rerun |
+| Run 1, ordinary custom theme | **wrong** — visible flash | **right** | **right** |
+| Run 1, host theme (SiS) | wrong → corrected | wrong → corrected | **still wrong** — host themes come from the embedder, not the server |
+| Added latency | none | none | +1 RTT before first content, every session, every app |
+| Proto change | 1 field | 3 fields, all additive | protocol reordering |
+| Backend code | none | ~110 lines | new pre-session message + handshake ordering |
+| Mirrors frontend rules | no | 3 rules | no |
+| Verdict | viable fallback | **proposed** | rejected — see below |
+
+### A vs B, in detail
+
+These are the two live candidates. C is rejected on grounds that do not depend on the
+adoption argument (see the end of this section).
+
+| | **A — lightweight** | **B — robust** |
+|---|---|---|
+| `theme_type.py` | not needed | ~110 lines; 189 with docs |
+| Of which mirrors frontend behaviour | — | 3 rules: section inheritance, dual-theme detection, single-theme light fallback |
+| Of which is standard or delegated | — | `_luminance` is the published WCAG formula; `_parse_color` delegates to Pillow |
+| Proto fields | `resolved_color_scheme` | + `theme_preference`, `theme_applied` |
+| `app_session` wiring | unchanged | must pass a **copy** of `context_info` to `RerunData` (§2) |
+| `AGENTS.md` "no backend theming" | not engaged | narrow exception; the rule targets styling/layout math, and its stated worry — the backend cannot see the active theme — is exactly what the echo answers |
+| Reruns, app that reads `type` | 2 on first load | 1 on first load |
+| Reruns, app that does not | none, after the gate | none, after the gate |
+| Residual wrong first runs | all custom themes | unparseable colour syntax; host-theme race |
+| Ongoing maintenance | none | keep 3 rules in step with the frontend |
+
+**What A costs the user.** Not an invisible delay. Run 1 renders with the wrong value — a
+light logo on a dark background, or `plotly_white` on a dark page — and then flips. For an
+API whose whole purpose is contrast adaptation, the first paint *is* the product, and "first
+run with a custom theme" is the first failure mode
+[#11920](https://github.com/streamlit/streamlit/issues/11920) lists. A closes the issue's
+second half and leaves the first visible on every load.
+
+**What B costs the team.** Three mirrored rules, anchored to the *public* `[theme]` config
+schema. That schema is user-facing contract and does not churn freely — it last changed when
+dual themes were introduced. So drift is a real but modest risk, and the echo bounds any
+drift to one wrong first run rather than a stale session. Note also that neither option
+avoids the harder part: six of the defects found while developing this design were in the
+shared client trigger, which A and B need identically. A is smaller, not safer.
+
+**Decision rule.** If a visible wrong-contrast flash on first load is acceptable, take A and
+delete the resolver. If it is not — and for a contrast-adaptation API that is hard to argue
+— take B. Nothing else changes either way, so A stays a clean retreat if the mirror ever
+becomes a burden.
+
+### Why C is rejected
+
+On connect the backend would send the `config.toml` theme; the client applies it and only
+then sends its first rerun, already carrying a correct `color_scheme`. That buys a correct
+first run with no resolver and no mirror — genuinely attractive — but:
+
+1. **An extra round trip before the script starts, every session.** `connect → client rerun
+   → script runs` becomes `connect → server theme → client applies → client rerun → script
+   runs`. The delay lands on time to first *content*; the client already paints a cached or
+   preset theme immediately, so users would see chrome as fast as ever and then wait longer
+   for the body.
+2. **Every app pays it**, to fix a value ~0.6% of apps read.
+3. **It hurts the deployments least able to absorb it** — Community Cloud and especially
+   SiS/SPCS sit behind longer paths, an iframe, and a container or warehouse layer, on top of
+   cold-start latency users already notice.
+4. **It does not fix the host-theme case, which is the SiS case.** Host themes arrive from
+   the embedder via `SET_CUSTOM_THEME_CONFIG`, not from the server, so the backend cannot
+   push them ahead of the first run. C would still need the echo — for exactly the platform
+   paying the most latency for it.
+5. **Protocol reordering rather than additive fields**, so version-skew combinations need
+   real thought instead of falling out of optional-field semantics.
+
+Point 4 is decisive: a universal, SiS-weighted latency cost that still does not remove the
+correction mechanism.
+
+### The access gate (required by either approach)
+
+`st.context.theme.type` is read by roughly **0.6% of apps**, so no approach may add reruns
+for the other 99.4%. Send `resolved_color_scheme` only when a correction could matter:
+
+```python
+correction_can_matter = not self._has_sent_new_session or self._context_theme_was_read
+```
+
+**Do not use `gather_metrics` to detect the access.** `@gather_metrics("context.theme")`
+only records when `ctx.gather_usage_stats` is true, and `metrics_util` skips tracking
+entirely when `browser.gatherUsageStats` is off — so telemetry-disabled deployments would
+silently lose corrections. Notify explicitly instead: `ContextProxy.theme` calls an
+`on_context_theme_read` callback carried on `ScriptRunContext`, following the route
+`on_script_error` already takes (`AppSession` → `ScriptRunner` → context). `AppSession`
+holds the memory in two sticky booleans, because a per-run context cannot outlive the run
+that made the access. There is no pre-existing "have we sent a `NewSession`" signal; add one.
+
+Put the callback *before* the `context_info is None` early return, so an access counts even
+when there is no value yet. Note the gate is intentionally coarse: bare `st.context.theme`
+with no field access still counts. `ContextProxy` is a plain class rather than a dict, so
+the property is the only door and both `.type` and `["type"]` route through it.
+
+**The client must treat an absent echo as "nothing to compare", not "keep the old value".**
+This is the part that is easy to get wrong and it is load-bearing:
+
+```tsx
+this.backendColorScheme =
+  resolved === "light" || resolved === "dark" ? resolved : null
+```
+
+Retaining the previous value instead — an `if (valid) { assign }` — creates an **infinite
+correction loop** once the gate engages: the client corrects, the resulting `NewSession`
+carries no echo, the stale value is kept while `themeCorrectionInFlight` is cleared, so the
+disagreement never resolves and the client corrects again, forever. The backend gate alone
+is *worse* than no gate. Cover this with a test that counts reruns rather than asserting an
+absence.
+
+**What it actually costs a non-reading app: one correction per session, not zero.** The
+first `NewSession` is emitted at `SCRIPT_STARTED`, before any user code runs, so the client
+necessarily holds a comparable value through run 1. A no-read app therefore pays exactly one
+correction — on the first theme change after load — and none thereafter, since the unechoed
+`NewSession` from that very rerun nulls the client's copy. If any unrelated rerun happens
+first, the cost is zero. The saving is one-per-session instead of one-per-theme-change.
+
 ## Alternatives considered
 
-Two of these are genuinely simpler than the proposal and deserve a real decision rather
-than a dismissal, because both eliminate the resolver — and with it the FE/BE mirror that
-is this design's main long-term liability. The proposal sits deliberately between them.
-
-### A. Echo only — delete the resolver
-
-Keep `resolved_color_scheme`, drop `theme_type.py` and `theme_preference` entirely. The
-first run uses whatever the client's provisional `color_scheme` says; the echo detects the
-disagreement and reruns once.
-
-- **Buys:** no second implementation of frontend theme rules in Python, so the drift risk
-  and the non-hex gap both disappear. Materially less code.
-- **Costs:** the first script run is wrong for *every* custom theme, not just edge cases —
-  which is the larger half of [#11920](https://github.com/streamlit/streamlit/issues/11920).
-
-Worth noting this is exactly what the proposal already does for non-hex backgrounds,
-generalized to all custom themes. **Rejected** for first-run correctness, but it is the
-right fallback if the mirror proves hard to maintain.
-
-### B. Backend uses config `base` / `backgroundColor` only (no preference)
+### Resolve from config alone, ignoring the client's preference
 
 Fixes single-custom-with-`base` quickly; fails for dual light/dark sections and
 preset-only Dark menu selection. **Rejected** as sole fix.
 
-### C. Push the theme to the client before the first script run
-
-On connect, the backend sends the `config.toml` theme; the client applies it and only then
-sends its first rerun, already carrying a correct `color_scheme`.
-
-**Buys:** no resolver, no mirror of frontend rules, no colour-parsing gap at all, and a
-correct first run for `config.toml` themes.
-
-**Costs — and they are larger than they first look:**
-
-1. **An extra round trip before the script starts, on every session.** Today the sequence
-   is `connect → client rerun → script runs`. This makes it
-   `connect → server theme → client applies → client rerun → script runs`. The delay lands
-   on **time to first content**, not time to first paint — the client already paints a
-   cached or preset theme immediately, so users would see the chrome just as fast and then
-   wait longer for the app body.
-2. **Every app pays it, to fix a value most apps read once or never.** The cost is
-   universal; the benefit is confined to apps that read `st.context.theme.type` on their
-   first run.
-3. **It hurts the deployments least able to absorb it.** Community Cloud and especially
-   SiS/SPCS sit behind longer network paths, an embedding iframe, and a container or
-   warehouse layer. An added RTT there is materially worse than on localhost, and it
-   compounds with cold-start latency that users already notice.
-4. **It does not even fix the host-theme case — which is the SiS case.** Host themes arrive
-   from the *embedder* via `SET_CUSTOM_THEME_CONFIG` postMessage, not from the server, so
-   the backend cannot push them ahead of the first run. C would still need a correction
-   mechanism for exactly the platform paying the most latency for it.
-5. **Protocol reordering rather than additive fields**, so old/new client-server
-   combinations need real thought instead of falling out of optional-field semantics.
-
-**Rejected.** Point 4 is decisive: C pays a universal, SiS-weighted latency cost and still
-does not remove the need for the echo. If reviewers weight first-run side effects heavily
-(see [When the first run is still wrong](#when-the-first-run-is-still-wrong)), the cheaper
-move is to narrow the resolver's remaining gaps rather than reorder the handshake.
-
-### D. Have the client *predict* the backend's answer instead of being told it
+### Have the client *predict* the backend's answer instead of being told it
 
 Instead of the echo, the client could key its rerun on the inputs the backend resolves
 from — the appearance preference plus a flag for whether a host theme is active — and rerun
@@ -631,7 +685,7 @@ explicitly about host-message arrival ordering. It also fires redundant reruns w
 preference changes but config pins the appearance either way — and it cannot detect a
 backend/frontend disagreement at all, which is the failure mode most worth catching.
 
-### If product picks A or B instead of C
+### If the product spec picks semantics A or B instead of C
 
 Only §2 changes. The proto and the §3/§4 exchange are agnostic to *what* the backend
 resolves — the echo compares whatever the script saw against what is painted either way.

--- a/specs/2026-08-08-st-context-theme-type/tech-spec.md
+++ b/specs/2026-08-08-st-context-theme-type/tech-spec.md
@@ -337,7 +337,7 @@ this.maybeRerunForThemeChange()
 **3. `maybeRerunForThemeChange`** compares, and either sends or does nothing:
 
 ```tsx
-private maybeRerunForThemeChange = (): void => {
+private readonly maybeRerunForThemeChange = (): void => {
   // `null` means we have not been told what Python holds, so there is nothing
   // to correct yet.
   if (
@@ -348,11 +348,13 @@ private maybeRerunForThemeChange = (): void => {
   }
 
   if (
+    this.themeCorrectionInFlight ||
     !this.isServerConnected() ||
     this.state.scriptRunState !== ScriptRunState.NOT_RUNNING
   ) {
-    // Cannot send right now. Nothing to remember: the disagreement persists, and
-    // reconnecting or the script finishing both re-render and re-check.
+    // Cannot or should not send right now. Nothing to remember: the disagreement
+    // persists in state, and reconnecting, the script finishing, or the server
+    // answering all re-render and re-check.
     return
   }
 

--- a/specs/2026-08-08-st-context-theme-type/tech-spec.md
+++ b/specs/2026-08-08-st-context-theme-type/tech-spec.md
@@ -7,14 +7,25 @@ created: 2026-08-08
 
 ## Summary
 
-Fix `st.context.theme.type` by having the client send a resolved appearance preference
-(`"light"` | `"dark"`) on every rerun, and having the backend resolve the effective type
-from that preference plus `config.toml` **before** the script runs — plus an MPA-safe
-auto-rerun whenever the inputs the backend resolves from change (menu, host, or OS).
+Fix `st.context.theme.type` with a two-way exchange:
 
-See the [product spec](./product-spec.md) for the A/B/C semantics decision and
-user-facing behavior. This tech spec is written against **Option C** (visual appearance);
-if product picks A or B, adjust §2 only.
+1. The client sends its resolved light/dark **preference** on every rerun, plus a flag
+   saying whether it is yet painting its final theme for this session.
+2. While that flag is false — the startup window before the `config.toml` theme has been
+   applied — the backend resolves `color_scheme` from the preference plus `config.toml`,
+   **before** the script runs. Otherwise it trusts the client's own `color_scheme`.
+3. The backend **echoes** whatever the script saw back in `NewSession`. The client reruns
+   once whenever what it paints disagrees with that echo.
+
+The echo is what makes the system self-correcting. The backend resolver is deliberately
+best-effort — it parses most CSS colours but not every syntax — and any disagreement, from
+an unparseable `backgroundColor` to a resolver bug to future frontend drift, is detected
+and fixed by one automatic rerun, with the client's painted value winning. That is the
+correct outcome under **Option C** (visual appearance) in the
+[product spec](./product-spec.md).
+
+See [Implementation notes](#implementation-notes) for behaviors of the existing code that
+this design depends on, and that are easy to get wrong.
 
 ### Terms
 
@@ -22,11 +33,12 @@ if product picks A or B, adjust §2 only.
 |------|---------|
 | **Frontend** / **FE**, **Backend** / **BE** | The React app in `frontend/` and the Python runtime in `lib/`, respectively |
 | **Appearance preference** | What the user or their OS asked for: menu `Light` / `Dark` / `System`, with `System` resolved against `prefers-color-scheme`. Sent as `theme_preference` |
-| **Painted appearance** | Whether the app actually renders light or dark, from the active theme's background luminance. What Option C defines `type` to mean |
+| **Painted appearance** | Whether the app actually renders light or dark, from the active theme's background luminance (`getThemeColorScheme`). What Option C defines `type` to mean |
+| **Theme applied** | Whether the client is painting its *final* theme for this session, which makes its own `color_scheme` authoritative. Sent as `theme_applied` |
+| **Echo** | `NewSession.resolved_color_scheme` — the value the script actually saw, sent back so the client can detect a disagreement |
 | **Dual theme** | A `config.toml` with `[theme.light]` and/or `[theme.dark]` sections, which makes the FE build separate light and dark custom themes |
 | **Section variant** | Which half of a dual theme is active — `"light"` or `"dark"`. The FE forces the theme's `base` from it |
 | **Host theme** | A theme pushed by an embedding host at runtime via the `SET_CUSTOM_THEME_CONFIG` postMessage, which replaces `config.toml` on the FE |
-| **Resolution key** | The `(appearance preference, host theme active)` pair — precisely the client-supplied inputs the backend resolves `type` from, and the trigger for the §4 auto-rerun |
 
 ## Problem
 
@@ -36,11 +48,12 @@ if product picks A or B, adjust §2 only.
 FE getThemeColorScheme()  →  ContextInfo.color_scheme  →  st.context.theme.type
 ```
 
-`color_scheme` is inferred from the active frontend theme’s background luminance
+`color_scheme` is inferred from the active frontend theme's background luminance
 ([`App.getThemeColorScheme`](../../frontend/app/src/App.tsx)) and sent inside
 `BackMsg.rerun_script`. Custom theme config arrives later in `NewSession.custom_theme`
 via [`_populate_theme_msg`](../../lib/streamlit/runtime/app_session.py). There is no
-backend resolution of `type` today.
+backend resolution of `type` today, and nothing tells the client what Python ended up
+with.
 
 ### Chicken-and-egg on first run
 
@@ -66,8 +79,9 @@ if (prevProps.theme.activeTheme.name !== this.props.theme.activeTheme.name) {
 Theme **name** changes for system-internal reasons — page navigation / connect /
 reconnect → `NewSession` → `processThemeInput` remaps `"Light"` → `"Custom Theme"` →
 extra `rerun_script` → page context not preserved → deep link bounces to the default
-page ([#11797](https://github.com/streamlit/streamlit/issues/11797)). [#11870](https://github.com/streamlit/streamlit/pull/11870)
-removed that path. **Do not restore** name-based `componentDidUpdate` reruns.
+page ([#11797](https://github.com/streamlit/streamlit/issues/11797)).
+[#11870](https://github.com/streamlit/streamlit/pull/11870) removed that path. **Do not
+restore** name-based `componentDidUpdate` reruns.
 
 ## Proposal
 
@@ -78,63 +92,65 @@ sequenceDiagram
     participant FE as Frontend
     participant BE as Backend
 
-    FE->>FE: Resolve System to OS light/dark
-    FE->>BE: BackMsg.rerun with theme_preference
-    BE->>BE: resolve_theme_type(preference, config.toml)
-    BE->>BE: Set context_info.color_scheme before ScriptRunner
-    BE->>BE: Script runs; st.context.theme.type is correct
-    BE->>FE: NewSession.custom_theme for UI paint
+    FE->>BE: BackMsg.rerun (theme_preference, theme_applied=false, color_scheme)
+    BE->>BE: theme_applied false → resolve from preference + config.toml
+    BE->>BE: Script runs; st.context.theme.type is the resolved value
+    BE->>FE: NewSession (custom_theme, resolved_color_scheme)
+    FE->>FE: Apply custom theme, compare paint against resolved_color_scheme
+    FE->>BE: One rerun, only if they disagree (theme_applied=true from here on)
 ```
-
-Preference selects which theme **branch/section** is active. Under Option C, `type` is
-then derived from that theme’s `base` / background (preference `"light"` + single dark
-custom theme → `type` `"dark"`).
-
-**Implementation order:** proto → backend resolver (+ unit tests) → FE preference on
-every BackMsg → FE auto-rerun hooks. Do not start auto-rerun work until the BE resolver
-is tested in isolation.
 
 ### 1. Proto
 
-In [`ClientState.proto`](../../proto/streamlit/proto/ClientState.proto), add to
-`ContextInfo`:
+Three new fields. In
+[`ClientState.proto`](../../proto/streamlit/proto/ClientState.proto), on `ContextInfo`:
 
 ```protobuf
-// Resolved light/dark value from the client: "light" or "dark".
-// Normally the user's appearance preference, with a System menu selection
-// resolved to the OS preference before send. When host_theme_active is true it
-// instead carries the painted luminance of the host theme, since that is the
-// only signal the backend can act on for a theme it cannot see.
+// The client's resolved light/dark appearance preference ("light" or "dark").
+// A "System" menu selection is resolved against the OS preference before send.
+// Only consulted when theme_applied is false.
 optional string theme_preference = 7;
 
-// True when a host-provided custom theme (SET_CUSTOM_THEME_CONFIG) is active.
-// When set, the backend skips config.toml resolution and uses theme_preference
-// directly — the host theme overrides config and only the FE knows its appearance.
-optional bool host_theme_active = 8;
+// True once the client is painting its final theme for this session, meaning
+// color_scheme above is authoritative. False only during the startup window
+// before the config.toml theme has been applied, when the backend must
+// resolve the appearance itself from theme_preference + config.toml.
+optional bool theme_applied = 8;
 ```
 
-Keep `color_scheme` as what Python exposes via `st.context.theme.type`. When
-`theme_preference` is present, the backend overwrites `color_scheme` before the script
-run. When `host_theme_active` is true, the backend returns `theme_preference` directly
-(config.toml is irrelevant — the FE is painting the host theme, not the config theme).
-**Old clients without fields 7-8 keep working:** the backend leaves `color_scheme` as
-sent, so existing deployed frontends against a new backend do not regress.
+In [`NewSession.proto`](../../proto/streamlit/proto/NewSession.proto), on `NewSession`:
+
+```protobuf
+// The light/dark appearance the script actually saw this run, as
+// st.context.theme.type. Echoed back so the client can tell whether the value
+// Python holds matches what the client is painting, and rerun if it does not.
+// Needed because the backend resolves this from config.toml on the first run,
+// and its colour parsing is best-effort: the client's CSS parser accepts more
+// syntax than the backend's, and the backend cannot see host-provided themes.
+optional string resolved_color_scheme = 12;
+```
+
+`color_scheme` remains what Python exposes via `st.context.theme.type`; the backend
+overwrites it only in the `theme_applied=false` window.
+
+**Backward compatibility.** Old FE + new BE: no `theme_preference`, so `color_scheme` is
+left exactly as sent — no regression. New FE + old BE: no `resolved_color_scheme`, so the
+client never sees a disagreement and behaves as it does today.
 
 ### 2. Backend resolver
 
-Add `lib/streamlit/runtime/theme_type.py` (sketch under Option C).
+[`lib/streamlit/runtime/theme_type.py`](../../lib/streamlit/runtime/theme_type.py) —
+`resolve_theme_type(preference: ThemeType) -> ThemeType`, with
+`ThemeType = Literal["light", "dark"]`. Private helpers: `_has_section_content`,
+`_merge_for_dual_theme`, `_type_from_bg_or_base`, `_parse_color`, `_luminance`.
 
-**Module comment required:** The general principle (per `AGENTS.md`) is that theming
-calculations belong on the frontend. This module is a justified exception: the backend is
-the only entity that has both the user's appearance preference AND `config.toml` at
-first-run time (the FE hasn't received `NewSession.custom_theme` yet). The implementation
-PR must include a short module-level docstring explaining this so future readers do not
-"fix" it back to FE-only luminance.
+The module docstring carries the justification for existing at all — `AGENTS.md` says
+theming calculations belong on the frontend, and this is the one window where the frontend
+cannot know the answer. It also points at `handleSectionInheritance` /
+`createCustomThemes` in `frontend/lib/src/theme/utils.ts` as the rules being mirrored.
 
 ```python
-def resolve_theme_type(
-    preference: Literal["light", "dark"],
-) -> Literal["light", "dark"]:
+def resolve_theme_type(preference: ThemeType) -> ThemeType:
     theme = config.get_options_for_section("theme")
     light = config.get_options_for_section("theme.light")
     dark = config.get_options_for_section("theme.dark")
@@ -142,893 +158,501 @@ def resolve_theme_type(
     light_sidebar = config.get_options_for_section("theme.light.sidebar")
     dark_sidebar = config.get_options_for_section("theme.dark.sidebar")
 
-    if not _has_any_theme_config(
-        theme, light, dark, sidebar, light_sidebar, dark_sidebar
+    if not any(
+        _has_section_content(section)
+        for section in (theme, light, dark, sidebar, light_sidebar, dark_sidebar)
     ):
-        return preference  # presets only
+        # Presets only: the frontend paints whatever was preferred.
+        return preference
 
-    # FE enters dual-theme mode when theme.light / theme.dark have content OR
-    # when their nested sidebar subsections do (hasThemeSectionConfigs checks
-    # one level deep into nested objects).
-    if (
-        _has_section_content(light)
-        or _has_section_content(dark)
-        or _has_section_content(light_sidebar)
-        or _has_section_content(dark_sidebar)
+    # The frontend enters dual-theme mode when [theme.light] / [theme.dark] have
+    # content, or when their nested sidebar subsections do (hasThemeSectionConfigs
+    # checks one level into nested objects).
+    if any(
+        _has_section_content(section)
+        for section in (light, dark, light_sidebar, dark_sidebar)
     ):
         section = dark if preference == "dark" else light
         merged = _merge_for_dual_theme(theme, section, variant=preference)
-        # fallback = preference (which equals the section variant name, e.g.
-        # "dark" for [theme.dark]) — mirrors the FE behavior where selecting
-        # the dark section implies dark appearance when no explicit base/bg.
         return _type_from_bg_or_base(merged, fallback=preference)
 
-    # Single custom theme — if neither bg nor base is set, FE defaults to
-    # light preset (no base → inherits from lightTheme). This also covers
-    # sidebar-only configs ([theme.sidebar] without main-area keys): the FE
-    # creates a single custom theme inheriting from lightTheme, so the main
-    # area always paints light.
+    # A single custom theme. With neither background nor base set the frontend
+    # inherits from lightTheme, so it paints light. This also covers sidebar-only
+    # configs, where the main area always follows lightTheme.
     return _type_from_bg_or_base(theme, fallback="light")
-
-
-def _merge_for_dual_theme(parent: dict, section: dict, *, variant: str) -> dict:
-    """Merge parent [theme] into a light/dark section for type resolution.
-
-    Section values override parent (mirrors frontend handleSectionInheritance).
-    After merging, `base` is ALWAYS forced to the section variant name —
-    matching the FE, which sets `base` from the variant last, overriding any
-    `base` inherited from `[theme]`.
-
-    Note: `base` is only a registered config option on `[theme]` — it is not a
-    valid key in `[theme.light]` / `[theme.dark]`, so the only `base` that can
-    reach this merge comes from the parent section. A contradictory
-    `[theme.dark] base = "light"` is a config error, not an input we resolve.
-
-    The only way to override the forced `base` in dual themes is via
-    `backgroundColor` luminance (priority 1 in `_type_from_bg_or_base`).
-
-    This ensures:
-    - [theme] base="light" + [theme.dark] primaryColor="..." → base forced to
-      "dark" (variant) → resolver returns "dark". Correct — the FE paints dark.
-    - [theme.dark] backgroundColor="#ffffff" (pathological) → bg luminance →
-      "light" (what is painted, overrides forced base). Correct.
-    """
-    # Filter None values — get_options_for_section includes all registered keys
-    # even when unset. Only non-None values represent user-provided config.
-    parent_set = {k: v for k, v in parent.items() if v is not None}
-    section_set = {k: v for k, v in section.items() if v is not None}
-    merged = {**parent_set, **section_set}
-    # Force base from variant — matches FE handleSectionInheritance
-    merged["base"] = variant
-    return merged
-
-
-def _type_from_bg_or_base(opts: dict, *, fallback: str) -> str:
-    """Classify appearance: hex background luminance, then base, then fallback.
-
-    Assumes `base` has already been normalized to "light"/"dark". That holds
-    because `theme.base` also accepts a TOML file path or URL, and
-    `config_util.process_theme_inheritance` rewrites it to a plain "light" /
-    "dark" (defaulting to "light" when the referenced file sets no base)
-    before options are read. Do NOT "fix" this to resolve paths itself.
-    """
-    bg = opts.get("backgroundColor")
-    if _is_hex_color(bg):
-        return "light" if _hex_luminance(bg) > 0.5 else "dark"
-    base = opts.get("base")
-    if base in ("light", "dark"):
-        return base
-    return fallback
-
-
-def _is_hex_color(value: object) -> bool:
-    """Accept all valid hex color forms: #rgb, #rgba, #rrggbb, #rrggbbaa.
-
-    Stricter than config validation's is_hex_color_like (which uses isalnum
-    and would accept non-hex chars like 'g'/'z'). We need actual hex digits
-    since _hex_luminance parses them with int(..., 16).
-    """
-    if not isinstance(value, str) or not value.startswith("#"):
-        return False
-    h = value[1:]
-    if len(h) not in (3, 4, 6, 8):
-        return False
-    return all(c in "0123456789abcdefABCDEF" for c in h)
 ```
 
-**`_hex_luminance` must normalize short forms and ignore alpha:** Expand `#rgb` →
-`#rrggbb` (double each digit), `#rgba` → `#rrggbbaa` (double each, then discard alpha),
-`#rrggbbaa` → use first 6 hex digits only. Then compute WCAG relative luminance (sRGB
-linearization + BT.709 coefficients) with threshold `> 0.5`, identical to the frontend's
-`hasLightBackgroundColor` / color2k `getLuminance`.
+| Config shape | Resolved `type` |
+|--------------|-----------------|
+| No custom theme (presets) | `preference` |
+| Single `[theme]` only | `_type_from_bg_or_base(theme, fallback="light")` — the FE default |
+| Only `[theme.sidebar]` (no main-area keys) | Same as single `[theme]` → `"light"` (main area inherits `lightTheme`) |
+| `[theme.light]` and/or `[theme.dark]` | Section from `preference`, `base` forced to the variant, then `_type_from_bg_or_base(..., fallback=preference)` |
+| `[theme.light.sidebar]` / `[theme.dark.sidebar]` only | Dual-theme path; merged section has only the forced `base` → `preference` |
 
-```python
-def _hex_luminance(hex_color: str) -> float:
-    """WCAG relative luminance from any hex form.
+`_has_section_content` returns True when the section holds any value that is neither `None`
+nor an empty list — empty lists are discounted because the frontend's
+`hasThemeSectionConfigs` treats them as "no config" too.
+`get_options_for_section` returns every registered key even when the user never wrote the
+TOML header, so the *values* are the signal. This is the same determination
+`_populate_theme_msg` makes before sending a theme to the client, and the two must agree —
+otherwise the backend resolves against config the frontend was never told about.
 
-    Short forms are expanded and any alpha channel is ignored.
-    """
-    h = hex_color.lstrip("#")
-    if len(h) in (3, 4):
-        # Expand short form: #rgb → rrggbb, #rgba → rrggbbaa
-        h = "".join(c * 2 for c in h)
-    # Use only first 6 chars (ignore alpha if present)
-    r, g, b = int(h[0:2], 16) / 255, int(h[2:4], 16) / 255, int(h[4:6], 16) / 255
-    # sRGB linearization
-    r = r / 12.92 if r <= 0.04045 else ((r + 0.055) / 1.055) ** 2.4
-    g = g / 12.92 if g <= 0.04045 else ((g + 0.055) / 1.055) ** 2.4
-    b = b / 12.92 if b <= 0.04045 else ((b + 0.055) / 1.055) ** 2.4
-    return 0.2126 * r + 0.7152 * g + 0.0722 * b
-```
+`_merge_for_dual_theme` lets section values win over `[theme]`, then forces
+`base = variant`, mirroring the FE merging `{ base }` last. (`base` is only registered on
+`[theme]`, so it cannot come from the section itself.) The only way to override the forced
+base is an explicit section `backgroundColor`.
 
-A divergent Python implementation would disagree with painted appearance for
-near-threshold hex backgrounds. Add a cross-check unit test comparing Python
-`_hex_luminance` against known FE outputs. **Pick colors that actually straddle the
-threshold** — mid-gray does not. Values measured against the vendored `color2k`:
+`_type_from_bg_or_base` checks `backgroundColor` luminance, then `base`, then the
+fallback. It assumes `base` is already `"light"`/`"dark"`;
+`config_util.process_theme_inheritance` guarantees that.
+
+`_parse_color` handles the CSS colour space rather than hex alone, using
+`PIL.ImageColor.getrgb` — **no new dependency**, since `pillow>=7.1.0,<13` is already a
+runtime dependency of the library. That covers hex in 3/4/6/8 digits, all 148 CSS named
+colours, `rgb()` with numbers or percentages, and `hsl()`; alpha is dropped, matching the
+frontend. It is imported lazily because the resolver runs at most once per session and the
+runtime should not pay for Pillow at startup.
+
+`_luminance` computes WCAG relative luminance (sRGB linearization + BT.709) with threshold
+`> 0.5` — identical to color2k's `getLuminance`, which the FE uses via
+`hasLightBackgroundColor`. Pin these boundary values in the tests, measured against the
+vendored color2k:
 
 | Color | `getLuminance` | Classified |
 |-------|---------------|------------|
-| `#000` | 0.0000 | dark |
 | `#7f7f7f` | 0.2122 | dark |
 | `#808080` | 0.2159 | dark |
 | `#bbbbbb` | 0.4969 | **dark** — just below |
 | `#bcbcbc` | 0.5029 | **light** — just above |
-| `#ccc` | 0.6038 | light |
-| `#fff` | 1.0000 | light |
 
-`#bbbbbb` / `#bcbcbc` is the real crossing; `#bbb` (0.4969) additionally covers short-form
-expansion right at the boundary. `#7f7f7f` / `#808080` sit at ~0.21 and would pass any
-implementation, testing nothing.
+`#bbbbbb`/`#bcbcbc` is the real crossing. Mid-gray sits at ~0.21 and would pass any
+implementation, proving nothing.
 
-**Known limitation — non-hex `backgroundColor` inverts the answer.** Theme color options
-are **not** validated as hex. `theme.backgroundColor` is a plain `str` config option
-(`_create_theme_options` applies no validator), so `config.set_option
-("theme.backgroundColor", "black")` is accepted today. Meanwhile `color2k` parses the full
-CSS color space — verified: `getLuminance("black") = 0`, `getLuminance("rgb(0,0,0)") = 0`,
-`getLuminance("hsl(0,0%,10%)") = 0.0103`. So:
+`_parse_color` must also retry with a `#` prefix, because the frontend's `parseColor` does
+— which makes a bare `backgroundColor = "121212"` a working config that the backend would
+otherwise misread.
 
-```toml
-[theme]
-backgroundColor = "black"   # no base set
-```
+**Still best-effort, but the gap is narrow.** What remains unparsed is CSS's
+space-separated syntax (`rgb(0 0 0)`, `hsl(0 0% 10%)`) and the `transparent` keyword. Those
+fall through to the fallback and can be the inverse of what is painted. The resolver
+deliberately does **not** grow a full CSS parser to chase them — the echo covers them at
+the cost of one extra rerun on that load, which is also what lets the resolver stay small
+as frontend theme logic evolves. Pin the remaining gap in a test so it stays visible.
 
-paints **dark** on the frontend, while `_is_hex_color("black")` is false, `base` is unset,
-and the resolver returns `fallback="light"` — the exact inverse of what Option C promises.
-Named colors, `rgb()`, and `hsl()` all land here.
+#### Wiring in `app_session.py`
 
-This is a real correctness gap, not a theoretical one, and it predates this design (today's
-frontend-computed `color_scheme` gets it right, because the FE has the parsed color). Three
-ways out, for reviewer decision — see product spec open question 5:
-
-1. **Accept and document.** Cheapest; leaves a wrong `type` for these configs.
-2. **Handle the common cases.** Add the 148 CSS named colors as a dict plus `rgb()`/`hsl()`
-   parsing. No new dependency, but it grows the very FE/BE duplication the risk table warns
-   about.
-3. **Validate theme colors as hex in config.** Closes it properly and benefits more than
-   `type`, but it would start rejecting configs that work today — a breaking change needing
-   its own deprecation path.
-
-Until this is decided, the resolver should at minimum **not** silently claim `"light"`: log
-a debug message when `backgroundColor` is set but unparseable, so the fallback is
-diagnosable.
-
-**`_has_section_content`** returns True when the section has at least one option with a
-non-None value. `get_options_for_section` returns all registered option keys for the
-section (even when the user didn't write that TOML header), so checking truthiness of
-the dict is insufficient — filter None values:
-
-```python
-def _has_section_content(section: dict) -> bool:
-    return any(v is not None for v in section.values())
-```
-
-**Reuse the existing gate rather than re-deriving it.** `_populate_theme_msg` already makes
-exactly this determination — `if all(val is None for val in theme_opts.values()): return`
-(`lib/streamlit/runtime/app_session.py:1262-1264`) — and it decides whether a
-`custom_theme` reaches the frontend at all. These two must agree: if the resolver thinks a
-section has content and `_populate_theme_msg` disagrees, the backend resolves against config
-the frontend was never told about. Factor the predicate into one shared helper (or have the
-resolver call it) so the "Resolver drifts from FE theme logic" risk does not apply to this
-*sibling* check too.
-
-A bare `[theme.dark]` header with no keys underneath has all-None values → returns
-False. This matches the FE's behavior, which also requires at least one key to trigger
-dual-theme mode.
-
-**`_has_any_theme_config`** is a simple OR over all six sections (main-area and sidebar):
-
-```python
-def _has_any_theme_config(
-    theme: dict,
-    light: dict,
-    dark: dict,
-    sidebar: dict,
-    light_sidebar: dict,
-    dark_sidebar: dict,
-) -> bool:
-    return (
-        _has_section_content(theme)
-        or _has_section_content(light)
-        or _has_section_content(dark)
-        or _has_section_content(sidebar)
-        or _has_section_content(light_sidebar)
-        or _has_section_content(dark_sidebar)
-    )
-```
-
-**Why sidebar sections matter:** The FE creates a custom theme whenever `custom_theme` is
-present in `NewSession` — even if only sidebar fields are set. A bare `[theme.sidebar]`
-(no main-area keys) produces a single custom theme inheriting from `lightTheme`; the main
-area always paints light regardless of OS preference. Without detecting sidebar sections,
-the resolver would return `preference` (wrong when OS = dark).
-
-`[theme.light.sidebar]` or `[theme.dark.sidebar]` trigger dual-theme mode on the FE
-because `hasThemeSectionConfigs` recursively checks one level of nested objects. The
-resolver mirrors this by including `light_sidebar` / `dark_sidebar` in the dual-theme
-condition.
-
-| Config shape | How to get `type` (Option C) |
-|--------------|------------------------------|
-| No custom theme (presets) | Return `preference` |
-| Single `[theme]` only | `_type_from_bg_or_base` with `fallback="light"` (FE default) |
-| Only `[theme.sidebar]` (no main-area keys) | Same as single `[theme]`: falls to `fallback="light"` (main area inherits lightTheme) |
-| `[theme.light]` and/or `[theme.dark]` | Pick section from `preference`, force `base=variant` (matching FE), then `_type_from_bg_or_base` with `fallback=preference` (= section variant name) |
-| `[theme.light.sidebar]` or `[theme.dark.sidebar]` (no main-area keys in .light/.dark) | Dual-theme path: merged section has only forced `base=variant` → returns `preference` (main area follows preset for each variant) |
-
-Wire in [`app_session.request_rerun`](../../lib/streamlit/runtime/app_session.py) after
-copying client `context_info` into `RerunData`. **Resolution targets the cached
-`_client_state` copy** so that server-initiated reruns (e.g. run-on-save) also use the
-resolved value:
+`request_rerun` resolves onto the session's **cached** `_client_state`, and `RerunData`
+then reads from that copy — the incoming `client_state` is a different object:
 
 ```python
 if client_state.HasField("context_info"):
     self._client_state.context_info.CopyFrom(client_state.context_info)
-    ctx = self._client_state.context_info
-    if ctx.HasField("theme_preference"):
-        if ctx.host_theme_active:
-            # Host theme overrides config.toml — FE already resolved appearance.
-            ctx.color_scheme = ctx.theme_preference
-        else:
-            ctx.color_scheme = resolve_theme_type(ctx.theme_preference)
+    _resolve_color_scheme(self._client_state.context_info)
+
+query_string = sanitize_query_string(client_state.query_string)
+rerun_data = RerunData(
+    ...
+    # Read from the cached copy, not the incoming parameter: the
+    # resolution above only applies to _client_state, and for a client
+    # BackMsg these are distinct objects.
+    context_info=self._client_state.context_info,
+)
 ```
 
-**Critical — required wiring change:** Today `request_rerun` constructs `RerunData`
-inline (there is no `_create_rerun_data` helper) and passes
-`context_info=client_state.context_info` — the incoming parameter, not
-`self._client_state`. This must be changed: after resolving `color_scheme` on
-`self._client_state.context_info` (snippet above), the inline `RerunData(...)`
-construction must pass `context_info=self._client_state.context_info` so the resolved
-value reaches the script. Without this change, the script still sees the unresolved
-`color_scheme` from the raw BackMsg.
+Resolving on the cached copy also means server-initiated reruns (run-on-save, fragment
+reruns) use the resolved value.
 
-Applies to **full-script and fragment** reruns alike.
+```python
+def _resolve_color_scheme(context_info: ContextInfo) -> None:
+    if not context_info.HasField("theme_preference") or context_info.theme_applied:
+        return
 
-**Required unit test:** Assert that when two distinct `client_state` BackMsg objects arrive
-(simulating a preference change), the `RerunData.context_info.color_scheme` exposed to
-the script equals the BE-resolved value (from `self._client_state`), not the raw value
-from the incoming parameter.
+    # Only the two known values are actionable; anything else means a client we
+    # don't understand, so leave color_scheme alone rather than guessing.
+    if context_info.theme_preference == "light":
+        preference: theme_type.ThemeType = "light"
+    elif context_info.theme_preference == "dark":
+        preference = "dark"
+    else:
+        return
 
-If product picks **Option A**, this collapses to
-`color_scheme = theme_preference`. If **Option B** (theme identity), return a
-descriptive string like `"Default Light"`, `"Custom"`, or `"Custom Dark"` instead of
-a binary light/dark classification — requires changing the return type and downstream
-`st.context.theme.type` contract.
+    context_info.color_scheme = theme_type.resolve_theme_type(preference)
+```
 
-### 3. Frontend: send preference on every rerun
+`_create_new_session_message` sends the echo, left unset when there is no value yet (e.g.
+a server-initiated first run) so the client treats it as "unknown" rather than a mismatch:
 
-In [`App.sendRerunBackMsg`](../../frontend/app/src/App.tsx) / `contextInfo`:
+```python
+if self._client_state.context_info.color_scheme:
+    msg.new_session.resolved_color_scheme = (
+        self._client_state.context_info.color_scheme
+    )
+```
 
-```ts
+### 3. Frontend: what it sends
+
+Two fields added to the `contextInfo` built in `sendRerunBackMsg`:
+
+```tsx
 themePreference: this.getResolvedThemePreference(), // "light" | "dark"
-hostThemeActive: this.isHostThemePainted(),
+themeApplied: this.isThemeApplied(),
 ```
 
-`isHostThemePainted()` returns `true` only when the host-imported theme is what is
-currently rendered — i.e. the theme installed by `handleThemeMessage` has not been
-replaced by a menu selection, config.toml theme, or embed override:
+```tsx
+isThemeApplied = (): boolean =>
+  this.hostThemeApplied || this.state.themeHash !== ""
 
-```ts
-private isHostThemePainted(): boolean {
-  if (this.hostImportedTheme == null) return false
-  if (this.hasEmbedThemeOverride()) return false
-  // Object identity, NOT name equality — see below.
-  return this.props.theme.activeTheme === this.hostImportedTheme
+getResolvedThemePreference = (): "light" | "dark" => {
+  // Embed params force a preset regardless of anything else.
+  if (isLightThemeInQueryParams()) return "light"
+  if (isDarkThemeInQueryParams()) return "dark"
+
+  const cachedSelection = getCachedThemeSelection()
+  if (cachedSelection === "Light") return "light"
+  if (cachedSelection === "Dark") return "dark"
+  return getSystemThemePreference()
 }
 ```
 
-**Compare by object identity, never by theme name.** Host runtime themes and config.toml
-*single* custom themes are both created with the same name constant `CUSTOM_THEME_NAME`
-("Custom Theme") — `setImportedTheme` calls `createTheme(CUSTOM_THEME_NAME, proto)`, and
-`createCustomThemes`' single-theme branch calls `createTheme(CUSTOM_THEME_NAME,
-themeInput)`. A name comparison therefore cannot distinguish them, and the sticky-host
-bug survives in this shape: with a single `[theme]` in config.toml plus a host dark
-theme, a user selecting "Custom Theme" from the menu still matches the stored host name,
-so the client would keep sending `host_theme_active=true` with the stale host preference
-while the UI paints the config theme.
+`state.themeHash` is `""` **exactly** during the pre-`processThemeInput` window — a
+session with no custom theme still gets a non-empty sentinel hash — so it is a reliable
+"has the final theme been applied" test. `hostThemeApplied` is a monotonic flag set **inside** each of
+`handleThemeMessage`'s three branches, never after the chain: a host message that matches no
+branch paints nothing, so it must not claim the client's `colorScheme` is authoritative.
+Once a branch does paint, the flag stays set for the session, which is why it needs no
+clearing.
 
-`hostImportedTheme` stores the `ThemeConfig` **object** created when the host theme was
-applied. `applyTheme` does `setTheme(newTheme)` without copying, and the manager exposes
-`activeTheme` as that same `useState` value, so the reference survives until something
-replaces it; any other selection — preset, config.toml theme, or a later host import —
-yields a different object and `isHostThemePainted()` goes false. Several config.toml paths
-do spread-copy their themes (`createCustomThemes` for the light/dark/auto variants,
-`createAutoCustomTheme` in the hook), but none of them copies a *host* import, so they all
-correctly compare unequal to `hostImportedTheme`.
+Because `theme_preference` is consulted **only** inside that startup window — before any
+in-session interaction — the cached selection and the OS preference are the whole story.
+There is no tracked `ThemeSelection`, no host-theme identity comparison, and no new embed
+helper: the two existing query-param predicates suffice.
 
-`hasEmbedThemeOverride()` reuses the existing embed query helpers — no new protocol:
+### 4. Self-correcting rerun
 
-```ts
-private hasEmbedThemeOverride(): boolean {
-  return isLightThemeInQueryParams() || isDarkThemeInQueryParams()
-}
-```
+Three instance fields on `App`:
 
-Both are already exported from `frontend/lib/src/util/utils.ts`. When an embed override is
-active the FE paints the preset variant rather than the host custom theme, so config.toml
-resolution on the BE remains correct and `hostThemeActive` must be false.
+| Field | Meaning |
+|-------|---------|
+| `backendColorScheme: "light" \| "dark" \| null` | What Python currently believes `type` is. `null` means we have not been told yet, which is **not** a disagreement |
+| `hostThemeApplied: boolean` | A host has pushed a theme. Monotonic — never cleared, so there is no stale-flag failure mode |
+| `pendingThemeRerun: boolean` | A theme rerun that could not be sent because we were busy or offline |
 
-**Source of truth** (do not reverse-engineer from active custom theme name after
-`processThemeInput`):
+Four hooks:
 
-1. Existing embed query options `embed_options=light_theme` /
-   `embed_options=dark_theme` (already used by host embedding — not a new protocol)
-   if present.
-2. Host-provided custom theme — **only when `isHostThemePainted()` is true** (the host
-   theme is still the active rendered theme). Returns `hostThemePreference`, which
-   `handleThemeMessage` derives from the applied theme's background luminance via
-   `hasLightBackgroundColor` (see the sketch in §4). If `isHostThemePainted()` is false,
-   this step is skipped even if `hostThemePreference` is non-null — prevents stale host
-   preference from leaking after the user picks a different theme from the menu.
-3. Else tracked `ThemeSelection` (`Light` / `Dark` / `System`), with
-   `System` → `getSystemThemePreference()`.
-4. `getCachedThemeSelection()` only for initial hydrate.
-
-`getResolvedThemePreference()` checks in order: embed query → host (if painted) →
-menu/OS selection.
-
-These two values — `themePreference` and `hostThemeActive` — are exactly the inputs the
-backend resolves from, so §4 uses the pair as its rerun trigger. Maintain
-`lastSentThemeResolutionKey` on the App instance (see §4 for semantics); update it whenever a
-rerun BackMsg is sent. Keep sending `colorScheme` for back-compat if useful; BE overwrites
-when `theme_preference` is present.
-
-**Backward compatibility:** New backend + old frontend (no `theme_preference`) leaves
-`color_scheme` untouched — existing deployed clients do not regress. New frontend +
-old backend ignores the unknown field until both sides are upgraded; once both are
-new, BE overwrites `color_scheme` from preference + config.
-
-**Host theme vs config.toml precedence:** Two distinct host mechanisms exist:
-
-1. **Pre-load** (`window.__streamlit.LIGHT_THEME` / `DARK_THEME`): merges host colors
-   into the preset Light/Dark themes via `getMergedLightTheme()`. These merged presets
-   appear in the theme picker. However, `createTheme` for config.toml custom themes
-   inherits from the **static** `lightTheme`/`darkTheme` (never the merged ones), so
-   pre-load host colors do NOT propagate into config.toml custom themes. When no custom
-   `[theme]` is configured (presets only), the resolver returns `preference` — correct,
-   since hosts customize within the same dark/light family.
-
-2. **Runtime** (`SET_CUSTOM_THEME_CONFIG` postMessage): creates a standalone custom
-   theme via `setImportedTheme` → `createTheme(CUSTOM_THEME_NAME, proto)`. No merge with
-   config.toml — last-write-wins, whichever arrives later. When `host_theme_active` is
-   true, config.toml colors are not painted — BE must not resolve from them. Arrival
-   order relative to `NewSession` varies by host; both orderings are specified below.
-
-**Host theme arrival ordering.** Hosts differ in when they post
-`SET_CUSTOM_THEME_CONFIG` relative to the WebSocket handshake, so both orderings must be
-handled. Neither is a "rare race" that can be waved off — each produces a wrong `type`
-under a naive implementation, and each is corrected by a different part of §4:
-
-| Ordering | First run resolves from | Then | Correction |
-|----------|------------------------|------|------------|
-| Host theme applied **before** the first BackMsg (host posts during iframe init, before connect) | Host appearance — first BackMsg already carries `host_theme_active=true` | `NewSession` arrives, `processThemeInput` paints the config.toml theme and clears the host fields | Resolution key flips `dark\|true` → `light\|false`, so §4 fires one rerun and the BE re-resolves from config.toml |
-| Host theme applied **after** `NewSession` (host posts once the app is live) | config.toml — first BackMsg carries `host_theme_active=false` | `handleThemeMessage` applies the host theme | Resolution key flips `light\|false` → `dark\|true`, so §4 fires one rerun and the BE takes `theme_preference` directly |
-
-The first ordering is the one an appearance-diff trigger gets wrong: the config.toml theme
-may paint the *same* luminance the host theme did, so painted appearance does not change,
-yet the backend must switch resolution source from host-preference to config.toml. This is
-why §4 keys on the `(preference, hostThemeActive)` resolution key rather than on luminance —
-see the design note there.
-
-In both orderings the first script run may briefly show a `type` resolved from the other
-source; the correcting rerun fires within milliseconds and is invisible to users.
-Eliminating the first run's exposure entirely would require a new protocol where the host
-pushes its theme to the server rather than only to the iframe — out of scope.
-
-**Pre-existing issue to decide on: host theme + no `config.toml` theme.** The table above
-assumes `processThemeInput` paints a config.toml theme. With **no** `[theme]` at all — a
-common SiS/Cloud shape — it takes its `else` branch instead, and that branch is destructive
-to host themes today. `usingCustomTheme` is `!isPresetTheme(activeTheme)`, which is `true`
-for a host theme (named `CUSTOM_THEME_NAME`), so the branch runs
-`setAndSendTheme(mappedTheme ?? createAutoTheme())` and **replaces the painted host theme
-with a preset**. That is existing behavior on `develop`, independent of this design: the
-host's theme visibly disappears on the first `NewSession`.
-
-For this spec it means ordering A's "correction" is not merely a `type` fix in that
-configuration — the host theme itself is lost, so `type` correctly reports the preset that
-ends up painted. **Reviewer decision needed:** treat the clobber as a separate bug (file it,
-keep it out of scope here, and note that `type` stays truthful either way), or fix it as
-part of this work by having the `else` branch leave a host-imported theme in place. The
-resolution-key design behaves correctly under both, so this is a scoping call rather than a
-design dependency.
-
-### 4. MPA-safe auto-rerun on theme change
-
-#### Design: `componentDidUpdate` resolution key diff
-
-The backend resolves `color_scheme` from exactly two client-supplied inputs —
-`theme_preference` and `host_theme_active` — plus `config.toml`. Holding `config.toml`
-constant, `st.context.theme.type` can only change when that pair changes, so the trigger
-is a **resolution key diff** on the pair rather than a painted-luminance diff:
+**1. `handleNewSession`** records the echo *before* `processThemeInput`, so the
+`componentDidUpdate` that follows the theme application can compare the two. Anything
+other than `"light"`/`"dark"` (including unset) is ignored:
 
 ```tsx
-private getThemeResolutionKey(): string {
-  return `${this.getResolvedThemePreference()}|${this.isHostThemePainted()}`
-}
-```
-
-A rerun fires whenever the current resolution key differs from the one sent with the last
-BackMsg. Against a fixed `config.toml` that condition is both necessary and sufficient: a
-changed resolution key means the backend would now compute a different `type`; an unchanged
-resolution key means it would compute the same one.
-
-`config.toml` is not strictly immutable — `bootstrap._install_config_watchers` reloads
-config options when the file changes — but that watcher only refreshes server-side options;
-it does not rerun the script or push a new theme to the client. So after a mid-session
-`[theme]` edit, neither the painted theme nor `type` changes until the next rerun, and on
-the next **full** rerun both update together: the resolver reads the new options while the
-accompanying `NewSession` carries the new `custom_theme`. The resolution key therefore does
-not need to track config edits.
-
-The one seam: a **fragment** rerun sends no `NewSession`, so between a mid-session `[theme]`
-edit and the next full rerun, a fragment run would resolve `type` from the new config while
-the client still paints the old theme. This is a developer-only window (editing
-`config.toml` against a live app) and self-corrects on the next full rerun.
-
-**Why not diff painted appearance?** Luminance is a proxy that fails in two ways. It
-misses the host→config.toml transition (§3's first ordering), where the resolution
-*source* changes while painted luminance may not — leaving `type` stuck on the host value
-for the rest of the session. And it forces a `skipNextThemeUpdate` flag, because applying
-a config.toml custom theme legitimately flips luminance without changing what the backend
-would compute, so the flag is needed to tell those apart. Keying on the resolution key removes
-both problems, and with them both the `skipNextThemeUpdate` flag and the
-`lastRerunAppearance` guard used in earlier drafts.
-
-**Accepted cost:** the resolution key fires a rerun in cases a luminance diff deduped — a
-preference change that the resolver ignores because config pins the answer, e.g. toggling
-menu Light↔Dark (or the OS flipping while System is selected) with a *single* custom
-theme. `type` is unchanged, so the rerun is redundant. Suppressing it would require
-reimplementing the resolver on the frontend, which is exactly the duplication this design
-is trying to contain; it stays one rerun per explicit change (Principle 34), never a loop.
-We take the redundant rerun over the duplicated logic.
-
-#### Implementation
-
-**1. Instance fields:**
-
-```tsx
-private lastSentThemeResolutionKey: string | null = null
-private pendingThemeRerun: boolean = false
-private themeSelection: ThemeSelection = getCachedThemeSelection() ?? "System"
-private hostThemePreference: "light" | "dark" | null = null
-private hostImportedTheme: ThemeConfig | null = null
-```
-
-- `lastSentThemeResolutionKey` — the `getThemeResolutionKey()` value carried by the most
-  recent rerun BackMsg. The dedup guard: no rerun fires while it matches the current
-  resolution key. Anchoring the guard to what was *sent* (rather than to the previous
-  render) is what makes a change impossible to lose across renders, disconnects, or script
-  runs. It starts `null`, so the key trivially differs before the first BackMsg; every
-  `componentDidUpdate` until then sets `pendingThemeRerun`, which is harmless (the first
-  real BackMsg sets the key and the drain no-ops) but will look odd in a debugger.
-- `pendingThemeRerun` — set when a resolution key change arrives while the script is
-  running, a rerun is already requested, or the socket is down. Ensures the rerun fires
-  once the app is connected and idle rather than being silently dropped.
-- `themeSelection` — the user's tracked `ThemeSelection` (`"Light"` / `"Dark"` /
-  `"System"`), step 3 of §3's source-of-truth list. **This field is load-bearing for MPA
-  safety, so its write sites matter:** it must be written only where the *user or host*
-  expresses a choice — the settings-menu callback, and `handleThemeMessage`'s preset
-  branches (below). It must **not** be written inside `setAndSendTheme`, because
-  `processThemeInput` calls `setAndSendTheme` itself while applying a server-sent theme; a
-  write there would let a `NewSession` overwrite the user's selection, flip the resolution
-  key, and fire a rerun *from `processThemeInput`* — exactly the #11797 regression the
-  failure-mode table below promises cannot happen. Never derive it by reversing the active
-  theme's name.
-- `hostThemePreference` / `hostImportedTheme` — see §3. The host theme is held as an
-  object reference for identity comparison, never as a name.
-
-**2. In `processThemeInput`, after the hash-check early return, before `this.setState`:**
-
-```tsx
-// A config.toml theme is now what gets painted, so a host theme (if any) is no
-// longer active. Clearing these flips isHostThemePainted() to false, which changes
-// the resolution key and lets componentDidUpdate fire the correcting rerun.
-this.hostThemePreference = null
-this.hostImportedTheme = null
-```
-
-No suppression flag is set here. If the previous BackMsg reported
-`host_theme_active=true`, clearing these fields *changes* the resolution key, and the rerun
-that follows is exactly the correction §3's first ordering requires. If the previous
-BackMsg already reported `host_theme_active=false` — the ordinary config.toml case,
-including MPA navigation and reconnection — the resolution key is unchanged and nothing fires.
-If the host later posts another `SET_CUSTOM_THEME_CONFIG`, `handleThemeMessage` re-sets
-both fields and the resolution key flips back.
-
-**3. In `componentDidUpdate`, appended after the existing `scriptRunState` handling:**
-
-```tsx
-// --- Theme resolution key diff ---
-// Compared against what was last SENT, not against the previous render, so a
-// change cannot be lost across renders. componentDidUpdate runs on every update,
-// so any state or prop change re-checks the resolution key.
-if (this.getThemeResolutionKey() !== this.lastSentThemeResolutionKey) {
-  this.maybeRerunForThemeChange()
-}
-
-// --- Drain a deferred theme rerun once connected + idle ---
 if (
-  this.pendingThemeRerun &&
-  this.isServerConnected() &&
-  this.state.scriptRunState === ScriptRunState.NOT_RUNNING
+  newSessionProto.resolvedColorScheme === "light" ||
+  newSessionProto.resolvedColorScheme === "dark"
+) {
+  this.backendColorScheme = newSessionProto.resolvedColorScheme
+}
+```
+
+**2. `sendRerunBackMsg`**, after the message is sent, records what Python will now believe:
+
+```tsx
+this.backendColorScheme = contextInfo.themeApplied
+  ? (contextInfo.colorScheme as "light" | "dark")
+  : null
+this.pendingThemeRerun = false
+```
+
+When we claimed our theme was applied, Python gets exactly the `colorScheme` we sent.
+Otherwise the backend is resolving and we learn the value from the echo.
+
+**3. `componentDidUpdate`**, appended after the existing `scriptRunState` handling:
+
+```tsx
+// Rerun when what we paint disagrees with what Python holds. `null` means we
+// have not been told yet, which is not a disagreement.
+if (
+  this.backendColorScheme !== null &&
+  this.getThemeColorScheme() !== this.backendColorScheme
 ) {
   this.maybeRerunForThemeChange()
 }
+
+if (this.pendingThemeRerun) {
+  this.maybeRerunForThemeChange()
+}
 ```
 
-Because the guard is the last-sent resolution key rather than `prevProps`, this hook needs no
-previous props. Note the method's current signature is `componentDidUpdate(_prevProps, prevState)`
-with `_prevProps` deliberately unused — it stays unused, so no rename is required.
-
-**Invariant this hook depends on — state it, test it, don't discover it later.** The trigger
-only fires when React renders, so it needs: *whenever the resolution key changes in a way
-that changes `type`, a render must follow.* That holds today, for two reasons worth making
-explicit because both are incidental rather than guaranteed:
-
-1. `App` is a `PureComponent`, but it re-renders on every `ThemedApp` render anyway because
-   `useThemeManager` returns a **fresh manager object literal** each time. If someone later
-   memoizes that manager for performance, this hook silently stops running. Leave a comment
-   at the `useThemeManager` return site saying so.
-2. The key can genuinely change with no render — OS flips while `System` is selected with a
-   *single* custom theme, where `updateAutoTheme` finds nothing to re-apply. No rerun fires,
-   which is **correct**, because a config-pinned theme makes `type` identical either way. The
-   invariant survives only because a preference change that fails to force a render is also
-   one the resolver ignores. Any future change that decouples those two — e.g. exposing
-   `st.context.theme.preference` (#11536), where preference alone becomes observable — breaks
-   it, and the trigger would then need an explicit hook on the `matchMedia` listener.
-
-Add a frontend test asserting the key is re-checked after a render caused by unrelated state,
-so a future memoization of the theme manager fails loudly instead of silently.
-
-**4. New method `maybeRerunForThemeChange`:**
+**4. `maybeRerunForThemeChange`** re-checks, defers, or sends:
 
 ```tsx
 private maybeRerunForThemeChange = (): void => {
-  if (this.getThemeResolutionKey() === this.lastSentThemeResolutionKey) {
-    // Nothing to correct — e.g. a queued rerun that a user-driven rerun already
-    // covered, since sendRerunBackMsg refreshes the resolution key.
+  // Same predicate as the caller: null means we have not been told what Python
+  // holds, which is not a disagreement to correct.
+  if (
+    this.backendColorScheme === null ||
+    this.getThemeColorScheme() === this.backendColorScheme
+  ) {
     this.pendingThemeRerun = false
     return
   }
   if (
     !this.isServerConnected() ||
-    // Mirror the drain condition exactly. Enumerating "busy" states would miss
-    // STOP_REQUESTED (script IS still running) and COMPILATION_ERROR.
     this.state.scriptRunState !== ScriptRunState.NOT_RUNNING
   ) {
-    // Defer: fire once connected + idle.
     this.pendingThemeRerun = true
     return
   }
-
-  this.pendingThemeRerun = false
+  // Left set until the BackMsg is actually sent, so a send that silently
+  // fails (e.g. the socket dropped underneath us) is retried rather than lost.
   this.widgetMgr.sendUpdateWidgetsMessage(undefined)
 }
 ```
 
-MPA safety: `sendUpdateWidgetsMessage(undefined)` passes no `pageScriptHash`, so
-`sendRerunBackMsg` falls through to `this.state.currentPageScriptHash` (the current
-page).
+**Why this preserves the current page.** The `undefined` argument to
+`sendUpdateWidgetsMessage` is the *fragment id*, which makes this a full-app rerun. The page
+hash matters separately: `WidgetStateManager.sendUpdateWidgetsMessage` always calls
+`sendRerunBackMsg` with `pageScriptHash` as `undefined`, and `sendRerunBackMsg` then falls
+through to `this.state.currentPageScriptHash`. So the rerun cannot carry a stale or empty
+page, which is what broke deep links in #11797.
 
-**5. In `sendRerunBackMsg`, after the BackMsg is sent:**
+**Loop safety.** Every send refreshes `backendColorScheme`, and the `NewSession` echo
+reports what the script actually saw, so once the two agree the comparison short-circuits.
+The menu E2E should assert a run counter, proving exactly one rerun per toggle (Principle 34).
 
-```tsx
-this.lastSentThemeResolutionKey = this.getThemeResolutionKey()
-```
+**Why this does not regress MPA:**
 
-Every rerun — user-driven or theme-driven — refreshes the guard, so it always reflects
-what the backend was last told. This is also why an ordinary interaction absorbs a pending
-theme change for free instead of causing a second rerun.
-
-#### Why no suppression flag is needed
-
-Earlier drafts needed `skipNextThemeUpdate` because `processThemeInput` legitimately flips
-painted luminance when it applies a config.toml custom theme, and a luminance-diff trigger
-could not tell that apart from a user-initiated change. The resolution key has no such
-ambiguity: applying a config.toml theme changes neither the user's preference nor whether a
-host theme is painted, so the resolution key is identical before and after and nothing fires.
-The one case where `processThemeInput` *does* change the resolution key — clearing an active
-host theme — is precisely the case that must rerun.
-
-That removes the cross-render-boundary reasoning the flag design depended on (set a flag
-synchronously, let React batch, and rely on `componentDidUpdate` consuming it on exactly
-the right render). The only ordering requirement left is in `handleThemeMessage`, below.
-
-#### Why this does not regress MPA (failure mode analysis)
-
-| Old failure mode (PR #10972) | How this proposal avoids it |
+| Old failure mode (PR #10972) | How this avoids it |
 |---|---|
-| Fired on `processThemeInput` (preset → custom name change) | Applying a config.toml theme changes neither preference nor host-active, so the resolution key is unchanged and nothing fires — no flag required |
-| Fired on page navigation (new `NewSession` → theme reapplication) | Same: page nav re-applies the same config theme, resolution key unchanged |
-| Fired on reconnection | Same: reconnection re-applies the same config theme, resolution key unchanged |
-| Used theme NAME comparison (fragile, changes for internal reasons) | Uses the `(preference, hostThemeActive)` resolution key — the backend's actual resolution inputs, never derived from a theme name |
-| `sendRerunBackMsg()` without page context lost current page | `sendUpdateWidgetsMessage(undefined)` → `sendRerunBackMsg` uses `this.state.currentPageScriptHash` |
-| Theme change while script running was silently dropped | `pendingThemeRerun` records the intent; `componentDidUpdate` drains it once connected and `NOT_RUNNING` |
-| Infinite loops (theme change → rerun → NewSession → theme change → ...) | `lastSentThemeResolutionKey` is refreshed on every send, and the `NewSession` that follows does not change the resolution key, so the next `componentDidUpdate` short-circuits |
+| Fired on `processThemeInput` (preset → custom name change) | Compares painted appearance against the value the backend echoed. Re-applying the same config theme leaves both sides equal, so nothing fires |
+| Fired on page navigation / reconnection | Same — a new `NewSession` re-applies the same theme and echoes the same value |
+| Used theme NAME comparison | Nothing reads theme names; the comparison is `getThemeColorScheme()` vs. the echo |
+| `sendRerunBackMsg()` without page context lost current page | The rerun goes through `sendUpdateWidgetsMessage`, so `sendRerunBackMsg` falls through to `this.state.currentPageScriptHash` |
+| Theme change while script running was silently dropped | `pendingThemeRerun`, drained by `componentDidUpdate` once connected and `NOT_RUNNING` |
 
-#### Scenario walkthrough
+**Invariant the trigger depends on:** it only fires when React renders. `App` is a
+`PureComponent` but re-renders on every `ThemedApp` render because `useThemeManager`
+returns a fresh object literal each time. Memoizing that manager for performance would
+silently disable this hook, so it is worth a test that would fail loudly if it happened.
 
-Resolution keys below are written `preference|hostThemeActive`.
+### When the first run is still wrong
 
-| Scenario | Resolution key: last sent → current | Result |
-|----------|-------------------------------|--------|
-| Initial load, custom dark theme, OS light | `light\|false` → `light\|false` (`processThemeInput` paints the config theme; preference unchanged) | No rerun — the first run already resolved `"dark"` from config.toml. Correct |
-| User toggles Dark in menu (presets) | `light\|false` → `dark\|false` | Rerun; BE returns `"dark"`. Correct |
-| MPA page navigation | unchanged | No rerun — deep link preserved (#11797). Correct |
-| Reconnection | unchanged | No rerun. Correct |
-| Host posts dark theme after `NewSession` | `light\|false` → `dark\|true` | Rerun; BE takes `theme_preference` directly. Correct |
-| Host theme painted before first BackMsg, then `NewSession` paints config | `dark\|true` → `light\|false` | Rerun; BE re-resolves from config.toml. Correct — **this is the case a luminance diff misses**, since both themes may paint the same luminance |
-| User switches away from host theme via menu | `dark\|true` → `light\|false` | `isHostThemePainted()` false by object identity; rerun; BE resumes config resolution. Correct |
-| User switches from host theme to a config.toml theme that shares `CUSTOM_THEME_NAME` | `dark\|true` → `light\|false` | Object identity separates them where a name comparison could not. Correct |
-| OS dark↔light while System selected | `light\|false` → `dark\|false` | `updateAutoTheme` re-applies the theme → `componentDidUpdate` → rerun. Correct |
-| Resolution key change while script is RUNNING | deferred | `pendingThemeRerun` set; `componentDidUpdate` drains it at `NOT_RUNNING`. Correct |
-| Resolution key change while disconnected | deferred | `pendingThemeRerun` set; drains on reconnect once `NOT_RUNNING`. Correct |
-| Resolution key change while RUNNING, then a hash-changing `processThemeInput` | pending stays set; the drain re-reads the *current* resolution key | Rerun fires if the resolution key still differs, no-ops if the config theme already made it match. Correct either way — no stale dedup guard to swallow it |
-| Menu Light↔Dark with a single custom theme (or OS flip while System) | `light\|false` → `dark\|false` | Rerun fires though `type` is unchanged — the accepted cost documented above |
+The rule is exact: **the first run is wrong precisely when the backend's config-based guess
+differs from what the client paints.** The echo then corrects it in one rerun. Known cases:
 
-#### Required changes to `handleThemeMessage` (and `setImportedTheme`)
+| Case | Why the guess differs |
+|------|----------------------|
+| `backgroundColor` in a CSS syntax Pillow cannot parse — `rgb(0 0 0)`, `hsl(0 0% 10%)`, `transparent` | The frontend's parser accepts more syntax than Pillow's. Named colours, `rgb()`, `rgb(%)` and `hsl()` **are** handled and are correct on the first run |
+| Host theme applied around or after the first `BackMsg` | The guess comes from `config.toml`, but a host theme is what gets painted |
+| A mirror divergence not yet found | The resolver re-implements five frontend rules; any of them could drift |
 
-`handleThemeMessage` has three branches today, and **all three** need to participate in
-the resolution key. Its current shape:
+Two properties worth stating explicitly, because they bound how much this matters:
 
-```tsx
-handleThemeMessage = (themeName?: PresetThemeName, theme?: ICustomThemeConfig): void => {
-  const [, lightTheme, darkTheme] = createPresetThemes()
-  const isUsingPresetTheme = isPresetTheme(this.props.theme.activeTheme)
+**No silently-wrong case remains.** If the client's luminance agrees with the guess, then
+`type` equals the painted appearance, which is correct by definition. So every divergence
+is detectable, and every detectable divergence produces exactly one corrective rerun.
 
-  if (themeName === lightTheme.name && isUsingPresetTheme) {
-    this.props.theme.setTheme(lightTheme)          // (1) host selects preset Light
-  } else if (themeName === darkTheme.name && isUsingPresetTheme) {
-    this.props.theme.setTheme(darkTheme)           // (2) host selects preset Dark
-  } else if (theme) {
-    this.props.theme.setImportedTheme(theme)       // (3) host pushes a custom theme
-  }
-}
-```
+**But "corrected in milliseconds" is not free.** The first run *executed* with the wrong
+value. For pure rendering the output flashes and settles, invisibly. For a script with
+side effects on that run — logging, an API call, a counter, an email — the work was done
+with the wrong `type`. This is the inherent cost of any resolver-based approach and the
+strongest argument for alternative C.
 
-**Branches 1 and 2 (host picks a preset).** These are a host-driven equivalent of a menu
-selection, so they must write `themeSelection` — otherwise painted appearance changes
-while the resolution key does not, and `type` goes stale. Set
-`this.themeSelection = "Light"` / `"Dark"` alongside the existing `setTheme` call.
-
-**Branch 3 (host pushes a custom theme).** This is where the identity comparison needs the
-`ThemeConfig` object — and App cannot currently obtain it. `handleThemeMessage` receives
-the **proto** (`ICustomThemeConfig`), while the `ThemeConfig` is constructed inside the
-hook by `setImportedTheme`, which returns `void`:
-
-```ts
-// frontend/app/src/util/useThemeManager.ts
-setImportedTheme: (themeInfo: ICustomThemeConfig) => void
-```
-
-**So `setImportedTheme` must return the `ThemeConfig` it creates**, and App must store it:
-
-```tsx
-// Assign synchronously, before React flushes the state update that
-// setImportedTheme() queued, so that componentDidUpdate — which fires on the first
-// render after the host theme is applied — already sees both fields set.
-const hostTheme = this.props.theme.setImportedTheme(theme)
-this.hostThemePreference = hasLightBackgroundColor(hostTheme.emotion)
-  ? "light" : "dark"
-// Store the ThemeConfig OBJECT, not its name: host imports and config.toml single
-// custom themes share the CUSTOM_THEME_NAME constant, so only identity distinguishes
-// them (see §3).
-this.hostImportedTheme = hostTheme
-```
-
-The stored object must be the same one handed to `setTheme` inside the hook, since
-`isHostThemePainted()` compares it against `props.theme.activeTheme` by reference.
-
-The alternative — App building the theme itself via `createTheme(CUSTOM_THEME_NAME, new
-CustomThemeConfig(themeInfo))` and calling `setTheme` — is **rejected**: it bypasses
-`setImportedTheme`'s `setFonts(themeInfo)` call and would regress host font loading.
-
-#### Interface changes this requires
-
-Returning the theme changes the `ThemeManager` contract, so these are **in** scope (they
-were listed as untouched in an earlier draft):
-
-- `ThemeManager.setImportedTheme` — return type `void` → `ThemeConfig`
-- `useThemeManager`'s `setImportedTheme` implementation — return the `customTheme` it
-  already builds (a one-line change; `updateTheme` is unaffected)
-
-#### No changes needed to
-
-- `ThemeContext`
-- `useThemeManager`'s `matchMedia` listener
-- The `setTheme` prop passed through context (stays as `this.setAndSendTheme`)
-- `setAndSendTheme` (its signature is unchanged, and it must **not** write
-  `themeSelection` — see the field notes above. A menu selection installs a different
-  `ThemeConfig` object, so `isHostThemePainted()` returns false by identity without any
-  code here, even when the selected theme shares the `CUSTOM_THEME_NAME` name with the
-  host import.)
-- `componentDidUpdate`'s parameter list — the resolution key diff needs no previous props,
-  so `_prevProps` stays unused
-
-#### Key files
-
-- `frontend/app/src/App.tsx` — all implementation changes
-- `frontend/lib/src/theme/getColors.ts` — `hasLightBackgroundColor` (existing, used to
-  derive `hostThemePreference` from the host theme's background)
-- `frontend/lib/src/util/utils.ts` — existing `isLightThemeInQueryParams` /
-  `isDarkThemeInQueryParams`, composed into `hasEmbedThemeOverride()`
-- `frontend/app/src/util/useThemeManager.ts` — `setImportedTheme` (host themes) and the
-  `matchMedia` listener (no changes; theme changes flow through props)
+By contrast, `config.toml` precedence is **not** a source of first-run error. The resolver
+reads through `get_options_for_section` *after* all merging has happened — global and
+project `config.toml`, environment variables, CLI flags, and `theme.base` file inheritance
+(`config_util.process_theme_inheritance` clears and re-applies every `theme.*` option,
+sections included). We read the merged answer rather than re-deriving it, so multi-config
+precedence cannot drift. Only the section→appearance mapping is mirrored, and that is what
+the echo guards.
 
 ### 5. Docs
 
-Update [`context.py`](../../lib/streamlit/runtime/context.py) docstring to match the
-chosen product meaning. Drop stale first-load / settings caveats; keep CSS-override note.
+Update the [`context.py`](../../lib/streamlit/runtime/context.py) `theme.type` docstring:
+drop the stale first-load and settings-change caveats (both fixed by this design), and keep
+the CSS-override note, which remains true.
 
 ### 6. Testing
 
-**Python unit**
+**Python unit** — a new `lib/tests/streamlit/runtime/theme_type_test.py`:
 
-- Resolver matrix matching the product behavior table (presets; single custom `base` /
-  hex / non-hex; light+dark sections; dual-theme forced variant `base` overrides a `base`
-  inherited from `[theme]`, matching FE `handleSectionInheritance`; missing colors →
-  preference).
-- Short hex forms: `#fff` → "light", `#000` → "dark", `#rgba` forms handled correctly.
-- `_is_hex_color` accepts `#` followed by 3, 4, 6, or 8 hex digits (i.e. total string
-  lengths 4, 5, 7, 9 including the `#`); rejects non-hex alphanumeric such as `#ghijkl` —
-  stricter than config validation's `is_hex_color_like`.
-- `_hex_luminance` expands short forms correctly (e.g. `#abc` → `#aabbcc`).
-- Sidebar-only configs: `[theme.sidebar]` alone → "light" (regardless of preference);
-  `[theme.light.sidebar]` alone → enters dual-theme path → returns preference.
-- `host_theme_active = true` → **`request_rerun`** sets `color_scheme` from
-  `theme_preference` directly and never calls `resolve_theme_type`, even when config has a
-  conflicting `[theme] base="light"`. (This bypass lives in `request_rerun`, not in the
-  resolver — `resolve_theme_type(preference)` takes no `host_theme_active` argument.)
-- Non-hex `backgroundColor`: `"black"` / `"rgb(0,0,0)"` currently fall through to the
-  fallback. Assert whatever behavior open question 5 settles on, and until then pin the
-  known-wrong result so the gap is visible in the suite rather than silent.
-- `_has_section_content` returns False for all-None dicts (registered but unset).
-- `request_rerun` resolves on `_client_state` (not the incoming `client_state`) for
-  full and fragment paths; verify server-initiated reruns also use resolved value.
+- **Luminance parity with the frontend.** Pin values measured against the vendored color2k,
+  including the true `#bbbbbb` / `#bcbcbc` crossing, plus short-form expansion and alpha
+  being ignored.
+- **Colour parsing.** Hex in all four lengths, named colours, `rgb()`, `rgb(%)`, `hsl()`;
+  and rejection of genuine garbage. Also pin the syntax that is *not* parsed
+  (`rgb(0 0 0)`, `transparent`) so the remaining gap stays visible rather than silent.
+- **The resolver matrix**, one case per row of the product spec's behavior table: presets
+  follow preference; single custom `base`; hex and non-hex backgrounds; background winning
+  over `base`; no-`base`-no-background falling to light; sidebar-only; dual themes following
+  preference; the forced variant `base` overriding a parent `[theme] base`; a section
+  background overriding the forced base; and a nested `[theme.light.sidebar]` triggering the
+  dual path.
 
-**Frontend unit**
+In `app_session_test.py`, four cases around the wiring:
 
-- Preference serialization (System→OS, Light, Dark, embed query, host theme); never
-  derived from a remapped custom theme name.
-- `getThemeResolutionKey()`: reflects `(getResolvedThemePreference(), isHostThemePainted())`;
-  changes when either input changes and is stable otherwise.
-- `componentDidUpdate` resolution key diff: fires a rerun when the resolution key differs from
-  `lastSentThemeResolutionKey`; no-op when it matches; defers when running or disconnected.
-- `sendRerunBackMsg` refreshes `lastSentThemeResolutionKey`, so a user-driven rerun absorbs a
-  pending theme change instead of causing a second rerun.
-- `pendingThemeRerun`: a resolution key change during `RUNNING` or while disconnected sets
-  pending; the drain fires once connected + `NOT_RUNNING`; the drain re-reads the current
-  resolution key and no-ops if it has since converged.
-- **MPA regression:** `processThemeInput` during `handleNewSession` / page navigation
-  leaves the resolution key unchanged, so `componentDidUpdate` must NOT trigger a rerun — with
-  no suppression flag involved.
-- **Host ordering A (host before first BackMsg):** host theme applied, first BackMsg
-  carries `hostThemeActive=true`; then `processThemeInput` paints the config theme and
-  clears the host fields → resolution key flips → exactly one rerun fires with
-  `hostThemeActive=false`. Assert the rerun happens **even when both themes paint the same
-  luminance**, which is the case a luminance diff missed.
-- **Host ordering B (host after `NewSession`):** `handleThemeMessage` applies the host
-  theme → resolution key flips → one rerun with `hostThemeActive=true`.
-- `handleThemeMessage` stores `hostThemePreference` and the `hostImportedTheme` **object**;
-  `getResolvedThemePreference()` returns the host preference only when
-  `isHostThemePainted()` is true, and falls through to menu/OS otherwise.
-- **Identity, not name:** with a config.toml single `[theme]` *and* a host import — both
-  named `CUSTOM_THEME_NAME` — selecting the config theme from the menu makes
-  `isHostThemePainted()` false and stops the stale host preference from being sent.
-- `isHostThemePainted()` is false when an embed theme override is present, even while a
-  host theme object is stored.
-- **`themeSelection` write sites (guards the MPA regression):** a `processThemeInput` call
-  that internally invokes `setAndSendTheme` must NOT change `themeSelection`, so the
-  resolution key is unchanged and no rerun fires. Cover the concrete trap: a cached `"Dark"`
-  selection plus a single `[theme]` config, where `getPreferredTheme` finds no match and
-  `processThemeInput` applies `customThemes[0]` — assert `themeSelection` stays `"Dark"` and
-  no BackMsg is sent.
-- **`handleThemeMessage` preset branches:** a host posting `themeName` Light/Dark while a
-  preset is active updates `themeSelection`, flips the resolution key, and fires exactly one
-  rerun.
-- **Deferral covers every non-idle state:** a resolution key change during `STOP_REQUESTED`
-  and `COMPILATION_ERROR` defers rather than firing immediately, matching the drain's
-  `NOT_RUNNING` condition.
-- `setImportedTheme` returns the created `ThemeConfig`, and `handleThemeMessage` stores that
-  exact object (identity, not a copy).
-- Regression: theme **name** change alone must not call `sendRerunBackMsg`.
+- An unapplied theme gets `color_scheme` resolved — and the **incoming BackMsg must stay
+  untouched**, which is what proves `RerunData` read the resolved copy rather than the
+  parameter.
+- An applied theme is trusted, with `resolve_theme_type` never called.
+- A client sending no `theme_preference` passes straight through, covering old frontends.
+- `_create_new_session_message` populates the echo, and leaves it unset when there is no
+  value to send.
 
-**E2E** (`make run-e2e-test`)
+**Frontend unit** — `App.test.tsx` needs the two new `contextInfo` fields added to the three
+existing `sendRerunBackMsg` assertions, plus dedicated coverage for the parts E2E reaches
+awkwardly: `isThemeApplied` across the startup window and after a host theme;
+`getResolvedThemePreference` for each source; and `maybeRerunForThemeChange` deferring while
+`RUNNING` or disconnected and draining once idle.
 
-- Custom `[theme]` `base = "dark"` + light OS/cache preference → first output
-  `type: dark`.
-- MPA deep link + `[theme]` lands on target page (#11797).
-- Main-menu Light↔Dark updates `type` without manual rerun.
-- Host theme **and** a config.toml `[theme]` both present: `type` follows whichever theme
-  is painted, and switching between them via the menu updates `type` without a manual
-  rerun (covers the shared-`CUSTOM_THEME_NAME` case).
-- Re-enable
-  [`test_st_context_theme_respects_dark_theme_message`](../../e2e_playwright/hostframe_app_test.py)
-  (skipped since #11870). No new CI host environment — this is an existing Playwright
-  hostframe suite; unskip only.
+**E2E** — one module per theme configuration, since a module can only apply one (see
+[Implementation notes](#implementation-notes)):
+
+| Scenario | Config | Assert |
+|----------|--------|--------|
+| First-run correctness — the core of #11920 | `base=dark` + a dark `backgroundColor`, light OS preference | `type` is `"dark"` with no interaction, and stays `"dark"` across a rerun (covering the handoff to the client's own value) |
+| Non-hex background | `backgroundColor="black"`, light OS preference | the computed background really is `rgb(0, 0, 0)`, and `type` is `"dark"` on the first run |
+| Menu appearance change — #15287 | none (presets) | Light→Dark→Light from the settings menu updates `type` with no manual rerun, and a run counter proves exactly one rerun per toggle |
+| MPA deep link — the #11797 guard | `[theme]` set | entering a non-default page by direct URL still lands on that page. **No such test exists today:** `mpa_v2_custom_theme_test.py` configures a theme but navigates by clicking, and `mpa_basics_test.py` deep-links with no theme — so the regression this design must not reintroduce is currently unguarded |
+
+Also unskip [`hostframe_app_test.py::test_st_context_theme_respects_dark_theme_message`](../../e2e_playwright/hostframe_app_test.py),
+skipped since #11870. No new CI infrastructure — the hostframe suite already exists.
+
+Run the theme E2Es on Firefox and WebKit as well as Chromium: the trigger depends on React
+lifecycle timing, which is the kind of thing that differs between engines.
+
+## Implementation notes
+
+Behaviors of the existing code that this design leans on. None is obvious from the
+surrounding code, and each one will cost time if it is discovered late.
+
+- **`patch_config_options` will not work for this resolver.**
+  `streamlit/testing/v1/util.py` patches only `config.get_option`, and the resolver reads
+  whole sections via `get_options_for_section`, which walks registered `ConfigOption`
+  values directly — so the usual helper has no effect. Resolver tests need to set real
+  values with `config._set_option` and restore both the value and `where_defined`
+  afterwards; a small context manager is the tidiest way.
+- **`hasThemeSectionConfigs` treats an empty array as "no config".** So the backend's
+  section-emptiness check has to discount empty lists too, or a `[theme.light]` containing
+  only `chartCategoricalColors = []` puts the backend on the dual-theme path while the
+  frontend builds a single custom theme.
+- **`createThemeHash(undefined)` returns a non-empty sentinel**
+  (`"hash_for_undefined_custom_theme"`). That is what makes `state.themeHash !== ""` a
+  sound test for "`processThemeInput` has run", even for apps with no custom theme, and
+  therefore what makes `theme_applied` computable at all.
+- **`setAndSendTheme` only sets the theme and notifies the host** — it does *not* send a
+  rerun, so a menu selection produces exactly one rerun, from the trigger in §4.
+- **A theming E2E module can exercise only ONE theme configuration.** The config fixture is
+  `@pytest.mark.early` and module-scoped, applied before the app server boots. A second
+  config fixture in the same file is silently ignored — the server keeps serving the first
+  config. Each theme scenario therefore needs its own module. The failure mode is a
+  confusing assertion mismatch rather than an error, so this is worth knowing up front.
+- **`theme.base` may be a TOML path or URL.** `config_util.process_theme_inheritance`
+  normalizes it to `"light"`/`"dark"` before options are read, so
+  `_type_from_bg_or_base` can treat `base` as a plain variant name. Do not make it resolve
+  paths.
+- **Non-hex `backgroundColor` is deliberately supported by the frontend.** `parseColor` in
+  `frontend/lib/src/theme/utils.ts` runs the value through the browser's CSS parser,
+  retries with a `#` prefix, and warns only on real failure. So `"black"` is a valid,
+  working config that must not be rejected — which is precisely why the echo exists.
 
 ## Alternatives considered
 
-### A. Fix the auto-rerun MPA-safely (no new proto field)
+Two of these are genuinely simpler than the proposal and deserve a real decision rather
+than a dismissal, because both eliminate the resolver — and with it the FE/BE mirror that
+is this design's main long-term liability. The proposal sits deliberately between them.
 
-Double-run on first load: wrong `type` → FE applies custom theme → corrected rerun.
+### A. Echo only — delete the resolver
 
-- Simpler; worse UX; first script execution still wrong.
+Keep `resolved_color_scheme`, drop `theme_type.py` and `theme_preference` entirely. The
+first run uses whatever the client's provisional `color_scheme` says; the echo detects the
+disagreement and reruns once.
 
-**Rejected** for first-run correctness.
+- **Buys:** no second implementation of frontend theme rules in Python, so the drift risk
+  and the non-hex gap both disappear. Materially less code.
+- **Costs:** the first script run is wrong for *every* custom theme, not just edge cases —
+  which is the larger half of [#11920](https://github.com/streamlit/streamlit/issues/11920).
+
+Worth noting this is exactly what the proposal already does for non-hex backgrounds,
+generalized to all custom themes. **Rejected** for first-run correctness, but it is the
+right fallback if the mirror proves hard to maintain.
 
 ### B. Backend uses config `base` / `backgroundColor` only (no preference)
 
-- Fixes common single-custom-with-`base` quickly.
-- Fails for dual light/dark sections and preset-only Dark menu selection.
-- Still needs auto-rerun for mid-session changes.
+Fixes single-custom-with-`base` quickly; fails for dual light/dark sections and
+preset-only Dark menu selection. **Rejected** as sole fix.
 
-**Rejected** as sole fix and as throwaway milestone (`theme_preference` is needed
-eventually).
+### C. Push the theme to the client before the first script run
 
-### C. Pre-session theme config before first script run
+On connect, the backend sends the `config.toml` theme; the client applies it and only then
+sends its first rerun, already carrying a correct `color_scheme`.
 
-Extra RTT every connection; protocol reordering; comparable complexity, worse latency.
+**Buys:** no resolver, no mirror of frontend rules, no colour-parsing gap at all, and a
+correct first run for `config.toml` themes.
 
-**Rejected.**
+**Costs — and they are larger than they first look:**
 
-### D. Ship first-run and auto-rerun as separate PRs
+1. **An extra round trip before the script starts, on every session.** Today the sequence
+   is `connect → client rerun → script runs`. This makes it
+   `connect → server theme → client applies → client rerun → script runs`. The delay lands
+   on **time to first content**, not time to first paint — the client already paints a
+   cached or preset theme immediately, so users would see the chrome just as fast and then
+   wait longer for the app body.
+2. **Every app pays it, to fix a value most apps read once or never.** The cost is
+   universal; the benefit is confined to apps that read `st.context.theme.type` on their
+   first run.
+3. **It hurts the deployments least able to absorb it.** Community Cloud and especially
+   SiS/SPCS sit behind longer network paths, an embedding iframe, and a container or
+   warehouse layer. An added RTT there is materially worse than on localhost, and it
+   compounds with cold-start latency that users already notice.
+4. **It does not even fix the host-theme case — which is the SiS case.** Host themes arrive
+   from the *embedder* via `SET_CUSTOM_THEME_CONFIG` postMessage, not from the server, so
+   the backend cannot push them ahead of the first run. C would still need a correction
+   mechanism for exactly the platform paying the most latency for it.
+5. **Protocol reordering rather than additive fields**, so old/new client-server
+   combinations need real thought instead of falling out of optional-field semantics.
 
-Separable for blast radius. **This spec still does both in one pass**, with hard order
-(resolver tested before auto-rerun) so auto-rerun can be reverted without undoing proto /
-BE work.
+**Rejected.** Point 4 is decisive: C pays a universal, SiS-weighted latency cost and still
+does not remove the need for the echo. If reviewers weight first-run side effects heavily
+(see [When the first run is still wrong](#when-the-first-run-is-still-wrong)), the cheaper
+move is to narrow the resolver's remaining gaps rather than reorder the handshake.
 
-## Risks
+### D. Have the client *predict* the backend's answer instead of being told it
 
-| Risk | Mitigation |
-|------|------------|
-| Auto-rerun reintroduces #11797 | Resolution key diff on `(preference, hostThemeActive)`, which `processThemeInput` and page navigation do not change — so no suppression flag is needed and there is no flag-timing failure mode; `sendUpdateWidgetsMessage` preserves page context; MPA E2E required |
-| BE luminance disagrees with FE | Use identical WCAG formula (sRGB linearization + BT.709, threshold `> 0.5`); normalize all hex forms (#rgb/#rgba/#rrggbb/#rrggbbaa); cross-check unit test against FE boundary values; fall back to `base`/preference for non-hex |
-| **Resolver drifts from FE theme logic** | The resolver is a second implementation of rules the FE already owns (section inheritance, forced variant `base`, sidebar-only handling, luminance). Every future change to FE theme resolution needs a matching Python change, and the cross-check unit test is the only guard. Keep the resolver small, keep its test matrix aligned with the product behavior table, and reference `handleSectionInheritance` from the module docstring |
-| Stale host theme forced onto the BE | `isHostThemePainted()` compares the active theme by **object identity** — host imports and config.toml single custom themes share the `CUSTOM_THEME_NAME` constant, so a name comparison would leak stale host preference; `processThemeInput` also clears the host fields |
-| Preference tracking drifts after `processThemeInput` | Track explicit `ThemeSelection`, never reverse from theme name |
-| Host/SiS theme messages ignored | Explicit `handleThemeMessage` path; both arrival orderings specified in §3; re-enable hostframe E2E |
-| Redundant reruns when config pins the answer | Accepted: a preference change the resolver ignores (single custom theme) still reruns once. Bounded to one rerun per explicit change; suppressing it would require duplicating the resolver on the FE |
-| Option A/B chosen late | §2 resolver is the only significant rewrite. Because §4 keys on preference rather than painted luminance, Option A needs **no** trigger redesign — a preference change already fires a rerun. Proto stays either way |
+Instead of the echo, the client could key its rerun on the inputs the backend resolves
+from — the appearance preference plus a flag for whether a host theme is active — and rerun
+whenever that pair changes.
+
+**Rejected.** Predicting the answer is strictly weaker than being told it, and the
+bookkeeping is worse: the client would have to track the user's `ThemeSelection` itself
+(with careful rules about which code paths may write it, since `processThemeInput` also
+applies themes), identify the host theme by object reference rather than name (host imports
+and single `config.toml` custom themes share the `CUSTOM_THEME_NAME` constant), and reason
+explicitly about host-message arrival ordering. It also fires redundant reruns when the
+preference changes but config pins the appearance either way — and it cannot detect a
+backend/frontend disagreement at all, which is the failure mode most worth catching.
+
+### If product picks A or B instead of C
+
+Only §2 changes. The proto and the §3/§4 exchange are agnostic to *what* the backend
+resolves — the echo compares whatever the script saw against what is painted either way.
 
 ## Out of scope
 
 - Full theme config on `st.context.theme` ([#11536](https://github.com/streamlit/streamlit/issues/11536)).
 - Programmatic theme setters at runtime ([#14172](https://github.com/streamlit/streamlit/issues/14172)).
 - Full Emotion theme build on the backend.
-- Non-hex CSS color parsing for luminance (named colors like `"red"`, `rgb()`, `hsl()`).
-  Only hex forms are handled. Note these values **are** accepted by config today — there is
-  no hex validation on theme color options — so this is a known gap with a wrong-answer
-  consequence, not merely an unsupported input. See the limitation in §2 and product spec
-  open question 5.
+- A complete CSS colour parser on the backend. `_parse_color` uses Pillow, which covers
+  hex, named colours, `rgb()` and `hsl()`; the space-separated syntax and `transparent`
+  are left to the echo rather than reimplemented.
 - CSS-injected backgrounds affecting `type`.
 
 ## Checklist
 
 | Item | ✅ or comment |
 |------|---------------|
-| Works on SiS, Cloud, etc? | Host theme path required; unskip existing hostframe E2E (no new CI infra) |
-| No breaking API changes | Additive proto field; `type` shape unchanged. Old FE + new BE: `color_scheme` left as client-sent (no regression) |
-| No new dependencies | Hex luminance only — no color-parsing library |
+| Works on SiS, Cloud, etc? | Host theme path is explicit; unskipping the existing hostframe E2E covers it, with no new CI infra |
+| No breaking API changes | Additive proto fields; `type` shape unchanged. Old FE + new BE leaves `color_scheme` as client-sent |
+| No new dependencies | `_parse_color` uses `PIL.ImageColor`, already a runtime dependency (`pillow>=7.1.0,<13`), imported lazily |
 | Metrics collected | Existing `context.theme` metrics sufficient |
 | Any security/legal impact? | No |
-| Any docs changes needed? | Docstring + API reference once semantics are signed off |
+| Any docs changes needed? | Yes — the `context.py` docstring (§5) |

--- a/specs/2026-08-08-st-context-theme-type/tech-spec.md
+++ b/specs/2026-08-08-st-context-theme-type/tech-spec.md
@@ -115,38 +115,72 @@ def resolve_theme_type(
 
     if _has_section_content(light) or _has_section_content(dark):
         section = dark if preference == "dark" else light
-        # Merge [theme] inheritance for base / backgroundColor only
-        return _type_from_base_or_bg(_merge_theme(theme, section), fallback=preference)
+        merged = _merge_for_dual_theme(theme, section)
+        # fallback = preference (which equals the section variant name, e.g.
+        # "dark" for [theme.dark]) — mirrors the FE behavior where selecting
+        # the dark section implies dark appearance when no explicit base/bg.
+        return _type_from_bg_or_base(merged, fallback=preference)
 
-    # Single custom theme — preference does not override appearance
-    return _type_from_base_or_bg(theme, fallback=preference)
+    # Single custom theme — if neither bg nor base is set, FE defaults to
+    # light preset (no base → inherits from lightTheme).
+    return _type_from_bg_or_base(theme, fallback="light")
 
 
-def _type_from_base_or_bg(opts: dict, *, fallback: str) -> str:
-    base = opts.get("base")
-    if base in ("light", "dark"):
-        return base
+def _merge_for_dual_theme(parent: dict, section: dict) -> dict:
+    """Merge parent [theme] into a light/dark section for type resolution.
+
+    Section values override parent (mirrors frontend handleSectionInheritance).
+    Parent's `base` is explicitly DROPPED — the FE never inherits `base` from
+    [theme] into a section. If the section explicitly sets `base`, that is kept.
+    If neither section nor parent provides `base`, the caller's `fallback`
+    parameter (= section variant name) provides the final answer.
+
+    This ensures:
+    - [theme] base="light" + [theme.dark] primaryColor="..." (no base in
+      section) → parent base dropped → no base in merged → fallback "dark"
+      (= preference = section variant). Correct.
+    - [theme.dark] backgroundColor="#ffffff" (pathological) → parent base
+      dropped → bg luminance → "light" (what is painted). Correct.
+    - [theme.dark] base="dark" → section's explicit base is kept. Correct.
+    """
+    merged = {**parent, **section}
+    if "base" not in section:
+        merged.pop("base", None)
+    return merged
+
+
+def _type_from_bg_or_base(opts: dict, *, fallback: str) -> str:
     bg = opts.get("backgroundColor")
     if _is_six_digit_hex(bg):
         return "light" if _hex_luminance(bg) > 0.5 else "dark"
+    base = opts.get("base")
+    if base in ("light", "dark"):
+        return base
     return fallback
 ```
+
+**`_has_section_content`** returns True when the section has at least one option key
+(e.g. `primaryColor`, `base`, `backgroundColor`). A TOML header with no keys (bare
+`[theme.dark]` with nothing underneath) is not detected as a section — this matches
+the FE's behavior, which also requires at least one key to trigger dual-theme mode.
 
 | Config shape | How to get `type` (Option C) |
 |--------------|------------------------------|
 | No custom theme (presets) | Return `preference` |
-| Single `[theme]` only | `_type_from_base_or_bg` (ignore preference for the value except as fallback) |
-| `[theme.light]` and/or `[theme.dark]` | Pick section from `preference`, merge inheritance, then `_type_from_base_or_bg` |
+| Single `[theme]` only | `_type_from_bg_or_base` with `fallback="light"` (FE default) |
+| `[theme.light]` and/or `[theme.dark]` | Pick section from `preference`, drop parent `base`, then `_type_from_bg_or_base` with `fallback=preference` (= section variant name) |
 
 Wire in [`app_session.request_rerun`](../../lib/streamlit/runtime/app_session.py) after
-copying client `context_info` into `RerunData`:
+copying client `context_info` into `RerunData`. **Resolution targets the cached
+`_client_state` copy** so that server-initiated reruns (e.g. run-on-save) also use the
+resolved value:
 
 ```python
 if client_state.HasField("context_info"):
     self._client_state.context_info.CopyFrom(client_state.context_info)
-    if client_state.context_info.HasField("theme_preference"):
-        client_state.context_info.color_scheme = resolve_theme_type(
-            client_state.context_info.theme_preference
+    if self._client_state.context_info.HasField("theme_preference"):
+        self._client_state.context_info.color_scheme = resolve_theme_type(
+            self._client_state.context_info.theme_preference
         )
 ```
 
@@ -172,13 +206,21 @@ themePreference: this.getResolvedThemePreference(), // "light" | "dark"
 1. Existing embed query options `embed_options=light_theme` /
    `embed_options=dark_theme` (already used by host embedding — not a new protocol)
    if present.
-2. Else tracked `ThemeSelection` (`Light` / `Dark` / `System`), with
+2. Host-provided custom theme (`SET_CUSTOM_THEME_CONFIG` / `handleThemeMessage`) →
+   resolve appearance from `themeInfo.backgroundColor` luminance. Store as
+   `hostThemePreference` on the App instance in `handleThemeMessage` after applying
+   the theme. This covers SiS / Cloud hosts that push themes without going through the
+   menu or embed queries.
+3. Else tracked `ThemeSelection` (`Light` / `Dark` / `System`), with
    `System` → `getSystemThemePreference()`.
-3. `getCachedThemeSelection()` only for initial hydrate.
+4. `getCachedThemeSelection()` only for initial hydrate.
 
-Maintain `lastSentThemePreference` on the App instance; update it whenever a BackMsg
-with that preference is actually sent. Keep sending `colorScheme` for back-compat if
-useful; BE overwrites when `theme_preference` is present.
+`getResolvedThemePreference()` checks these in order: embed query → host override →
+menu/OS selection.
+
+Maintain `lastRerunAppearance` on the App instance (see §4 for semantics); update it
+with painted luminance whenever a rerun BackMsg is sent. Keep sending `colorScheme` for
+back-compat if useful; BE overwrites when `theme_preference` is present.
 
 **Backward compatibility:** New backend + old frontend (no `theme_preference`) leaves
 `color_scheme` untouched — existing deployed clients do not regress. New frontend +
@@ -196,19 +238,28 @@ suppress is `processThemeInput` (called during `handleNewSession`).
 
 #### Implementation
 
-**1. Two instance fields:**
+**1. Three instance fields:**
 
 ```tsx
-private lastSentThemePreference: "light" | "dark" | null = null
+private lastRerunAppearance: "light" | "dark" | null = null
 private skipNextThemeUpdate: boolean = false
+private pendingThemeRerun: boolean = false
 ```
 
-- `lastSentThemePreference` — tracks the preference sent in the last
-  `sendRerunBackMsg`. Prevents duplicate reruns and handles edge cases where
-  appearance does not actually change.
+- `lastRerunAppearance` — tracks the **painted appearance** (luminance) at the time
+  of the last `sendRerunBackMsg`. Used as a dedup guard: prevents firing another
+  auto-rerun when the visual state hasn't changed since the last rerun. This is
+  intentionally distinct from what `themePreference` (menu/OS) was *sent* in the
+  BackMsg — the trigger/dedup dimension is what the user *sees*, not what they
+  *selected*, because a preference change that doesn't flip painted luminance (e.g.
+  toggling Light→Dark with a single dark custom theme) doesn't require a rerun (the
+  backend resolver returns the same `type` either way).
 - `skipNextThemeUpdate` — set by `processThemeInput` when it applies a server-sent
   custom theme. Consumed (cleared) by the next `componentDidUpdate` to prevent that
   render from triggering an auto-rerun.
+- `pendingThemeRerun` — set when a theme change arrives while the script is running
+  or a rerun is already requested. Ensures the rerun fires once the script becomes
+  idle, rather than being silently dropped.
 
 **2. In `processThemeInput`, after the hash-check early return (~line 1738), before
 `this.setState`:**
@@ -223,6 +274,7 @@ to suppress a later legitimate change.
 **3. In `componentDidUpdate`, appended after the existing `scriptRunState` handling:**
 
 ```tsx
+// --- Theme preference diff ---
 const prevPreference = hasLightBackgroundColor(prevProps.theme.activeTheme.emotion)
   ? "light" : "dark"
 const currPreference = hasLightBackgroundColor(this.props.theme.activeTheme.emotion)
@@ -234,6 +286,15 @@ if (prevPreference !== currPreference && !this.skipNextThemeUpdate) {
 if (this.skipNextThemeUpdate) {
   this.skipNextThemeUpdate = false
 }
+
+// --- Drain pending theme rerun when script becomes idle ---
+if (
+  this.pendingThemeRerun &&
+  this.state.scriptRunState === ScriptRunState.NOT_RUNNING
+) {
+  this.pendingThemeRerun = false
+  this.maybeRerunForThemeChange()
+}
 ```
 
 **4. New method `maybeRerunForThemeChange`:**
@@ -244,13 +305,17 @@ private maybeRerunForThemeChange = (): void => {
     this.props.theme.activeTheme.emotion
   ) ? "light" : "dark"
 
-  if (currentPreference === this.lastSentThemePreference) return
+  if (currentPreference === this.lastRerunAppearance) return
   if (!this.isServerConnected()) return
   if (
     this.state.scriptRunState === ScriptRunState.RUNNING ||
     this.state.scriptRunState === ScriptRunState.RERUN_REQUESTED
-  ) return
+  ) {
+    this.pendingThemeRerun = true
+    return
+  }
 
+  this.pendingThemeRerun = false
   this.widgetMgr.sendUpdateWidgetsMessage(undefined)
 }
 ```
@@ -262,7 +327,7 @@ page).
 **5. In `sendRerunBackMsg`, after the BackMsg is sent (~line 2243):**
 
 ```tsx
-this.lastSentThemePreference = hasLightBackgroundColor(
+this.lastRerunAppearance = hasLightBackgroundColor(
   this.props.theme.activeTheme.emotion
 ) ? "light" : "dark"
 ```
@@ -289,7 +354,8 @@ this.lastSentThemePreference = hasLightBackgroundColor(
 | Fired on reconnection | Same: reconnection → `handleNewSession` → `processThemeInput` → suppressed |
 | Used theme NAME comparison (fragile, changes for internal reasons) | Uses resolved PREFERENCE (luminance "light"/"dark") — only changes on actual appearance flip |
 | `sendRerunBackMsg()` without page context lost current page | `sendUpdateWidgetsMessage(undefined)` → `sendRerunBackMsg` uses `this.state.currentPageScriptHash` |
-| Infinite loops (theme change → rerun → NewSession → theme change → ...) | `lastSentThemePreference` updated after send; next `componentDidUpdate` sees no diff and short-circuits. Plus `processThemeInput` sets skip flag. |
+| Theme change while script running was silently dropped | `pendingThemeRerun` records the intent; `componentDidUpdate` drains it once `scriptRunState` → `NOT_RUNNING` |
+| Infinite loops (theme change → rerun → NewSession → theme change → ...) | `lastRerunAppearance` updated after send; next `componentDidUpdate` sees no diff and short-circuits. Plus `processThemeInput` sets skip flag. |
 
 #### Scenario walkthrough
 
@@ -301,12 +367,21 @@ this.lastSentThemePreference = hasLightBackgroundColor(
 | Host sends dark theme | `handleThemeMessage` → `setTheme()` → React re-renders → `componentDidUpdate` fires → rerun | Correct |
 | OS dark↔light while System selected | `updateAutoTheme` in `useThemeManager` → prop changes → `componentDidUpdate` fires → rerun | Correct |
 | Reconnection | Same path as initial load through `handleNewSession` → suppressed | Correct |
-| Script already running when theme changes | `maybeRerunForThemeChange` sees `RUNNING` → returns without firing | Correct |
+| Script already running when theme changes | `maybeRerunForThemeChange` sees `RUNNING` → sets `pendingThemeRerun=true` → script finishes → `componentDidUpdate` sees `NOT_RUNNING` + pending → fires rerun | Correct |
+
+#### Minor modification to `handleThemeMessage`
+
+After applying the host theme, store the resolved preference for
+`getResolvedThemePreference()`:
+
+```tsx
+this.hostThemePreference = hasLightBackgroundColor(newTheme.emotion)
+  ? "light" : "dark"
+```
 
 #### No changes needed to
 
 - `setAndSendTheme` (signature unchanged)
-- `handleThemeMessage` (no modification)
 - `ThemeContext` or `ThemeManager` interface
 - `useThemeManager` hook (the `matchMedia` listener stays as-is)
 - The `setTheme` prop passed through context (stays as `this.setAndSendTheme`)
@@ -329,18 +404,24 @@ chosen product meaning. Drop stale first-load / settings caveats; keep CSS-overr
 **Python unit**
 
 - Resolver matrix matching the product behavior table (presets; single custom `base` /
-  hex / non-hex; light+dark sections; inheritance; missing colors → preference).
-- `request_rerun` sets `color_scheme` for full and fragment paths.
+  hex / non-hex; light+dark sections; section-wins inheritance merge; parent `base`
+  does not override section; missing colors → preference).
+- `request_rerun` resolves on `_client_state` (not the incoming `client_state`) for
+  full and fragment paths; verify server-initiated reruns also use resolved value.
 
 **Frontend unit**
 
-- Preference serialization (System→OS, Light, Dark, host query); not from remapped
-  custom theme name.
+- Preference serialization (System→OS, Light, Dark, embed query, host theme); not
+  from remapped custom theme name.
 - `componentDidUpdate` preference-diff: fires rerun on light↔dark flip; suppressed
-  when `skipNextThemeUpdate` is set; no-op when `lastSentThemePreference` matches;
-  no-op when script is running.
+  when `skipNextThemeUpdate` is set; no-op when `lastRerunAppearance` matches;
+  deferred when script is running.
+- `pendingThemeRerun`: theme change during `RUNNING` sets pending; transition to
+  `NOT_RUNNING` drains it by calling `maybeRerunForThemeChange`.
 - `processThemeInput` sets `skipNextThemeUpdate` — verify that `componentDidUpdate`
   after `handleNewSession` / page navigation does NOT trigger rerun.
+- `handleThemeMessage` stores `hostThemePreference` and
+  `getResolvedThemePreference()` returns it when set.
 - Regression: theme **name** change alone must not call `sendRerunBackMsg`.
 
 **E2E** (`make run-e2e-test`)

--- a/specs/2026-08-08-st-context-theme-type/tech-spec.md
+++ b/specs/2026-08-08-st-context-theme-type/tech-spec.md
@@ -107,7 +107,14 @@ sent, so existing deployed frontends against a new backend do not regress.
 
 ### 2. Backend resolver
 
-Add `lib/streamlit/runtime/theme_type.py` (sketch under Option C):
+Add `lib/streamlit/runtime/theme_type.py` (sketch under Option C).
+
+**Module comment required:** The general principle (per `AGENTS.md`) is that theming
+calculations belong on the frontend. This module is a justified exception: the backend is
+the only entity that has both the user's appearance preference AND `config.toml` at
+first-run time (the FE hasn't received `NewSession.custom_theme` yet). The implementation
+PR must include a short module-level docstring explaining this so future readers do not
+"fix" it back to FE-only luminance.
 
 ```python
 def resolve_theme_type(
@@ -481,11 +488,14 @@ if (prevAppearance !== currAppearance && !this.skipNextThemeUpdate) {
 }
 if (this.skipNextThemeUpdate) {
   this.skipNextThemeUpdate = false
-  // Update dedup guard to match what the script currently sees (the custom theme
-  // just applied by processThemeInput). Without this, lastRerunAppearance stays at
-  // the initial preset value, and a later toggle back to that appearance would be
-  // incorrectly suppressed by the dedup guard.
-  this.lastRerunAppearance = currAppearance
+  // Update dedup guard to match what the script currently sees — BUT only if
+  // no pending rerun is waiting. A pending rerun means a legitimate appearance
+  // change happened while the script was running; advancing the guard here would
+  // make the subsequent drain no-op (currentAppearance === lastRerunAppearance),
+  // swallowing the rerun and leaving Python with a stale type.
+  if (!this.pendingThemeRerun) {
+    this.lastRerunAppearance = currAppearance
+  }
 }
 
 // --- Drain pending theme rerun when connected + idle ---
@@ -546,8 +556,10 @@ this.lastRerunAppearance = hasLightBackgroundColor(
    `activeTheme` prop flows to `App`.
 5. `componentDidUpdate` fires for the new render — `skipNextThemeUpdate` is still
    `true`.
-6. Flag is consumed, cleared, and `lastRerunAppearance` is updated to the new
-   appearance (ensures dedup guard tracks the custom theme's visual state).
+6. Flag is consumed and cleared. If no `pendingThemeRerun` is outstanding,
+   `lastRerunAppearance` is updated to the new appearance (ensures dedup guard
+   tracks the custom theme's visual state). If `pendingThemeRerun` IS set, the
+   guard is left stale so the subsequent drain can fire correctly.
 
 #### Why this does not regress MPA (failure mode analysis)
 
@@ -574,6 +586,7 @@ this.lastRerunAppearance = hasLightBackgroundColor(
 | Script already running when theme changes | `maybeRerunForThemeChange` sees `RUNNING` → sets `pendingThemeRerun=true` → script finishes → `componentDidUpdate` sees `NOT_RUNNING` + pending → fires rerun | Correct |
 | Theme change while disconnected | `maybeRerunForThemeChange` sees `!isServerConnected()` → sets `pendingThemeRerun=true` → reconnect → `componentDidUpdate` drain sees connected + `NOT_RUNNING` + pending → fires rerun | Correct |
 | User switches away from host theme via menu | `setAndSendTheme` → active theme name changes → `isHostThemePainted()` returns false → next BackMsg sends `hostThemeActive=false` + menu preference → BE resumes config.toml resolution | Correct |
+| Appearance change while RUNNING + hash-changing `processThemeInput` | Theme flip sets `pendingThemeRerun=true` → script finishes → `NewSession` with different config theme → `processThemeInput` sets `skip=true` → `componentDidUpdate`: skip consumed but `lastRerunAppearance` NOT updated (pending guard) → drain fires → `currentAppearance !== lastRerunAppearance` → rerun sends | Correct |
 
 #### Minor modification to `handleThemeMessage`
 
@@ -645,6 +658,10 @@ chosen product meaning. Drop stale first-load / settings caveats; keep CSS-overr
 - Skip consumption updates `lastRerunAppearance` to the new appearance — verify that a
   subsequent toggle back to the pre-custom-theme appearance still fires a rerun (dedup
   guard is not stale).
+- Skip consumption does NOT update `lastRerunAppearance` when `pendingThemeRerun` is
+  true — verify that an appearance change deferred while RUNNING, followed by a
+  hash-changing `processThemeInput`, still fires once idle (the pending guard prevents
+  the dedup from swallowing the drain).
 - `handleThemeMessage` stores `hostThemePreference` and `hostImportedThemeName`;
   `getResolvedThemePreference()` returns host preference only when
   `isHostThemePainted()` is true; falls through to menu/OS otherwise.
@@ -704,7 +721,7 @@ BE work.
 | BE luminance disagrees with FE | Use identical WCAG formula (sRGB linearization + BT.709, threshold `> 0.5`); normalize all hex forms (#rgb/#rgba/#rrggbb/#rrggbbaa); cross-check unit test against FE boundary values; fall back to `base`/preference for non-hex |
 | Preference tracking drifts after `processThemeInput` | Track explicit `ThemeSelection`, never reverse from theme name |
 | Host/SiS theme messages ignored | Explicit `handleThemeMessage` path; re-enable hostframe E2E |
-| Option A/B chosen late | §2 is the only major rewrite; proto + auto-rerun stay |
+| Option A/B chosen late | §2 resolver is the primary rewrite. However, Option A also requires §4 trigger/dedup redesign: a preference change that does NOT flip painted luminance (e.g. Light→Dark with a single dark custom theme) must still trigger a rerun under A, so the auto-rerun dimension would need to track preference-diff (or dual-track preference + appearance), not only appearance-diff. Proto stays either way. |
 
 ## Out of scope
 

--- a/specs/2026-08-08-st-context-theme-type/tech-spec.md
+++ b/specs/2026-08-08-st-context-theme-type/tech-spec.md
@@ -170,6 +170,13 @@ def _type_from_bg_or_base(opts: dict, *, fallback: str) -> str:
     return fallback
 ```
 
+**`_hex_luminance` must match the frontend formula exactly:** Use WCAG relative luminance
+(sRGB linearization + BT.709 coefficients) with threshold `> 0.5`, identical to the
+frontend's `hasLightBackgroundColor` / color2k `getLuminance`. A divergent Python
+implementation would disagree with painted appearance for near-threshold hex backgrounds.
+Add a cross-check unit test comparing Python `_hex_luminance` against known FE outputs
+for boundary colors (e.g. `#7f7f7f`, `#808080`).
+
 **`_has_section_content`** returns True when the section has at least one option with a
 non-None value. `get_options_for_section` returns all registered option keys for the
 section (even when the user didn't write that TOML header), so checking truthiness of
@@ -207,14 +214,20 @@ if client_state.HasField("context_info"):
             ctx.color_scheme = resolve_theme_type(ctx.theme_preference)
 ```
 
-**Critical:** `RerunData.context_info` must be sourced from `self._client_state` (the
-resolved copy), not from the incoming `client_state` parameter. After the snippet above,
-all downstream code that builds `RerunData` reads from `self._client_state.context_info`
-which now has the correct `color_scheme`. Verify that the existing `_create_rerun_data`
-helper (or equivalent) already uses `self._client_state` — if it reads the raw parameter
-instead, the resolved value never reaches the script.
+**Critical — required wiring change:** Today `request_rerun` builds
+`RerunData(context_info=client_state.context_info)` from the incoming parameter (not
+`self._client_state`). This must be changed: after resolving `color_scheme` on
+`self._client_state.context_info` (snippet above), `_create_rerun_data` (or equivalent)
+must pass `self._client_state.context_info` into `RerunData` so the resolved value
+reaches the script. Without this change, the script still sees the unresolved
+`color_scheme` from the raw BackMsg.
 
 Applies to **full-script and fragment** reruns alike.
+
+**Required unit test:** Assert that when two distinct `client_state` BackMsg objects arrive
+(simulating a preference change), the `RerunData.context_info.color_scheme` exposed to
+the script equals the BE-resolved value (from `self._client_state`), not the raw value
+from the incoming parameter.
 
 If product picks **Option A**, this collapses to
 `color_scheme = theme_preference`. If **Option B** (theme identity), return a
@@ -228,8 +241,32 @@ In [`App.sendRerunBackMsg`](../../frontend/app/src/App.tsx) / `contextInfo`:
 
 ```ts
 themePreference: this.getResolvedThemePreference(), // "light" | "dark"
-hostThemeActive: this.hostThemePreference != null && !this.hasEmbedThemeOverride(),
+hostThemeActive: this.isHostThemePainted(),
 ```
+
+`isHostThemePainted()` returns `true` only when the host-imported theme is what is
+currently rendered — i.e. the theme installed by `handleThemeMessage` has not been
+replaced by a menu selection, config.toml theme, or embed override:
+
+```ts
+private isHostThemePainted(): boolean {
+  if (this.hostThemePreference == null) return false
+  if (this.hasEmbedThemeOverride()) return false
+  // The active custom theme name must still be the host-imported one
+  return this.props.theme.activeTheme.name === this.hostImportedThemeName
+}
+```
+
+`hostImportedThemeName` is set in `handleThemeMessage` alongside `hostThemePreference`.
+This avoids a sticky flag: if the user picks a different theme from the menu (which calls
+`setAndSendTheme`), the active theme name changes and `isHostThemePainted()` returns
+false — no need to explicitly clear `hostThemePreference` in every non-host path.
+
+`hasEmbedThemeOverride()` returns `true` when embed query params (`embed_options=light_theme`
+or `embed_options=dark_theme`) are present — these already exist in the codebase and force
+a preset theme regardless of host or menu selection. When an embed override is active, the
+FE paints the preset variant (not the host custom theme), so config.toml resolution on the
+BE remains correct and `hostThemeActive` must be false.
 
 **Source of truth** (do not reverse-engineer from active custom theme name after
 `processThemeInput`):
@@ -239,9 +276,9 @@ hostThemeActive: this.hostThemePreference != null && !this.hasEmbedThemeOverride
    if present.
 2. Host-provided custom theme (`SET_CUSTOM_THEME_CONFIG` / `handleThemeMessage`) →
    resolve appearance from `themeInfo.backgroundColor` luminance. Store as
-   `hostThemePreference` on the App instance in `handleThemeMessage` after applying
-   the theme. This covers SiS / Cloud hosts that push themes without going through the
-   menu or embed queries.
+   `hostThemePreference` (and `hostImportedThemeName`) on the App instance in
+   `handleThemeMessage` after applying the theme. This covers SiS / Cloud hosts that
+   push themes without going through the menu or embed queries.
 3. Else tracked `ThemeSelection` (`Light` / `Dark` / `System`), with
    `System` → `getSystemThemePreference()`.
 4. `getCachedThemeSelection()` only for initial hydrate.
@@ -284,7 +321,7 @@ require a new protocol where the host pushes theme to the server, not just the i
 
 ### 4. MPA-safe auto-rerun on appearance change
 
-#### Design: unified `componentDidUpdate` preference-diff with suppression flag
+#### Design: unified `componentDidUpdate` appearance-diff with suppression flag
 
 All three trigger sources (menu toggle, host message, OS preference change) produce
 the same observable: `props.theme.activeTheme` changes its visual appearance in
@@ -293,12 +330,14 @@ suppress is `processThemeInput` (called during `handleNewSession`).
 
 #### Implementation
 
-**1. Three instance fields:**
+**1. Instance fields:**
 
 ```tsx
 private lastRerunAppearance: "light" | "dark" | null = null
 private skipNextThemeUpdate: boolean = false
 private pendingThemeRerun: boolean = false
+private hostThemePreference: "light" | "dark" | null = null
+private hostImportedThemeName: string | null = null
 ```
 
 - `lastRerunAppearance` — tracks the **painted appearance** (luminance) at the time
@@ -322,25 +361,31 @@ private pendingThemeRerun: boolean = false
 ```tsx
 this.skipNextThemeUpdate = true
 this.hostThemePreference = null  // config.toml theme replaces host theme
+this.hostImportedThemeName = null
 ```
 
 `skipNextThemeUpdate` only set when the theme actually changes (hash differs), so it
 will not stick around to suppress a later legitimate change. Clearing
-`hostThemePreference` ensures `hostThemeActive` goes false on the next BackMsg — the BE
-resumes config.toml resolution since the FE is now painting the config theme, not the
-host theme. If the host later sends another `SET_CUSTOM_THEME_CONFIG`, `handleThemeMessage`
-re-sets `hostThemePreference` and the flag flips back to true.
+`hostThemePreference` and `hostImportedThemeName` ensures `isHostThemePainted()` returns
+false on the next BackMsg — the BE resumes config.toml resolution since the FE is now
+painting the config theme, not the host theme. If the host later sends another
+`SET_CUSTOM_THEME_CONFIG`, `handleThemeMessage` re-sets both fields and the flag flips
+back to true.
+
+Note: even without this explicit clear, `isHostThemePainted()` would return false because
+the active theme name changed to the config.toml theme. The clear is belt-and-suspenders
+to avoid stale state.
 
 **3. In `componentDidUpdate`, appended after the existing `scriptRunState` handling:**
 
 ```tsx
-// --- Theme preference diff ---
-const prevPreference = hasLightBackgroundColor(prevProps.theme.activeTheme.emotion)
+// --- Theme appearance diff ---
+const prevAppearance = hasLightBackgroundColor(prevProps.theme.activeTheme.emotion)
   ? "light" : "dark"
-const currPreference = hasLightBackgroundColor(this.props.theme.activeTheme.emotion)
+const currAppearance = hasLightBackgroundColor(this.props.theme.activeTheme.emotion)
   ? "light" : "dark"
 
-if (prevPreference !== currPreference && !this.skipNextThemeUpdate) {
+if (prevAppearance !== currAppearance && !this.skipNextThemeUpdate) {
   this.maybeRerunForThemeChange()
 }
 if (this.skipNextThemeUpdate) {
@@ -361,11 +406,11 @@ if (
 
 ```tsx
 private maybeRerunForThemeChange = (): void => {
-  const currentPreference = hasLightBackgroundColor(
+  const currentAppearance = hasLightBackgroundColor(
     this.props.theme.activeTheme.emotion
   ) ? "light" : "dark"
 
-  if (currentPreference === this.lastRerunAppearance) return
+  if (currentAppearance === this.lastRerunAppearance) return
   if (!this.isServerConnected()) return
   if (
     this.state.scriptRunState === ScriptRunState.RUNNING ||
@@ -431,20 +476,23 @@ this.lastRerunAppearance = hasLightBackgroundColor(
 
 #### Minor modification to `handleThemeMessage`
 
-After applying the host theme, store the resolved preference for
-`getResolvedThemePreference()`:
+After applying the host theme, store the resolved preference and imported theme name for
+`isHostThemePainted()` / `getResolvedThemePreference()`:
 
 ```tsx
 this.hostThemePreference = hasLightBackgroundColor(newTheme.emotion)
   ? "light" : "dark"
+this.hostImportedThemeName = newTheme.name  // used by isHostThemePainted()
 ```
 
 #### No changes needed to
 
-- `setAndSendTheme` (signature unchanged)
 - `ThemeContext` or `ThemeManager` interface
 - `useThemeManager` hook (the `matchMedia` listener stays as-is)
 - The `setTheme` prop passed through context (stays as `this.setAndSendTheme`)
+- `setAndSendTheme` (signature unchanged — when the user picks a different theme from
+  the menu, the active theme name changes, so `isHostThemePainted()` naturally returns
+  false without needing any code in `setAndSendTheme`)
 
 #### Key files
 
@@ -476,15 +524,19 @@ chosen product meaning. Drop stale first-load / settings caveats; keep CSS-overr
 
 - Preference serialization (System→OS, Light, Dark, embed query, host theme); not
   from remapped custom theme name.
-- `componentDidUpdate` preference-diff: fires rerun on light↔dark flip; suppressed
+- `componentDidUpdate` appearance-diff: fires rerun on light↔dark flip; suppressed
   when `skipNextThemeUpdate` is set; no-op when `lastRerunAppearance` matches;
   deferred when script is running.
 - `pendingThemeRerun`: theme change during `RUNNING` sets pending; transition to
   `NOT_RUNNING` drains it by calling `maybeRerunForThemeChange`.
 - `processThemeInput` sets `skipNextThemeUpdate` — verify that `componentDidUpdate`
   after `handleNewSession` / page navigation does NOT trigger rerun.
-- `handleThemeMessage` stores `hostThemePreference` and
-  `getResolvedThemePreference()` returns it when set.
+- `handleThemeMessage` stores `hostThemePreference` and `hostImportedThemeName`;
+  `getResolvedThemePreference()` returns host preference when set;
+  `isHostThemePainted()` returns true only when active theme matches
+  `hostImportedThemeName`.
+- `isHostThemePainted()` returns false after user selects a different theme from
+  the menu (non-sticky host activation).
 - Regression: theme **name** change alone must not call `sendRerunBackMsg`.
 
 **E2E** (`make run-e2e-test`)
@@ -533,8 +585,8 @@ BE work.
 
 | Risk | Mitigation |
 |------|------------|
-| Auto-rerun reintroduces #11797 | `skipNextThemeUpdate` suppresses `processThemeInput` renders; preference-diff (not name); `sendUpdateWidgetsMessage` preserves page context; MPA E2E required |
-| BE luminance disagrees with FE | Prefer `base`; hex-only luminance; fall back to preference |
+| Auto-rerun reintroduces #11797 | `skipNextThemeUpdate` suppresses `processThemeInput` renders; appearance-diff (not name); `sendUpdateWidgetsMessage` preserves page context; MPA E2E required |
+| BE luminance disagrees with FE | Use identical WCAG formula (sRGB linearization + BT.709, threshold `> 0.5`); cross-check unit test against FE boundary values; hex-only; fall back to `base`/preference |
 | Preference tracking drifts after `processThemeInput` | Track explicit `ThemeSelection`, never reverse from theme name |
 | Host/SiS theme messages ignored | Explicit `handleThemeMessage` path; re-enable hostframe E2E |
 | Option A/B chosen late | §2 is the only major rewrite; proto + auto-rerun stay |

--- a/specs/2026-08-08-st-context-theme-type/tech-spec.md
+++ b/specs/2026-08-08-st-context-theme-type/tech-spec.md
@@ -10,11 +10,23 @@ created: 2026-08-08
 Fix `st.context.theme.type` by having the client send a resolved appearance preference
 (`"light"` | `"dark"`) on every rerun, and having the backend resolve the effective type
 from that preference plus `config.toml` **before** the script runs — plus an MPA-safe
-auto-rerun when appearance changes via menu, host, or OS.
+auto-rerun whenever the inputs the backend resolves from change (menu, host, or OS).
 
 See the [product spec](./product-spec.md) for the A/B/C semantics decision and
 user-facing behavior. This tech spec is written against **Option C** (visual appearance);
 if product picks A or B, adjust §2 only.
+
+### Terms
+
+| Term | Meaning |
+|------|---------|
+| **Frontend** / **FE**, **Backend** / **BE** | The React app in `frontend/` and the Python runtime in `lib/`, respectively |
+| **Appearance preference** | What the user or their OS asked for: menu `Light` / `Dark` / `System`, with `System` resolved against `prefers-color-scheme`. Sent as `theme_preference` |
+| **Painted appearance** | Whether the app actually renders light or dark, from the active theme's background luminance. What Option C defines `type` to mean |
+| **Dual theme** | A `config.toml` with `[theme.light]` and/or `[theme.dark]` sections, which makes the FE build separate light and dark custom themes |
+| **Section variant** | Which half of a dual theme is active — `"light"` or `"dark"`. The FE forces the theme's `base` from it |
+| **Host theme** | A theme pushed by an embedding host at runtime via the `SET_CUSTOM_THEME_CONFIG` postMessage, which replaces `config.toml` on the FE |
+| **Resolution key** | The `(appearance preference, host theme active)` pair — precisely the client-supplied inputs the backend resolves `type` from, and the trigger for the §4 auto-rerun |
 
 ## Problem
 
@@ -88,8 +100,11 @@ In [`ClientState.proto`](../../proto/streamlit/proto/ClientState.proto), add to
 `ContextInfo`:
 
 ```protobuf
-// Resolved appearance from the client: "light" or "dark".
-// System menu selection must be resolved to OS preference before send.
+// Resolved light/dark value from the client: "light" or "dark".
+// Normally the user's appearance preference, with a System menu selection
+// resolved to the OS preference before send. When host_theme_active is true it
+// instead carries the painted luminance of the host theme, since that is the
+// only signal the backend can act on for a theme it cannot see.
 optional string theme_preference = 7;
 
 // True when a host-provided custom theme (SET_CUSTOM_THEME_CONFIG) is active.
@@ -161,21 +176,22 @@ def _merge_for_dual_theme(parent: dict, section: dict, *, variant: str) -> dict:
 
     Section values override parent (mirrors frontend handleSectionInheritance).
     After merging, `base` is ALWAYS forced to the section variant name —
-    matching the FE, which unconditionally sets `base` from the variant last
-    (overriding both parent and any explicit section `base`). This means a
-    pathological `[theme.dark] base="light"` still gets `base="dark"` — the FE
-    paints dark, so the resolver must agree.
+    matching the FE, which sets `base` from the variant last, overriding any
+    `base` inherited from `[theme]`.
 
-    The only way to override `base` in dual themes is via `backgroundColor`
-    luminance (priority 1 in `_type_from_bg_or_base`).
+    Note: `base` is only a registered config option on `[theme]` — it is not a
+    valid key in `[theme.light]` / `[theme.dark]`, so the only `base` that can
+    reach this merge comes from the parent section. A contradictory
+    `[theme.dark] base = "light"` is a config error, not an input we resolve.
+
+    The only way to override the forced `base` in dual themes is via
+    `backgroundColor` luminance (priority 1 in `_type_from_bg_or_base`).
 
     This ensures:
     - [theme] base="light" + [theme.dark] primaryColor="..." → base forced to
-      "dark" (variant) → resolver returns "dark". Correct.
+      "dark" (variant) → resolver returns "dark". Correct — the FE paints dark.
     - [theme.dark] backgroundColor="#ffffff" (pathological) → bg luminance →
       "light" (what is painted, overrides forced base). Correct.
-    - [theme.dark] base="light" (contradictory) → base forced to "dark"
-      (variant, matching FE). Correct — FE paints dark.
     """
     # Filter None values — get_options_for_section includes all registered keys
     # even when unset. Only non-None values represent user-provided config.
@@ -188,6 +204,14 @@ def _merge_for_dual_theme(parent: dict, section: dict, *, variant: str) -> dict:
 
 
 def _type_from_bg_or_base(opts: dict, *, fallback: str) -> str:
+    """Classify appearance: hex background luminance, then base, then fallback.
+
+    Assumes `base` has already been normalized to "light"/"dark". That holds
+    because `theme.base` also accepts a TOML file path or URL, and
+    `config_util.process_theme_inheritance` rewrites it to a plain "light" /
+    "dark" (defaulting to "light" when the referenced file sets no base)
+    before options are read. Do NOT "fix" this to resolve paths itself.
+    """
     bg = opts.get("backgroundColor")
     if _is_hex_color(bg):
         return "light" if _hex_luminance(bg) > 0.5 else "dark"
@@ -220,7 +244,10 @@ linearization + BT.709 coefficients) with threshold `> 0.5`, identical to the fr
 
 ```python
 def _hex_luminance(hex_color: str) -> float:
-    """WCAG relative luminance from any valid hex color string."""
+    """WCAG relative luminance from any hex form.
+
+    Short forms are expanded and any alpha channel is ignored.
+    """
     h = hex_color.lstrip("#")
     if len(h) in (3, 4):
         # Expand short form: #rgb → rrggbb, #rgba → rrggbbaa
@@ -236,8 +263,54 @@ def _hex_luminance(hex_color: str) -> float:
 
 A divergent Python implementation would disagree with painted appearance for
 near-threshold hex backgrounds. Add a cross-check unit test comparing Python
-`_hex_luminance` against known FE outputs for boundary colors (e.g. `#7f7f7f`,
-`#808080`, `#fff`, `#000`).
+`_hex_luminance` against known FE outputs. **Pick colors that actually straddle the
+threshold** — mid-gray does not. Values measured against the vendored `color2k`:
+
+| Color | `getLuminance` | Classified |
+|-------|---------------|------------|
+| `#000` | 0.0000 | dark |
+| `#7f7f7f` | 0.2122 | dark |
+| `#808080` | 0.2159 | dark |
+| `#bbbbbb` | 0.4969 | **dark** — just below |
+| `#bcbcbc` | 0.5029 | **light** — just above |
+| `#ccc` | 0.6038 | light |
+| `#fff` | 1.0000 | light |
+
+`#bbbbbb` / `#bcbcbc` is the real crossing; `#bbb` (0.4969) additionally covers short-form
+expansion right at the boundary. `#7f7f7f` / `#808080` sit at ~0.21 and would pass any
+implementation, testing nothing.
+
+**Known limitation — non-hex `backgroundColor` inverts the answer.** Theme color options
+are **not** validated as hex. `theme.backgroundColor` is a plain `str` config option
+(`_create_theme_options` applies no validator), so `config.set_option
+("theme.backgroundColor", "black")` is accepted today. Meanwhile `color2k` parses the full
+CSS color space — verified: `getLuminance("black") = 0`, `getLuminance("rgb(0,0,0)") = 0`,
+`getLuminance("hsl(0,0%,10%)") = 0.0103`. So:
+
+```toml
+[theme]
+backgroundColor = "black"   # no base set
+```
+
+paints **dark** on the frontend, while `_is_hex_color("black")` is false, `base` is unset,
+and the resolver returns `fallback="light"` — the exact inverse of what Option C promises.
+Named colors, `rgb()`, and `hsl()` all land here.
+
+This is a real correctness gap, not a theoretical one, and it predates this design (today's
+frontend-computed `color_scheme` gets it right, because the FE has the parsed color). Three
+ways out, for reviewer decision — see product spec open question 5:
+
+1. **Accept and document.** Cheapest; leaves a wrong `type` for these configs.
+2. **Handle the common cases.** Add the 148 CSS named colors as a dict plus `rgb()`/`hsl()`
+   parsing. No new dependency, but it grows the very FE/BE duplication the risk table warns
+   about.
+3. **Validate theme colors as hex in config.** Closes it properly and benefits more than
+   `type`, but it would start rejecting configs that work today — a breaking change needing
+   its own deprecation path.
+
+Until this is decided, the resolver should at minimum **not** silently claim `"light"`: log
+a debug message when `backgroundColor` is set but unparseable, so the fallback is
+diagnosable.
 
 **`_has_section_content`** returns True when the section has at least one option with a
 non-None value. `get_options_for_section` returns all registered option keys for the
@@ -248,6 +321,15 @@ the dict is insufficient — filter None values:
 def _has_section_content(section: dict) -> bool:
     return any(v is not None for v in section.values())
 ```
+
+**Reuse the existing gate rather than re-deriving it.** `_populate_theme_msg` already makes
+exactly this determination — `if all(val is None for val in theme_opts.values()): return`
+(`lib/streamlit/runtime/app_session.py:1262-1264`) — and it decides whether a
+`custom_theme` reaches the frontend at all. These two must agree: if the resolver thinks a
+section has content and `_populate_theme_msg` disagrees, the backend resolves against config
+the frontend was never told about. Factor the predicate into one shared helper (or have the
+resolver call it) so the "Resolver drifts from FE theme logic" risk does not apply to this
+*sibling* check too.
 
 A bare `[theme.dark]` header with no keys underneath has all-None values → returns
 False. This matches the FE's behavior, which also requires at least one key to trigger
@@ -310,12 +392,13 @@ if client_state.HasField("context_info"):
             ctx.color_scheme = resolve_theme_type(ctx.theme_preference)
 ```
 
-**Critical — required wiring change:** Today `request_rerun` builds
-`RerunData(context_info=client_state.context_info)` from the incoming parameter (not
-`self._client_state`). This must be changed: after resolving `color_scheme` on
-`self._client_state.context_info` (snippet above), `_create_rerun_data` (or equivalent)
-must pass `self._client_state.context_info` into `RerunData` so the resolved value
-reaches the script. Without this change, the script still sees the unresolved
+**Critical — required wiring change:** Today `request_rerun` constructs `RerunData`
+inline (there is no `_create_rerun_data` helper) and passes
+`context_info=client_state.context_info` — the incoming parameter, not
+`self._client_state`. This must be changed: after resolving `color_scheme` on
+`self._client_state.context_info` (snippet above), the inline `RerunData(...)`
+construction must pass `context_info=self._client_state.context_info` so the resolved
+value reaches the script. Without this change, the script still sees the unresolved
 `color_scheme` from the raw BackMsg.
 
 Applies to **full-script and fragment** reruns alike.
@@ -346,23 +429,43 @@ replaced by a menu selection, config.toml theme, or embed override:
 
 ```ts
 private isHostThemePainted(): boolean {
-  if (this.hostThemePreference == null) return false
+  if (this.hostImportedTheme == null) return false
   if (this.hasEmbedThemeOverride()) return false
-  // The active custom theme name must still be the host-imported one
-  return this.props.theme.activeTheme.name === this.hostImportedThemeName
+  // Object identity, NOT name equality — see below.
+  return this.props.theme.activeTheme === this.hostImportedTheme
 }
 ```
 
-`hostImportedThemeName` is set in `handleThemeMessage` alongside `hostThemePreference`.
-This avoids a sticky flag: if the user picks a different theme from the menu (which calls
-`setAndSendTheme`), the active theme name changes and `isHostThemePainted()` returns
-false — no need to explicitly clear `hostThemePreference` in every non-host path.
+**Compare by object identity, never by theme name.** Host runtime themes and config.toml
+*single* custom themes are both created with the same name constant `CUSTOM_THEME_NAME`
+("Custom Theme") — `setImportedTheme` calls `createTheme(CUSTOM_THEME_NAME, proto)`, and
+`createCustomThemes`' single-theme branch calls `createTheme(CUSTOM_THEME_NAME,
+themeInput)`. A name comparison therefore cannot distinguish them, and the sticky-host
+bug survives in this shape: with a single `[theme]` in config.toml plus a host dark
+theme, a user selecting "Custom Theme" from the menu still matches the stored host name,
+so the client would keep sending `host_theme_active=true` with the stale host preference
+while the UI paints the config theme.
 
-`hasEmbedThemeOverride()` returns `true` when embed query params (`embed_options=light_theme`
-or `embed_options=dark_theme`) are present — these already exist in the codebase and force
-a preset theme regardless of host or menu selection. When an embed override is active, the
-FE paints the preset variant (not the host custom theme), so config.toml resolution on the
-BE remains correct and `hostThemeActive` must be false.
+`hostImportedTheme` stores the `ThemeConfig` **object** created when the host theme was
+applied. `applyTheme` does `setTheme(newTheme)` without copying, and the manager exposes
+`activeTheme` as that same `useState` value, so the reference survives until something
+replaces it; any other selection — preset, config.toml theme, or a later host import —
+yields a different object and `isHostThemePainted()` goes false. Several config.toml paths
+do spread-copy their themes (`createCustomThemes` for the light/dark/auto variants,
+`createAutoCustomTheme` in the hook), but none of them copies a *host* import, so they all
+correctly compare unequal to `hostImportedTheme`.
+
+`hasEmbedThemeOverride()` reuses the existing embed query helpers — no new protocol:
+
+```ts
+private hasEmbedThemeOverride(): boolean {
+  return isLightThemeInQueryParams() || isDarkThemeInQueryParams()
+}
+```
+
+Both are already exported from `frontend/lib/src/util/utils.ts`. When an embed override is
+active the FE paints the preset variant rather than the host custom theme, so config.toml
+resolution on the BE remains correct and `hostThemeActive` must be false.
 
 **Source of truth** (do not reverse-engineer from active custom theme name after
 `processThemeInput`):
@@ -371,11 +474,11 @@ BE remains correct and `hostThemeActive` must be false.
    `embed_options=dark_theme` (already used by host embedding — not a new protocol)
    if present.
 2. Host-provided custom theme — **only when `isHostThemePainted()` is true** (the host
-   theme is still the active rendered theme). Returns `hostThemePreference` (stored in
-   `handleThemeMessage` from `themeInfo.backgroundColor` luminance). If
-   `isHostThemePainted()` is false, this step is skipped even if `hostThemePreference`
-   is non-null — prevents stale host preference from leaking after the user picks a
-   different theme from the menu.
+   theme is still the active rendered theme). Returns `hostThemePreference`, which
+   `handleThemeMessage` derives from the applied theme's background luminance via
+   `hasLightBackgroundColor` (see the sketch in §4). If `isHostThemePainted()` is false,
+   this step is skipped even if `hostThemePreference` is non-null — prevents stale host
+   preference from leaking after the user picks a different theme from the menu.
 3. Else tracked `ThemeSelection` (`Light` / `Dark` / `System`), with
    `System` → `getSystemThemePreference()`.
 4. `getCachedThemeSelection()` only for initial hydrate.
@@ -383,10 +486,11 @@ BE remains correct and `hostThemeActive` must be false.
 `getResolvedThemePreference()` checks in order: embed query → host (if painted) →
 menu/OS selection.
 
-Maintain `lastRerunAppearance` on the App instance (see §4 `lastRerunAppearance`
-definition for dedup semantics); update it with painted luminance whenever a rerun
-BackMsg is sent. Keep sending `colorScheme` for
-back-compat if useful; BE overwrites when `theme_preference` is present.
+These two values — `themePreference` and `hostThemeActive` — are exactly the inputs the
+backend resolves from, so §4 uses the pair as its rerun trigger. Maintain
+`lastSentThemeResolutionKey` on the App instance (see §4 for semantics); update it whenever a
+rerun BackMsg is sent. Keep sending `colorScheme` for back-compat if useful; BE overwrites
+when `theme_preference` is present.
 
 **Backward compatibility:** New backend + old frontend (no `theme_preference`) leaves
 `color_scheme` untouched — existing deployed clients do not regress. New frontend +
@@ -404,126 +508,214 @@ new, BE overwrites `color_scheme` from preference + config.
    since hosts customize within the same dark/light family.
 
 2. **Runtime** (`SET_CUSTOM_THEME_CONFIG` postMessage): creates a standalone custom
-   theme via `setImportedTheme` → `createTheme(name, proto)`. No merge with config.toml
-   — last-write-wins. In practice the host theme arrives after `NewSession` so it
-   replaces config.toml entirely. When `host_theme_active` is true, config.toml colors
-   are not painted — BE must not resolve from them.
+   theme via `setImportedTheme` → `createTheme(CUSTOM_THEME_NAME, proto)`. No merge with
+   config.toml — last-write-wins, whichever arrives later. When `host_theme_active` is
+   true, config.toml colors are not painted — BE must not resolve from them. Arrival
+   order relative to `NewSession` varies by host; both orderings are specified below.
 
-**Known limitation — host theme first-run race:** If the host sends its theme *after*
-the FE's first BackMsg (rare — hosts typically send during iframe init handshake before
-WebSocket connects), the first script run resolves from config.toml (potentially wrong).
-The auto-rerun in §4 corrects this within milliseconds once the host theme arrives and
-luminance changes. This is acceptable because: (a) the race is uncommon in practice, (b)
-the correction is immediate and invisible to users, and (c) solving it fully would
-require a new protocol where the host pushes theme to the server, not just the iframe.
+**Host theme arrival ordering.** Hosts differ in when they post
+`SET_CUSTOM_THEME_CONFIG` relative to the WebSocket handshake, so both orderings must be
+handled. Neither is a "rare race" that can be waved off — each produces a wrong `type`
+under a naive implementation, and each is corrected by a different part of §4:
 
-### 4. MPA-safe auto-rerun on appearance change
+| Ordering | First run resolves from | Then | Correction |
+|----------|------------------------|------|------------|
+| Host theme applied **before** the first BackMsg (host posts during iframe init, before connect) | Host appearance — first BackMsg already carries `host_theme_active=true` | `NewSession` arrives, `processThemeInput` paints the config.toml theme and clears the host fields | Resolution key flips `dark\|true` → `light\|false`, so §4 fires one rerun and the BE re-resolves from config.toml |
+| Host theme applied **after** `NewSession` (host posts once the app is live) | config.toml — first BackMsg carries `host_theme_active=false` | `handleThemeMessage` applies the host theme | Resolution key flips `light\|false` → `dark\|true`, so §4 fires one rerun and the BE takes `theme_preference` directly |
 
-#### Design: unified `componentDidUpdate` appearance-diff with suppression flag
+The first ordering is the one an appearance-diff trigger gets wrong: the config.toml theme
+may paint the *same* luminance the host theme did, so painted appearance does not change,
+yet the backend must switch resolution source from host-preference to config.toml. This is
+why §4 keys on the `(preference, hostThemeActive)` resolution key rather than on luminance —
+see the design note there.
 
-All three trigger sources (menu toggle, host message, OS preference change) produce
-the same observable: `props.theme.activeTheme` changes its visual appearance in
-`App.tsx`. A single `componentDidUpdate` check handles all three. The only path to
-suppress is `processThemeInput` (called during `handleNewSession`).
+In both orderings the first script run may briefly show a `type` resolved from the other
+source; the correcting rerun fires within milliseconds and is invisible to users.
+Eliminating the first run's exposure entirely would require a new protocol where the host
+pushes its theme to the server rather than only to the iframe — out of scope.
+
+**Pre-existing issue to decide on: host theme + no `config.toml` theme.** The table above
+assumes `processThemeInput` paints a config.toml theme. With **no** `[theme]` at all — a
+common SiS/Cloud shape — it takes its `else` branch instead, and that branch is destructive
+to host themes today. `usingCustomTheme` is `!isPresetTheme(activeTheme)`, which is `true`
+for a host theme (named `CUSTOM_THEME_NAME`), so the branch runs
+`setAndSendTheme(mappedTheme ?? createAutoTheme())` and **replaces the painted host theme
+with a preset**. That is existing behavior on `develop`, independent of this design: the
+host's theme visibly disappears on the first `NewSession`.
+
+For this spec it means ordering A's "correction" is not merely a `type` fix in that
+configuration — the host theme itself is lost, so `type` correctly reports the preset that
+ends up painted. **Reviewer decision needed:** treat the clobber as a separate bug (file it,
+keep it out of scope here, and note that `type` stays truthful either way), or fix it as
+part of this work by having the `else` branch leave a host-imported theme in place. The
+resolution-key design behaves correctly under both, so this is a scoping call rather than a
+design dependency.
+
+### 4. MPA-safe auto-rerun on theme change
+
+#### Design: `componentDidUpdate` resolution key diff
+
+The backend resolves `color_scheme` from exactly two client-supplied inputs —
+`theme_preference` and `host_theme_active` — plus `config.toml`. Holding `config.toml`
+constant, `st.context.theme.type` can only change when that pair changes, so the trigger
+is a **resolution key diff** on the pair rather than a painted-luminance diff:
+
+```tsx
+private getThemeResolutionKey(): string {
+  return `${this.getResolvedThemePreference()}|${this.isHostThemePainted()}`
+}
+```
+
+A rerun fires whenever the current resolution key differs from the one sent with the last
+BackMsg. Against a fixed `config.toml` that condition is both necessary and sufficient: a
+changed resolution key means the backend would now compute a different `type`; an unchanged
+resolution key means it would compute the same one.
+
+`config.toml` is not strictly immutable — `bootstrap._install_config_watchers` reloads
+config options when the file changes — but that watcher only refreshes server-side options;
+it does not rerun the script or push a new theme to the client. So after a mid-session
+`[theme]` edit, neither the painted theme nor `type` changes until the next rerun, and on
+the next **full** rerun both update together: the resolver reads the new options while the
+accompanying `NewSession` carries the new `custom_theme`. The resolution key therefore does
+not need to track config edits.
+
+The one seam: a **fragment** rerun sends no `NewSession`, so between a mid-session `[theme]`
+edit and the next full rerun, a fragment run would resolve `type` from the new config while
+the client still paints the old theme. This is a developer-only window (editing
+`config.toml` against a live app) and self-corrects on the next full rerun.
+
+**Why not diff painted appearance?** Luminance is a proxy that fails in two ways. It
+misses the host→config.toml transition (§3's first ordering), where the resolution
+*source* changes while painted luminance may not — leaving `type` stuck on the host value
+for the rest of the session. And it forces a `skipNextThemeUpdate` flag, because applying
+a config.toml custom theme legitimately flips luminance without changing what the backend
+would compute, so the flag is needed to tell those apart. Keying on the resolution key removes
+both problems, and with them both the `skipNextThemeUpdate` flag and the
+`lastRerunAppearance` guard used in earlier drafts.
+
+**Accepted cost:** the resolution key fires a rerun in cases a luminance diff deduped — a
+preference change that the resolver ignores because config pins the answer, e.g. toggling
+menu Light↔Dark (or the OS flipping while System is selected) with a *single* custom
+theme. `type` is unchanged, so the rerun is redundant. Suppressing it would require
+reimplementing the resolver on the frontend, which is exactly the duplication this design
+is trying to contain; it stays one rerun per explicit change (Principle 34), never a loop.
+We take the redundant rerun over the duplicated logic.
 
 #### Implementation
 
 **1. Instance fields:**
 
 ```tsx
-private lastRerunAppearance: "light" | "dark" | null = null
-private skipNextThemeUpdate: boolean = false
+private lastSentThemeResolutionKey: string | null = null
 private pendingThemeRerun: boolean = false
+private themeSelection: ThemeSelection = getCachedThemeSelection() ?? "System"
 private hostThemePreference: "light" | "dark" | null = null
-private hostImportedThemeName: string | null = null
+private hostImportedTheme: ThemeConfig | null = null
 ```
 
-- `lastRerunAppearance` — tracks the **painted appearance** (luminance) at the time
-  of the last `sendRerunBackMsg`. Used as a dedup guard: prevents firing another
-  auto-rerun when the visual state hasn't changed since the last rerun. This is
-  intentionally distinct from what `themePreference` (menu/OS) was *sent* in the
-  BackMsg — the trigger/dedup dimension is what the user *sees*, not what they
-  *selected*, because a preference change that doesn't flip painted luminance (e.g.
-  toggling Light→Dark with a single dark custom theme) doesn't require a rerun (the
-  backend resolver returns the same `type` either way).
-- `skipNextThemeUpdate` — set by `processThemeInput` when it applies a server-sent
-  custom theme. Consumed (cleared) by the next `componentDidUpdate` to prevent that
-  render from triggering an auto-rerun.
-- `pendingThemeRerun` — set when a theme change arrives while the script is running
-  or a rerun is already requested. Ensures the rerun fires once the script becomes
-  idle, rather than being silently dropped.
+- `lastSentThemeResolutionKey` — the `getThemeResolutionKey()` value carried by the most
+  recent rerun BackMsg. The dedup guard: no rerun fires while it matches the current
+  resolution key. Anchoring the guard to what was *sent* (rather than to the previous
+  render) is what makes a change impossible to lose across renders, disconnects, or script
+  runs. It starts `null`, so the key trivially differs before the first BackMsg; every
+  `componentDidUpdate` until then sets `pendingThemeRerun`, which is harmless (the first
+  real BackMsg sets the key and the drain no-ops) but will look odd in a debugger.
+- `pendingThemeRerun` — set when a resolution key change arrives while the script is
+  running, a rerun is already requested, or the socket is down. Ensures the rerun fires
+  once the app is connected and idle rather than being silently dropped.
+- `themeSelection` — the user's tracked `ThemeSelection` (`"Light"` / `"Dark"` /
+  `"System"`), step 3 of §3's source-of-truth list. **This field is load-bearing for MPA
+  safety, so its write sites matter:** it must be written only where the *user or host*
+  expresses a choice — the settings-menu callback, and `handleThemeMessage`'s preset
+  branches (below). It must **not** be written inside `setAndSendTheme`, because
+  `processThemeInput` calls `setAndSendTheme` itself while applying a server-sent theme; a
+  write there would let a `NewSession` overwrite the user's selection, flip the resolution
+  key, and fire a rerun *from `processThemeInput`* — exactly the #11797 regression the
+  failure-mode table below promises cannot happen. Never derive it by reversing the active
+  theme's name.
+- `hostThemePreference` / `hostImportedTheme` — see §3. The host theme is held as an
+  object reference for identity comparison, never as a name.
 
-**2. In `processThemeInput`, after the hash-check early return (~line 1738), before
-`this.setState`:**
+**2. In `processThemeInput`, after the hash-check early return, before `this.setState`:**
 
 ```tsx
-this.skipNextThemeUpdate = true
-this.hostThemePreference = null  // config.toml theme replaces host theme
-this.hostImportedThemeName = null
+// A config.toml theme is now what gets painted, so a host theme (if any) is no
+// longer active. Clearing these flips isHostThemePainted() to false, which changes
+// the resolution key and lets componentDidUpdate fire the correcting rerun.
+this.hostThemePreference = null
+this.hostImportedTheme = null
 ```
 
-`skipNextThemeUpdate` only set when the theme actually changes (hash differs), so it
-will not stick around to suppress a later legitimate change. Clearing
-`hostThemePreference` and `hostImportedThemeName` ensures `isHostThemePainted()` returns
-false on the next BackMsg — the BE resumes config.toml resolution since the FE is now
-painting the config theme, not the host theme. If the host later sends another
-`SET_CUSTOM_THEME_CONFIG`, `handleThemeMessage` re-sets both fields and the flag flips
-back to true.
-
-Note: even without this explicit clear, `isHostThemePainted()` would return false because
-the active theme name changed to the config.toml theme. The clear is belt-and-suspenders
-to avoid stale state.
+No suppression flag is set here. If the previous BackMsg reported
+`host_theme_active=true`, clearing these fields *changes* the resolution key, and the rerun
+that follows is exactly the correction §3's first ordering requires. If the previous
+BackMsg already reported `host_theme_active=false` — the ordinary config.toml case,
+including MPA navigation and reconnection — the resolution key is unchanged and nothing fires.
+If the host later posts another `SET_CUSTOM_THEME_CONFIG`, `handleThemeMessage` re-sets
+both fields and the resolution key flips back.
 
 **3. In `componentDidUpdate`, appended after the existing `scriptRunState` handling:**
 
 ```tsx
-// --- Theme appearance diff ---
-const prevAppearance = hasLightBackgroundColor(prevProps.theme.activeTheme.emotion)
-  ? "light" : "dark"
-const currAppearance = hasLightBackgroundColor(this.props.theme.activeTheme.emotion)
-  ? "light" : "dark"
-
-if (prevAppearance !== currAppearance && !this.skipNextThemeUpdate) {
+// --- Theme resolution key diff ---
+// Compared against what was last SENT, not against the previous render, so a
+// change cannot be lost across renders. componentDidUpdate runs on every update,
+// so any state or prop change re-checks the resolution key.
+if (this.getThemeResolutionKey() !== this.lastSentThemeResolutionKey) {
   this.maybeRerunForThemeChange()
 }
-if (this.skipNextThemeUpdate) {
-  this.skipNextThemeUpdate = false
-  // Update dedup guard to match what the script currently sees — BUT only if
-  // no pending rerun is waiting. A pending rerun means a legitimate appearance
-  // change happened while the script was running; advancing the guard here would
-  // make the subsequent drain no-op (currentAppearance === lastRerunAppearance),
-  // swallowing the rerun and leaving Python with a stale type.
-  if (!this.pendingThemeRerun) {
-    this.lastRerunAppearance = currAppearance
-  }
-}
 
-// --- Drain pending theme rerun when connected + idle ---
+// --- Drain a deferred theme rerun once connected + idle ---
 if (
   this.pendingThemeRerun &&
   this.isServerConnected() &&
   this.state.scriptRunState === ScriptRunState.NOT_RUNNING
 ) {
-  this.pendingThemeRerun = false
   this.maybeRerunForThemeChange()
 }
 ```
+
+Because the guard is the last-sent resolution key rather than `prevProps`, this hook needs no
+previous props. Note the method's current signature is `componentDidUpdate(_prevProps, prevState)`
+with `_prevProps` deliberately unused — it stays unused, so no rename is required.
+
+**Invariant this hook depends on — state it, test it, don't discover it later.** The trigger
+only fires when React renders, so it needs: *whenever the resolution key changes in a way
+that changes `type`, a render must follow.* That holds today, for two reasons worth making
+explicit because both are incidental rather than guaranteed:
+
+1. `App` is a `PureComponent`, but it re-renders on every `ThemedApp` render anyway because
+   `useThemeManager` returns a **fresh manager object literal** each time. If someone later
+   memoizes that manager for performance, this hook silently stops running. Leave a comment
+   at the `useThemeManager` return site saying so.
+2. The key can genuinely change with no render — OS flips while `System` is selected with a
+   *single* custom theme, where `updateAutoTheme` finds nothing to re-apply. No rerun fires,
+   which is **correct**, because a config-pinned theme makes `type` identical either way. The
+   invariant survives only because a preference change that fails to force a render is also
+   one the resolver ignores. Any future change that decouples those two — e.g. exposing
+   `st.context.theme.preference` (#11536), where preference alone becomes observable — breaks
+   it, and the trigger would then need an explicit hook on the `matchMedia` listener.
+
+Add a frontend test asserting the key is re-checked after a render caused by unrelated state,
+so a future memoization of the theme manager fails loudly instead of silently.
 
 **4. New method `maybeRerunForThemeChange`:**
 
 ```tsx
 private maybeRerunForThemeChange = (): void => {
-  const currentAppearance = hasLightBackgroundColor(
-    this.props.theme.activeTheme.emotion
-  ) ? "light" : "dark"
-
-  if (currentAppearance === this.lastRerunAppearance) return
+  if (this.getThemeResolutionKey() === this.lastSentThemeResolutionKey) {
+    // Nothing to correct — e.g. a queued rerun that a user-driven rerun already
+    // covered, since sendRerunBackMsg refreshes the resolution key.
+    this.pendingThemeRerun = false
+    return
+  }
   if (
     !this.isServerConnected() ||
-    this.state.scriptRunState === ScriptRunState.RUNNING ||
-    this.state.scriptRunState === ScriptRunState.RERUN_REQUESTED
+    // Mirror the drain condition exactly. Enumerating "busy" states would miss
+    // STOP_REQUESTED (script IS still running) and COMPILATION_ERROR.
+    this.state.scriptRunState !== ScriptRunState.NOT_RUNNING
   ) {
-    // Defer: fire once connected + idle
+    // Defer: fire once connected + idle.
     this.pendingThemeRerun = true
     return
   }
@@ -537,87 +729,150 @@ MPA safety: `sendUpdateWidgetsMessage(undefined)` passes no `pageScriptHash`, so
 `sendRerunBackMsg` falls through to `this.state.currentPageScriptHash` (the current
 page).
 
-**5. In `sendRerunBackMsg`, after the BackMsg is sent (~line 2243):**
+**5. In `sendRerunBackMsg`, after the BackMsg is sent:**
 
 ```tsx
-this.lastRerunAppearance = hasLightBackgroundColor(
-  this.props.theme.activeTheme.emotion
-) ? "light" : "dark"
+this.lastSentThemeResolutionKey = this.getThemeResolutionKey()
 ```
 
-#### Why `skipNextThemeUpdate` works across the React render boundary
+Every rerun — user-driven or theme-driven — refreshes the guard, so it always reflects
+what the backend was last told. This is also why an ordinary interaction absorbs a pending
+theme change for free instead of causing a second rerun.
 
-1. `processThemeInput` sets `skipNextThemeUpdate = true` synchronously.
-2. It calls `setAndSendTheme` → `this.props.theme.setTheme()` → triggers React state
-   update (batched).
-3. React schedules a re-render; `processThemeInput` returns; `handleNewSession`
-   continues.
-4. React flushes the batched state update → re-renders `ThemedApp` → new
-   `activeTheme` prop flows to `App`.
-5. `componentDidUpdate` fires for the new render — `skipNextThemeUpdate` is still
-   `true`.
-6. Flag is consumed and cleared. If no `pendingThemeRerun` is outstanding,
-   `lastRerunAppearance` is updated to the new appearance (ensures dedup guard
-   tracks the custom theme's visual state). If `pendingThemeRerun` IS set, the
-   guard is left stale so the subsequent drain can fire correctly.
+#### Why no suppression flag is needed
+
+Earlier drafts needed `skipNextThemeUpdate` because `processThemeInput` legitimately flips
+painted luminance when it applies a config.toml custom theme, and a luminance-diff trigger
+could not tell that apart from a user-initiated change. The resolution key has no such
+ambiguity: applying a config.toml theme changes neither the user's preference nor whether a
+host theme is painted, so the resolution key is identical before and after and nothing fires.
+The one case where `processThemeInput` *does* change the resolution key — clearing an active
+host theme — is precisely the case that must rerun.
+
+That removes the cross-render-boundary reasoning the flag design depended on (set a flag
+synchronously, let React batch, and rely on `componentDidUpdate` consuming it on exactly
+the right render). The only ordering requirement left is in `handleThemeMessage`, below.
 
 #### Why this does not regress MPA (failure mode analysis)
 
 | Old failure mode (PR #10972) | How this proposal avoids it |
 |---|---|
-| Fired on `processThemeInput` (preset → custom name change) | `skipNextThemeUpdate` suppresses the resulting `componentDidUpdate` |
-| Fired on page navigation (new `NewSession` → theme reapplication) | Page nav → `handleNewSession` → `processThemeInput` → flag set → suppressed |
-| Fired on reconnection | Same: reconnection → `handleNewSession` → `processThemeInput` → suppressed |
-| Used theme NAME comparison (fragile, changes for internal reasons) | Uses resolved APPEARANCE (luminance "light"/"dark") — only changes on actual appearance flip |
+| Fired on `processThemeInput` (preset → custom name change) | Applying a config.toml theme changes neither preference nor host-active, so the resolution key is unchanged and nothing fires — no flag required |
+| Fired on page navigation (new `NewSession` → theme reapplication) | Same: page nav re-applies the same config theme, resolution key unchanged |
+| Fired on reconnection | Same: reconnection re-applies the same config theme, resolution key unchanged |
+| Used theme NAME comparison (fragile, changes for internal reasons) | Uses the `(preference, hostThemeActive)` resolution key — the backend's actual resolution inputs, never derived from a theme name |
 | `sendRerunBackMsg()` without page context lost current page | `sendUpdateWidgetsMessage(undefined)` → `sendRerunBackMsg` uses `this.state.currentPageScriptHash` |
-| Theme change while script running was silently dropped | `pendingThemeRerun` records the intent; `componentDidUpdate` drains it once `scriptRunState` → `NOT_RUNNING` |
-| Infinite loops (theme change → rerun → NewSession → theme change → ...) | `lastRerunAppearance` updated after send; next `componentDidUpdate` sees no diff and short-circuits. Plus `processThemeInput` sets skip flag. |
+| Theme change while script running was silently dropped | `pendingThemeRerun` records the intent; `componentDidUpdate` drains it once connected and `NOT_RUNNING` |
+| Infinite loops (theme change → rerun → NewSession → theme change → ...) | `lastSentThemeResolutionKey` is refreshed on every send, and the `NewSession` that follows does not change the resolution key, so the next `componentDidUpdate` short-circuits |
 
 #### Scenario walkthrough
 
-| Scenario | Flow | Result |
-|----------|------|--------|
-| Initial load, custom dark theme | `processThemeInput` applies dark → `skip=true` → `componentDidUpdate` sees light→dark but skip is true → consumed, no rerun | Correct |
-| User toggles Dark in menu | `setAndSendTheme` → React re-renders → `componentDidUpdate` sees light→dark, `skip=false` → `maybeRerunForThemeChange()` fires | Correct |
-| MPA page navigation | `handleNewSession` → `processThemeInput` → `skip=true` → suppressed | Correct |
-| Host sends dark theme | `handleThemeMessage` → `setTheme()` → React re-renders → `componentDidUpdate` fires → rerun | Correct |
-| OS dark↔light while System selected | `updateAutoTheme` in `useThemeManager` → prop changes → `componentDidUpdate` fires → rerun | Correct |
-| Reconnection | Same path as initial load through `handleNewSession` → suppressed | Correct |
-| Script already running when theme changes | `maybeRerunForThemeChange` sees `RUNNING` → sets `pendingThemeRerun=true` → script finishes → `componentDidUpdate` sees `NOT_RUNNING` + pending → fires rerun | Correct |
-| Theme change while disconnected | `maybeRerunForThemeChange` sees `!isServerConnected()` → sets `pendingThemeRerun=true` → reconnect → `componentDidUpdate` drain sees connected + `NOT_RUNNING` + pending → fires rerun | Correct |
-| User switches away from host theme via menu | `setAndSendTheme` → active theme name changes → `isHostThemePainted()` returns false → next BackMsg sends `hostThemeActive=false` + menu preference → BE resumes config.toml resolution | Correct |
-| Appearance change while RUNNING + hash-changing `processThemeInput` | Theme flip sets `pendingThemeRerun=true` → script finishes → `NewSession` with different config theme → `processThemeInput` sets `skip=true` → `componentDidUpdate`: skip consumed but `lastRerunAppearance` NOT updated (pending guard) → drain fires → `currentAppearance !== lastRerunAppearance` → rerun sends | Correct |
+Resolution keys below are written `preference|hostThemeActive`.
 
-#### Minor modification to `handleThemeMessage`
+| Scenario | Resolution key: last sent → current | Result |
+|----------|-------------------------------|--------|
+| Initial load, custom dark theme, OS light | `light\|false` → `light\|false` (`processThemeInput` paints the config theme; preference unchanged) | No rerun — the first run already resolved `"dark"` from config.toml. Correct |
+| User toggles Dark in menu (presets) | `light\|false` → `dark\|false` | Rerun; BE returns `"dark"`. Correct |
+| MPA page navigation | unchanged | No rerun — deep link preserved (#11797). Correct |
+| Reconnection | unchanged | No rerun. Correct |
+| Host posts dark theme after `NewSession` | `light\|false` → `dark\|true` | Rerun; BE takes `theme_preference` directly. Correct |
+| Host theme painted before first BackMsg, then `NewSession` paints config | `dark\|true` → `light\|false` | Rerun; BE re-resolves from config.toml. Correct — **this is the case a luminance diff misses**, since both themes may paint the same luminance |
+| User switches away from host theme via menu | `dark\|true` → `light\|false` | `isHostThemePainted()` false by object identity; rerun; BE resumes config resolution. Correct |
+| User switches from host theme to a config.toml theme that shares `CUSTOM_THEME_NAME` | `dark\|true` → `light\|false` | Object identity separates them where a name comparison could not. Correct |
+| OS dark↔light while System selected | `light\|false` → `dark\|false` | `updateAutoTheme` re-applies the theme → `componentDidUpdate` → rerun. Correct |
+| Resolution key change while script is RUNNING | deferred | `pendingThemeRerun` set; `componentDidUpdate` drains it at `NOT_RUNNING`. Correct |
+| Resolution key change while disconnected | deferred | `pendingThemeRerun` set; drains on reconnect once `NOT_RUNNING`. Correct |
+| Resolution key change while RUNNING, then a hash-changing `processThemeInput` | pending stays set; the drain re-reads the *current* resolution key | Rerun fires if the resolution key still differs, no-ops if the config theme already made it match. Correct either way — no stale dedup guard to swallow it |
+| Menu Light↔Dark with a single custom theme (or OS flip while System) | `light\|false` → `dark\|false` | Rerun fires though `type` is unchanged — the accepted cost documented above |
 
-After applying the host theme, store the resolved preference and imported theme name for
-`isHostThemePainted()` / `getResolvedThemePreference()`:
+#### Required changes to `handleThemeMessage` (and `setImportedTheme`)
+
+`handleThemeMessage` has three branches today, and **all three** need to participate in
+the resolution key. Its current shape:
 
 ```tsx
-// Set BEFORE React flushes the batched state update from setTheme() above.
-// React 18 automatic batching ensures componentDidUpdate fires AFTER these
-// synchronous assignments, so isHostThemePainted() sees the correct state.
-this.hostThemePreference = hasLightBackgroundColor(newTheme.emotion)
-  ? "light" : "dark"
-this.hostImportedThemeName = newTheme.name  // used by isHostThemePainted()
+handleThemeMessage = (themeName?: PresetThemeName, theme?: ICustomThemeConfig): void => {
+  const [, lightTheme, darkTheme] = createPresetThemes()
+  const isUsingPresetTheme = isPresetTheme(this.props.theme.activeTheme)
+
+  if (themeName === lightTheme.name && isUsingPresetTheme) {
+    this.props.theme.setTheme(lightTheme)          // (1) host selects preset Light
+  } else if (themeName === darkTheme.name && isUsingPresetTheme) {
+    this.props.theme.setTheme(darkTheme)           // (2) host selects preset Dark
+  } else if (theme) {
+    this.props.theme.setImportedTheme(theme)       // (3) host pushes a custom theme
+  }
+}
 ```
+
+**Branches 1 and 2 (host picks a preset).** These are a host-driven equivalent of a menu
+selection, so they must write `themeSelection` — otherwise painted appearance changes
+while the resolution key does not, and `type` goes stale. Set
+`this.themeSelection = "Light"` / `"Dark"` alongside the existing `setTheme` call.
+
+**Branch 3 (host pushes a custom theme).** This is where the identity comparison needs the
+`ThemeConfig` object — and App cannot currently obtain it. `handleThemeMessage` receives
+the **proto** (`ICustomThemeConfig`), while the `ThemeConfig` is constructed inside the
+hook by `setImportedTheme`, which returns `void`:
+
+```ts
+// frontend/app/src/util/useThemeManager.ts
+setImportedTheme: (themeInfo: ICustomThemeConfig) => void
+```
+
+**So `setImportedTheme` must return the `ThemeConfig` it creates**, and App must store it:
+
+```tsx
+// Assign synchronously, before React flushes the state update that
+// setImportedTheme() queued, so that componentDidUpdate — which fires on the first
+// render after the host theme is applied — already sees both fields set.
+const hostTheme = this.props.theme.setImportedTheme(theme)
+this.hostThemePreference = hasLightBackgroundColor(hostTheme.emotion)
+  ? "light" : "dark"
+// Store the ThemeConfig OBJECT, not its name: host imports and config.toml single
+// custom themes share the CUSTOM_THEME_NAME constant, so only identity distinguishes
+// them (see §3).
+this.hostImportedTheme = hostTheme
+```
+
+The stored object must be the same one handed to `setTheme` inside the hook, since
+`isHostThemePainted()` compares it against `props.theme.activeTheme` by reference.
+
+The alternative — App building the theme itself via `createTheme(CUSTOM_THEME_NAME, new
+CustomThemeConfig(themeInfo))` and calling `setTheme` — is **rejected**: it bypasses
+`setImportedTheme`'s `setFonts(themeInfo)` call and would regress host font loading.
+
+#### Interface changes this requires
+
+Returning the theme changes the `ThemeManager` contract, so these are **in** scope (they
+were listed as untouched in an earlier draft):
+
+- `ThemeManager.setImportedTheme` — return type `void` → `ThemeConfig`
+- `useThemeManager`'s `setImportedTheme` implementation — return the `customTheme` it
+  already builds (a one-line change; `updateTheme` is unaffected)
 
 #### No changes needed to
 
-- `ThemeContext` or `ThemeManager` interface
-- `useThemeManager` hook (the `matchMedia` listener stays as-is)
+- `ThemeContext`
+- `useThemeManager`'s `matchMedia` listener
 - The `setTheme` prop passed through context (stays as `this.setAndSendTheme`)
-- `setAndSendTheme` (signature unchanged — when the user picks a different theme from
-  the menu, the active theme name changes, so `isHostThemePainted()` naturally returns
-  false without needing any code in `setAndSendTheme`)
+- `setAndSendTheme` (its signature is unchanged, and it must **not** write
+  `themeSelection` — see the field notes above. A menu selection installs a different
+  `ThemeConfig` object, so `isHostThemePainted()` returns false by identity without any
+  code here, even when the selected theme shares the `CUSTOM_THEME_NAME` name with the
+  host import.)
+- `componentDidUpdate`'s parameter list — the resolution key diff needs no previous props,
+  so `_prevProps` stays unused
 
 #### Key files
 
 - `frontend/app/src/App.tsx` — all implementation changes
-- `frontend/lib/src/theme/getColors.ts` — `hasLightBackgroundColor` (existing, used
-  for preference comparison)
-- `frontend/app/src/util/useThemeManager.ts` — contains `matchMedia` listener (no
-  changes; theme changes flow through props)
+- `frontend/lib/src/theme/getColors.ts` — `hasLightBackgroundColor` (existing, used to
+  derive `hostThemePreference` from the host theme's background)
+- `frontend/lib/src/util/utils.ts` — existing `isLightThemeInQueryParams` /
+  `isDarkThemeInQueryParams`, composed into `hasEmbedThemeOverride()`
+- `frontend/app/src/util/useThemeManager.ts` — `setImportedTheme` (host themes) and the
+  `matchMedia` listener (no changes; theme changes flow through props)
 
 ### 5. Docs
 
@@ -629,46 +884,72 @@ chosen product meaning. Drop stale first-load / settings caveats; keep CSS-overr
 **Python unit**
 
 - Resolver matrix matching the product behavior table (presets; single custom `base` /
-  hex / non-hex; light+dark sections; dual-theme forced variant `base` overrides
-  explicit section `base` (matching FE `handleSectionInheritance`); missing colors →
+  hex / non-hex; light+dark sections; dual-theme forced variant `base` overrides a `base`
+  inherited from `[theme]`, matching FE `handleSectionInheritance`; missing colors →
   preference).
 - Short hex forms: `#fff` → "light", `#000` → "dark", `#rgba` forms handled correctly.
-- `_is_hex_color` accepts lengths {4, 5, 7, 9} with valid hex digits; rejects
-  non-hex alphanumeric (e.g. `#ghijkl`) — stricter than config validation.
+- `_is_hex_color` accepts `#` followed by 3, 4, 6, or 8 hex digits (i.e. total string
+  lengths 4, 5, 7, 9 including the `#`); rejects non-hex alphanumeric such as `#ghijkl` —
+  stricter than config validation's `is_hex_color_like`.
 - `_hex_luminance` expands short forms correctly (e.g. `#abc` → `#aabbcc`).
 - Sidebar-only configs: `[theme.sidebar]` alone → "light" (regardless of preference);
   `[theme.light.sidebar]` alone → enters dual-theme path → returns preference.
-- `host_theme_active = true` → resolver returns `preference` directly, ignoring
-  config.toml (even if config has conflicting `[theme] base="light"`).
+- `host_theme_active = true` → **`request_rerun`** sets `color_scheme` from
+  `theme_preference` directly and never calls `resolve_theme_type`, even when config has a
+  conflicting `[theme] base="light"`. (This bypass lives in `request_rerun`, not in the
+  resolver — `resolve_theme_type(preference)` takes no `host_theme_active` argument.)
+- Non-hex `backgroundColor`: `"black"` / `"rgb(0,0,0)"` currently fall through to the
+  fallback. Assert whatever behavior open question 5 settles on, and until then pin the
+  known-wrong result so the gap is visible in the suite rather than silent.
 - `_has_section_content` returns False for all-None dicts (registered but unset).
 - `request_rerun` resolves on `_client_state` (not the incoming `client_state`) for
   full and fragment paths; verify server-initiated reruns also use resolved value.
 
 **Frontend unit**
 
-- Preference serialization (System→OS, Light, Dark, embed query, host theme); not
-  from remapped custom theme name.
-- `componentDidUpdate` appearance-diff: fires rerun on light↔dark flip; suppressed
-  when `skipNextThemeUpdate` is set; no-op when `lastRerunAppearance` matches;
-  deferred when script is running.
-- `pendingThemeRerun`: theme change during `RUNNING` or disconnect sets pending;
-  drain when connected + `NOT_RUNNING` by calling `maybeRerunForThemeChange`.
-- `processThemeInput` sets `skipNextThemeUpdate` — verify that `componentDidUpdate`
-  after `handleNewSession` / page navigation does NOT trigger rerun.
-- Skip consumption updates `lastRerunAppearance` to the new appearance — verify that a
-  subsequent toggle back to the pre-custom-theme appearance still fires a rerun (dedup
-  guard is not stale).
-- Skip consumption does NOT update `lastRerunAppearance` when `pendingThemeRerun` is
-  true — verify that an appearance change deferred while RUNNING, followed by a
-  hash-changing `processThemeInput`, still fires once idle (the pending guard prevents
-  the dedup from swallowing the drain).
-- `handleThemeMessage` stores `hostThemePreference` and `hostImportedThemeName`;
-  `getResolvedThemePreference()` returns host preference only when
-  `isHostThemePainted()` is true; falls through to menu/OS otherwise.
-- `isHostThemePainted()` returns false after user selects a different theme from
-  the menu (non-sticky host activation).
-- `getResolvedThemePreference()` does NOT return stale `hostThemePreference` after
-  user selects different theme from menu (guards on `isHostThemePainted()`).
+- Preference serialization (System→OS, Light, Dark, embed query, host theme); never
+  derived from a remapped custom theme name.
+- `getThemeResolutionKey()`: reflects `(getResolvedThemePreference(), isHostThemePainted())`;
+  changes when either input changes and is stable otherwise.
+- `componentDidUpdate` resolution key diff: fires a rerun when the resolution key differs from
+  `lastSentThemeResolutionKey`; no-op when it matches; defers when running or disconnected.
+- `sendRerunBackMsg` refreshes `lastSentThemeResolutionKey`, so a user-driven rerun absorbs a
+  pending theme change instead of causing a second rerun.
+- `pendingThemeRerun`: a resolution key change during `RUNNING` or while disconnected sets
+  pending; the drain fires once connected + `NOT_RUNNING`; the drain re-reads the current
+  resolution key and no-ops if it has since converged.
+- **MPA regression:** `processThemeInput` during `handleNewSession` / page navigation
+  leaves the resolution key unchanged, so `componentDidUpdate` must NOT trigger a rerun — with
+  no suppression flag involved.
+- **Host ordering A (host before first BackMsg):** host theme applied, first BackMsg
+  carries `hostThemeActive=true`; then `processThemeInput` paints the config theme and
+  clears the host fields → resolution key flips → exactly one rerun fires with
+  `hostThemeActive=false`. Assert the rerun happens **even when both themes paint the same
+  luminance**, which is the case a luminance diff missed.
+- **Host ordering B (host after `NewSession`):** `handleThemeMessage` applies the host
+  theme → resolution key flips → one rerun with `hostThemeActive=true`.
+- `handleThemeMessage` stores `hostThemePreference` and the `hostImportedTheme` **object**;
+  `getResolvedThemePreference()` returns the host preference only when
+  `isHostThemePainted()` is true, and falls through to menu/OS otherwise.
+- **Identity, not name:** with a config.toml single `[theme]` *and* a host import — both
+  named `CUSTOM_THEME_NAME` — selecting the config theme from the menu makes
+  `isHostThemePainted()` false and stops the stale host preference from being sent.
+- `isHostThemePainted()` is false when an embed theme override is present, even while a
+  host theme object is stored.
+- **`themeSelection` write sites (guards the MPA regression):** a `processThemeInput` call
+  that internally invokes `setAndSendTheme` must NOT change `themeSelection`, so the
+  resolution key is unchanged and no rerun fires. Cover the concrete trap: a cached `"Dark"`
+  selection plus a single `[theme]` config, where `getPreferredTheme` finds no match and
+  `processThemeInput` applies `customThemes[0]` — assert `themeSelection` stays `"Dark"` and
+  no BackMsg is sent.
+- **`handleThemeMessage` preset branches:** a host posting `themeName` Light/Dark while a
+  preset is active updates `themeSelection`, flips the resolution key, and fires exactly one
+  rerun.
+- **Deferral covers every non-idle state:** a resolution key change during `STOP_REQUESTED`
+  and `COMPILATION_ERROR` defers rather than firing immediately, matching the drain's
+  `NOT_RUNNING` condition.
+- `setImportedTheme` returns the created `ThemeConfig`, and `handleThemeMessage` stores that
+  exact object (identity, not a copy).
 - Regression: theme **name** change alone must not call `sendRerunBackMsg`.
 
 **E2E** (`make run-e2e-test`)
@@ -677,6 +958,9 @@ chosen product meaning. Drop stale first-load / settings caveats; keep CSS-overr
   `type: dark`.
 - MPA deep link + `[theme]` lands on target page (#11797).
 - Main-menu Light↔Dark updates `type` without manual rerun.
+- Host theme **and** a config.toml `[theme]` both present: `type` follows whichever theme
+  is painted, and switching between them via the menu updates `type` without a manual
+  rerun (covers the shared-`CUSTOM_THEME_NAME` case).
 - Re-enable
   [`test_st_context_theme_respects_dark_theme_message`](../../e2e_playwright/hostframe_app_test.py)
   (skipped since #11870). No new CI host environment — this is an existing Playwright
@@ -717,19 +1001,25 @@ BE work.
 
 | Risk | Mitigation |
 |------|------------|
-| Auto-rerun reintroduces #11797 | `skipNextThemeUpdate` suppresses `processThemeInput` renders; appearance-diff (not name); `sendUpdateWidgetsMessage` preserves page context; MPA E2E required |
+| Auto-rerun reintroduces #11797 | Resolution key diff on `(preference, hostThemeActive)`, which `processThemeInput` and page navigation do not change — so no suppression flag is needed and there is no flag-timing failure mode; `sendUpdateWidgetsMessage` preserves page context; MPA E2E required |
 | BE luminance disagrees with FE | Use identical WCAG formula (sRGB linearization + BT.709, threshold `> 0.5`); normalize all hex forms (#rgb/#rgba/#rrggbb/#rrggbbaa); cross-check unit test against FE boundary values; fall back to `base`/preference for non-hex |
+| **Resolver drifts from FE theme logic** | The resolver is a second implementation of rules the FE already owns (section inheritance, forced variant `base`, sidebar-only handling, luminance). Every future change to FE theme resolution needs a matching Python change, and the cross-check unit test is the only guard. Keep the resolver small, keep its test matrix aligned with the product behavior table, and reference `handleSectionInheritance` from the module docstring |
+| Stale host theme forced onto the BE | `isHostThemePainted()` compares the active theme by **object identity** — host imports and config.toml single custom themes share the `CUSTOM_THEME_NAME` constant, so a name comparison would leak stale host preference; `processThemeInput` also clears the host fields |
 | Preference tracking drifts after `processThemeInput` | Track explicit `ThemeSelection`, never reverse from theme name |
-| Host/SiS theme messages ignored | Explicit `handleThemeMessage` path; re-enable hostframe E2E |
-| Option A/B chosen late | §2 resolver is the primary rewrite. However, Option A also requires §4 trigger/dedup redesign: a preference change that does NOT flip painted luminance (e.g. Light→Dark with a single dark custom theme) must still trigger a rerun under A, so the auto-rerun dimension would need to track preference-diff (or dual-track preference + appearance), not only appearance-diff. Proto stays either way. |
+| Host/SiS theme messages ignored | Explicit `handleThemeMessage` path; both arrival orderings specified in §3; re-enable hostframe E2E |
+| Redundant reruns when config pins the answer | Accepted: a preference change the resolver ignores (single custom theme) still reruns once. Bounded to one rerun per explicit change; suppressing it would require duplicating the resolver on the FE |
+| Option A/B chosen late | §2 resolver is the only significant rewrite. Because §4 keys on preference rather than painted luminance, Option A needs **no** trigger redesign — a preference change already fires a rerun. Proto stays either way |
 
 ## Out of scope
 
 - Full theme config on `st.context.theme` ([#11536](https://github.com/streamlit/streamlit/issues/11536)).
 - Programmatic theme setters at runtime ([#14172](https://github.com/streamlit/streamlit/issues/14172)).
 - Full Emotion theme build on the backend.
-- Non-hex CSS color parsing for luminance (named colors like `"red"`, `hsl()`, etc. —
-  only hex forms accepted by config validation are handled).
+- Non-hex CSS color parsing for luminance (named colors like `"red"`, `rgb()`, `hsl()`).
+  Only hex forms are handled. Note these values **are** accepted by config today — there is
+  no hex validation on theme color options — so this is a known gap with a wrong-answer
+  consequence, not merely an unsupported input. See the limitation in §2 and product spec
+  open question 5.
 - CSS-injected backgrounds affecting `type`.
 
 ## Checklist

--- a/specs/2026-08-08-st-context-theme-type/tech-spec.md
+++ b/specs/2026-08-08-st-context-theme-type/tech-spec.md
@@ -122,7 +122,7 @@ def resolve_theme_type(
 
     if _has_section_content(light) or _has_section_content(dark):
         section = dark if preference == "dark" else light
-        merged = _merge_for_dual_theme(theme, section)
+        merged = _merge_for_dual_theme(theme, section, variant=preference)
         # fallback = preference (which equals the section variant name, e.g.
         # "dark" for [theme.dark]) — mirrors the FE behavior where selecting
         # the dark section implies dark appearance when no explicit base/bg.
@@ -133,30 +133,34 @@ def resolve_theme_type(
     return _type_from_bg_or_base(theme, fallback="light")
 
 
-def _merge_for_dual_theme(parent: dict, section: dict) -> dict:
+def _merge_for_dual_theme(parent: dict, section: dict, *, variant: str) -> dict:
     """Merge parent [theme] into a light/dark section for type resolution.
 
     Section values override parent (mirrors frontend handleSectionInheritance).
-    Parent's `base` is explicitly DROPPED — the FE never inherits `base` from
-    [theme] into a section. If the section explicitly sets `base`, that is kept.
-    If neither section nor parent provides `base`, the caller's `fallback`
-    parameter (= section variant name) provides the final answer.
+    After merging, `base` is ALWAYS forced to the section variant name —
+    matching the FE, which unconditionally sets `base` from the variant last
+    (overriding both parent and any explicit section `base`). This means a
+    pathological `[theme.dark] base="light"` still gets `base="dark"` — the FE
+    paints dark, so the resolver must agree.
+
+    The only way to override `base` in dual themes is via `backgroundColor`
+    luminance (priority 1 in `_type_from_bg_or_base`).
 
     This ensures:
-    - [theme] base="light" + [theme.dark] primaryColor="..." (no base in
-      section) → parent base dropped → no base in merged → fallback "dark"
-      (= preference = section variant). Correct.
-    - [theme.dark] backgroundColor="#ffffff" (pathological) → parent base
-      dropped → bg luminance → "light" (what is painted). Correct.
-    - [theme.dark] base="dark" → section's explicit base is kept. Correct.
+    - [theme] base="light" + [theme.dark] primaryColor="..." → base forced to
+      "dark" (variant) → resolver returns "dark". Correct.
+    - [theme.dark] backgroundColor="#ffffff" (pathological) → bg luminance →
+      "light" (what is painted, overrides forced base). Correct.
+    - [theme.dark] base="light" (contradictory) → base forced to "dark"
+      (variant, matching FE). Correct — FE paints dark.
     """
     # Filter None values — get_options_for_section includes all registered keys
     # even when unset. Only non-None values represent user-provided config.
     parent_set = {k: v for k, v in parent.items() if v is not None}
     section_set = {k: v for k, v in section.items() if v is not None}
     merged = {**parent_set, **section_set}
-    if "base" not in section_set:
-        merged.pop("base", None)
+    # Force base from variant — matches FE handleSectionInheritance
+    merged["base"] = variant
     return merged
 
 
@@ -191,11 +195,22 @@ A bare `[theme.dark]` header with no keys underneath has all-None values → ret
 False. This matches the FE's behavior, which also requires at least one key to trigger
 dual-theme mode.
 
+**`_has_any_theme_config`** is a simple OR over the three sections:
+
+```python
+def _has_any_theme_config(theme: dict, light: dict, dark: dict) -> bool:
+    return (
+        _has_section_content(theme)
+        or _has_section_content(light)
+        or _has_section_content(dark)
+    )
+```
+
 | Config shape | How to get `type` (Option C) |
 |--------------|------------------------------|
 | No custom theme (presets) | Return `preference` |
 | Single `[theme]` only | `_type_from_bg_or_base` with `fallback="light"` (FE default) |
-| `[theme.light]` and/or `[theme.dark]` | Pick section from `preference`, drop parent `base`, then `_type_from_bg_or_base` with `fallback=preference` (= section variant name) |
+| `[theme.light]` and/or `[theme.dark]` | Pick section from `preference`, force `base=variant` (matching FE), then `_type_from_bg_or_base` with `fallback=preference` (= section variant name) |
 
 Wire in [`app_session.request_rerun`](../../lib/streamlit/runtime/app_session.py) after
 copying client `context_info` into `RerunData`. **Resolution targets the cached
@@ -274,20 +289,22 @@ BE remains correct and `hostThemeActive` must be false.
 1. Existing embed query options `embed_options=light_theme` /
    `embed_options=dark_theme` (already used by host embedding — not a new protocol)
    if present.
-2. Host-provided custom theme (`SET_CUSTOM_THEME_CONFIG` / `handleThemeMessage`) →
-   resolve appearance from `themeInfo.backgroundColor` luminance. Store as
-   `hostThemePreference` (and `hostImportedThemeName`) on the App instance in
-   `handleThemeMessage` after applying the theme. This covers SiS / Cloud hosts that
-   push themes without going through the menu or embed queries.
+2. Host-provided custom theme — **only when `isHostThemePainted()` is true** (the host
+   theme is still the active rendered theme). Returns `hostThemePreference` (stored in
+   `handleThemeMessage` from `themeInfo.backgroundColor` luminance). If
+   `isHostThemePainted()` is false, this step is skipped even if `hostThemePreference`
+   is non-null — prevents stale host preference from leaking after the user picks a
+   different theme from the menu.
 3. Else tracked `ThemeSelection` (`Light` / `Dark` / `System`), with
    `System` → `getSystemThemePreference()`.
 4. `getCachedThemeSelection()` only for initial hydrate.
 
-`getResolvedThemePreference()` checks these in order: embed query → host override →
+`getResolvedThemePreference()` checks in order: embed query → host (if painted) →
 menu/OS selection.
 
-Maintain `lastRerunAppearance` on the App instance (see §4 for semantics); update it
-with painted luminance whenever a rerun BackMsg is sent. Keep sending `colorScheme` for
+Maintain `lastRerunAppearance` on the App instance (see §4 `lastRerunAppearance`
+definition for dedup semantics); update it with painted luminance whenever a rerun
+BackMsg is sent. Keep sending `colorScheme` for
 back-compat if useful; BE overwrites when `theme_preference` is present.
 
 **Backward compatibility:** New backend + old frontend (no `theme_preference`) leaves
@@ -390,11 +407,17 @@ if (prevAppearance !== currAppearance && !this.skipNextThemeUpdate) {
 }
 if (this.skipNextThemeUpdate) {
   this.skipNextThemeUpdate = false
+  // Update dedup guard to match what the script currently sees (the custom theme
+  // just applied by processThemeInput). Without this, lastRerunAppearance stays at
+  // the initial preset value, and a later toggle back to that appearance would be
+  // incorrectly suppressed by the dedup guard.
+  this.lastRerunAppearance = currAppearance
 }
 
-// --- Drain pending theme rerun when script becomes idle ---
+// --- Drain pending theme rerun when connected + idle ---
 if (
   this.pendingThemeRerun &&
+  this.isServerConnected() &&
   this.state.scriptRunState === ScriptRunState.NOT_RUNNING
 ) {
   this.pendingThemeRerun = false
@@ -411,11 +434,12 @@ private maybeRerunForThemeChange = (): void => {
   ) ? "light" : "dark"
 
   if (currentAppearance === this.lastRerunAppearance) return
-  if (!this.isServerConnected()) return
   if (
+    !this.isServerConnected() ||
     this.state.scriptRunState === ScriptRunState.RUNNING ||
     this.state.scriptRunState === ScriptRunState.RERUN_REQUESTED
   ) {
+    // Defer: fire once connected + idle
     this.pendingThemeRerun = true
     return
   }
@@ -448,7 +472,8 @@ this.lastRerunAppearance = hasLightBackgroundColor(
    `activeTheme` prop flows to `App`.
 5. `componentDidUpdate` fires for the new render — `skipNextThemeUpdate` is still
    `true`.
-6. Flag is consumed and cleared.
+6. Flag is consumed, cleared, and `lastRerunAppearance` is updated to the new
+   appearance (ensures dedup guard tracks the custom theme's visual state).
 
 #### Why this does not regress MPA (failure mode analysis)
 
@@ -457,7 +482,7 @@ this.lastRerunAppearance = hasLightBackgroundColor(
 | Fired on `processThemeInput` (preset → custom name change) | `skipNextThemeUpdate` suppresses the resulting `componentDidUpdate` |
 | Fired on page navigation (new `NewSession` → theme reapplication) | Page nav → `handleNewSession` → `processThemeInput` → flag set → suppressed |
 | Fired on reconnection | Same: reconnection → `handleNewSession` → `processThemeInput` → suppressed |
-| Used theme NAME comparison (fragile, changes for internal reasons) | Uses resolved PREFERENCE (luminance "light"/"dark") — only changes on actual appearance flip |
+| Used theme NAME comparison (fragile, changes for internal reasons) | Uses resolved APPEARANCE (luminance "light"/"dark") — only changes on actual appearance flip |
 | `sendRerunBackMsg()` without page context lost current page | `sendUpdateWidgetsMessage(undefined)` → `sendRerunBackMsg` uses `this.state.currentPageScriptHash` |
 | Theme change while script running was silently dropped | `pendingThemeRerun` records the intent; `componentDidUpdate` drains it once `scriptRunState` → `NOT_RUNNING` |
 | Infinite loops (theme change → rerun → NewSession → theme change → ...) | `lastRerunAppearance` updated after send; next `componentDidUpdate` sees no diff and short-circuits. Plus `processThemeInput` sets skip flag. |
@@ -473,6 +498,8 @@ this.lastRerunAppearance = hasLightBackgroundColor(
 | OS dark↔light while System selected | `updateAutoTheme` in `useThemeManager` → prop changes → `componentDidUpdate` fires → rerun | Correct |
 | Reconnection | Same path as initial load through `handleNewSession` → suppressed | Correct |
 | Script already running when theme changes | `maybeRerunForThemeChange` sees `RUNNING` → sets `pendingThemeRerun=true` → script finishes → `componentDidUpdate` sees `NOT_RUNNING` + pending → fires rerun | Correct |
+| Theme change while disconnected | `maybeRerunForThemeChange` sees `!isServerConnected()` → sets `pendingThemeRerun=true` → reconnect → `componentDidUpdate` drain sees connected + `NOT_RUNNING` + pending → fires rerun | Correct |
+| User switches away from host theme via menu | `setAndSendTheme` → active theme name changes → `isHostThemePainted()` returns false → next BackMsg sends `hostThemeActive=false` + menu preference → BE resumes config.toml resolution | Correct |
 
 #### Minor modification to `handleThemeMessage`
 
@@ -480,6 +507,9 @@ After applying the host theme, store the resolved preference and imported theme 
 `isHostThemePainted()` / `getResolvedThemePreference()`:
 
 ```tsx
+// Set BEFORE React flushes the batched state update from setTheme() above.
+// React 18 automatic batching ensures componentDidUpdate fires AFTER these
+// synchronous assignments, so isHostThemePainted() sees the correct state.
 this.hostThemePreference = hasLightBackgroundColor(newTheme.emotion)
   ? "light" : "dark"
 this.hostImportedThemeName = newTheme.name  // used by isHostThemePainted()
@@ -512,8 +542,9 @@ chosen product meaning. Drop stale first-load / settings caveats; keep CSS-overr
 **Python unit**
 
 - Resolver matrix matching the product behavior table (presets; single custom `base` /
-  hex / non-hex; light+dark sections; section-wins inheritance merge; parent `base`
-  does not override section; missing colors → preference).
+  hex / non-hex; light+dark sections; dual-theme forced variant `base` overrides
+  explicit section `base` (matching FE `handleSectionInheritance`); missing colors →
+  preference).
 - `host_theme_active = true` → resolver returns `preference` directly, ignoring
   config.toml (even if config has conflicting `[theme] base="light"`).
 - `_has_section_content` returns False for all-None dicts (registered but unset).
@@ -527,16 +558,20 @@ chosen product meaning. Drop stale first-load / settings caveats; keep CSS-overr
 - `componentDidUpdate` appearance-diff: fires rerun on light↔dark flip; suppressed
   when `skipNextThemeUpdate` is set; no-op when `lastRerunAppearance` matches;
   deferred when script is running.
-- `pendingThemeRerun`: theme change during `RUNNING` sets pending; transition to
-  `NOT_RUNNING` drains it by calling `maybeRerunForThemeChange`.
+- `pendingThemeRerun`: theme change during `RUNNING` or disconnect sets pending;
+  drain when connected + `NOT_RUNNING` by calling `maybeRerunForThemeChange`.
 - `processThemeInput` sets `skipNextThemeUpdate` — verify that `componentDidUpdate`
   after `handleNewSession` / page navigation does NOT trigger rerun.
+- Skip consumption updates `lastRerunAppearance` to the new appearance — verify that a
+  subsequent toggle back to the pre-custom-theme appearance still fires a rerun (dedup
+  guard is not stale).
 - `handleThemeMessage` stores `hostThemePreference` and `hostImportedThemeName`;
-  `getResolvedThemePreference()` returns host preference when set;
-  `isHostThemePainted()` returns true only when active theme matches
-  `hostImportedThemeName`.
+  `getResolvedThemePreference()` returns host preference only when
+  `isHostThemePainted()` is true; falls through to menu/OS otherwise.
 - `isHostThemePainted()` returns false after user selects a different theme from
   the menu (non-sticky host activation).
+- `getResolvedThemePreference()` does NOT return stale `hostThemePreference` after
+  user selects different theme from menu (guards on `isHostThemePainted()`).
 - Regression: theme **name** change alone must not call `sendRerunBackMsg`.
 
 **E2E** (`make run-e2e-test`)

--- a/specs/2026-08-08-st-context-theme-type/tech-spec.md
+++ b/specs/2026-08-08-st-context-theme-type/tech-spec.md
@@ -103,7 +103,9 @@ sent, so existing deployed frontends against a new backend do not regress.
 Add `lib/streamlit/runtime/theme_type.py` (sketch under Option C):
 
 ```python
-def resolve_theme_type(preference: Literal["light", "dark"]) -> Literal["light", "dark"]:
+def resolve_theme_type(
+    preference: Literal["light", "dark"],
+) -> Literal["light", "dark"]:
     theme = config.get_options_for_section("theme")
     light = config.get_options_for_section("theme.light")
     dark = config.get_options_for_section("theme.dark")
@@ -183,61 +185,137 @@ new, BE overwrites `color_scheme` from preference + config.
 
 ### 4. MPA-safe auto-rerun on appearance change
 
-#### Hard invariant (source allowlist + preference ref)
+#### Design: unified `componentDidUpdate` preference-diff with suppression flag
 
-```text
-Auto-rerun fires ONLY when BOTH:
-  (a) resolved theme_preference !== lastSentThemePreference, AND
-  (b) trigger source is an intentional appearance action:
-        - main menu / settings Light|Dark|System toggle
-        - handleThemeMessage (host)
-        - OS matchMedia change while selection is System
-      NEVER as a side-effect of processThemeInput, handleNewSession,
-      or any setAndSendTheme call initiated from those paths.
+All three trigger sources (menu toggle, host message, OS preference change) produce
+the same observable: `props.theme.activeTheme` changes its visual appearance in
+`App.tsx`. A single `componentDidUpdate` check handles all three. The only path to
+suppress is `processThemeInput` (called during `handleNewSession`).
+
+#### Implementation (4 touch points in `App.tsx`)
+
+**1. Two instance fields:**
+
+```tsx
+private lastSentThemePreference: "light" | "dark" | null = null
+private skipNextThemeUpdate: boolean = false
 ```
 
-Sketch:
+- `lastSentThemePreference` — tracks the preference sent in the last
+  `sendRerunBackMsg`. Prevents duplicate reruns and handles edge cases where
+  appearance does not actually change.
+- `skipNextThemeUpdate` — set by `processThemeInput` when it applies a server-sent
+  custom theme. Consumed (cleared) by the next `componentDidUpdate` to prevent that
+  render from triggering an auto-rerun.
 
-```ts
-maybeRerunForThemePreference = (source: "menu" | "host" | "os"): void => {
-  if (this.suppressThemeRerun) return // belt-and-suspenders during NewSession
-  const next = this.getResolvedThemePreference()
-  if (next === this.lastSentThemePreference) return
-  this.sendRerunBackMsg(
-    this.state.widgetStates,
-    undefined, // fragmentId — full script
-    this.state.currentPageScriptHash,
-    /* pageName / query from current URL state */
-  )
+**2. In `processThemeInput`, after the hash-check early return (~line 1738), before
+`this.setState`:**
+
+```tsx
+this.skipNextThemeUpdate = true
+```
+
+Only set when the theme actually changes (hash differs), so it will not stick around
+to suppress a later legitimate change.
+
+**3. In `componentDidUpdate`, appended after the existing `scriptRunState` handling:**
+
+```tsx
+const prevPreference = hasLightBackgroundColor(prevProps.theme.activeTheme.emotion)
+  ? "light" : "dark"
+const currPreference = hasLightBackgroundColor(this.props.theme.activeTheme.emotion)
+  ? "light" : "dark"
+
+if (prevPreference !== currPreference && !this.skipNextThemeUpdate) {
+  this.maybeRerunForThemeChange()
 }
-
-// Allowlisted call sites only — NOT the end of setAndSendTheme:
-// - menu/settings handler after updating tracked ThemeSelection
-// - handleThemeMessage after mapping host light/dark → selection
-// - matchMedia listener when selection === "System"
+if (this.skipNextThemeUpdate) {
+  this.skipNextThemeUpdate = false
+}
 ```
 
-#### Why preference-diff alone is not enough
+**4. New method `maybeRerunForThemeChange`:**
 
-`processThemeInput` calls `setAndSendTheme` on every NewSession. An ungated hook inside
-`setAndSendTheme` would fire on connect/nav/reconnect.
+```tsx
+private maybeRerunForThemeChange = (): void => {
+  const currentPreference = hasLightBackgroundColor(
+    this.props.theme.activeTheme.emotion
+  ) ? "light" : "dark"
 
-- **NewSession / first connect:** preference already sent; BE resolved `type`; preference
-  unchanged after paint → **no** second rerun (avoids #11797).
-- **Intentional toggle on MPA Page B:** preference changes → auto-rerun must send
-  current `pageScriptHash` / page name / query from live App state **synchronously**
-  (no debounce that can observe stale page state).
+  if (currentPreference === this.lastSentThemePreference) return
+  if (!this.isServerConnected()) return
+  if (
+    this.state.scriptRunState === ScriptRunState.RUNNING ||
+    this.state.scriptRunState === ScriptRunState.RERUN_REQUESTED
+  ) return
 
-#### Implementation commitments
+  this.widgetMgr.sendUpdateWidgetsMessage(undefined)
+}
+```
 
-1. Compare **preference only**, never theme name / FE luminance.
-2. **Do not** put an ungated auto-rerun at the end of `setAndSendTheme`. Prefer
-   allowlisted call sites, or an explicit `rerunOnPreferenceChange` flag that NewSession
-   never sets.
-3. `suppressThemeRerun` around `handleNewSession` / `processThemeInput` is a backstop,
-   not the sole defense.
-4. Update [`handleThemeMessage`](../../frontend/app/src/App.tsx) — today visual-only.
-5. **Do not restore** name-based `componentDidUpdate` reruns.
+MPA safety: `sendUpdateWidgetsMessage(undefined)` passes no `pageScriptHash`, so
+`sendRerunBackMsg` falls through to `this.state.currentPageScriptHash` (the current
+page).
+
+**5. In `sendRerunBackMsg`, after the BackMsg is sent (~line 2243):**
+
+```tsx
+this.lastSentThemePreference = hasLightBackgroundColor(
+  this.props.theme.activeTheme.emotion
+) ? "light" : "dark"
+```
+
+#### Why `skipNextThemeUpdate` works across the React render boundary
+
+1. `processThemeInput` sets `skipNextThemeUpdate = true` synchronously.
+2. It calls `setAndSendTheme` → `this.props.theme.setTheme()` → triggers React state
+   update (batched).
+3. React schedules a re-render; `processThemeInput` returns; `handleNewSession`
+   continues.
+4. React flushes the batched state update → re-renders `ThemedApp` → new
+   `activeTheme` prop flows to `App`.
+5. `componentDidUpdate` fires for the new render — `skipNextThemeUpdate` is still
+   `true`.
+6. Flag is consumed and cleared.
+
+#### Why this does not regress MPA (failure mode analysis)
+
+| Old failure mode (PR #10972) | How this proposal avoids it |
+|---|---|
+| Fired on `processThemeInput` (preset → custom name change) | `skipNextThemeUpdate` suppresses the resulting `componentDidUpdate` |
+| Fired on page navigation (new `NewSession` → theme reapplication) | Page nav → `handleNewSession` → `processThemeInput` → flag set → suppressed |
+| Fired on reconnection | Same: reconnection → `handleNewSession` → `processThemeInput` → suppressed |
+| Used theme NAME comparison (fragile, changes for internal reasons) | Uses resolved PREFERENCE (luminance "light"/"dark") — only changes on actual appearance flip |
+| `sendRerunBackMsg()` without page context lost current page | `sendUpdateWidgetsMessage(undefined)` → `sendRerunBackMsg` uses `this.state.currentPageScriptHash` |
+| Infinite loops (theme change → rerun → NewSession → theme change → ...) | `lastSentThemePreference` updated after send; next `componentDidUpdate` sees no diff and short-circuits. Plus `processThemeInput` sets skip flag. |
+
+#### Scenario walkthrough
+
+| Scenario | Flow | Result |
+|----------|------|--------|
+| Initial load, custom dark theme | `processThemeInput` applies dark → `skip=true` → `componentDidUpdate` sees light→dark but skip is true → consumed, no rerun | Correct |
+| User toggles Dark in menu | `setAndSendTheme` → React re-renders → `componentDidUpdate` sees light→dark, `skip=false` → `maybeRerunForThemeChange()` fires | Correct |
+| MPA page navigation | `handleNewSession` → `processThemeInput` → `skip=true` → suppressed | Correct |
+| Host sends dark theme | `handleThemeMessage` → `setTheme()` → React re-renders → `componentDidUpdate` fires → rerun | Correct |
+| OS dark↔light while System selected | `updateAutoTheme` in `useThemeManager` → prop changes → `componentDidUpdate` fires → rerun | Correct |
+| Reconnection | Same path as initial load through `handleNewSession` → suppressed | Correct |
+| Script already running when theme changes | `maybeRerunForThemeChange` sees `RUNNING` → returns without firing | Correct |
+
+#### No changes needed to
+
+- `setAndSendTheme` (signature unchanged)
+- `handleThemeMessage` (no modification)
+- `ThemeContext` or `ThemeManager` interface
+- `useThemeManager` hook (the `matchMedia` listener stays as-is)
+- The `setTheme` prop passed through context (stays as `this.setAndSendTheme`)
+
+#### Key files
+
+- `frontend/app/src/App.tsx` — all implementation changes
+- `frontend/lib/src/theme/getColors.ts` — `hasLightBackgroundColor` (existing, used
+  for preference comparison)
+- `frontend/app/src/util/useThemeManager.ts` — contains `matchMedia` listener (no
+  changes; theme changes flow through props)
 
 ### 5. Docs
 
@@ -256,9 +334,11 @@ chosen product meaning. Drop stale first-load / settings caveats; keep CSS-overr
 
 - Preference serialization (System→OS, Light, Dark, host query); not from remapped
   custom theme name.
-- `maybeRerunForThemePreference`: allowlisted sources only; no-op when preference
-  unchanged; **no** rerun from `processThemeInput` / `handleNewSession`; page hash /
-  name / query from current state.
+- `componentDidUpdate` preference-diff: fires rerun on light↔dark flip; suppressed
+  when `skipNextThemeUpdate` is set; no-op when `lastSentThemePreference` matches;
+  no-op when script is running.
+- `processThemeInput` sets `skipNextThemeUpdate` — verify that `componentDidUpdate`
+  after `handleNewSession` / page navigation does NOT trigger rerun.
 - Regression: theme **name** change alone must not call `sendRerunBackMsg`.
 
 **E2E** (`make run-e2e-test`)
@@ -306,7 +386,7 @@ BE work.
 
 | Risk | Mitigation |
 |------|------------|
-| Auto-rerun reintroduces #11797 | Source allowlist + preference-diff + sync page hash; MPA E2E required |
+| Auto-rerun reintroduces #11797 | `skipNextThemeUpdate` suppresses `processThemeInput` renders; preference-diff (not name); `sendUpdateWidgetsMessage` preserves page context; MPA E2E required |
 | BE luminance disagrees with FE | Prefer `base`; hex-only luminance; fall back to preference |
 | Preference tracking drifts after `processThemeInput` | Track explicit `ThemeSelection`, never reverse from theme name |
 | Host/SiS theme messages ignored | Explicit `handleThemeMessage` path; re-enable hostframe E2E |

--- a/specs/2026-08-08-st-context-theme-type/tech-spec.md
+++ b/specs/2026-08-08-st-context-theme-type/tech-spec.md
@@ -22,7 +22,7 @@ Fix `st.context.theme.type` with a two-way exchange:
 
 Point 4 matters as much as the rest. `st.context.theme.type` is read by roughly **0.6% of
 apps**, so a correction mechanism that fired for everyone would charge the other 99.4% for a
-value they never read. See [the access gate](#the-access-gate-required-by-either-approach)
+value they never read. See [the access gate](#5-the-access-gate)
 for what it costs them (one correction per session, not zero) and for the client-side
 condition that makes gating safe rather than harmful.
 
@@ -92,7 +92,94 @@ page ([#11797](https://github.com/streamlit/streamlit/issues/11797)).
 [#11870](https://github.com/streamlit/streamlit/pull/11870) removed that path. **Do not
 restore** name-based `componentDidUpdate` reruns.
 
+## The design space: three approaches
+
+Everything else in this spec is shared: the echo (`resolved_color_scheme`), the client
+comparison in §3-§4, and the access gate in §5. The three approaches differ **only in how
+the first script run gets its value**.
+
+These are approaches to *implementation*. They are unrelated to the product spec's Options
+A/B/C, which decide what `type` should *mean*; that decision is settled as Option C
+(visual appearance) and all three approaches below implement it.
+
+| | **A — lightweight** | **B — robust** (proposed) | **C — push theme ahead** |
+|---|---|---|---|
+| How run 1 gets its value | the client's provisional value; corrected on run 2 | the backend resolves from `config.toml` before the run | the backend sends the theme *before* the client's first rerun |
+| Run 1, ordinary custom theme | **wrong** — visible flash | **right** | **right** |
+| Run 1, host theme (SiS) | wrong → corrected | wrong → corrected | **still wrong** — host themes come from the embedder, not the server |
+| Added latency | none | none | +1 RTT before first content, every session, every app |
+| Proto change | 1 field | 3 fields, all additive | protocol reordering |
+| Backend code | none | ~110 lines | new pre-session message + handshake ordering |
+| Mirrors frontend rules | no | 3 rules | no |
+| Verdict | viable fallback | **proposed** | rejected — see below |
+
+### A vs B, in detail
+
+These are the two live candidates. C is rejected on grounds that do not depend on the
+adoption argument (see the end of this section).
+
+| | **A — lightweight** | **B — robust** |
+|---|---|---|
+| `theme_type.py` | not needed | ~110 lines; 189 with docs |
+| Of which mirrors frontend behaviour | — | 3 rules: section inheritance, dual-theme detection, single-theme light fallback |
+| Of which is standard or delegated | — | `_luminance` is the published WCAG formula; `_parse_color` delegates to Pillow |
+| Proto fields | `resolved_color_scheme` | + `theme_preference`, `theme_applied` |
+| `app_session` wiring | unchanged | must pass a **copy** of `context_info` to `RerunData` (§2) |
+| `AGENTS.md` "no backend theming" | not engaged | narrow exception; the rule targets styling/layout math, and its stated worry — the backend cannot see the active theme — is exactly what the echo answers |
+| Reruns, app that reads `type` | 2 on first load | 1 on first load |
+| Reruns, app that does not | none, after the gate | none, after the gate |
+| Residual wrong first runs | all custom themes | unparseable colour syntax; host-theme race |
+| Ongoing maintenance | none | keep 3 rules in step with the frontend |
+
+**What A costs the user.** Not an invisible delay. Run 1 renders with the wrong value — a
+light logo on a dark background, or `plotly_white` on a dark page — and then flips. For an
+API whose whole purpose is contrast adaptation, the first paint *is* the product, and "first
+run with a custom theme" is the first failure mode
+[#11920](https://github.com/streamlit/streamlit/issues/11920) lists. A closes the issue's
+second half and leaves the first visible on every load.
+
+**What B costs the team.** Three mirrored rules, anchored to the *public* `[theme]` config
+schema. That schema is user-facing contract and does not churn freely — it last changed when
+dual themes were introduced. So drift is a real but modest risk, and the echo bounds any
+drift to one wrong first run rather than a stale session. Note also that neither option
+avoids the harder part — the shared client trigger in §4, where the subtle failure modes live
+(dropped sends, duplicate corrections, stale comparisons) and which A and B need identically.
+A is smaller, not safer.
+
+**Decision rule.** If a visible wrong-contrast flash on first load is acceptable, take A and
+delete the resolver. If it is not — and for a contrast-adaptation API that is hard to argue
+— take B. Nothing else changes either way, so A stays a clean retreat if the mirror ever
+becomes a burden.
+
+### Why C is rejected
+
+On connect the backend would send the `config.toml` theme; the client applies it and only
+then sends its first rerun, already carrying a correct `color_scheme`. That buys a correct
+first run with no resolver and no mirror — genuinely attractive — but:
+
+1. **An extra round trip before the script starts, every session.** `connect → client rerun
+   → script runs` becomes `connect → server theme → client applies → client rerun → script
+   runs`. The delay lands on time to first *content*; the client already paints a cached or
+   preset theme immediately, so users would see chrome as fast as ever and then wait longer
+   for the body.
+2. **Every app pays it**, to fix a value ~0.6% of apps read.
+3. **It hurts the deployments least able to absorb it** — Community Cloud and especially
+   SiS/SPCS sit behind longer paths, an iframe, and a container or warehouse layer, on top of
+   cold-start latency users already notice.
+4. **It does not fix the host-theme case, which is the SiS case.** Host themes arrive from
+   the embedder via `SET_CUSTOM_THEME_CONFIG`, not from the server, so the backend cannot
+   push them ahead of the first run. C would still need the echo — for exactly the platform
+   paying the most latency for it.
+5. **Protocol reordering rather than additive fields**, so version-skew combinations need
+   real thought instead of falling out of optional-field semantics.
+
+Point 4 is decisive: a universal, SiS-weighted latency cost that still does not remove the
+correction mechanism.
+
 ## Proposal
+
+This describes **approach B**. Under approach A, §2 is dropped entirely and §1 carries only
+`resolved_color_scheme`; everything else — §3 through §7 — is identical.
 
 ### 1. Proto
 
@@ -128,7 +215,7 @@ optional string resolved_color_scheme = 12;
 overwrites it only in the `theme_applied=false` window.
 
 `resolved_color_scheme` is **conditionally** populated — see
-[the access gate](#the-access-gate-required-by-either-approach). Its absence is meaningful
+[the access gate](#5-the-access-gate). Its absence is meaningful
 rather than merely empty: it tells the client there is nothing to keep truthful, and the
 client must clear its copy rather than retain the last value.
 
@@ -209,10 +296,13 @@ if client_state.HasField("context_info"):
     self._client_state.context_info.CopyFrom(client_state.context_info)
     _resolve_color_scheme(self._client_state.context_info)
 
+# A snapshot, NOT the session's own object -- see below.
+context_info = ContextInfo()
+context_info.CopyFrom(self._client_state.context_info)
+
 query_string = sanitize_query_string(client_state.query_string)
 rerun_data = RerunData(
     ...
-    # A snapshot, NOT the session's own object -- see below.
     context_info=context_info,
 )
 ```
@@ -245,7 +335,7 @@ def _resolve_color_scheme(context_info: ContextInfo) -> None:
 ```
 
 `_create_new_session_message` sends the echo — **subject to the
-[access gate](#the-access-gate-required-by-either-approach)**, and left unset when there is
+[access gate](#5-the-access-gate)**, and left unset when there is
 no value yet (e.g. a server-initiated first run), which the client treats as "nothing to
 compare" rather than a mismatch:
 
@@ -378,11 +468,8 @@ reason (see the `ChatInput` comment).
 it when a `NewSession` arrives, and when the connection drops — the latter is what retries a
 discarded send, since the disagreement is still recorded and reconnecting re-renders.
 
-**The echo is the only writer of `backendColorScheme`.** Do not also set it at send time from
-the value just sent: that is predicting the server's answer, and a discarded send would leave
-the client believing Python holds a value it never received, with no disagreement left to
-detect. Loop safety then follows — once the echo and the paint agree, the comparison
-short-circuits.
+**The echo is the only writer of `backendColorScheme`** (hook 1). Loop safety follows from
+that: once the echo and the paint agree, the comparison short-circuits.
 
 **Corrections land one script completion later.** The echo rides on `NewSession`, which
 carries `sessionStatus.scriptIsRunning = true`, so the client learns Python's value while the
@@ -432,13 +519,58 @@ Note that `config.toml` **precedence** is not a source of error: the resolver re
 flags, and `theme.base` file inheritance — so it reads the merged answer rather than
 re-deriving it. Only the section→appearance mapping is mirrored.
 
-### 5. Docs
+### 5. The access gate
+
+`st.context.theme.type` is read by roughly **0.6% of apps**, so no approach may add reruns
+for the other 99.4%. Send `resolved_color_scheme` only when a correction could matter:
+
+```python
+correction_can_matter = not self._has_sent_new_session or self._context_theme_was_read
+```
+
+**Do not use `gather_metrics` to detect the access.** `@gather_metrics("context.theme")`
+only records when `ctx.gather_usage_stats` is true, and `metrics_util` skips tracking
+entirely when `browser.gatherUsageStats` is off — so telemetry-disabled deployments would
+silently lose corrections. Notify explicitly instead: `ContextProxy.theme` calls an
+`on_context_theme_read` callback carried on `ScriptRunContext`, following the route
+`on_script_error` already takes (`AppSession` → `ScriptRunner` → context). `AppSession`
+holds the memory in two sticky booleans, because a per-run context cannot outlive the run
+that made the access. There is no pre-existing "have we sent a `NewSession`" signal; add one.
+
+Put the callback *before* the `context_info is None` early return, so an access counts even
+when there is no value yet. Note the gate is intentionally coarse: bare `st.context.theme`
+with no field access still counts. `ContextProxy` is a plain class rather than a dict, so
+the property is the only door and both `.type` and `["type"]` route through it.
+
+**The client must treat an absent echo as "nothing to compare", not "keep the old value".**
+This is the part that is easy to get wrong and it is load-bearing:
+
+```tsx
+this.backendColorScheme =
+  resolved === "light" || resolved === "dark" ? resolved : null
+```
+
+Retaining the previous value instead — an `if (valid) { assign }` — creates an **infinite
+correction loop** once the gate engages: the client corrects, the resulting `NewSession`
+carries no echo, the stale value is kept while `themeCorrectionInFlight` is cleared, so the
+disagreement never resolves and the client corrects again, forever. The backend gate alone
+is *worse* than no gate. Cover this with a test that counts reruns rather than asserting an
+absence.
+
+**What it actually costs a non-reading app: one correction per session, not zero.** The
+first `NewSession` is emitted at `SCRIPT_STARTED`, before any user code runs, so the client
+necessarily holds a comparable value through run 1. A no-read app therefore pays exactly one
+correction — on the first theme change after load — and none thereafter, since the unechoed
+`NewSession` from that very rerun nulls the client's copy. If any unrelated rerun happens
+first, the cost is zero. The saving is one-per-session instead of one-per-theme-change.
+
+### 6. Docs
 
 Update the [`context.py`](../../lib/streamlit/runtime/context.py) `theme.type` docstring:
 drop the stale first-load and settings-change caveats (both fixed by this design), and keep
 the CSS-override note, which remains true.
 
-### 6. Testing
+### 7. Testing
 
 **Python unit** — a new `lib/tests/streamlit/runtime/theme_type_test.py`:
 
@@ -537,135 +669,11 @@ surrounding code, and each one will cost time if it is discovered late.
   retries with a `#` prefix, and warns only on real failure. So `"black"` is a valid,
   working config that must not be rejected — which is precisely why the echo exists.
 
-## The design space: three approaches
-
-Everything else in this spec is shared: the echo (`resolved_color_scheme`), the client
-comparison in §3-§4, and the access gate below. The three approaches differ **only in how
-the first script run gets its value**.
-
-These are approaches to *implementation*. They are unrelated to the product spec's Options
-A/B/C, which decide what `type` should *mean*; that decision is settled as Option C
-(visual appearance) and all three approaches below implement it.
-
-| | **A — lightweight** | **B — robust** (proposed) | **C — push theme ahead** |
-|---|---|---|---|
-| How run 1 gets its value | the client's provisional value; corrected on run 2 | the backend resolves from `config.toml` before the run | the backend sends the theme *before* the client's first rerun |
-| Run 1, ordinary custom theme | **wrong** — visible flash | **right** | **right** |
-| Run 1, host theme (SiS) | wrong → corrected | wrong → corrected | **still wrong** — host themes come from the embedder, not the server |
-| Added latency | none | none | +1 RTT before first content, every session, every app |
-| Proto change | 1 field | 3 fields, all additive | protocol reordering |
-| Backend code | none | ~110 lines | new pre-session message + handshake ordering |
-| Mirrors frontend rules | no | 3 rules | no |
-| Verdict | viable fallback | **proposed** | rejected — see below |
-
-### A vs B, in detail
-
-These are the two live candidates. C is rejected on grounds that do not depend on the
-adoption argument (see the end of this section).
-
-| | **A — lightweight** | **B — robust** |
-|---|---|---|
-| `theme_type.py` | not needed | ~110 lines; 189 with docs |
-| Of which mirrors frontend behaviour | — | 3 rules: section inheritance, dual-theme detection, single-theme light fallback |
-| Of which is standard or delegated | — | `_luminance` is the published WCAG formula; `_parse_color` delegates to Pillow |
-| Proto fields | `resolved_color_scheme` | + `theme_preference`, `theme_applied` |
-| `app_session` wiring | unchanged | must pass a **copy** of `context_info` to `RerunData` (§2) |
-| `AGENTS.md` "no backend theming" | not engaged | narrow exception; the rule targets styling/layout math, and its stated worry — the backend cannot see the active theme — is exactly what the echo answers |
-| Reruns, app that reads `type` | 2 on first load | 1 on first load |
-| Reruns, app that does not | none, after the gate | none, after the gate |
-| Residual wrong first runs | all custom themes | unparseable colour syntax; host-theme race |
-| Ongoing maintenance | none | keep 3 rules in step with the frontend |
-
-**What A costs the user.** Not an invisible delay. Run 1 renders with the wrong value — a
-light logo on a dark background, or `plotly_white` on a dark page — and then flips. For an
-API whose whole purpose is contrast adaptation, the first paint *is* the product, and "first
-run with a custom theme" is the first failure mode
-[#11920](https://github.com/streamlit/streamlit/issues/11920) lists. A closes the issue's
-second half and leaves the first visible on every load.
-
-**What B costs the team.** Three mirrored rules, anchored to the *public* `[theme]` config
-schema. That schema is user-facing contract and does not churn freely — it last changed when
-dual themes were introduced. So drift is a real but modest risk, and the echo bounds any
-drift to one wrong first run rather than a stale session. Note also that neither option
-avoids the harder part: six of the defects found while developing this design were in the
-shared client trigger, which A and B need identically. A is smaller, not safer.
-
-**Decision rule.** If a visible wrong-contrast flash on first load is acceptable, take A and
-delete the resolver. If it is not — and for a contrast-adaptation API that is hard to argue
-— take B. Nothing else changes either way, so A stays a clean retreat if the mirror ever
-becomes a burden.
-
-### Why C is rejected
-
-On connect the backend would send the `config.toml` theme; the client applies it and only
-then sends its first rerun, already carrying a correct `color_scheme`. That buys a correct
-first run with no resolver and no mirror — genuinely attractive — but:
-
-1. **An extra round trip before the script starts, every session.** `connect → client rerun
-   → script runs` becomes `connect → server theme → client applies → client rerun → script
-   runs`. The delay lands on time to first *content*; the client already paints a cached or
-   preset theme immediately, so users would see chrome as fast as ever and then wait longer
-   for the body.
-2. **Every app pays it**, to fix a value ~0.6% of apps read.
-3. **It hurts the deployments least able to absorb it** — Community Cloud and especially
-   SiS/SPCS sit behind longer paths, an iframe, and a container or warehouse layer, on top of
-   cold-start latency users already notice.
-4. **It does not fix the host-theme case, which is the SiS case.** Host themes arrive from
-   the embedder via `SET_CUSTOM_THEME_CONFIG`, not from the server, so the backend cannot
-   push them ahead of the first run. C would still need the echo — for exactly the platform
-   paying the most latency for it.
-5. **Protocol reordering rather than additive fields**, so version-skew combinations need
-   real thought instead of falling out of optional-field semantics.
-
-Point 4 is decisive: a universal, SiS-weighted latency cost that still does not remove the
-correction mechanism.
-
-### The access gate (required by either approach)
-
-`st.context.theme.type` is read by roughly **0.6% of apps**, so no approach may add reruns
-for the other 99.4%. Send `resolved_color_scheme` only when a correction could matter:
-
-```python
-correction_can_matter = not self._has_sent_new_session or self._context_theme_was_read
-```
-
-**Do not use `gather_metrics` to detect the access.** `@gather_metrics("context.theme")`
-only records when `ctx.gather_usage_stats` is true, and `metrics_util` skips tracking
-entirely when `browser.gatherUsageStats` is off — so telemetry-disabled deployments would
-silently lose corrections. Notify explicitly instead: `ContextProxy.theme` calls an
-`on_context_theme_read` callback carried on `ScriptRunContext`, following the route
-`on_script_error` already takes (`AppSession` → `ScriptRunner` → context). `AppSession`
-holds the memory in two sticky booleans, because a per-run context cannot outlive the run
-that made the access. There is no pre-existing "have we sent a `NewSession`" signal; add one.
-
-Put the callback *before* the `context_info is None` early return, so an access counts even
-when there is no value yet. Note the gate is intentionally coarse: bare `st.context.theme`
-with no field access still counts. `ContextProxy` is a plain class rather than a dict, so
-the property is the only door and both `.type` and `["type"]` route through it.
-
-**The client must treat an absent echo as "nothing to compare", not "keep the old value".**
-This is the part that is easy to get wrong and it is load-bearing:
-
-```tsx
-this.backendColorScheme =
-  resolved === "light" || resolved === "dark" ? resolved : null
-```
-
-Retaining the previous value instead — an `if (valid) { assign }` — creates an **infinite
-correction loop** once the gate engages: the client corrects, the resulting `NewSession`
-carries no echo, the stale value is kept while `themeCorrectionInFlight` is cleared, so the
-disagreement never resolves and the client corrects again, forever. The backend gate alone
-is *worse* than no gate. Cover this with a test that counts reruns rather than asserting an
-absence.
-
-**What it actually costs a non-reading app: one correction per session, not zero.** The
-first `NewSession` is emitted at `SCRIPT_STARTED`, before any user code runs, so the client
-necessarily holds a comparable value through run 1. A no-read app therefore pays exactly one
-correction — on the first theme change after load — and none thereafter, since the unechoed
-`NewSession` from that very rerun nulls the client's copy. If any unrelated rerun happens
-first, the cost is zero. The saving is one-per-session instead of one-per-theme-change.
-
 ## Alternatives considered
+
+Approach C — pushing the theme ahead of the first rerun — is the main rejected alternative;
+it is weighed with A and B in
+[the design space](#the-design-space-three-approaches) rather than repeated here.
 
 ### Resolve from config alone, ignoring the client's preference
 
@@ -687,9 +695,10 @@ explicitly about host-message arrival ordering. It also fires redundant reruns w
 preference changes but config pins the appearance either way — and it cannot detect a
 backend/frontend disagreement at all, which is the failure mode most worth catching.
 
-### If the product spec picks semantics A or B instead of C
+### If the product spec picks meaning A or B instead of C
 
-Only §2 changes. The proto and the §3/§4 exchange are agnostic to *what* the backend
+That is the product spec's Options A/B/C — what `type` *means* — not the implementation
+approaches above. Only §2 changes. The proto and the §3/§4 exchange are agnostic to *what* the backend
 resolves — the echo compares whatever the script saw against what is painted either way.
 
 ## Out of scope
@@ -711,4 +720,4 @@ resolves — the echo compares whatever the script saw against what is painted e
 | No new dependencies | `_parse_color` uses `PIL.ImageColor`, already a runtime dependency (`pillow>=7.1.0,<13`), imported lazily |
 | Metrics collected | Existing `context.theme` metrics sufficient |
 | Any security/legal impact? | No |
-| Any docs changes needed? | Yes — the `context.py` docstring (§5) |
+| Any docs changes needed? | Yes — the `context.py` docstring (§6) |

--- a/specs/2026-08-08-st-context-theme-type/tech-spec.md
+++ b/specs/2026-08-08-st-context-theme-type/tech-spec.md
@@ -5,6 +5,12 @@ created: 2026-08-08
 
 # Make `st.context.theme.type` correct — tech design
 
+> **Status: proposed, not fully vetted.** This documents a design and the hazards found while
+> developing it. It is **not** a validated implementation plan, and the approach itself is
+> still open. Read [What is not settled](#what-is-not-settled) before implementing —
+> the self-correcting trigger in §4 has produced a defect in every review round so far, the
+> most recent depending on forward-message ordering that nothing in the design surfaces.
+
 ## Summary
 
 Fix `st.context.theme.type` with a two-way exchange:
@@ -91,6 +97,45 @@ extra `rerun_script` → page context not preserved → deep link bounces to the
 page ([#11797](https://github.com/streamlit/streamlit/issues/11797)).
 [#11870](https://github.com/streamlit/streamlit/pull/11870) removed that path. **Do not
 restore** name-based `componentDidUpdate` reruns.
+
+## What is not settled
+
+Recorded plainly so nobody mistakes this document for a vetted plan.
+
+**The approach is undecided.** A vs B below is an open cost question, and it is not a detail:
+B exists to make the first run correct, and B's version of "correct" is partial — every modern
+CSS colour function (`oklch()` and friends, which the frontend explicitly supports) is wrong on
+the first run, as is any host-provided theme. That set grows as CSS evolves and Pillow trails
+it, so B's benefit decays while its cost — a mirror of three frontend rules, plus a documented
+exception to `AGENTS.md`'s "no backend theming" — is permanent.
+
+**The self-correcting trigger (§4) is the risk, and it is shared by A and B.** Its state space
+is larger than it looks: reconnects, dropped sends that return `void`, fragment reruns, the
+access gate, and message ordering all interact. Defects found there across review rounds
+include two aliasing races, an infinite-correction loop, and a duplicate correction caused by
+clearing the in-flight flag on a fragment `NewSession`. Each was individually subtle, each
+looked correct when written, and several survived passing tests — they were caught by review,
+not by the suite. Expect more.
+
+**Nothing here has run end to end.** §7 is a test plan, not results. There is no E2E coverage
+of this design, and the trigger depends on React lifecycle timing that has not been checked
+across browser engines.
+
+**Two product questions are unanswered**, and either could remove work rather than add it:
+
+1. Do we want a script to re-execute because the OS flipped to dark at sunset? If not, the
+   appearance-change half — and most of §4's complexity — should not be built.
+2. Is any of this justified at **~0.6%** adoption? Note that the echo now requires changing
+   `ScriptRunner`'s `SCRIPT_STARTED` payload and `AppSession`'s handler signatures — core
+   plumbing every session traverses.
+
+**A smaller decomposition exists** and is worth considering before building the whole design.
+The two fixes are separable: first-run correctness needs only §2's resolver plus the two
+`ContextInfo` fields — no echo, no trigger, no gate, no rerun-behaviour change — because once
+`theme_applied` is true the client's own value is authoritative, so a wrong first run
+self-corrects on the next rerun anyway. The echo and trigger earn their place only for the
+appearance-change half ([#15287](https://github.com/streamlit/streamlit/issues/15287)). The
+cost of splitting is that #11920 cannot be fully closed by the first half alone.
 
 ## The design space: three approaches
 

--- a/specs/2026-08-08-st-context-theme-type/tech-spec.md
+++ b/specs/2026-08-08-st-context-theme-type/tech-spec.md
@@ -153,8 +153,10 @@ if client_state.HasField("context_info"):
 Applies to **full-script and fragment** reruns alike.
 
 If product picks **Option A**, this collapses to
-`color_scheme = theme_preference`. If **Option B**, return the selected section’s
-nominal variant without luminance.
+`color_scheme = theme_preference`. If **Option B** (theme identity), return a
+descriptive string like `"Default Light"`, `"Custom"`, or `"Custom Dark"` instead of
+a binary light/dark classification — requires changing the return type and downstream
+`st.context.theme.type` contract.
 
 ### 3. Frontend: send preference on every rerun
 
@@ -192,7 +194,7 @@ the same observable: `props.theme.activeTheme` changes its visual appearance in
 `App.tsx`. A single `componentDidUpdate` check handles all three. The only path to
 suppress is `processThemeInput` (called during `handleNewSession`).
 
-#### Implementation (4 touch points in `App.tsx`)
+#### Implementation
 
 **1. Two instance fields:**
 
@@ -351,6 +353,7 @@ chosen product meaning. Drop stale first-load / settings caveats; keep CSS-overr
   [`test_st_context_theme_respects_dark_theme_message`](../../e2e_playwright/hostframe_app_test.py)
   (skipped since #11870). No new CI host environment — this is an existing Playwright
   hostframe suite; unskip only.
+
 ## Alternatives considered
 
 ### A. Fix the auto-rerun MPA-safely (no new proto field)
@@ -395,6 +398,7 @@ BE work.
 ## Out of scope
 
 - Full theme config on `st.context.theme` ([#11536](https://github.com/streamlit/streamlit/issues/11536)).
+- Programmatic theme setters at runtime ([#14172](https://github.com/streamlit/streamlit/issues/14172)).
 - Full Emotion theme build on the backend.
 - Non-hex CSS color parsing for luminance.
 - CSS-injected backgrounds affecting `type`.


### PR DESCRIPTION
## Describe your changes

Product and tech specs for making `st.context.theme.type` correct on the first script run and after appearance changes (#11920), without regressing the multipage-app (MPA) deep links #11870 fixed (#11797).

The design in brief — details in the [tech spec](specs/2026-08-08-st-context-theme-type/tech-spec.md):

- The client sends its resolved light/dark preference and whether it is yet painting its final theme.
- While it is not, the backend resolves `color_scheme` from `config.toml` before the script runs. Afterwards it trusts the client.
- The backend reports back what the script saw; the client reruns once if that disagrees with what it paints. This makes the design self-correcting rather than dependent on the backend being right.
- That correction is gated on apps that actually read `st.context.theme` (~0.6%), so it does not cost everyone else.

Public surface is unchanged: `Literal["light", "dark"] | None`.

## GitHub Issue Link (if applicable)

* Fix proposal for https://github.com/streamlit/streamlit/issues/11920
* Related to https://github.com/streamlit/streamlit/issues/15287 and https://github.com/streamlit/streamlit/issues/11536

## Testing Plan

Specs only — no code changes, so no tests here. The tech spec's §7 carries the unit and E2E matrix for the implementation PR, including an MPA deep-link guard and a rerun-counting test for apps that never read the value; neither exists in the repo today.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only specs with no runtime code. Risk is design-review risk (auto-rerun races, backend theming exception), not production impact.
> 
> **Overview**
> Adds **proposed** product and tech specs for making `st.context.theme.type` reliable on first run and after appearance changes (#11920 / #15287), without restoring the MPA deep-link regression #11870 fixed.
> 
> The product spec asks reviewers to lock **Option C**: `type` means painted appearance (background luminance, then `base`), not user preference or theme identity. Public API stays `Literal["light", "dark"] | None`.
> 
> The tech spec proposes a two-way exchange: client sends preference + `theme_applied`; backend may resolve from `config.toml` before the first run (approach **B**, with lighter **A** as fallback); `NewSession` echoes what the script saw; the client auto-reruns once on disagreement. Echoes are gated so apps that never read `st.context.theme` (~99.4%) are not charged per theme change.
> 
> Status is explicitly **not a vetted implementation plan**. Open gates include A vs B, whether OS-driven reruns are wanted, and whether the work is justified at ~0.6% adoption. The self-correcting trigger is called out as the hard part (aliasing, fragment `NewSession`, infinite-loop if an absent echo is retained).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92efe55f4f2716b3872f5e5f807357373773fecb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

