### PR TITLE
[fix] Reset a widget in the browser when its session state key is deleted

### DIFF
--- a/e2e_playwright/st_session_state_widget_reset.py
+++ b/e2e_playwright/st_session_state_widget_reset.py
@@ -1,0 +1,56 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import streamlit as st
+
+KEYS = ["text", "num", "sel", "multi", "slide", "check", "bound", "body"]
+
+
+def _delete_all() -> None:
+    """Delete every widget key from session state."""
+    for key in KEYS:
+        st.session_state.pop(key, None)
+
+
+def _count_text_change() -> None:
+    """Count every on_change the Text widget reports."""
+    st.session_state["text_changes"] = st.session_state.get("text_changes", 0) + 1
+
+
+st.text_input("Text", value="default", key="text", on_change=_count_text_change)
+st.number_input("Num", value=1, key="num")
+st.selectbox("Sel", ["A", "B", "C"], key="sel")
+st.multiselect("Multi", ["A", "B", "C"], key="multi")
+st.slider("Slide", 0, 10, 3, key="slide")
+st.checkbox("Check", value=False, key="check")
+st.text_input("Bound", value="default", key="bound", bind="query-params")
+st.text_input("Body", value="body_default", key="body")
+
+st.button("Delete in callback", key="delete_cb", on_click=_delete_all)
+delete_in_body = st.button("Delete in script body", key="delete_body")
+st.button("Noop", key="noop")
+
+for key in KEYS:
+    # Always display the current session_state value so a test can assert it
+    # next to the value rendered in the widget itself.
+    with st.container(key=f"{key}_value"):
+        st.write(f"{key}: {st.session_state.get(key, 'UNSET')}")
+
+with st.container(key="text_changes_value"):
+    st.write(f"text_changes: {st.session_state.get('text_changes', 0)}")
+
+if delete_in_body:
+    # The delete runs after the widget rendered, so the reset waits for the next
+    # rerun. A user change that arrives first must win over the reset.
+    st.session_state.pop("body", None)

--- a/e2e_playwright/st_session_state_widget_reset_test.py
+++ b/e2e_playwright/st_session_state_widget_reset_test.py
@@ -1,0 +1,210 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Deleting a widget key from st.session_state resets the widget UI too.
+
+See issue #16388 and the ``SessionState._pending_delete_resets`` field comment.
+"""
+
+import re
+
+from playwright.sync_api import Locator, Page, expect
+
+from e2e_playwright.conftest import wait_for_app_run
+from e2e_playwright.shared.app_utils import (
+    click_button,
+    click_checkbox,
+    fill_number_input,
+    get_checkbox,
+    get_element_by_key,
+    get_multiselect,
+    get_number_input,
+    get_selectbox,
+    get_slider,
+    get_text_input,
+    select_selectbox_option,
+)
+
+
+def _text_input_field(app: Page, label: str) -> Locator:
+    """Return the input element of a text input, so a test can read its value."""
+    return get_text_input(app, label).locator("input").first
+
+
+def _slider_thumb_value(app: Page, label: str) -> Locator:
+    """Return the value label a slider renders above its thumb."""
+    return get_slider(app, label).get_by_test_id("stSliderThumbValue")
+
+
+def _fill_text_input(app: Page, label: str, value: str) -> None:
+    """Fill a text input, submit it with Enter, and wait for the rerun."""
+    field = _text_input_field(app, label)
+    field.fill(value)
+    field.press("Enter")
+    wait_for_app_run(app)
+
+
+def _select_multiselect_option(app: Page, label: str, option: str) -> None:
+    """Select one multiselect option, close the dropdown, and wait for the rerun."""
+    multiselect = get_multiselect(app, label)
+    multiselect.locator("input").click()
+    app.get_by_role("option", name=option, exact=True).first.click()
+    app.keyboard.press("Escape")
+    wait_for_app_run(app)
+
+
+def _nudge_slider(app: Page) -> None:
+    """Move the slider one step away from its default with the keyboard."""
+    get_slider(app, "Slide").get_by_role("slider").press("ArrowRight")
+    wait_for_app_run(app)
+
+
+def _expect_state_value(app: Page, key: str, expected: str) -> None:
+    """Assert the st.session_state readout rendered by the app."""
+    expect(get_element_by_key(app, f"{key}_value")).to_have_text(f"{key}: {expected}")
+
+
+def _change_every_widget(app: Page) -> None:
+    _fill_text_input(app, "Text", "hello")
+    fill_number_input(app, "Num", 7)
+    select_selectbox_option(app, "Sel", "C")
+    _select_multiselect_option(app, "Multi", "B")
+    _nudge_slider(app)
+    click_checkbox(app, "Check")
+    _fill_text_input(app, "Bound", "bound_value")
+
+
+def _expect_defaults_in_widget_ui(app: Page) -> None:
+    """Assert every widget renders its default, not only the state readout.
+
+    Without the fix the backend resolves the default while the browser keeps
+    showing the deleted value, so these seven assertions fail.
+    """
+    expect(_text_input_field(app, "Text")).to_have_value("default")
+    expect(get_number_input(app, "Num").locator("input").first).to_have_value("1")
+    expect(get_selectbox(app, "Sel").locator("input").first).to_have_value("A")
+    expect(
+        get_multiselect(app, "Multi").get_by_role(
+            "button", name=re.compile(r"^Remove ")
+        )
+    ).to_have_count(0)
+    expect(_slider_thumb_value(app, "Slide")).to_have_text("3")
+    expect(get_checkbox(app, "Check").locator("input").first).not_to_be_checked()
+    expect(_text_input_field(app, "Bound")).to_have_value("default")
+
+
+def _expect_defaults_in_state(app: Page) -> None:
+    _expect_state_value(app, "text", "default")
+    _expect_state_value(app, "num", "1")
+    _expect_state_value(app, "sel", "A")
+    _expect_state_value(app, "multi", "[]")
+    _expect_state_value(app, "slide", "3")
+    _expect_state_value(app, "check", "False")
+    _expect_state_value(app, "bound", "default")
+
+
+def test_delete_in_callback_resets_every_widget(app: Page) -> None:
+    """A delete in a callback resets every widget, and the reset then holds.
+
+    The scenario changes every widget once, deletes every key, and asserts the
+    default in the widget UI and in the state readout. It then reruns the app to
+    prove the browser does not resend the deleted value, and changes a widget
+    again to prove the reset is one-shot.
+
+    Issue #5442 claims st.slider already behaves correctly. The slider
+    assertions in _expect_defaults_in_widget_ui show that it does not.
+    """
+    _change_every_widget(app)
+    # The slider must really leave its default, or the reset assertion below
+    # would hold for the wrong reason.
+    expect(_slider_thumb_value(app, "Slide")).to_have_text("4")
+    _expect_state_value(app, "text_changes", "1")
+
+    click_button(app, "Delete in callback")
+
+    _expect_defaults_in_widget_ui(app)
+    _expect_defaults_in_state(app)
+    # The reset must not look like a user change, so on_change must not fire.
+    _expect_state_value(app, "text_changes", "1")
+
+    # A plain rerun must not bring the deleted values back.
+    click_button(app, "Noop")
+
+    _expect_defaults_in_widget_ui(app)
+    _expect_defaults_in_state(app)
+
+    # The reset is one-shot, so the user can change a widget again.
+    _fill_text_input(app, "Text", "second")
+
+    expect(_text_input_field(app, "Text")).to_have_value("second")
+    _expect_state_value(app, "text", "second")
+    # on_change stays live after the reset.
+    _expect_state_value(app, "text_changes", "2")
+
+
+def test_delete_clears_the_url_of_a_bound_widget(app: Page) -> None:
+    """A bind="query-params" widget also loses its query parameter."""
+    _fill_text_input(app, "Bound", "bound_value")
+    expect(app).to_have_url(re.compile(r"bound=bound_value"))
+
+    click_button(app, "Delete in callback")
+
+    expect(app).not_to_have_url(re.compile(r"bound="))
+    expect(_text_input_field(app, "Bound")).to_have_value("default")
+
+    # The URL must stay clear, or the next rerun seeds the deleted value back.
+    click_button(app, "Noop")
+
+    expect(app).not_to_have_url(re.compile(r"bound="))
+    _expect_state_value(app, "bound", "default")
+
+
+def test_script_body_delete_defers_the_reset_and_yields_to_a_change(
+    app: Page,
+) -> None:
+    """A script-body delete resets on the next rerun, but a change beats it.
+
+    The delete runs after the widget rendered, so both sides keep the old value
+    for the rest of that run. A plain rerun then applies the reset. A user change
+    that arrives before the reset is newer than the delete, so it must survive.
+    """
+    field = _text_input_field(app, "Body")
+
+    _fill_text_input(app, "Body", "body1")
+    _expect_state_value(app, "body", "body1")
+
+    # The delete run keeps the old value on both sides.
+    click_button(app, "Delete in script body")
+    expect(field).to_have_value("body1")
+    _expect_state_value(app, "body", "body1")
+
+    # A plain rerun resends the same value, so the reset applies.
+    click_button(app, "Noop")
+    expect(field).to_have_value("body_default")
+    _expect_state_value(app, "body", "body_default")
+
+    # The widget still works after the reset.
+    _fill_text_input(app, "Body", "body2")
+    _expect_state_value(app, "body", "body2")
+
+    # Arm the delete again, then change the widget before the reset applies.
+    click_button(app, "Delete in script body")
+    _fill_text_input(app, "Body", "body3")
+
+    # The change must win over the pending delete reset, and it must hold.
+    expect(field).to_have_value("body3")
+    _expect_state_value(app, "body", "body3")
+    click_button(app, "Noop")
+    expect(field).to_have_value("body3")
+    _expect_state_value(app, "body", "body3")

--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/session-state.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/session-state.md
@@ -37,6 +37,33 @@ name = st.text_input("Name", key="user_name")
 # st.session_state.user_name contains the same value as `name`
 ```
 
+## Resetting a widget by deleting its key
+
+Delete a keyed widget's entry to return the widget to its default in Python and in the browser. A few widgets cannot correct the browser yet; see the end of this section:
+
+```python
+def reset() -> None:
+    del st.session_state["user_name"]
+
+
+st.text_input("Name", value="", key="user_name")
+st.button("Reset", on_click=reset)
+```
+
+`st.session_state.pop("user_name")` and `st.session_state.clear()` behave the same way for the widget key, because both delete it. `clear()` also removes every other key in session state, including the keys your app owns.
+
+For a widget with `bind="query-params"`, the delete also removes the widget's query parameter from the URL. Other query parameters stay.
+
+Delete the key in a callback to reset the widget in the same run. That is the recommended pattern.
+
+If you delete the key in the script body after the widget rendered, the reset waits for the next rerun:
+
+- For the rest of the delete run, the widget on screen keeps the old value, and the widget's return value is the old value. Inside a fragment run, the key itself already reads as missing, because the widget outside the fragment does not register again.
+- On the next rerun the widget falls back to its default, unless the user changed the widget first. A change the user makes after the delete is newer than the delete, so it wins and `on_change` fires as usual.
+- A script that deletes the key on every run therefore keeps a user's value for one run only, and returns to the default on the run after that.
+
+A few widgets have no way to correct the browser, so a delete resets the Python value but leaves the browser showing the old value, and the old value returns on the next rerun: `st.file_uploader`, `st.camera_input`, `st.audio_input`, `st.data_editor`, custom components, and the selection state of `st.plotly_chart`, `st.altair_chart`, `st.vega_lite_chart`, and `st.pydeck_chart`.
+
 ## Widget input constraints are mostly client-side
 
 Most widget input constraints—`options` allow-lists (`st.selectbox`, `st.multiselect`, `st.radio`), `min_value`/`max_value` (`st.slider`, `st.number_input`), `max_chars` (`st.text_input`), `disabled`, and `st.data_editor` column `validate`/`num_rows`—are primarily enforced in the browser for UX. Treat them as guardrails for normal users, **not** as a security boundary: a widget's return value (and its `st.session_state` entry) reflects what the client sent, and a modified or malicious client can submit values outside those constraints.

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -632,6 +632,13 @@ class SessionState:
         default_factory=PersistedWidgetTracker
     )
 
+    # Widget values that `del st.session_state[key]` removed, keyed by widget id.
+    # The frontend keeps its own copy of every widget value and resends it on the
+    # next rerun, so a delete must also tell the frontend to fall back to the
+    # widget's default. The recorded value lets the next registration separate a
+    # resent value from a fresh user change. One-shot per id.
+    _pending_delete_resets: dict[str, Any] = field(default_factory=dict)
+
     def __repr__(self) -> str:
         return util.repr_(self)
 
@@ -659,6 +666,11 @@ class SessionState:
         self._key_id_mapper.clear()
         self._query_param_bound_widget_ids.clear()
         self._persist_tracker.clear()
+        # This is the internal full reset, so drop the pending delete resets
+        # instead of recording them. The user-facing st.session_state.clear()
+        # takes a different path: MutableMapping.clear() calls __delitem__ for
+        # each key, which records a pending delete reset per widget.
+        self._pending_delete_resets.clear()
 
     @property
     def filtered_state(self) -> dict[str, Any]:
@@ -810,6 +822,20 @@ class SessionState:
         if not (key in self or widget_id in self):
             raise KeyError(_missing_key_error_message(key))
 
+        if key in self._key_id_mapper:
+            # The key belongs to a widget, so record the value that goes away.
+            # Read the stored value rather than self[key]: apply_presenter can
+            # change what self[key] shows the app, while the frontend holds and
+            # resends the stored value. The guard above proves this read cannot
+            # raise.
+            #
+            # Known gap: a value the app set earlier in this run reaches the
+            # frontend through the widget's serializer. A set that uses another
+            # container type (a tuple for st.multiselect) therefore records a
+            # value that no longer equals the list the frontend resends, and the
+            # reset does not apply.
+            self._pending_delete_resets[widget_id] = self._getitem(widget_id, key)
+
         if key in self._new_session_state:
             del self._new_session_state[key]
 
@@ -862,6 +888,15 @@ class SessionState:
         # suppressed.
 
         # Path 1: single callback.
+        #
+        # Skip `on_change` while the frontend only resends a deleted value. That
+        # looks like a change the user never made. A value the user really changed
+        # differs, so its callback still runs.
+        #
+        # Path 2 stays unguarded on purpose. It serves custom components v2 and
+        # JSON-valued widgets, which have no set_value path, so a delete never
+        # corrects their frontend value and every change they report is a genuine
+        # one-shot trigger.
         changed_widget_ids_for_single_callback = [
             wid
             for wid in self._new_widget_state
@@ -870,6 +905,7 @@ class SessionState:
             is not None
             and metadata.callback is not None
             and not metadata.disabled
+            and not self._needs_delete_reset(wid)
         ]
 
         for wid in changed_widget_ids_for_single_callback:
@@ -1206,6 +1242,19 @@ class SessionState:
         self._query_param_bound_widget_ids.intersection_update(wid_key_map.keys())
         self._persist_tracker.prune(wid_key_map.keys(), self._old_state)
 
+        # A stale widget needs no delete reset. Both sides forget its value: the
+        # backend above, and the frontend in WidgetStateManager.removeInactive.
+        # The widget therefore starts from its default when it reappears.
+        self._pending_delete_resets = {
+            wid: deleted_value
+            for wid, deleted_value in self._pending_delete_resets.items()
+            if not _is_stale_widget(
+                self._new_widget_state.widget_metadata.get(wid),
+                active_widget_ids,
+                ctx.fragment_ids_this_run,
+            )
+        }
+
     def _get_widget_metadata(self, widget_id: str) -> WidgetMetadata[Any] | None:
         """Return the metadata for a widget id from the current widget state."""
         return self._new_widget_state.widget_metadata.get(widget_id)
@@ -1241,6 +1290,27 @@ class SessionState:
         removed = self._old_state.pop(widget_id, None) is not None or removed
         removed = self._old_state.pop(user_key, None) is not None or removed
         return removed
+
+    def _needs_delete_reset(self, widget_id: str) -> bool:
+        """True if a pending delete reset still applies to a widget.
+
+        The reset applies while the frontend holds the deleted value. It stops
+        applying once the user changes the widget to a different value: that
+        change is newer than the delete, so it wins. A user who retypes the
+        deleted value gets the reset, because the two values are equal and the
+        backend cannot tell the two cases apart.
+        """
+        if widget_id not in self._pending_delete_resets:
+            return False
+
+        if widget_id not in self._new_widget_state:
+            # The delete removed the frontend value in this same run, so no user
+            # change can exist yet.
+            return True
+
+        return _equals_deleted_value(
+            self._new_widget_state[widget_id], self._pending_delete_resets[widget_id]
+        )
 
     def register_widget(
         self, metadata: WidgetMetadata[T], user_key: str | None
@@ -1283,12 +1353,32 @@ class SessionState:
             # If the widget has a user_key, update its user_key:widget_id mapping
             self._set_key_widget_mapping(widget_id, user_key)
 
+        # Consume the pending delete reset, if the widget has one. Drop the value
+        # the frontend resends and flag the frontend to adopt the widget's
+        # default. See _pending_delete_resets for the recording side.
+        delete_reset_applied = self._needs_delete_reset(widget_id)
+        # Pop unconditionally: this registration either applies the reset, or a
+        # newer user change replaced it. Neither outcome may apply again.
+        self._pending_delete_resets.pop(widget_id, None)
+        if delete_reset_applied:
+            self._drop_widget_value(widget_id, user_key or widget_id)
+            # Clear the captured wire value too. Otherwise a caller like
+            # st.selectbox reconciles its options against the deleted label (see
+            # resolve_value_against_options) and hands back the deleted value.
+            incoming_serialized_value = None
+            incoming_serialized_values = None
+            if metadata.bind == "query-params" and user_key is not None:
+                # The URL is a second source of truth, and the backend re-reads
+                # the query string on every same-page rerun. Remove the param so
+                # the browser URL loses it and the next run cannot re-seed it.
+                self.query_params.remove_param(user_key)
+
         # Handle query param binding
         url_value_seeded = False
         if metadata.bind == "query-params" and user_key is not None:
             self._query_param_bound_widget_ids.add(widget_id)
             url_value_seeded = self._handle_query_param_binding(
-                metadata, user_key, widget_id
+                metadata, user_key, widget_id, skip_url_seeding=delete_reset_applied
             )
         elif metadata.bind is None and user_key is not None:
             # Widget stopped using bind — clean up any stale binding
@@ -1440,13 +1530,17 @@ class SessionState:
         # - a persisted value was restored from session state on (re)mount, for
         #   the same reason;
         # - a "page"-scoped value was dropped on a page switch, so the frontend
-        #   must fall back to the default for the reused widget id.
+        #   must fall back to the default for the reused widget id;
+        # - a forged value was discarded for a disabled widget;
+        # - a pending delete reset applied, so the frontend must fall back to the
+        #   widget's default.
         widget_value_changed = (
             (user_key is not None and self.is_new_state_value(user_key))
             or restored_bound_value
             or restored_persisted_value
             or dropped_page_scoped_value
             or disabled_value_discarded
+            or delete_reset_applied
         )
 
         return RegisterWidgetResult(
@@ -1457,7 +1551,12 @@ class SessionState:
         )
 
     def _handle_query_param_binding(
-        self, metadata: WidgetMetadata[T], user_key: str, widget_id: str
+        self,
+        metadata: WidgetMetadata[T],
+        user_key: str,
+        widget_id: str,
+        *,
+        skip_url_seeding: bool = False,
     ) -> bool:
         """Handle query param binding for a widget.
 
@@ -1467,6 +1566,13 @@ class SessionState:
         - On initial load, URL wins (enables shareable URLs)
         - On subsequent reruns, session_state values win
         - User interaction (frontend value) always wins
+
+        Pass ``skip_url_seeding=True`` to register the binding and skip the
+        seeding. A pending delete reset needs this, because the two stores hold
+        the deleted value separately. ``remove_param`` clears ``_query_params``
+        and updates the browser URL, but same-page ``ctx.reset`` has already
+        refreshed ``_initial_query_params`` from the stale query string, and the
+        seeding below reads that snapshot.
 
         Returns True if the widget's value was seeded from URL, False otherwise.
         """
@@ -1479,6 +1585,9 @@ class SessionState:
             value_type=metadata.value_type,
             script_hash=script_hash,
         )
+
+        if skip_url_seeding:
+            return False
 
         # Check priority rules - skip seeding if user/code has already set a value.
         # A disabled widget is exempt: it cannot be interacted with, so any value in
@@ -1679,6 +1788,25 @@ class SessionState:
 
 def _is_internal_key(key: str) -> bool:
     return key.startswith(STREAMLIT_INTERNAL_KEY_PREFIX)
+
+
+def _equals_deleted_value(incoming_value: Any, deleted_value: Any) -> bool:
+    """True if a widget's incoming value equals the value that `del` removed.
+
+    Some widget values give no bool for `==`. A list of numpy arrays from
+    st.multiselect options raises ValueError, and a pd.NA option raises
+    TypeError. Such a comparison is not conclusive, so treat the value as the
+    deleted one and apply the reset the app asked for.
+
+    Returning True for an inconclusive comparison is a deliberate trade-off, not
+    an oversight. It can discard a change the user made after the delete when the
+    two values cannot be compared. Do not change it to False: equal values raise
+    here too, so False would stop the reset for every widget of that value type.
+    """
+    try:
+        return bool(incoming_value == deleted_value)
+    except (ValueError, TypeError):
+        return True
 
 
 def _is_stale_widget(

--- a/lib/tests/streamlit/elements/multiselect_test.py
+++ b/lib/tests/streamlit/elements/multiselect_test.py
@@ -984,3 +984,27 @@ class MultiSelectBindQueryParamsTest(DeltaGeneratorTestCase):
         c = self.get_delta_from_queue().new_element.multiselect
         assert c.query_param_key == "my_key"
         assert c.accept_new_options is True
+
+
+def test_delete_session_state_key_pushes_default_to_frontend() -> None:
+    """Deleting the key resets the widget in the browser too (issue #16388)."""
+
+    def script() -> None:
+        import streamlit as st
+
+        st.multiselect("Multi", ["A", "B", "C"], key="multi")
+
+        def delete() -> None:
+            del st.session_state["multi"]
+
+        st.button("Delete", on_click=delete)
+
+    at = AppTest.from_function(script).run()
+    at.multiselect[0].set_value(["B"]).run()
+
+    # The frontend still holds ["B"] when the Delete button is clicked.
+    at.multiselect[0].set_value(["B"])
+    at = at.button[0].click().run()
+
+    assert at.multiselect[0].proto.set_value is True
+    assert list(at.multiselect[0].proto.raw_values) == []

--- a/lib/tests/streamlit/elements/number_input_test.py
+++ b/lib/tests/streamlit/elements/number_input_test.py
@@ -878,3 +878,27 @@ def test_serde_resets_non_finite_float_to_default(ui_value: float) -> None:
         value=0.5, data_type=NumberInput.FLOAT, min_value=0.0, max_value=1.0
     )
     assert serde.deserialize(ui_value) == 0.5
+
+
+def test_delete_session_state_key_pushes_default_to_frontend() -> None:
+    """Deleting the key resets the widget in the browser too (issue #16388)."""
+
+    def script() -> None:
+        import streamlit as st
+
+        st.number_input("Num", value=1, key="num")
+
+        def delete() -> None:
+            del st.session_state["num"]
+
+        st.button("Delete", on_click=delete)
+
+    at = AppTest.from_function(script).run()
+    at.number_input[0].set_value(7).run()
+
+    # The frontend still holds 7 when the Delete button is clicked.
+    at.number_input[0].set_value(7)
+    at = at.button[0].click().run()
+
+    assert at.number_input[0].proto.set_value is True
+    assert at.number_input[0].proto.value == 1

--- a/lib/tests/streamlit/elements/selectbox_test.py
+++ b/lib/tests/streamlit/elements/selectbox_test.py
@@ -1075,3 +1075,27 @@ class SelectboxBindQueryParamsTest(DeltaGeneratorTestCase):
         c = self.get_delta_from_queue().new_element.selectbox
         assert c.query_param_key == "my_key"
         assert c.accept_new_options
+
+
+def test_delete_session_state_key_pushes_default_to_frontend() -> None:
+    """Deleting the key resets the widget in the browser too (issue #16388)."""
+
+    def script() -> None:
+        import streamlit as st
+
+        st.selectbox("Sel", ["A", "B", "C"], key="sel")
+
+        def delete() -> None:
+            del st.session_state["sel"]
+
+        st.button("Delete", on_click=delete)
+
+    at = AppTest.from_function(script).run()
+    at.selectbox[0].set_value("C").run()
+
+    # The frontend still holds "C" when the Delete button is clicked.
+    at.selectbox[0].set_value("C")
+    at = at.button[0].click().run()
+
+    assert at.selectbox[0].proto.set_value is True
+    assert at.selectbox[0].proto.raw_value == "A"

--- a/lib/tests/streamlit/elements/slider_test.py
+++ b/lib/tests/streamlit/elements/slider_test.py
@@ -795,3 +795,32 @@ class SliderEdgeCasesTest(DeltaGeneratorTestCase):
     def test_empty_value_list_uses_outer_bounds(self):
         """An empty value list uses min_value and max_value as bounds."""
         assert st.slider("label", value=[], min_value=0, max_value=100) == (0, 100)
+
+
+def test_delete_session_state_key_pushes_default_to_frontend() -> None:
+    """Deleting the key resets the slider in the browser too.
+
+    Issue #5442 claims that st.slider already behaves correctly. It does not:
+    the slider uses the same registration path and the same value_changed flag
+    as every other widget, so it needs the same fix (issue #16388).
+    """
+
+    def script() -> None:
+        import streamlit as st
+
+        st.slider("Slide", 0, 10, 3, key="slide")
+
+        def delete() -> None:
+            del st.session_state["slide"]
+
+        st.button("Delete", on_click=delete)
+
+    at = AppTest.from_function(script).run()
+    at.slider[0].set_value(8).run()
+
+    # The frontend still holds 8 when the Delete button is clicked.
+    at.slider[0].set_value(8)
+    at = at.button[0].click().run()
+
+    assert at.slider[0].proto.set_value is True
+    assert list(at.slider[0].proto.value) == [3]

--- a/lib/tests/streamlit/elements/text_input_test.py
+++ b/lib/tests/streamlit/elements/text_input_test.py
@@ -797,3 +797,27 @@ def test_None_session_state_value_retained():
     at = AppTest.from_function(script).run()
     at = at.button[0].click().run()
     assert at.text_input[0].value is None
+
+
+def test_delete_session_state_key_pushes_default_to_frontend() -> None:
+    """Deleting the key resets the widget in the browser too (issue #16388)."""
+
+    def script() -> None:
+        import streamlit as st
+
+        st.text_input("Foo", value="default", key="foo")
+
+        def delete() -> None:
+            del st.session_state["foo"]
+
+        st.button("Delete", on_click=delete)
+
+    at = AppTest.from_function(script).run()
+    at.text_input[0].set_value("hello").run()
+
+    # The frontend still holds "hello" when the Delete button is clicked.
+    at.text_input[0].set_value("hello")
+    at = at.button[0].click().run()
+
+    assert at.text_input[0].proto.set_value is True
+    assert at.text_input[0].proto.value == "default"

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -21,9 +21,11 @@ import unittest
 from copy import deepcopy
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, patch
 
+import numpy as np
+import pandas as pd
 import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as hst
@@ -70,6 +72,7 @@ from streamlit.runtime.state.session_state import (
     SessionStateStatProvider,
     Value,
     WStates,
+    _equals_deleted_value,
     _is_stale_widget,
     _sanitize_url_array,
 )
@@ -78,6 +81,11 @@ from streamlit.runtime.uploaded_file_manager import UploadedFile, UploadedFileRe
 from streamlit.testing.v1.app_test import AppTest
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 from tests.testutil import patch_config_options
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from streamlit.runtime.state.common import WidgetCallback
 
 
 def identity(x):
@@ -4058,3 +4066,959 @@ class DisabledWidgetAppTest(unittest.TestCase):
         at.button[0].click().run()
 
         assert at.session_state["clicked"] is True
+
+
+def _create_delete_reset_metadata(
+    widget_id: str,
+    *,
+    value_type: str = "string_value",
+    deserializer: Callable[[Any], Any] | None = None,
+    callback: WidgetCallback | None = None,
+    disabled: bool = False,
+    bind: BindOption = None,
+    persist_state: PersistStateOption = None,
+    fragment_id: str | None = None,
+) -> WidgetMetadata:
+    """Create widget metadata for the widget delete reset tests."""
+    return WidgetMetadata(
+        id=widget_id,
+        deserializer=deserializer or (lambda x: x if x is not None else "default"),
+        serializer=lambda x: x,
+        value_type=value_type,
+        callback=callback,
+        disabled=disabled,
+        bind=bind,
+        persist_state=persist_state,
+        fragment_id=fragment_id,
+    )
+
+
+class WidgetDeleteResetTest(DeltaGeneratorTestCase):
+    """The delete reset: ``del st.session_state[key]`` restores a widget's default.
+
+    The reset must reach the browser as well as Python. See issue #16388 and the
+    ``SessionState._pending_delete_resets`` field comment.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.session_state = SessionState()
+
+    def _register_and_store_frontend_value(
+        self, metadata: WidgetMetadata, widget_id: str
+    ) -> None:
+        """Run one registration, store the frontend value "hello", end the run."""
+        self.session_state.register_widget(metadata, user_key="foo")
+        self.session_state._new_widget_state.set_from_value(widget_id, "hello")
+        self.session_state._compact_state()
+
+    @patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=MockScriptRunCtx(),
+    )
+    def test_delete_in_callback_resets_widget_in_same_run(
+        self, mock_ctx: MagicMock
+    ) -> None:
+        """A delete before registration resets the widget in the same run.
+
+        The delete removes the frontend value in the same run, and nothing can
+        arrive from the frontend between the callback and the registration. The
+        reset must apply even though no incoming value is left to compare.
+        """
+        widget_id = "$$ID-hash-foo"
+        metadata = _create_delete_reset_metadata(widget_id)
+        self._register_and_store_frontend_value(metadata, widget_id)
+
+        # The browser resends the old value, then a callback deletes the key.
+        self.session_state._new_widget_state.set_from_value(widget_id, "hello")
+        del self.session_state["foo"]
+        assert widget_id not in self.session_state._new_widget_state
+
+        result = self.session_state.register_widget(metadata, user_key="foo")
+
+        assert result.value == "default"
+        assert result.value_changed is True
+
+    @patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=MockScriptRunCtx(),
+    )
+    def test_delete_then_resent_frontend_value_is_dropped(
+        self, mock_ctx: MagicMock
+    ) -> None:
+        """A delete after registration resets the widget on the next rerun."""
+        widget_id = "$$ID-hash-foo"
+        metadata = _create_delete_reset_metadata(widget_id)
+        self._register_and_store_frontend_value(metadata, widget_id)
+
+        # Run 2: the widget renders, then the script body deletes the key.
+        self.session_state._new_widget_state.set_from_value(widget_id, "hello")
+        self.session_state.register_widget(metadata, user_key="foo")
+        del self.session_state["foo"]
+        self.session_state._compact_state()
+
+        # Run 3: the browser still holds the old value and resends it.
+        self.session_state._new_widget_state.set_from_value(widget_id, "hello")
+        result = self.session_state.register_widget(metadata, user_key="foo")
+
+        assert result.value == "default"
+        assert result.value_changed is True
+        assert self.session_state._new_widget_state[widget_id] == "default"
+
+    @patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=MockScriptRunCtx(),
+    )
+    def test_reset_is_one_shot(self, mock_ctx: MagicMock) -> None:
+        """The widget accepts a new frontend value after the reset."""
+        widget_id = "$$ID-hash-foo"
+        metadata = _create_delete_reset_metadata(widget_id)
+        self._register_and_store_frontend_value(metadata, widget_id)
+
+        self.session_state._new_widget_state.set_from_value(widget_id, "hello")
+        del self.session_state["foo"]
+        self.session_state.register_widget(metadata, user_key="foo")
+        self.session_state._compact_state()
+
+        # The user changes the widget again.
+        self.session_state._new_widget_state.set_from_value(widget_id, "second")
+        result = self.session_state.register_widget(metadata, user_key="foo")
+
+        assert result.value == "second"
+        assert result.value_changed is False
+        assert not self.session_state._pending_delete_resets
+
+    @patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=MockScriptRunCtx(),
+    )
+    def test_change_after_delete_wins_over_reset(self, mock_ctx: MagicMock) -> None:
+        """A user change that arrives after the delete beats the reset.
+
+        The script deletes the key after the widget rendered, so the reset waits
+        for the next run. If the user changes the widget first, that change is
+        newer than the delete and must survive.
+        """
+        widget_id = "$$ID-hash-foo"
+        metadata = _create_delete_reset_metadata(widget_id)
+        self._register_and_store_frontend_value(metadata, widget_id)
+
+        # Run 2: the widget renders, then the script body deletes the key.
+        self.session_state._new_widget_state.set_from_value(widget_id, "hello")
+        self.session_state.register_widget(metadata, user_key="foo")
+        del self.session_state["foo"]
+        self.session_state._compact_state()
+
+        # Run 3: the user typed a new value instead of resending the old one.
+        self.session_state._new_widget_state.set_from_value(widget_id, "typed")
+        result = self.session_state.register_widget(metadata, user_key="foo")
+
+        assert result.value == "typed"
+        assert result.value_changed is False
+        assert not self.session_state._pending_delete_resets
+
+    @patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=MockScriptRunCtx(),
+    )
+    def test_delete_on_every_run_keeps_a_change_for_one_run(
+        self, mock_ctx: MagicMock
+    ) -> None:
+        """A script that deletes the key on every run keeps a change one run.
+
+        The user's value wins on the run it arrives, because it is newer than the
+        delete. The script then deletes it again, so the next run resets the
+        widget. The widget is never pinned to its default.
+        """
+        widget_id = "$$ID-hash-foo"
+        metadata = _create_delete_reset_metadata(widget_id)
+
+        # Run 1: the widget renders its default, then the script deletes the key.
+        self.session_state.register_widget(metadata, user_key="foo")
+        del self.session_state["foo"]
+        self.session_state._compact_state()
+
+        # Run 2: the user types a value, which is newer than the delete.
+        self.session_state._new_widget_state.set_from_value(widget_id, "typed")
+        result = self.session_state.register_widget(metadata, user_key="foo")
+        assert result.value == "typed"
+        assert result.value_changed is False
+        del self.session_state["foo"]
+        self.session_state._compact_state()
+
+        # Run 3: the frontend resends the same value, so the reset applies.
+        self.session_state._new_widget_state.set_from_value(widget_id, "typed")
+        result = self.session_state.register_widget(metadata, user_key="foo")
+        assert result.value == "default"
+        assert result.value_changed is True
+
+    @patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=MockScriptRunCtx(),
+    )
+    def test_list_valued_widget_resets_only_on_a_resend(
+        self, mock_ctx: MagicMock
+    ) -> None:
+        """A list-valued widget such as st.multiselect compares by value."""
+        widget_id = "$$ID-hash-foo"
+        metadata = _create_delete_reset_metadata(
+            widget_id,
+            value_type="string_array_value",
+            deserializer=lambda x: list(x) if x is not None else [],
+        )
+        self.session_state.register_widget(metadata, user_key="foo")
+        self.session_state._new_widget_state.set_from_value(widget_id, ["A", "B"])
+        self.session_state._compact_state()
+
+        self.session_state._new_widget_state.set_from_value(widget_id, ["A", "B"])
+        self.session_state.register_widget(metadata, user_key="foo")
+        del self.session_state["foo"]
+        self.session_state._compact_state()
+
+        # An equal list is a resend, so the reset applies.
+        self.session_state._new_widget_state.set_from_value(widget_id, ["A", "B"])
+        result = self.session_state.register_widget(metadata, user_key="foo")
+        assert result.value == []
+        assert result.value_changed is True
+
+        # A different list is a user change, so it wins.
+        self.session_state._new_widget_state.set_from_value(widget_id, ["C"])
+        self.session_state.register_widget(metadata, user_key="foo")
+        del self.session_state["foo"]
+        self.session_state._compact_state()
+        self.session_state._new_widget_state.set_from_value(widget_id, ["A"])
+        result = self.session_state.register_widget(metadata, user_key="foo")
+        assert result.value == ["A"]
+        assert result.value_changed is False
+
+    @patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=MockScriptRunCtx(),
+    )
+    def test_bound_widget_change_after_delete_wins(self, mock_ctx: MagicMock) -> None:
+        """A bound widget keeps a change made after the delete."""
+        ThreadState.update(active_script_hash="main_hash")
+        widget_id = "$$ID-hash-foo"
+        metadata = _create_delete_reset_metadata(widget_id, bind="query-params")
+        query_params = self.session_state.query_params
+        query_params.set_initial_query_params("foo=hello")
+        query_params.set_with_no_forward_msg("foo", "hello")
+
+        self.session_state.register_widget(metadata, user_key="foo")
+        self.session_state._compact_state()
+
+        self.session_state._new_widget_state.set_from_value(widget_id, "hello")
+        self.session_state.register_widget(metadata, user_key="foo")
+        del self.session_state["foo"]
+        self.session_state._compact_state()
+
+        # The user typed a new value after the delete.
+        self.session_state._new_widget_state.set_from_value(widget_id, "typed")
+        result = self.session_state.register_widget(metadata, user_key="foo")
+
+        assert result.value == "typed"
+        assert result.value_changed is False
+        # The reset did not run, so it must not clear the URL parameter. For a
+        # change made in the UI the browser writes the new value to the URL.
+        assert query_params.has_param("foo")
+
+    @patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=MockScriptRunCtx(),
+    )
+    def test_delete_of_plain_key_records_no_pending_delete_reset(
+        self, mock_ctx: MagicMock
+    ) -> None:
+        """A key with no widget mapping records no delete reset."""
+        self.session_state._new_session_state["plain"] = 1
+
+        del self.session_state["plain"]
+
+        assert not self.session_state._pending_delete_resets
+
+    @patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=MockScriptRunCtx(),
+    )
+    def test_programmatic_set_after_delete_wins(self, mock_ctx: MagicMock) -> None:
+        """A set after the delete takes precedence over the default."""
+        widget_id = "$$ID-hash-foo"
+        metadata = _create_delete_reset_metadata(widget_id)
+        self._register_and_store_frontend_value(metadata, widget_id)
+
+        self.session_state._new_widget_state.set_from_value(widget_id, "hello")
+        del self.session_state["foo"]
+        self.session_state._new_session_state["foo"] = "programmatic"
+        result = self.session_state.register_widget(metadata, user_key="foo")
+
+        assert result.value == "programmatic"
+        assert result.value_changed is True
+
+    @patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=MockScriptRunCtx(),
+    )
+    def test_incoming_serialized_value_cleared_on_reset(
+        self, mock_ctx: MagicMock
+    ) -> None:
+        """The wire label of the dropped value must not reach the caller.
+
+        Otherwise an option-based widget such as st.selectbox reconciles its
+        options against the deleted label and hands back the deleted value.
+        """
+        widget_id = "$$ID-hash-foo"
+        metadata = _create_delete_reset_metadata(widget_id)
+        self._register_and_store_frontend_value(metadata, widget_id)
+
+        stale_proto = WidgetStateProto()
+        stale_proto.id = widget_id
+        stale_proto.string_value = "hello"
+        self.session_state._new_widget_state.set_widget_from_proto(stale_proto)
+        self.session_state.register_widget(metadata, user_key="foo")
+        del self.session_state["foo"]
+        self.session_state._compact_state()
+
+        self.session_state._new_widget_state.set_widget_from_proto(stale_proto)
+        result = self.session_state.register_widget(metadata, user_key="foo")
+
+        assert result.incoming_serialized_value is None
+
+    @patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=MockScriptRunCtx(),
+    )
+    def test_incoming_serialized_values_cleared_on_reset(
+        self, mock_ctx: MagicMock
+    ) -> None:
+        """A string-array widget such as st.multiselect clears its wire labels."""
+        widget_id = "$$ID-hash-foo"
+        metadata = _create_delete_reset_metadata(
+            widget_id,
+            value_type="string_array_value",
+            deserializer=lambda x: x if x is not None else [],
+        )
+        self.session_state.register_widget(metadata, user_key="foo")
+        self.session_state._compact_state()
+
+        stale_proto = WidgetStateProto()
+        stale_proto.id = widget_id
+        stale_proto.string_array_value.data[:] = ["A"]
+        self.session_state._new_widget_state.set_widget_from_proto(stale_proto)
+        self.session_state.register_widget(metadata, user_key="foo")
+        del self.session_state["foo"]
+        self.session_state._compact_state()
+
+        self.session_state._new_widget_state.set_widget_from_proto(stale_proto)
+        result = self.session_state.register_widget(metadata, user_key="foo")
+
+        assert result.value == []
+        assert result.value_changed is True
+        assert result.incoming_serialized_values is None
+
+    @patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=MockScriptRunCtx(),
+    )
+    def test_pending_delete_reset_pruned_when_widget_goes_stale(
+        self, mock_ctx: MagicMock
+    ) -> None:
+        """A stale widget needs no reset, because both sides drop its value."""
+        widget_id = "$$ID-hash-foo"
+        metadata = _create_delete_reset_metadata(widget_id)
+        self.session_state.register_widget(metadata, user_key="foo")
+        del self.session_state["foo"]
+
+        self.session_state._remove_stale_widgets(frozenset())
+
+        assert not self.session_state._pending_delete_resets
+
+    @patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=MockScriptRunCtx(),
+    )
+    def test_pending_delete_reset_survives_when_widget_is_active(
+        self, mock_ctx: MagicMock
+    ) -> None:
+        """An active widget keeps its pending delete reset for the next run."""
+        widget_id = "$$ID-hash-foo"
+        metadata = _create_delete_reset_metadata(widget_id)
+        self.session_state.register_widget(metadata, user_key="foo")
+        del self.session_state["foo"]
+
+        self.session_state._remove_stale_widgets(frozenset({widget_id}))
+
+        assert set(self.session_state._pending_delete_resets) == {widget_id}
+
+    def test_pending_delete_reset_survives_fragment_run_for_outside_widget(
+        self,
+    ) -> None:
+        """A fragment run must not drop the reset of a widget outside it."""
+        widget_id = "$$ID-hash-foo"
+        metadata = _create_delete_reset_metadata(widget_id)
+        with patch(
+            "streamlit.runtime.state.session_state.get_script_run_ctx",
+            return_value=MockScriptRunCtx(fragment_ids_this_run=["frag_1"]),
+        ):
+            self.session_state.register_widget(metadata, user_key="foo")
+            del self.session_state["foo"]
+
+            self.session_state._remove_stale_widgets(frozenset())
+
+        assert set(self.session_state._pending_delete_resets) == {widget_id}
+
+    def test_callback_suppressed_for_pending_delete_reset(self) -> None:
+        """The on_change callback must not fire for the deleted value.
+
+        On the run after a mid-script delete the browser resends the old value,
+        which looks like a change. The user did not make that change.
+        """
+        widget_id = "$$ID-hash-foo"
+        callback = MagicMock()
+        metadata = _create_delete_reset_metadata(widget_id, callback=callback)
+        self.session_state._set_widget_metadata(metadata)
+        self.session_state._old_state[widget_id] = "old"
+        self.session_state._new_widget_state.set_from_value(widget_id, "hello")
+        self.session_state._pending_delete_resets[widget_id] = "hello"
+
+        self.session_state._call_callbacks()
+
+        callback.assert_not_called()
+
+    def test_callback_still_runs_without_pending_delete_reset(self) -> None:
+        """A changed widget with no pending delete reset still runs its callback."""
+        widget_id = "$$ID-hash-foo"
+        callback = MagicMock()
+        metadata = _create_delete_reset_metadata(widget_id, callback=callback)
+        self.session_state._set_widget_metadata(metadata)
+        self.session_state._old_state[widget_id] = "old"
+        self.session_state._new_widget_state.set_from_value(widget_id, "hello")
+
+        self.session_state._call_callbacks()
+
+        callback.assert_called_once()
+
+    def test_callback_runs_for_a_change_after_the_delete(self) -> None:
+        """A real change after the delete still fires on_change.
+
+        The incoming value differs from the deleted value, so the user made it.
+        Only a resent deleted value suppresses the callback.
+        """
+        widget_id = "$$ID-hash-foo"
+        callback = MagicMock()
+        metadata = _create_delete_reset_metadata(widget_id, callback=callback)
+        self.session_state._set_widget_metadata(metadata)
+        self.session_state._old_state[widget_id] = "old"
+        self.session_state._new_widget_state.set_from_value(widget_id, "typed")
+        self.session_state._pending_delete_resets[widget_id] = "hello"
+
+        self.session_state._call_callbacks()
+
+        callback.assert_called_once()
+
+    @patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=MockScriptRunCtx(),
+    )
+    def test_bound_widget_delete_removes_url_param(self, mock_ctx: MagicMock) -> None:
+        """A delete clears the query parameter of a bound widget."""
+        ThreadState.update(active_script_hash="main_hash")
+        widget_id = "$$ID-hash-foo"
+        metadata = _create_delete_reset_metadata(widget_id, bind="query-params")
+        query_params = self.session_state.query_params
+        query_params.set_initial_query_params("foo=hello")
+        query_params.set_with_no_forward_msg("foo", "hello")
+
+        result = self.session_state.register_widget(metadata, user_key="foo")
+        assert result.value == "hello"
+        self.session_state._compact_state()
+
+        self.session_state._new_widget_state.set_from_value(widget_id, "hello")
+        del self.session_state["foo"]
+        result = self.session_state.register_widget(metadata, user_key="foo")
+
+        assert result.value == "default"
+        assert result.value_changed is True
+        assert "foo" not in query_params._query_params
+
+    @patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=MockScriptRunCtx(),
+    )
+    def test_bound_widget_delete_removes_only_its_own_param(
+        self, mock_ctx: MagicMock
+    ) -> None:
+        """Removing one bound parameter leaves the other parameters alone."""
+        ThreadState.update(active_script_hash="main_hash")
+        widget_id = "$$ID-hash-foo"
+        metadata = _create_delete_reset_metadata(widget_id, bind="query-params")
+        query_params = self.session_state.query_params
+        query_params.set_initial_query_params("foo=hello&other=keep")
+        query_params.set_with_no_forward_msg("foo", "hello")
+        query_params.set_with_no_forward_msg("other", "keep")
+
+        self.session_state.register_widget(metadata, user_key="foo")
+        self.session_state._compact_state()
+
+        self.session_state._new_widget_state.set_from_value(widget_id, "hello")
+        del self.session_state["foo"]
+        self.session_state.register_widget(metadata, user_key="foo")
+
+        assert query_params._query_params == {"other": "keep"}
+
+    @patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=MockScriptRunCtx(),
+    )
+    def test_bound_widget_delete_skips_url_seeding(self, mock_ctx: MagicMock) -> None:
+        """The resetting registration must not re-seed from the URL.
+
+        The backend re-reads the query string on every same-page rerun, so the
+        old value is still available for seeding.
+        """
+        ThreadState.update(active_script_hash="main_hash")
+        widget_id = "$$ID-hash-foo"
+        metadata = _create_delete_reset_metadata(widget_id, bind="query-params")
+        self.session_state.query_params.set_initial_query_params("foo=hello")
+
+        self.session_state.register_widget(metadata, user_key="foo")
+        self.session_state._compact_state()
+
+        self.session_state._new_widget_state.set_from_value(widget_id, "hello")
+        del self.session_state["foo"]
+        result = self.session_state.register_widget(metadata, user_key="foo")
+
+        assert result.value == "default"
+        assert result.value_changed is True
+
+    @patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=MockScriptRunCtx(),
+    )
+    def test_bound_widget_script_body_delete_resets_on_next_rerun(
+        self, mock_ctx: MagicMock
+    ) -> None:
+        """A script-body delete clears a bound parameter one run later.
+
+        The URL keeps the deleted value for the whole delete run, and the backend
+        re-reads the query string on every same-page rerun. The reset must still
+        clear the parameter and must not seed the deleted value back.
+        """
+        ThreadState.update(active_script_hash="main_hash")
+        widget_id = "$$ID-hash-foo"
+        metadata = _create_delete_reset_metadata(widget_id, bind="query-params")
+        query_params = self.session_state.query_params
+        query_params.set_initial_query_params("foo=hello")
+        query_params.set_with_no_forward_msg("foo", "hello")
+
+        self.session_state.register_widget(metadata, user_key="foo")
+        self.session_state._compact_state()
+
+        # Run 2: the widget renders, then the script body deletes the key.
+        self.session_state._new_widget_state.set_from_value(widget_id, "hello")
+        self.session_state.register_widget(metadata, user_key="foo")
+        del self.session_state["foo"]
+        assert query_params.has_param("foo")
+        self.session_state._compact_state()
+
+        # Run 3: the URL and the frontend both still hold the deleted value.
+        query_params.set_initial_query_params("foo=hello")
+        self.session_state._new_widget_state.set_from_value(widget_id, "hello")
+        result = self.session_state.register_widget(metadata, user_key="foo")
+
+        assert result.value == "default"
+        assert result.value_changed is True
+        assert "foo" not in query_params._query_params
+
+    @patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=MockScriptRunCtx(),
+    )
+    def test_persist_state_widget_delete_resets(self, mock_ctx: MagicMock) -> None:
+        """A persist_state widget also falls back to its default."""
+        widget_id = "$$ID-hash-foo"
+        metadata = _create_delete_reset_metadata(widget_id, persist_state="session")
+        self._register_and_store_frontend_value(metadata, widget_id)
+
+        self.session_state._new_widget_state.set_from_value(widget_id, "hello")
+        del self.session_state["foo"]
+        result = self.session_state.register_widget(metadata, user_key="foo")
+
+        assert result.value == "default"
+        assert result.value_changed is True
+
+    @patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=MockScriptRunCtx(),
+    )
+    def test_disabled_widget_delete_resets(self, mock_ctx: MagicMock) -> None:
+        """A disabled widget resets once, and the two guards do not conflict."""
+        widget_id = "$$ID-hash-foo"
+        metadata = _create_delete_reset_metadata(widget_id, disabled=True)
+        self._register_and_store_frontend_value(metadata, widget_id)
+
+        self.session_state._new_widget_state.set_from_value(widget_id, "hello")
+        del self.session_state["foo"]
+        result = self.session_state.register_widget(metadata, user_key="foo")
+
+        assert result.value == "default"
+        assert result.value_changed is True
+
+    @patch(
+        "streamlit.runtime.state.session_state.get_script_run_ctx",
+        return_value=MockScriptRunCtx(),
+    )
+    def test_internal_clear_drops_pending_delete_resets(
+        self, mock_ctx: MagicMock
+    ) -> None:
+        """SessionState.clear wipes the pending delete resets with everything else."""
+        widget_id = "$$ID-hash-foo"
+        metadata = _create_delete_reset_metadata(widget_id)
+        self.session_state.register_widget(metadata, user_key="foo")
+        del self.session_state["foo"]
+
+        self.session_state.clear()
+
+        assert not self.session_state._pending_delete_resets
+
+
+class WidgetDeleteResetAppTest(unittest.TestCase):
+    """Widget delete reset through the whole backend, via AppTest.
+
+    An AppTest widget node reads its value from session state unless the test
+    sets one, so every run below calls ``set_value`` again to model a browser
+    that still holds the old value.
+    """
+
+    @staticmethod
+    def _text_input_script_with_callback() -> None:
+        import streamlit as st
+
+        value = st.text_input("Foo", value="default", key="foo")
+        st.write("got " + repr(value))
+
+        def delete() -> None:
+            del st.session_state["foo"]
+
+        st.button("Delete", on_click=delete)
+        st.button("Noop")
+
+    @staticmethod
+    def _run_then_delete(script: Callable[[], None]) -> AppTest:
+        """Run the script, type "hello", then click the script's first button.
+
+        The second ``set_value`` models a browser that still holds "hello" when
+        the click arrives.
+        """
+        at = AppTest.from_function(script).run()
+        at.text_input[0].set_value("hello").run()
+        at.text_input[0].set_value("hello")
+        at.button[0].click().run()
+        return at
+
+    def test_delete_in_callback_pushes_default_to_frontend(self) -> None:
+        """A delete in a callback resets the widget in the same run."""
+        at = AppTest.from_function(self._text_input_script_with_callback).run()
+        at.text_input[0].set_value("hello").run()
+        assert at.markdown[0].value == "got 'hello'"
+
+        # The frontend still holds "hello" when the Delete button is clicked.
+        at.text_input[0].set_value("hello")
+        at.button[0].click().run()
+
+        assert at.markdown[0].value == "got 'default'"
+        # The proto must carry the correction, or the browser keeps "hello" and
+        # resends it on the next rerun (issue #16388).
+        assert at.text_input[0].proto.set_value is True
+        assert at.text_input[0].proto.value == "default"
+
+    def test_reset_survives_a_plain_rerun(self) -> None:
+        """A real browser adopts the default, so the next rerun keeps it.
+
+        This is a smoke test, not a regression test. AppTest cannot model a
+        browser that ignores ``set_value``, so this case also passes without the
+        fix. ``test_delete_in_script_body_resets_on_next_rerun`` guards the
+        re-adoption of a stale value, because there the browser legitimately
+        still holds the old value.
+        """
+        at = self._run_then_delete(self._text_input_script_with_callback)
+
+        at.button[1].click().run()
+
+        assert at.markdown[0].value == "got 'default'"
+        # The reset is one-shot, so it must not correct the frontend again.
+        assert at.text_input[0].proto.set_value is False
+
+    def test_widget_is_usable_after_reset(self) -> None:
+        """The user can change the widget again after the reset.
+
+        This is a smoke test, not a regression test: it also passes without the
+        fix. ``test_reset_is_one_shot`` covers the one-shot rule directly.
+        """
+        at = self._run_then_delete(self._text_input_script_with_callback)
+
+        at.text_input[0].set_value("second").run()
+
+        assert at.markdown[0].value == "got 'second'"
+        assert at.text_input[0].proto.set_value is False
+
+    def test_delete_in_script_body_resets_on_next_rerun(self) -> None:
+        """A delete after the widget rendered resets on the next rerun."""
+
+        def script() -> None:
+            import streamlit as st
+
+            value = st.text_input("Foo", value="default", key="foo")
+            st.write("got " + repr(value))
+            delete = st.button("Delete")
+            st.button("Noop")
+            if delete:
+                del st.session_state["foo"]
+
+        at = AppTest.from_function(script).run()
+        at.text_input[0].set_value("hello").run()
+        assert at.markdown[0].value == "got 'hello'"
+
+        # The delete runs after the widget rendered, so both sides still show
+        # the old value for the rest of this run.
+        at.text_input[0].set_value("hello")
+        at.button[0].click().run()
+        assert at.markdown[0].value == "got 'hello'"
+
+        # The browser resends the old value on the next rerun. The backend must
+        # drop it and push the default.
+        at.text_input[0].set_value("hello")
+        at.button[1].click().run()
+
+        assert at.markdown[0].value == "got 'default'"
+        assert at.text_input[0].proto.set_value is True
+        assert at.text_input[0].proto.value == "default"
+
+    def test_session_state_clear_resets_widget(self) -> None:
+        """st.session_state.clear() resets a keyed widget."""
+
+        def script() -> None:
+            import streamlit as st
+
+            value = st.text_input("Foo", value="default", key="foo")
+            st.write("got " + repr(value))
+            st.button("Clear", on_click=st.session_state.clear)
+
+        at = self._run_then_delete(script)
+
+        assert at.markdown[0].value == "got 'default'"
+        assert at.text_input[0].proto.set_value is True
+
+    def test_session_state_pop_resets_widget(self) -> None:
+        """st.session_state.pop() resets a keyed widget."""
+
+        def script() -> None:
+            import streamlit as st
+
+            value = st.text_input("Foo", value="default", key="foo")
+            st.write("got " + repr(value))
+
+            def pop() -> None:
+                st.session_state.pop("foo")
+
+            st.button("Pop", on_click=pop)
+
+        at = self._run_then_delete(script)
+
+        assert at.markdown[0].value == "got 'default'"
+        assert at.text_input[0].proto.set_value is True
+
+    def test_delete_in_callback_resets_selectbox(self) -> None:
+        """An option-based widget resets to its default option.
+
+        st.selectbox reconciles the incoming wire label against its options, so
+        the reset must also clear that label.
+        """
+
+        def script() -> None:
+            import streamlit as st
+
+            value = st.selectbox("Sel", ["A", "B", "C"], key="sel")
+            st.write("got " + repr(value))
+
+            def delete() -> None:
+                del st.session_state["sel"]
+
+            st.button("Delete", on_click=delete)
+
+        at = AppTest.from_function(script).run()
+        at.selectbox[0].set_value("C").run()
+        assert at.markdown[0].value == "got 'C'"
+
+        at.selectbox[0].set_value("C")
+        at.button[0].click().run()
+
+        assert at.markdown[0].value == "got 'A'"
+        assert at.selectbox[0].proto.set_value is True
+
+    def test_change_during_a_deferred_reset_is_kept(self) -> None:
+        """A user change after a script-body delete must not disappear.
+
+        The script deletes the key at the end of the run, so the reset waits for
+        the next run. The user then changes the widget. That change is newer than
+        the delete, so the app must receive it and on_change must fire.
+        """
+
+        def script() -> None:
+            import streamlit as st
+
+            def on_change() -> None:
+                st.session_state["change_count"] = (
+                    st.session_state.get("change_count", 0) + 1
+                )
+
+            value = st.text_input(
+                "Cb", value="cb_default", key="cb", on_change=on_change
+            )
+            st.write("got " + repr(value))
+
+            def arm() -> None:
+                st.session_state["armed"] = True
+
+            st.button("Arm", on_click=arm)
+
+            if st.session_state.get("armed"):
+                st.session_state["armed"] = False
+                st.session_state.pop("cb", None)
+
+        at = AppTest.from_function(script).run()
+        at.text_input[0].set_value("cb2").run()
+        assert at.markdown[0].value == "got 'cb2'"
+        assert at.session_state["change_count"] == 1
+
+        # Arm the script-body delete. The browser still holds "cb2".
+        at.text_input[0].set_value("cb2")
+        at.button[0].click().run()
+        assert at.markdown[0].value == "got 'cb2'"
+
+        # The user types a new value before the browser sees any correction.
+        at.text_input[0].set_value("cb3").run()
+
+        assert at.markdown[0].value == "got 'cb3'"
+        assert at.text_input[0].proto.set_value is False
+        assert at.session_state["change_count"] == 2
+
+    def test_delete_after_a_set_in_the_same_run_resets(self) -> None:
+        """The recorded value must match the value the frontend then holds.
+
+        A callback sets the key, so the frontend adopts that value. The script
+        body then deletes the key. The recorded value must be the value the app
+        set, not the value the frontend sent before the callback ran.
+        """
+
+        def script() -> None:
+            import streamlit as st
+
+            def seed() -> None:
+                st.session_state["multi"] = ["A"]
+
+            go = st.button("Go", on_click=seed)
+            value = st.multiselect("M", ["A", "B"], key="multi")
+            st.write("got " + repr(value))
+            st.button("Noop")
+            if go:
+                del st.session_state["multi"]
+
+        at = AppTest.from_function(script).run()
+        at.button[0].click().run()
+        assert at.markdown[0].value == "got ['A']"
+
+        # The browser resends the value it adopted, so the reset applies.
+        at.multiselect[0].set_value(["A"])
+        at.button[1].click().run()
+
+        assert at.markdown[0].value == "got []"
+        assert at.multiselect[0].proto.set_value is True
+
+    def test_delete_after_a_set_of_another_container_type_does_not_reset(self) -> None:
+        """Known limitation: the recorded value must equal the resent value.
+
+        The app sets a tuple, but the widget serializes it and the browser stores
+        a list. The recorded tuple no longer equals the resent list, so the
+        backend reads the resend as a fresh user change and skips the reset. The
+        behavior matches Streamlit before the delete reset existed.
+        """
+
+        def script() -> None:
+            import streamlit as st
+
+            def seed() -> None:
+                st.session_state["multi"] = ("A",)
+
+            go = st.button("Go", on_click=seed)
+            value = st.multiselect("M", ["A", "B"], key="multi")
+            st.write("got " + repr(value))
+            st.button("Noop")
+            if go:
+                del st.session_state["multi"]
+
+        at = AppTest.from_function(script).run()
+        at.button[0].click().run()
+        assert at.markdown[0].value == "got ('A',)"
+
+        at.multiselect[0].set_value(["A"])
+        at.button[1].click().run()
+
+        assert at.markdown[0].value == "got ['A']"
+        assert at.multiselect[0].proto.set_value is False
+
+    def test_delete_on_every_run_keeps_a_change_for_one_run(self) -> None:
+        """A script that deletes the key on every run stays usable.
+
+        The user's value wins on the run it arrives. The script deletes it again,
+        so the following run resets the widget. The widget is never pinned to its
+        default.
+        """
+
+        def script() -> None:
+            import streamlit as st
+
+            value = st.text_input("Always", value="alwaysdefault", key="s_always")
+            st.write("got " + repr(value))
+            st.session_state.pop("s_always", None)
+            st.button("Noop")
+
+        at = AppTest.from_function(script).run()
+        assert at.markdown[0].value == "got 'alwaysdefault'"
+
+        at.text_input[0].set_value("typed").run()
+        assert at.markdown[0].value == "got 'typed'"
+
+        # The browser resends the same value, so the reset applies.
+        at.text_input[0].set_value("typed")
+        at.button[0].click().run()
+        assert at.markdown[0].value == "got 'alwaysdefault'"
+        assert at.text_input[0].proto.set_value is True
+
+
+@pytest.mark.parametrize(
+    ("incoming_value", "deleted_value", "expected"),
+    [
+        ("hello", "hello", True),
+        (["A", "B"], ["A", "B"], True),
+        ("typed", "hello", False),
+        (["A"], ["A", "B"], False),
+    ],
+    ids=["same_string", "same_list", "other_string", "other_list"],
+)
+def test_equals_deleted_value(
+    incoming_value: Any, deleted_value: Any, expected: bool
+) -> None:
+    """An equal value is a resend of the deleted value, a different one a change."""
+    assert _equals_deleted_value(incoming_value, deleted_value) is expected
+
+
+def test_equals_deleted_value_applies_reset_on_inconclusive_comparison() -> None:
+    """A comparison with no bool result falls back to the reset.
+
+    A widget value can hold an object whose `==` gives no bool. An st.multiselect
+    option can be a numpy array, which raises ValueError, or a pd.NA from a
+    dataframe column with a missing value, which raises TypeError. The app asked
+    for the reset, so apply it instead of letting the error reach the app.
+    """
+    assert _equals_deleted_value([np.array([1, 2, 3])], [np.array([4, 5, 6])]) is True
+    assert _equals_deleted_value(pd.NA, pd.NA) is True


### PR DESCRIPTION
## Describe your changes

`del st.session_state[key]` returned the widget to its default in Python but never told the browser. The browser kept the old value and resent it, so the next rerun re-adopted it and the delete was undone.

- `SessionState` records the widget's value when the key goes away. The widget's next registration compares that value with the value the browser sends.
- The two values match: the browser only resent the deleted value. The backend drops it, returns the default, and sets `value_changed`, so the element proto carries `set_value=True` and the browser adopts the default.
- The two values differ: the user changed the widget after the delete. That change is newer, so it wins and `on_change` fires as usual.
- The record is one-shot per widget, so a widget never stays pinned to its default. `_remove_stale_widgets` prunes it, which keeps fragment reruns correct.
- A widget with `bind="query-params"` also loses its query parameter, because the URL would otherwise re-seed the deleted value. Other query parameters stay.

The fix needs no proto change and no frontend change. The protocol already carries `set_value` and `has_one_shot_effect`.

`st.session_state.pop(key)` and `st.session_state.clear()` get the fix through `__delitem__`.

### Behavior change

A delete in a callback resets the widget in the same run. That is the recommended pattern.

A delete in the script body after the widget rendered resets on the next rerun. So an app that deletes the key on every run keeps a user value for one run only. `lib/streamlit/.agents/skills/developing-with-streamlit/references/session-state.md` documents both cases.

### Backward compatibility

This changes observable behavior for apps that delete widget keys, so it needs a deliberate call before merge. The table below comes from `compat-probe.py` (attached in the agent docs comment), run against `develop` and against this branch.

| App pattern | `develop` | This PR |
| --- | --- | --- |
| Reset button that calls `st.session_state.clear()` in a callback | Python returns the default, the browser keeps the old value, and the next rerun re-adopts it | Python returns the default and the browser adopts it, so both agree and it stays |
| Guarded script-body `pop`, an intentional Reset button (the #5442 repro) | The reset never happens. The old value stays for ever | The widget resets on the next rerun |
| Script-body `pop(key, None)` on every run | The value sticks for ever. The `pop` has no effect on the widget at all | The value lives for one run, then returns to the default |

The first two rows are the reported bugs, so the change makes those apps do what the author intended. The third row is the real break. Note that on `develop` that `pop` has no effect on the widget, so an app that contains the line already achieves nothing with it.

The pattern most at risk is an app that bulk-deletes session state on every run for non-widget cleanup, through a loop over the keys or through `clear()`, and does not realize the keys include widget keys. Those widgets now return to their defaults.

I found no precedent in this repo for gating a widget-state behavior change behind a config option. #16209 enforced `disabled` server-side, which is a comparable change, and shipped with `impact:users` and no flag. This PR follows that. If the team prefers a narrower first step, resetting only when the delete happens before the widget registers (the callback case) would cover #16388 but would not cover #5442, since #5442's repro deletes in the script body.

### Known limits

- Widgets with no `set_value` field still reset in Python only: `st.file_uploader`, `st.camera_input`, `st.audio_input`, `st.data_editor`, custom components, and the selection state of `st.plotly_chart`, `st.altair_chart`, `st.vega_lite_chart`, and `st.pydeck_chart`. The reference documents this gap. Extending those protos is out of scope here.
- A callback can set a value whose container type differs from the serialized form, for example a tuple that reaches the browser as a list. If the same run then deletes the key, the reset does not apply. This matches current behavior, so it is a missing improvement rather than a regression. `test_delete_after_a_set_of_another_container_type_does_not_reset` pins it.
- `_call_callbacks` Path 2 (multi-callback dispatch) stays unguarded on purpose. A guard there would suppress a genuine one-shot trigger, and those widgets have no `set_value` path anyway. `develop` dispatches the same spurious change today, so this is not a regression.
- The pending-edit divergence for a widget inside `st.form` is pre-existing. A control test against a plain `st.session_state[key] = value` shows the same result, so it belongs to every programmatic write into a form. It deserves its own issue.
- A reviewer suggested an `@pytest.mark.external_test` case for the bound-widget reset inside an iframe. The URL rewrite path is not new code, only a new caller, so this PR does not add one.

### A note on #5442

Issue #5442 states that `st.slider` behaves correctly while the other widgets do not. It does not. `st.slider` shares the same registration path, the same `value_changed` gate, and the same `useBasicWidgetState` hook, so it had the same bug. The 2022 comment was never confirmed by a maintainer. `slider_test.py` now covers this.

## GitHub Issue Link (if applicable)

- Closes #16388
- Closes #5442

## Testing Plan

- [x] Unit Tests (JS and/or Python)
- [x] E2E Tests
- [x] Any manual testing needed?

Unit tests: `session_state_test.py` gains `WidgetDeleteResetTest`, `WidgetDeleteResetAppTest`, and cases for the value comparison, including a numpy value whose comparison gives no bool. The five element test files assert that the proto carries `set_value=True` plus the default.

E2E tests: `e2e_playwright/st_session_state_widget_reset.py` and its test file cover a callback delete across seven widget types, a bound widget losing its URL parameter, and a script-body delete that defers the reset and then yields to a user change.

Manual testing: the repro from #16388 was driven in Chromium, plus a QA pass of 128 browser assertions over 18 widget types, `pop()`, `clear()`, a bound widget, `st.form`, `st.fragment`, a page switch, and a `persist_state` widget.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | committing-with-conventional-commits | 1 |
| subagent | Plan | 1 |
| subagent | general-purpose | 3 |
| subagent | qa-testing-feature | 1 |
| subagent | reviewing-local-changes | 1 |
| subagent | simplifying-local-changes | 1 |

</details>
<!-- agent-metrics-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes observable widget/session-state behavior for any app that deletes widget keys (including bulk clear), though it fixes intended reset flows; core runtime logic with nuanced callback vs script-body timing.
> 
> **Overview**
> Fixes **#16388** / **#5442**: deleting a keyed widget’s `st.session_state` entry used to restore the default in Python while the browser kept resending the old value, undoing the reset on the next rerun.
> 
> **`SessionState`** now tracks **`_pending_delete_resets`** when a widget key is removed (`del`, `pop`, or per-key deletes via `clear()`). On the next registration it compares the browser’s value to the recorded one: a match is treated as a stale resend (drop it, return the default, set **`value_changed`** so the proto pushes **`set_value`** to the client); a mismatch means a newer user edit wins. Resets are **one-shot**; **`on_change`** is skipped for resent deleted values. **`bind="query-params"`** widgets also drop their query param and skip URL re-seeding so the URL cannot revive the deleted value.
> 
> Docs in **`session-state.md`** describe callback vs script-body delete timing and widgets that still can’t sync the browser. Coverage adds Playwright e2e, broad **`session_state_test`** cases, and per-widget AppTest checks for **`set_value`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f100e52fce66d153f5def3602290b08f88599678. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->