### PR TITLE
[feature] Add wrap parameter to st.checkbox and st.toggle

### DIFF
--- a/e2e_playwright/st_checkbox.py
+++ b/e2e_playwright/st_checkbox.py
@@ -75,6 +75,28 @@ st.checkbox("checkbox with content width", width="content")
 st.checkbox("checkbox with stretch width", width="stretch")
 st.checkbox("checkbox with 200px width", width=200)
 
+# wrap=False keeps the checkbox on one row and ellipsizes an overflowing label,
+# exposing the full label via a native title (skipped when help is set). A narrow
+# fixed width forces the long label to overflow, so the auto default (wrap=None)
+# in a vertical layout wraps and grows taller while wrap=False stays single-row.
+_WRAP_LABEL = "Include archived projects from the last several quarters"
+with st.container(key="wrap_checkboxes"):
+    st.checkbox(_WRAP_LABEL, width=200, wrap=False, key="wrap_false_checkbox")
+    st.checkbox(_WRAP_LABEL, width=200, key="wrap_auto_vertical_checkbox")
+    st.checkbox(
+        _WRAP_LABEL,
+        width=200,
+        wrap=False,
+        help="wrap help text",
+        key="wrap_help_checkbox",
+    )
+
+# Default (auto) wrap: inside a horizontal container the label does not wrap; it
+# ellipsizes and exposes the full label via a native title. A fixed container
+# width narrower than the label forces the overflow.
+with st.container(horizontal=True, width=250, key="wrap_auto_horizontal_checkbox"):
+    st.checkbox(_WRAP_LABEL, key="wrap_auto_checkbox")
+
 st.markdown("Dynamic checkbox:")
 
 if st.toggle("Update checkbox props"):

--- a/e2e_playwright/st_checkbox.py
+++ b/e2e_playwright/st_checkbox.py
@@ -76,9 +76,10 @@ st.checkbox("checkbox with stretch width", width="stretch")
 st.checkbox("checkbox with 200px width", width=200)
 
 # wrap=False keeps the checkbox on one row and ellipsizes an overflowing label,
-# exposing the full label via a native title (skipped when help is set). A narrow
-# fixed width forces the long label to overflow, so the auto default (wrap=None)
-# in a vertical layout wraps and grows taller while wrap=False stays single-row.
+# exposing the full label via a native title on the label (help lives on a
+# separate icon, so both coexist). A narrow fixed width forces the long label to
+# overflow, so the auto default (wrap=None) in a vertical layout wraps and grows
+# taller while wrap=False stays single-row.
 _WRAP_LABEL = "Include archived projects from the last several quarters"
 with st.container(key="wrap_checkboxes"):
     st.checkbox(_WRAP_LABEL, width=200, wrap=False, key="wrap_false_checkbox")

--- a/e2e_playwright/st_checkbox_test.py
+++ b/e2e_playwright/st_checkbox_test.py
@@ -193,11 +193,16 @@ def test_wrap_false_single_row_and_auto_resolution(app: Page):
     expect(wrap_auto_horizontal.get_by_title(WRAP_LABEL, exact=True)).to_be_visible()
 
 
-def test_wrap_false_help_takes_precedence_over_title(app: Page):
-    """When help is set, no native title is added and the help tooltip shows."""
+def test_wrap_false_title_and_help_coexist(app: Page):
+    """With help set, the full-label title stays on the label (the help tooltip
+    lives on a separate icon), so both coexist.
+    """
     container = get_element_by_key(app, "wrap_help_checkbox")
-    expect(container.get_by_title(WRAP_LABEL, exact=True)).to_have_count(0)
+    # The label is still ellipsized and exposes the full label via a native title.
+    expect_label_truncated(container)
+    expect(container.get_by_title(WRAP_LABEL, exact=True)).to_be_visible()
 
+    # Hovering the separate help icon still shows the help tooltip.
     reset_hovering(app)
     expect_help_tooltip(app, container, "wrap help text")
 

--- a/e2e_playwright/st_checkbox_test.py
+++ b/e2e_playwright/st_checkbox_test.py
@@ -173,8 +173,10 @@ def test_wrap_false_single_row_and_auto_resolution(app: Page):
     wrap_auto_vertical = get_element_by_key(app, "wrap_auto_vertical_checkbox")
 
     # wrap=False: label ellipsized and full label exposed via a native title.
+    # The checkbox indicator itself must remain visible (not clipped by truncation).
     expect_label_truncated(wrap_false)
     expect(wrap_false.get_by_title(WRAP_LABEL, exact=True)).to_be_visible()
+    expect(wrap_false.get_by_role("checkbox")).to_be_visible()
 
     # Auto default in a vertical layout wraps onto another line and adds no title.
     expect(wrap_auto_vertical.get_by_title(WRAP_LABEL, exact=True)).to_have_count(0)

--- a/e2e_playwright/st_checkbox_test.py
+++ b/e2e_playwright/st_checkbox_test.py
@@ -201,8 +201,12 @@ def test_wrap_false_title_and_help_coexist(app: Page):
     """
     container = get_element_by_key(app, "wrap_help_checkbox")
     # The label is still ellipsized and exposes the full label via a native title.
+    # The checkbox indicator and help icon must remain visible (not clipped when
+    # the help icon shares the truncated row).
     expect_label_truncated(container)
     expect(container.get_by_title(WRAP_LABEL, exact=True)).to_be_visible()
+    expect(container.get_by_role("checkbox")).to_be_visible()
+    expect(container.get_by_test_id("stTooltipHoverTarget")).to_be_visible()
 
     # Hovering the separate help icon still shows the help tooltip.
     reset_hovering(app)

--- a/e2e_playwright/st_checkbox_test.py
+++ b/e2e_playwright/st_checkbox_test.py
@@ -26,14 +26,18 @@ from e2e_playwright.shared.app_utils import (
     click_checkbox,
     click_toggle,
     expect_help_tooltip,
+    expect_label_truncated,
     expect_markdown,
     expect_prefixed_markdown,
     get_checkbox,
     get_element_by_key,
     get_expander,
+    reset_hovering,
 )
 
-CHECKBOX_ELEMENTS = 20
+CHECKBOX_ELEMENTS = 24
+
+WRAP_LABEL = "Include archived projects from the last several quarters"
 
 
 def test_checkbox_widget_display(
@@ -158,6 +162,44 @@ def test_grouped_checkboxes_height(app: Page, assert_snapshot: ImageCompareFunct
     expect(get_checkbox(expander_details, "checkbox group - 1")).to_have_css(
         "height", "24px"
     )
+
+
+def test_wrap_false_single_row_and_auto_resolution(app: Page):
+    """wrap=False keeps the checkbox on one row and exposes the full label via a
+    native title, while the auto default (wrap=None) wraps and grows taller in a
+    vertical layout but ellipsizes with a title inside a horizontal container.
+    """
+    wrap_false = get_element_by_key(app, "wrap_false_checkbox")
+    wrap_auto_vertical = get_element_by_key(app, "wrap_auto_vertical_checkbox")
+
+    # wrap=False: label ellipsized and full label exposed via a native title.
+    expect_label_truncated(wrap_false)
+    expect(wrap_false.get_by_title(WRAP_LABEL, exact=True)).to_be_visible()
+
+    # Auto default in a vertical layout wraps onto another line and adds no title.
+    expect(wrap_auto_vertical.get_by_title(WRAP_LABEL, exact=True)).to_have_count(0)
+
+    false_box = wrap_false.get_by_test_id("stCheckbox").bounding_box()
+    auto_box = wrap_auto_vertical.get_by_test_id("stCheckbox").bounding_box()
+    assert false_box is not None
+    assert auto_box is not None
+    # The 4px margin absorbs sub-pixel rounding so the wrapped (two-line) checkbox
+    # is clearly taller than the single-row one, not just larger by rounding.
+    assert auto_box["height"] > false_box["height"] + 4
+
+    # Auto default inside a horizontal container keeps one row with a title.
+    wrap_auto_horizontal = get_element_by_key(app, "wrap_auto_checkbox")
+    expect_label_truncated(wrap_auto_horizontal)
+    expect(wrap_auto_horizontal.get_by_title(WRAP_LABEL, exact=True)).to_be_visible()
+
+
+def test_wrap_false_help_takes_precedence_over_title(app: Page):
+    """When help is set, no native title is added and the help tooltip shows."""
+    container = get_element_by_key(app, "wrap_help_checkbox")
+    expect(container.get_by_title(WRAP_LABEL, exact=True)).to_have_count(0)
+
+    reset_hovering(app)
+    expect_help_tooltip(app, container, "wrap help text")
 
 
 def test_check_top_level_class(app: Page):

--- a/e2e_playwright/st_toggle.py
+++ b/e2e_playwright/st_toggle.py
@@ -66,9 +66,10 @@ st.toggle("toggle with stretch width", width="stretch")
 st.toggle("toggle with 150px width", width=150)
 
 # wrap=False keeps the toggle on one row and ellipsizes an overflowing label,
-# exposing the full label via a native title (skipped when help is set). A narrow
-# fixed width forces the long label to overflow, so the auto default (wrap=None)
-# in a vertical layout wraps and grows taller while wrap=False stays single-row.
+# exposing the full label via a native title on the label (help lives on a
+# separate icon, so both coexist). A narrow fixed width forces the long label to
+# overflow, so the auto default (wrap=None) in a vertical layout wraps and grows
+# taller while wrap=False stays single-row.
 _WRAP_LABEL = "Enable live updates for every connected data source right now"
 with st.container(key="wrap_toggles"):
     st.toggle(_WRAP_LABEL, width=200, wrap=False, key="wrap_false_toggle")

--- a/e2e_playwright/st_toggle.py
+++ b/e2e_playwright/st_toggle.py
@@ -65,6 +65,28 @@ st.toggle("toggle with content width", width="content")
 st.toggle("toggle with stretch width", width="stretch")
 st.toggle("toggle with 150px width", width=150)
 
+# wrap=False keeps the toggle on one row and ellipsizes an overflowing label,
+# exposing the full label via a native title (skipped when help is set). A narrow
+# fixed width forces the long label to overflow, so the auto default (wrap=None)
+# in a vertical layout wraps and grows taller while wrap=False stays single-row.
+_WRAP_LABEL = "Enable live updates for every connected data source right now"
+with st.container(key="wrap_toggles"):
+    st.toggle(_WRAP_LABEL, width=200, wrap=False, key="wrap_false_toggle")
+    st.toggle(_WRAP_LABEL, width=200, key="wrap_auto_vertical_toggle")
+    st.toggle(
+        _WRAP_LABEL,
+        width=200,
+        wrap=False,
+        help="wrap help text",
+        key="wrap_help_toggle",
+    )
+
+# Default (auto) wrap: inside a horizontal container the label does not wrap; it
+# ellipsizes and exposes the full label via a native title. A fixed container
+# width narrower than the label forces the overflow.
+with st.container(horizontal=True, width=250, key="wrap_auto_horizontal_toggle"):
+    st.toggle(_WRAP_LABEL, key="wrap_auto_toggle")
+
 st.markdown("Dynamic toggle props:")
 
 if st.toggle("Update toggle props"):

--- a/e2e_playwright/st_toggle_test.py
+++ b/e2e_playwright/st_toggle_test.py
@@ -175,8 +175,12 @@ def test_wrap_false_title_and_help_coexist(app: Page):
     """
     container = get_element_by_key(app, "wrap_help_toggle")
     # The label is still ellipsized and exposes the full label via a native title.
+    # The toggle switch and help icon must remain visible (not clipped when
+    # the help icon shares the truncated row).
     expect_label_truncated(container)
     expect(container.get_by_title(WRAP_LABEL, exact=True)).to_be_visible()
+    expect(container.get_by_role("switch")).to_be_visible()
+    expect(container.get_by_test_id("stTooltipHoverTarget")).to_be_visible()
 
     # Hovering the separate help icon still shows the help tooltip.
     reset_hovering(app)

--- a/e2e_playwright/st_toggle_test.py
+++ b/e2e_playwright/st_toggle_test.py
@@ -26,14 +26,18 @@ from e2e_playwright.shared.app_utils import (
     check_top_level_class,
     click_toggle,
     expect_help_tooltip,
+    expect_label_truncated,
     expect_markdown,
     expect_prefixed_markdown,
     get_element_by_key,
     get_expander,
     get_toggle,
+    reset_hovering,
 )
 
-TOGGLE_ELEMENTS = 19
+TOGGLE_ELEMENTS = 23
+
+WRAP_LABEL = "Enable live updates for every connected data source right now"
 
 
 def test_toggle_widget_display(themed_app: Page, assert_snapshot: ImageCompareFunction):
@@ -132,6 +136,44 @@ def test_grouped_toggles_height(app: Page, assert_snapshot: ImageCompareFunction
     expect(get_toggle(expander_details, "toggle group - 1")).to_have_css(
         "height", "24px"
     )
+
+
+def test_wrap_false_single_row_and_auto_resolution(app: Page):
+    """wrap=False keeps the toggle on one row and exposes the full label via a
+    native title, while the auto default (wrap=None) wraps and grows taller in a
+    vertical layout but ellipsizes with a title inside a horizontal container.
+    """
+    wrap_false = get_element_by_key(app, "wrap_false_toggle")
+    wrap_auto_vertical = get_element_by_key(app, "wrap_auto_vertical_toggle")
+
+    # wrap=False: label ellipsized and full label exposed via a native title.
+    expect_label_truncated(wrap_false)
+    expect(wrap_false.get_by_title(WRAP_LABEL, exact=True)).to_be_visible()
+
+    # Auto default in a vertical layout wraps onto another line and adds no title.
+    expect(wrap_auto_vertical.get_by_title(WRAP_LABEL, exact=True)).to_have_count(0)
+
+    false_box = wrap_false.get_by_test_id("stCheckbox").bounding_box()
+    auto_box = wrap_auto_vertical.get_by_test_id("stCheckbox").bounding_box()
+    assert false_box is not None
+    assert auto_box is not None
+    # The 4px margin absorbs sub-pixel rounding so the wrapped (two-line) toggle
+    # is clearly taller than the single-row one, not just larger by rounding.
+    assert auto_box["height"] > false_box["height"] + 4
+
+    # Auto default inside a horizontal container keeps one row with a title.
+    wrap_auto_horizontal = get_element_by_key(app, "wrap_auto_toggle")
+    expect_label_truncated(wrap_auto_horizontal)
+    expect(wrap_auto_horizontal.get_by_title(WRAP_LABEL, exact=True)).to_be_visible()
+
+
+def test_wrap_false_help_takes_precedence_over_title(app: Page):
+    """When help is set, no native title is added and the help tooltip shows."""
+    container = get_element_by_key(app, "wrap_help_toggle")
+    expect(container.get_by_title(WRAP_LABEL, exact=True)).to_have_count(0)
+
+    reset_hovering(app)
+    expect_help_tooltip(app, container, "wrap help text")
 
 
 def test_check_top_level_class(app: Page):

--- a/e2e_playwright/st_toggle_test.py
+++ b/e2e_playwright/st_toggle_test.py
@@ -147,8 +147,10 @@ def test_wrap_false_single_row_and_auto_resolution(app: Page):
     wrap_auto_vertical = get_element_by_key(app, "wrap_auto_vertical_toggle")
 
     # wrap=False: label ellipsized and full label exposed via a native title.
+    # The toggle indicator itself must remain visible (not clipped by truncation).
     expect_label_truncated(wrap_false)
     expect(wrap_false.get_by_title(WRAP_LABEL, exact=True)).to_be_visible()
+    expect(wrap_false.get_by_role("switch")).to_be_visible()
 
     # Auto default in a vertical layout wraps onto another line and adds no title.
     expect(wrap_auto_vertical.get_by_title(WRAP_LABEL, exact=True)).to_have_count(0)

--- a/e2e_playwright/st_toggle_test.py
+++ b/e2e_playwright/st_toggle_test.py
@@ -167,11 +167,16 @@ def test_wrap_false_single_row_and_auto_resolution(app: Page):
     expect(wrap_auto_horizontal.get_by_title(WRAP_LABEL, exact=True)).to_be_visible()
 
 
-def test_wrap_false_help_takes_precedence_over_title(app: Page):
-    """When help is set, no native title is added and the help tooltip shows."""
+def test_wrap_false_title_and_help_coexist(app: Page):
+    """With help set, the full-label title stays on the label (the help tooltip
+    lives on a separate icon), so both coexist.
+    """
     container = get_element_by_key(app, "wrap_help_toggle")
-    expect(container.get_by_title(WRAP_LABEL, exact=True)).to_have_count(0)
+    # The label is still ellipsized and exposes the full label via a native title.
+    expect_label_truncated(container)
+    expect(container.get_by_title(WRAP_LABEL, exact=True)).to_be_visible()
 
+    # Hovering the separate help icon still shows the help tooltip.
     reset_hovering(app)
     expect_help_tooltip(app, container, "wrap help text")
 

--- a/frontend/lib/src/components/shared/BaseButton/DynamicButtonLabel.tsx
+++ b/frontend/lib/src/components/shared/BaseButton/DynamicButtonLabel.tsx
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-import { useEffect, useMemo, useRef } from "react"
+import { useMemo } from "react"
 
 import { DynamicIcon } from "~lib/components/shared/Icon/DynamicIcon"
 import StreamlitMarkdown from "~lib/components/shared/StreamlitMarkdown/StreamlitMarkdown"
+import { useLabelTitleTooltip } from "~lib/hooks/useLabelTitleTooltip"
 import { formatShortcutForDisplay } from "~lib/hooks/useRegisterShortcut"
 import type { IconSize } from "~lib/theme/types"
 import { isFromMac } from "~lib/util/utils"
@@ -65,51 +66,13 @@ export const DynamicButtonLabel = ({
 
   const truncate = !wrap
 
-  const labelRef = useRef<HTMLDivElement>(null)
-  // Wraps only the rendered Markdown label so we can read its plain text without
-  // picking up the icon or shortcut. Uses `display: contents`, so it adds no box
-  // and leaves the flex/truncation layout unchanged.
-  const labelTextRef = useRef<HTMLSpanElement>(null)
-
-  // Set the native tooltip to the rendered plain-text label (the accessible
-  // name) rather than the raw Markdown source. This reads from the DOM because
-  // Markdown can only be converted to plain text after it is rendered. Observe
-  // DOM mutations so we re-sync after async Markdown plugins (e.g. emoji)
-  // replace a loading skeleton with the real label. Skip the observer when
-  // no title is needed so most buttons do not subscribe to DOM mutations.
-  useEffect(() => {
-    const node = labelRef.current
-    if (!node) {
-      return
-    }
-
-    if (!addTitleTooltip) {
-      node.removeAttribute("title")
-      return
-    }
-
-    const syncTitle = (): void => {
-      const labelText = labelTextRef.current?.textContent ?? ""
-      if (labelText) {
-        node.title = labelText
-      } else {
-        node.removeAttribute("title")
-      }
-    }
-
-    syncTitle()
-
-    const observer = new MutationObserver(syncTitle)
-    observer.observe(node, {
-      childList: true,
-      subtree: true,
-      characterData: true,
-    })
-    return () => observer.disconnect()
-  }, [addTitleTooltip, label])
+  const { titleRef, labelTextRef } = useLabelTitleTooltip(
+    addTitleTooltip,
+    label
+  )
 
   return (
-    <StyledButtonLabel ref={labelRef} $truncate={truncate}>
+    <StyledButtonLabel ref={titleRef} $truncate={truncate}>
       <StyledButtonMainLabel
         data-has-shortcut={Boolean(displayShortcut)}
         $truncate={truncate}
@@ -118,6 +81,9 @@ export const DynamicButtonLabel = ({
           <DynamicIcon size={iconSize ?? "base"} iconValue={icon} />
         )}
         {label && (
+          // Wrap only the rendered Markdown label so we can read its plain text
+          // for the native title without picking up the icon or shortcut.
+          // `display: contents` adds no box and leaves the layout unchanged.
           <span ref={labelTextRef} style={{ display: "contents" }}>
             <StreamlitMarkdown
               source={label}

--- a/frontend/lib/src/components/widgets/Checkbox/Checkbox.test.tsx
+++ b/frontend/lib/src/components/widgets/Checkbox/Checkbox.test.tsx
@@ -22,6 +22,11 @@ import {
   LabelVisibility as LabelVisibilityProto,
 } from "@streamlit/protobuf"
 
+import {
+  FlexContext,
+  IFlexContext,
+} from "~lib/components/core/Layout/FlexContext"
+import { Direction } from "~lib/components/core/Layout/utils"
 import { render } from "~lib/test_util"
 import { WidgetStateManager } from "~lib/WidgetStateManager"
 
@@ -451,5 +456,61 @@ describe("Checkbox query param binding", () => {
       false,
       undefined
     )
+  })
+})
+
+describe("Checkbox wrap", () => {
+  const LONG_LABEL = "A very long checkbox label that should ellipsize"
+
+  const horizontalContext: IFlexContext = {
+    direction: Direction.HORIZONTAL,
+    isInHorizontalLayout: true,
+    isInRoot: false,
+    isInContentWidthContainer: false,
+  }
+
+  it.each([
+    ["checkbox", CheckboxProto.StyleType.DEFAULT],
+    ["toggle", CheckboxProto.StyleType.TOGGLE],
+  ])(
+    "sets a native title with the full label when %s wrap is false",
+    (_name, type) => {
+      render(
+        <Checkbox {...getProps({ type, wrap: false, label: LONG_LABEL })} />
+      )
+      expect(screen.getByTitle(LONG_LABEL)).toBeVisible()
+    }
+  )
+
+  it("does not set a title by default outside a horizontal layout", () => {
+    render(<Checkbox {...getProps({ label: LONG_LABEL })} />)
+    expect(screen.queryByTitle(LONG_LABEL)).not.toBeInTheDocument()
+  })
+
+  it("auto default sets a title inside a horizontal layout", () => {
+    render(
+      <FlexContext.Provider value={horizontalContext}>
+        <Checkbox {...getProps({ label: LONG_LABEL })} />
+      </FlexContext.Provider>
+    )
+    expect(screen.getByTitle(LONG_LABEL)).toBeVisible()
+  })
+
+  it("explicit wrap=true keeps wrapping inside a horizontal layout", () => {
+    render(
+      <FlexContext.Provider value={horizontalContext}>
+        <Checkbox {...getProps({ wrap: true, label: LONG_LABEL })} />
+      </FlexContext.Provider>
+    )
+    expect(screen.queryByTitle(LONG_LABEL)).not.toBeInTheDocument()
+  })
+
+  it("does not set a title when help is set (help tooltip takes over)", () => {
+    render(
+      <Checkbox
+        {...getProps({ wrap: false, label: LONG_LABEL, help: "Help wins" })}
+      />
+    )
+    expect(screen.queryByTitle(LONG_LABEL)).not.toBeInTheDocument()
   })
 })

--- a/frontend/lib/src/components/widgets/Checkbox/Checkbox.test.tsx
+++ b/frontend/lib/src/components/widgets/Checkbox/Checkbox.test.tsx
@@ -462,6 +462,14 @@ describe("Checkbox query param binding", () => {
 describe("Checkbox wrap", () => {
   const LONG_LABEL = "A very long checkbox label that should ellipsize"
 
+  // Both checkbox and toggle share the same truncation/title wiring, so the
+  // wrap behavior is exercised over both style types to catch a regression in
+  // either root (StyledCheckboxRoot / StyledSwitchRoot).
+  const STYLE_TYPES = [
+    ["checkbox", CheckboxProto.StyleType.DEFAULT],
+    ["toggle", CheckboxProto.StyleType.TOGGLE],
+  ] as const
+
   const horizontalContext: IFlexContext = {
     direction: Direction.HORIZONTAL,
     isInHorizontalLayout: true,
@@ -469,10 +477,7 @@ describe("Checkbox wrap", () => {
     isInContentWidthContainer: false,
   }
 
-  it.each([
-    ["checkbox", CheckboxProto.StyleType.DEFAULT],
-    ["toggle", CheckboxProto.StyleType.TOGGLE],
-  ])(
+  it.each(STYLE_TYPES)(
     "sets a native title with the full label when %s wrap is false",
     (_name, type) => {
       render(
@@ -482,35 +487,66 @@ describe("Checkbox wrap", () => {
     }
   )
 
-  it("does not set a title by default outside a horizontal layout", () => {
-    render(<Checkbox {...getProps({ label: LONG_LABEL })} />)
-    expect(screen.queryByTitle(LONG_LABEL)).not.toBeInTheDocument()
-  })
+  it.each(STYLE_TYPES)(
+    "uses the plain text of a Markdown %s label for the title",
+    (_name, type) => {
+      render(
+        <Checkbox
+          {...getProps({ type, wrap: false, label: "**Bold** report" })}
+        />
+      )
+      // The title is the rendered plain text, not the raw Markdown source.
+      expect(screen.getByTitle("Bold report")).toBeVisible()
+      expect(screen.queryByTitle("**Bold** report")).not.toBeInTheDocument()
+    }
+  )
 
-  it("auto default sets a title inside a horizontal layout", () => {
-    render(
-      <FlexContext.Provider value={horizontalContext}>
-        <Checkbox {...getProps({ label: LONG_LABEL })} />
-      </FlexContext.Provider>
-    )
-    expect(screen.getByTitle(LONG_LABEL)).toBeVisible()
-  })
+  it.each(STYLE_TYPES)(
+    "does not set a title by default outside a horizontal layout (%s)",
+    (_name, type) => {
+      render(<Checkbox {...getProps({ type, label: LONG_LABEL })} />)
+      expect(screen.queryByTitle(LONG_LABEL)).not.toBeInTheDocument()
+    }
+  )
 
-  it("explicit wrap=true keeps wrapping inside a horizontal layout", () => {
-    render(
-      <FlexContext.Provider value={horizontalContext}>
-        <Checkbox {...getProps({ wrap: true, label: LONG_LABEL })} />
-      </FlexContext.Provider>
-    )
-    expect(screen.queryByTitle(LONG_LABEL)).not.toBeInTheDocument()
-  })
+  it.each(STYLE_TYPES)(
+    "auto default sets a title inside a horizontal layout (%s)",
+    (_name, type) => {
+      render(
+        <FlexContext.Provider value={horizontalContext}>
+          <Checkbox {...getProps({ type, label: LONG_LABEL })} />
+        </FlexContext.Provider>
+      )
+      expect(screen.getByTitle(LONG_LABEL)).toBeVisible()
+    }
+  )
 
-  it("does not set a title when help is set (help tooltip takes over)", () => {
-    render(
-      <Checkbox
-        {...getProps({ wrap: false, label: LONG_LABEL, help: "Help wins" })}
-      />
-    )
-    expect(screen.queryByTitle(LONG_LABEL)).not.toBeInTheDocument()
-  })
+  it.each(STYLE_TYPES)(
+    "explicit wrap=true keeps wrapping inside a horizontal layout (%s)",
+    (_name, type) => {
+      render(
+        <FlexContext.Provider value={horizontalContext}>
+          <Checkbox {...getProps({ type, wrap: true, label: LONG_LABEL })} />
+        </FlexContext.Provider>
+      )
+      expect(screen.queryByTitle(LONG_LABEL)).not.toBeInTheDocument()
+    }
+  )
+
+  it.each(STYLE_TYPES)(
+    "does not set a %s title when help is set (help tooltip takes over)",
+    (_name, type) => {
+      render(
+        <Checkbox
+          {...getProps({
+            type,
+            wrap: false,
+            label: LONG_LABEL,
+            help: "Help wins",
+          })}
+        />
+      )
+      expect(screen.queryByTitle(LONG_LABEL)).not.toBeInTheDocument()
+    }
+  )
 })

--- a/frontend/lib/src/components/widgets/Checkbox/Checkbox.test.tsx
+++ b/frontend/lib/src/components/widgets/Checkbox/Checkbox.test.tsx
@@ -534,7 +534,7 @@ describe("Checkbox wrap", () => {
   )
 
   it.each(STYLE_TYPES)(
-    "does not set a %s title when help is set (help tooltip takes over)",
+    "still sets a %s title when help is set (help lives on a separate icon)",
     (_name, type) => {
       render(
         <Checkbox
@@ -542,11 +542,36 @@ describe("Checkbox wrap", () => {
             type,
             wrap: false,
             label: LONG_LABEL,
-            help: "Help wins",
+            help: "Extra context",
           })}
         />
       )
-      expect(screen.queryByTitle(LONG_LABEL)).not.toBeInTheDocument()
+      // Unlike a button, the help tooltip is triggered by the separate help icon,
+      // so the label's native title stays enabled and both coexist.
+      expect(screen.getByTitle(LONG_LABEL)).toBeVisible()
+      expect(screen.getByTestId("stTooltipHoverTarget")).toBeVisible()
+    }
+  )
+
+  it.each(STYLE_TYPES)(
+    "scopes the %s title to the label, not the help icon",
+    (_name, type) => {
+      render(
+        <Checkbox
+          {...getProps({
+            type,
+            wrap: false,
+            label: LONG_LABEL,
+            help: "Extra context",
+          })}
+        />
+      )
+      // The title is on the label element, so the help icon is not a descendant
+      // of the titled element and won't surface the full-label tooltip on hover.
+      const titledElement = screen.getByTitle(LONG_LABEL)
+      expect(
+        titledElement.querySelector('[data-testid="stTooltipHoverTarget"]')
+      ).toBeNull()
     }
   )
 })

--- a/frontend/lib/src/components/widgets/Checkbox/Checkbox.test.tsx
+++ b/frontend/lib/src/components/widgets/Checkbox/Checkbox.test.tsx
@@ -484,6 +484,10 @@ describe("Checkbox wrap", () => {
         <Checkbox {...getProps({ type, wrap: false, label: LONG_LABEL })} />
       )
       expect(screen.getByTitle(LONG_LABEL)).toBeVisible()
+      expect(screen.getByTestId("stMarkdownContainer")).toHaveStyle({
+        "text-overflow": "ellipsis",
+        "white-space": "nowrap",
+      })
     }
   )
 
@@ -506,6 +510,9 @@ describe("Checkbox wrap", () => {
     (_name, type) => {
       render(<Checkbox {...getProps({ type, label: LONG_LABEL })} />)
       expect(screen.queryByTitle(LONG_LABEL)).not.toBeInTheDocument()
+      expect(screen.getByTestId("stMarkdownContainer")).not.toHaveStyle({
+        "text-overflow": "ellipsis",
+      })
     }
   )
 
@@ -518,6 +525,10 @@ describe("Checkbox wrap", () => {
         </FlexContext.Provider>
       )
       expect(screen.getByTitle(LONG_LABEL)).toBeVisible()
+      expect(screen.getByTestId("stMarkdownContainer")).toHaveStyle({
+        "text-overflow": "ellipsis",
+        "white-space": "nowrap",
+      })
     }
   )
 
@@ -530,6 +541,9 @@ describe("Checkbox wrap", () => {
         </FlexContext.Provider>
       )
       expect(screen.queryByTitle(LONG_LABEL)).not.toBeInTheDocument()
+      expect(screen.getByTestId("stMarkdownContainer")).not.toHaveStyle({
+        "text-overflow": "ellipsis",
+      })
     }
   )
 

--- a/frontend/lib/src/components/widgets/Checkbox/Checkbox.tsx
+++ b/frontend/lib/src/components/widgets/Checkbox/Checkbox.tsx
@@ -88,10 +88,8 @@ function Checkbox({
     element.labelVisibility?.value
   )
 
-  // wrap defaults to auto (no wrap in horizontal layouts, wrap otherwise). When
-  // wrap resolves to no-wrap, the label ellipsizes on one line and the full
-  // label is revealed on hover via a native title, skipped when help is set
-  // since help provides the tooltip.
+  // wrap=None resolves from layout: no-wrap in horizontal containers, wrap otherwise.
+  // When truncated, a native title reveals the full label on hover (skipped when help is set).
   const wrap = useResolvedWrap(element.wrap)
   const truncate = !wrap
   const addTitleTooltip = truncate && !element.help

--- a/frontend/lib/src/components/widgets/Checkbox/Checkbox.tsx
+++ b/frontend/lib/src/components/widgets/Checkbox/Checkbox.tsx
@@ -18,6 +18,7 @@ import { memo, ReactElement, useCallback } from "react"
 
 import { Checkbox as CheckboxProto } from "@streamlit/protobuf"
 
+import { useResolvedWrap } from "~lib/components/shared/BaseButton/useResolvedWrap"
 import StreamlitMarkdown from "~lib/components/shared/StreamlitMarkdown/StreamlitMarkdown"
 import { Placement } from "~lib/components/shared/Tooltip/Tooltip"
 import { WidgetLabelHelpIconInline } from "~lib/components/widgets/BaseWidget/WidgetLabelHelpIconInline"
@@ -25,6 +26,7 @@ import {
   useBasicWidgetState,
   ValueWithSource,
 } from "~lib/hooks/useBasicWidgetState"
+import { useLabelTitleTooltip } from "~lib/hooks/useLabelTitleTooltip"
 import { labelVisibilityProtoValueToEnum } from "~lib/util/utils"
 import { WidgetStateManager } from "~lib/WidgetStateManager"
 
@@ -86,9 +88,35 @@ function Checkbox({
     element.labelVisibility?.value
   )
 
+  // wrap defaults to auto (no wrap in horizontal layouts, wrap otherwise). When
+  // wrap resolves to no-wrap, the label ellipsizes on one line and the full
+  // label is revealed on hover via a native title, skipped when help is set
+  // since help provides the tooltip.
+  const wrap = useResolvedWrap(element.wrap)
+  const truncate = !wrap
+  const addTitleTooltip = truncate && !element.help
+  const { titleRef, labelTextRef } = useLabelTitleTooltip(
+    addTitleTooltip,
+    element.label
+  )
+
   const labelContent = (
-    <StyledContent visibility={labelVisibility} data-testid="stWidgetLabel">
-      <StreamlitMarkdown source={element.label} allowHTML={false} isLabel />
+    <StyledContent
+      ref={titleRef}
+      visibility={labelVisibility}
+      $truncate={truncate}
+      data-testid="stWidgetLabel"
+    >
+      {/* Wrap the label so we can read its plain text for the native title
+          without picking up the help icon. `display: contents` adds no box. */}
+      <span ref={labelTextRef} style={{ display: "contents" }}>
+        <StreamlitMarkdown
+          source={element.label}
+          allowHTML={false}
+          isLabel
+          truncate={truncate}
+        />
+      </span>
       {element.help && (
         <WidgetLabelHelpIconInline
           content={element.help}
@@ -110,6 +138,7 @@ function Checkbox({
           isDisabled={disabled}
           onChange={handleChange}
           aria-label={element.label}
+          $truncate={truncate}
         >
           {({ isSelected, isHovered, isDisabled: isDisab }) => (
             <>
@@ -138,6 +167,7 @@ function Checkbox({
         isDisabled={disabled}
         onChange={handleChange}
         aria-label={element.label}
+        $truncate={truncate}
       >
         {({ isSelected, isFocusVisible, isDisabled: isDisab }) => (
           <>

--- a/frontend/lib/src/components/widgets/Checkbox/Checkbox.tsx
+++ b/frontend/lib/src/components/widgets/Checkbox/Checkbox.tsx
@@ -35,6 +35,7 @@ import {
   StyledCheckboxIndicator,
   StyledCheckboxRoot,
   StyledContent,
+  StyledLabelText,
   StyledSwitchRoot,
   StyledToggleThumb,
   StyledToggleTrack,
@@ -89,32 +90,35 @@ function Checkbox({
   )
 
   // wrap=None resolves from layout: no-wrap in horizontal containers, wrap otherwise.
-  // When truncated, a native title reveals the full label on hover (skipped when help is set).
+  // When truncated, a native title on the label reveals the full label on hover.
+  // Unlike a button (whose help tooltip covers the whole control), help here lives
+  // on a separate icon, so the title and help never compete and both stay enabled.
   const wrap = useResolvedWrap(element.wrap)
   const truncate = !wrap
-  const addTitleTooltip = truncate && !element.help
   const { titleRef, labelTextRef } = useLabelTitleTooltip(
-    addTitleTooltip,
+    truncate,
     element.label
   )
 
   const labelContent = (
     <StyledContent
-      ref={titleRef}
       visibility={labelVisibility}
       $truncate={truncate}
       data-testid="stWidgetLabel"
     >
-      {/* Wrap the label so we can read its plain text for the native title
-          without picking up the help icon. `display: contents` adds no box. */}
-      <span ref={labelTextRef} style={{ display: "contents" }}>
-        <StreamlitMarkdown
-          source={element.label}
-          allowHTML={false}
-          isLabel
-          truncate={truncate}
-        />
-      </span>
+      {/* The title is scoped to the label (not the help icon) so hovering the
+          help icon shows only its tooltip. The inner `display: contents` span
+          lets us read the label's plain text without adding a box. */}
+      <StyledLabelText ref={titleRef} $truncate={truncate}>
+        <span ref={labelTextRef} style={{ display: "contents" }}>
+          <StreamlitMarkdown
+            source={element.label}
+            allowHTML={false}
+            isLabel
+            truncate={truncate}
+          />
+        </span>
+      </StyledLabelText>
       {element.help && (
         <WidgetLabelHelpIconInline
           content={element.help}

--- a/frontend/lib/src/components/widgets/Checkbox/styled-components.tsx
+++ b/frontend/lib/src/components/widgets/Checkbox/styled-components.tsx
@@ -50,6 +50,23 @@ export const StyledContent = styled.div<StyledContentProps>(
   })
 )
 
+interface StyledLabelTextProps {
+  /** When true, the label truncates on one line, so it must be shrinkable. */
+  $truncate?: boolean
+}
+
+/**
+ * Wraps the label markdown so the native `title` tooltip is scoped to the label
+ * only (not the sibling help icon). When truncating it becomes a shrinkable flex
+ * box so the markdown can ellipsize; otherwise it stays transparent to layout.
+ */
+export const StyledLabelText = styled.div<StyledLabelTextProps>(
+  ({ $truncate }) =>
+    $truncate
+      ? { display: "flex", alignItems: "center", minWidth: 0 }
+      : { display: "contents" }
+)
+
 interface StyledRootProps {
   /** When true, the control can shrink within its container so the label can ellipsize. */
   $truncate?: boolean

--- a/frontend/lib/src/components/widgets/Checkbox/styled-components.tsx
+++ b/frontend/lib/src/components/widgets/Checkbox/styled-components.tsx
@@ -31,10 +31,12 @@ export const StyledCheckbox = styled.div(({ theme }) => ({
 
 interface StyledContentProps {
   visibility?: LabelVisibilityOptions
+  /** When true, the label truncates on one line, so it must be shrinkable. */
+  $truncate?: boolean
 }
 
 export const StyledContent = styled.div<StyledContentProps>(
-  ({ theme, visibility }) => ({
+  ({ theme, visibility, $truncate }) => ({
     display: visibility === LabelVisibilityOptions.Collapsed ? "none" : "flex",
     visibility:
       visibility === LabelVisibilityOptions.Hidden ? "hidden" : "visible",
@@ -42,11 +44,21 @@ export const StyledContent = styled.div<StyledContentProps>(
     flexDirection: "row",
     alignItems: "center",
     lineHeight: theme.lineHeights.small,
+    // Allow the label to shrink below its content size so the markdown can
+    // ellipsize. The help icon keeps its intrinsic size and stays visible.
+    ...($truncate && { minWidth: 0 }),
   })
 )
 
+interface StyledRootProps {
+  /** When true, the control fills its width so the label can be constrained. */
+  $truncate?: boolean
+}
+
 /** Wrapper around React Aria Checkbox — handles layout and keyboard-focus background. */
-export const StyledCheckboxRoot = styled(RACheckbox)(({ theme }) => ({
+export const StyledCheckboxRoot = styled(RACheckbox, {
+  shouldForwardProp: (prop: string) => !prop.startsWith("$"),
+})<StyledRootProps>(({ theme, $truncate }) => ({
   display: "flex",
   alignItems: "flex-start",
   gap: theme.spacing.sm,
@@ -54,6 +66,10 @@ export const StyledCheckboxRoot = styled(RACheckbox)(({ theme }) => ({
   marginTop: 0,
   cursor: "pointer",
   position: "relative",
+  // Bound the control to its container (without expanding a short label to full
+  // width) and let it shrink so an overflowing label can ellipsize instead of
+  // widening the control past its container.
+  ...($truncate && { minWidth: 0, maxWidth: "100%" }),
 
   "&[data-disabled]": {
     cursor: "not-allowed",
@@ -125,7 +141,9 @@ export const StyledCheckboxIndicator =
   )
 
 /** Wrapper around React Aria Switch — handles layout for the toggle variant. */
-export const StyledSwitchRoot = styled(RASwitch)(({ theme }) => ({
+export const StyledSwitchRoot = styled(RASwitch, {
+  shouldForwardProp: (prop: string) => !prop.startsWith("$"),
+})<StyledRootProps>(({ theme, $truncate }) => ({
   display: "flex",
   alignItems: "flex-start",
   gap: theme.spacing.sm,
@@ -133,6 +151,10 @@ export const StyledSwitchRoot = styled(RASwitch)(({ theme }) => ({
   marginTop: 0,
   cursor: "pointer",
   position: "relative",
+  // Bound the control to its container (without expanding a short label to full
+  // width) and let it shrink so an overflowing label can ellipsize instead of
+  // widening the control past its container.
+  ...($truncate && { minWidth: 0, maxWidth: "100%" }),
 
   "&[data-disabled]": {
     cursor: "not-allowed",

--- a/frontend/lib/src/components/widgets/Checkbox/styled-components.tsx
+++ b/frontend/lib/src/components/widgets/Checkbox/styled-components.tsx
@@ -51,7 +51,7 @@ export const StyledContent = styled.div<StyledContentProps>(
 )
 
 interface StyledRootProps {
-  /** When true, the control fills its width so the label can be constrained. */
+  /** When true, the control can shrink within its container so the label can ellipsize. */
   $truncate?: boolean
 }
 

--- a/frontend/lib/src/hooks/useLabelTitleTooltip.test.tsx
+++ b/frontend/lib/src/hooks/useLabelTitleTooltip.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ReactElement } from "react"
+
+import { screen, waitFor } from "@testing-library/react"
+
+import { render } from "~lib/test_util"
+
+import { useLabelTitleTooltip } from "./useLabelTitleTooltip"
+
+interface HarnessProps {
+  addTitleTooltip: boolean
+  label: string
+  /** Optional rendered label content (simulates Markdown plain text). */
+  labelContent?: string
+}
+
+function LabelTitleHarness({
+  addTitleTooltip,
+  label,
+  labelContent,
+}: HarnessProps): ReactElement {
+  const { titleRef, labelTextRef } = useLabelTitleTooltip(
+    addTitleTooltip,
+    label
+  )
+
+  return (
+    <div ref={titleRef} data-testid="title-host">
+      <span ref={labelTextRef} data-testid="label-text">
+        {labelContent ?? label}
+      </span>
+    </div>
+  )
+}
+
+describe("useLabelTitleTooltip", () => {
+  it("sets a native title from the rendered label text when enabled", () => {
+    render(
+      <LabelTitleHarness
+        addTitleTooltip={true}
+        label="**Bold** label"
+        labelContent="Bold label"
+      />
+    )
+
+    expect(screen.getByTitle("Bold label")).toBeVisible()
+    // Title uses DOM plain text, not the raw Markdown source.
+    expect(screen.queryByTitle("**Bold** label")).not.toBeInTheDocument()
+  })
+
+  it("does not set a title when disabled", () => {
+    render(<LabelTitleHarness addTitleTooltip={false} label="Plain label" />)
+
+    expect(screen.queryByTitle("Plain label")).not.toBeInTheDocument()
+  })
+
+  it("removes the title and stops observing when addTitleTooltip flips to false", async () => {
+    const disconnect = vi.fn()
+    const observe = vi.fn()
+    const OriginalMutationObserver = globalThis.MutationObserver
+
+    class MockMutationObserver {
+      public observe = observe
+      public disconnect = disconnect
+
+      constructor(_callback: MutationCallback) {}
+    }
+
+    globalThis.MutationObserver =
+      MockMutationObserver as unknown as typeof MutationObserver
+
+    try {
+      const { rerender } = render(
+        <LabelTitleHarness addTitleTooltip={true} label="Plain label" />
+      )
+
+      expect(screen.getByTitle("Plain label")).toBeVisible()
+      expect(observe).toHaveBeenCalled()
+
+      rerender(
+        <LabelTitleHarness addTitleTooltip={false} label="Plain label" />
+      )
+
+      expect(screen.queryByTitle("Plain label")).not.toBeInTheDocument()
+      expect(disconnect).toHaveBeenCalled()
+
+      // A late DOM mutation must not re-attach a title after the observer is gone.
+      screen.getByTestId("label-text").textContent = "Updated label"
+      await waitFor(() => {
+        expect(screen.queryByTitle("Updated label")).not.toBeInTheDocument()
+      })
+    } finally {
+      globalThis.MutationObserver = OriginalMutationObserver
+    }
+  })
+
+  it("re-syncs the title when observed label DOM content changes", async () => {
+    render(<LabelTitleHarness addTitleTooltip={true} label="First label" />)
+
+    expect(screen.getByTitle("First label")).toBeVisible()
+
+    screen.getByTestId("label-text").textContent = "Updated plain text"
+
+    await waitFor(() => {
+      expect(screen.getByTitle("Updated plain text")).toBeVisible()
+    })
+    expect(screen.queryByTitle("First label")).not.toBeInTheDocument()
+  })
+})

--- a/frontend/lib/src/hooks/useLabelTitleTooltip.test.tsx
+++ b/frontend/lib/src/hooks/useLabelTitleTooltip.test.tsx
@@ -69,16 +69,24 @@ describe("useLabelTitleTooltip", () => {
     expect(screen.queryByTitle("Plain label")).not.toBeInTheDocument()
   })
 
-  it("removes the title and stops observing when addTitleTooltip flips to false", async () => {
-    const disconnect = vi.fn()
+  it("removes the title and stops observing when addTitleTooltip flips to false", () => {
     const observe = vi.fn()
+    // disconnect() clears the stored callback so a later fire() is a no-op, matching
+    // a real MutationObserver after teardown. If cleanup skipped disconnect, fire()
+    // would still invoke syncTitle and re-attach the title.
+    let mutationCallback: MutationCallback | undefined
+    const disconnect = vi.fn(() => {
+      mutationCallback = undefined
+    })
     const OriginalMutationObserver = globalThis.MutationObserver
 
     class MockMutationObserver {
       public observe = observe
       public disconnect = disconnect
 
-      constructor(_callback: MutationCallback) {}
+      constructor(callback: MutationCallback) {
+        mutationCallback = callback
+      }
     }
 
     globalThis.MutationObserver =
@@ -101,9 +109,8 @@ describe("useLabelTitleTooltip", () => {
 
       // A late DOM mutation must not re-attach a title after the observer is gone.
       screen.getByTestId("label-text").textContent = "Updated label"
-      await waitFor(() => {
-        expect(screen.queryByTitle("Updated label")).not.toBeInTheDocument()
-      })
+      mutationCallback?.([], {} as MutationObserver)
+      expect(screen.queryByTitle("Updated label")).not.toBeInTheDocument()
     } finally {
       globalThis.MutationObserver = OriginalMutationObserver
     }

--- a/frontend/lib/src/hooks/useLabelTitleTooltip.ts
+++ b/frontend/lib/src/hooks/useLabelTitleTooltip.ts
@@ -31,16 +31,14 @@ interface LabelTitleTooltipRefs<
  * label truncated with an ellipsis (e.g. `wrap=false`) can still be read on
  * hover.
  *
- * The title uses the rendered plain text (the control's accessible name), so a
- * Markdown label is shown without its raw syntax. Because it is a native
- * `title`, the browser shows it on hover whenever it is set, regardless of
- * whether the label is actually clipped.
- *
- * The plain text is read from the DOM because Markdown can only be converted to
- * plain text after it is rendered. DOM mutations are observed so the title
- * re-syncs after async Markdown plugins (e.g. emoji) replace a loading skeleton
- * with the real label. When `addTitleTooltip` is false, no observer is attached
- * so most controls do not subscribe to DOM mutations.
+ * - Uses the rendered plain text (the control's accessible name), so a Markdown
+ *   label is shown without its raw syntax. It is read from the DOM because
+ *   Markdown can only be converted to plain text after it renders.
+ * - The native `title` is always set when enabled; the browser shows it on hover
+ *   without measuring whether the label is actually clipped.
+ * - A MutationObserver re-syncs the title after async Markdown plugins (e.g.
+ *   emoji) replace a loading skeleton with the real label. When
+ *   `addTitleTooltip` is false, no observer is attached.
  *
  * @param addTitleTooltip Whether to attach the native title tooltip.
  * @param label The raw label source, used to re-sync when it changes.

--- a/frontend/lib/src/hooks/useLabelTitleTooltip.ts
+++ b/frontend/lib/src/hooks/useLabelTitleTooltip.ts
@@ -31,9 +31,9 @@ interface LabelTitleTooltipRefs<
  * label truncated with an ellipsis (e.g. `wrap=false`) can still be read on
  * hover.
  *
- * - Uses the rendered plain text (the control's accessible name), so a Markdown
- *   label is shown without its raw syntax. It is read from the DOM because
- *   Markdown can only be converted to plain text after it renders.
+ * - The hook reads rendered plain text from the DOM (the control's accessible
+ *   name), so a Markdown label is shown without its raw syntax. It reads from the
+ *   DOM because Markdown only yields plain text after it renders.
  * - The native `title` is always set when enabled; the browser shows it on hover
  *   without measuring whether the label is actually clipped.
  * - A MutationObserver re-syncs the title after async Markdown plugins (e.g.

--- a/frontend/lib/src/hooks/useLabelTitleTooltip.ts
+++ b/frontend/lib/src/hooks/useLabelTitleTooltip.ts
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { RefObject, useEffect, useRef } from "react"
+
+interface LabelTitleTooltipRefs<
+  ContainerElement extends HTMLElement,
+  LabelElement extends HTMLElement,
+> {
+  /** Attach to the element that should carry the native `title` attribute. */
+  titleRef: RefObject<ContainerElement>
+  /** Attach to the element wrapping the rendered label text. */
+  labelTextRef: RefObject<LabelElement>
+}
+
+/**
+ * Syncs a native browser tooltip (`title`) exposing the full label text so a
+ * label truncated with an ellipsis (e.g. `wrap=false`) can still be read on
+ * hover.
+ *
+ * The title uses the rendered plain text (the control's accessible name), so a
+ * Markdown label is shown without its raw syntax. Because it is a native
+ * `title`, the browser shows it on hover whenever it is set, regardless of
+ * whether the label is actually clipped.
+ *
+ * The plain text is read from the DOM because Markdown can only be converted to
+ * plain text after it is rendered. DOM mutations are observed so the title
+ * re-syncs after async Markdown plugins (e.g. emoji) replace a loading skeleton
+ * with the real label. When `addTitleTooltip` is false, no observer is attached
+ * so most controls do not subscribe to DOM mutations.
+ *
+ * @param addTitleTooltip Whether to attach the native title tooltip.
+ * @param label The raw label source, used to re-sync when it changes.
+ * @returns Refs to attach to the title container and the label text wrapper.
+ */
+export function useLabelTitleTooltip<
+  ContainerElement extends HTMLElement = HTMLDivElement,
+  LabelElement extends HTMLElement = HTMLSpanElement,
+>(
+  addTitleTooltip: boolean,
+  label: string | null | undefined
+): LabelTitleTooltipRefs<ContainerElement, LabelElement> {
+  const titleRef = useRef<ContainerElement>(null)
+  const labelTextRef = useRef<LabelElement>(null)
+
+  useEffect(() => {
+    const node = titleRef.current
+    if (!node) {
+      return
+    }
+
+    if (!addTitleTooltip) {
+      node.removeAttribute("title")
+      return
+    }
+
+    const syncTitle = (): void => {
+      const labelText = labelTextRef.current?.textContent ?? ""
+      if (labelText) {
+        node.title = labelText
+      } else {
+        node.removeAttribute("title")
+      }
+    }
+
+    syncTitle()
+
+    const observer = new MutationObserver(syncTitle)
+    observer.observe(node, {
+      childList: true,
+      subtree: true,
+      characterData: true,
+    })
+    return () => observer.disconnect()
+  }, [addTitleTooltip, label])
+
+  return { titleRef, labelTextRef }
+}

--- a/frontend/lib/src/hooks/useLabelTitleTooltip.ts
+++ b/frontend/lib/src/hooks/useLabelTitleTooltip.ts
@@ -31,9 +31,9 @@ interface LabelTitleTooltipRefs<
  * label truncated with an ellipsis (e.g. `wrap=false`) can still be read on
  * hover.
  *
- * - The hook reads rendered plain text from the DOM (the control's accessible
- *   name), so a Markdown label is shown without its raw syntax. It reads from the
- *   DOM because Markdown only yields plain text after it renders.
+ * - The hook reads rendered plain text from the DOM so a Markdown label is
+ *   shown without its raw syntax (Markdown only yields plain text after it
+ *   renders).
  * - The native `title` is always set when enabled; the browser shows it on hover
  *   without measuring whether the label is actually clipped.
  * - A MutationObserver re-syncs the title after async Markdown plugins (e.g.

--- a/lib/streamlit/elements/widgets/checkbox.py
+++ b/lib/streamlit/elements/widgets/checkbox.py
@@ -181,8 +181,8 @@ class CheckboxMixin:
               label that is too wide is truncated with an ellipsis.
 
             When the checkbox keeps a single-row label, hovering the label
-            reveals the full label in a tooltip. The checkbox indicator and help
-            icon remain visible.
+            reveals the full label in a tooltip, including when ``help`` is set.
+            The checkbox indicator and help icon remain visible.
 
         bind : "query-params" or None
             Binding mode for syncing the widget's value with a URL query
@@ -371,8 +371,8 @@ class CheckboxMixin:
               label that is too wide is truncated with an ellipsis.
 
             When the toggle keeps a single-row label, hovering the label reveals
-            the full label in a tooltip. The toggle switch and help icon remain
-            visible.
+            the full label in a tooltip, including when ``help`` is set. The
+            toggle switch and help icon remain visible.
 
         bind : "query-params" or None
             Binding mode for syncing the widget's value with a URL query

--- a/lib/streamlit/elements/widgets/checkbox.py
+++ b/lib/streamlit/elements/widgets/checkbox.py
@@ -76,6 +76,7 @@ class CheckboxMixin:
         disabled: bool = False,
         label_visibility: LabelVisibility = "visible",
         width: Width = "content",
+        wrap: bool | None = None,
         bind: BindOption = None,
         persist_state: PersistStateOption = None,
     ) -> bool:
@@ -165,6 +166,24 @@ class CheckboxMixin:
               the parent container, the width of the widget matches the width
               of the parent container.
 
+        wrap : bool or None
+            Whether the checkbox label can wrap onto multiple lines. This can be
+            one of the following:
+
+            - ``None`` (default): Streamlit decides based on the surrounding
+              layout. Inside a horizontal container, the checkbox keeps its
+              standard, single-row height and truncates an overflowing label
+              with an ellipsis; in other layouts, the label wraps onto
+              additional lines.
+            - ``True``: If the label is too wide for the checkbox, it wraps onto
+              additional lines and the widget grows taller.
+            - ``False``: The checkbox keeps its standard, single-row height. A
+              label that is too wide is truncated with an ellipsis.
+
+            When the checkbox keeps a single-row label and no ``help`` is set,
+            hovering reveals the full label. The checkbox indicator and help
+            icon remain visible.
+
         bind : "query-params" or None
             Binding mode for syncing the widget's value with a URL query
             parameter. If this is ``None`` (default), the widget's value
@@ -228,6 +247,7 @@ class CheckboxMixin:
             type=CheckboxProto.StyleType.DEFAULT,
             ctx=ctx,
             width=width,
+            wrap=wrap,
             bind=bind,
             persist_state=persist_state,
         )
@@ -246,6 +266,7 @@ class CheckboxMixin:
         disabled: bool = False,
         label_visibility: LabelVisibility = "visible",
         width: Width = "content",
+        wrap: bool | None = None,
         bind: BindOption = None,
         persist_state: PersistStateOption = None,
     ) -> bool:
@@ -335,6 +356,24 @@ class CheckboxMixin:
               the parent container, the width of the widget matches the width
               of the parent container.
 
+        wrap : bool or None
+            Whether the toggle label can wrap onto multiple lines. This can be
+            one of the following:
+
+            - ``None`` (default): Streamlit decides based on the surrounding
+              layout. Inside a horizontal container, the toggle keeps its
+              standard, single-row height and truncates an overflowing label
+              with an ellipsis; in other layouts, the label wraps onto
+              additional lines.
+            - ``True``: If the label is too wide for the toggle, it wraps onto
+              additional lines and the widget grows taller.
+            - ``False``: The toggle keeps its standard, single-row height. A
+              label that is too wide is truncated with an ellipsis.
+
+            When the toggle keeps a single-row label and no ``help`` is set,
+            hovering reveals the full label. The toggle switch and help icon
+            remain visible.
+
         bind : "query-params" or None
             Binding mode for syncing the widget's value with a URL query
             parameter. If this is ``None`` (default), the widget's value
@@ -398,6 +437,7 @@ class CheckboxMixin:
             type=CheckboxProto.StyleType.TOGGLE,
             ctx=ctx,
             width=width,
+            wrap=wrap,
             bind=bind,
             persist_state=persist_state,
         )
@@ -417,6 +457,7 @@ class CheckboxMixin:
         type: CheckboxProto.StyleType.ValueType = CheckboxProto.StyleType.DEFAULT,
         ctx: ScriptRunContext | None = None,
         width: Width = "content",
+        wrap: bool | None = None,
         bind: BindOption = None,
         persist_state: PersistStateOption = None,
     ) -> bool:
@@ -454,6 +495,12 @@ class CheckboxMixin:
 
         if help is not None:
             checkbox_proto.help = dedent(help)
+
+        # wrap is layout-only, so it is intentionally excluded from the element
+        # id above. Leaving it unset lets the frontend resolve the auto default
+        # from the surrounding layout.
+        if wrap is not None:
+            checkbox_proto.wrap = wrap
 
         # Set query param key if bound
         if bind == "query-params" and key is not None:

--- a/lib/streamlit/elements/widgets/checkbox.py
+++ b/lib/streamlit/elements/widgets/checkbox.py
@@ -180,8 +180,8 @@ class CheckboxMixin:
             - ``False``: The checkbox keeps its standard, single-row height. A
               label that is too wide is truncated with an ellipsis.
 
-            When the checkbox keeps a single-row label and no ``help`` is set,
-            hovering reveals the full label. The checkbox indicator and help
+            When the checkbox keeps a single-row label, hovering the label
+            reveals the full label in a tooltip. The checkbox indicator and help
             icon remain visible.
 
         bind : "query-params" or None
@@ -370,9 +370,9 @@ class CheckboxMixin:
             - ``False``: The toggle keeps its standard, single-row height. A
               label that is too wide is truncated with an ellipsis.
 
-            When the toggle keeps a single-row label and no ``help`` is set,
-            hovering reveals the full label. The toggle switch and help icon
-            remain visible.
+            When the toggle keeps a single-row label, hovering the label reveals
+            the full label in a tooltip. The toggle switch and help icon remain
+            visible.
 
         bind : "query-params" or None
             Binding mode for syncing the widget's value with a URL query

--- a/lib/tests/streamlit/elements/checkbox_test.py
+++ b/lib/tests/streamlit/elements/checkbox_test.py
@@ -21,7 +21,11 @@ from parameterized import parameterized
 
 import streamlit as st
 from streamlit.elements.lib.policies import _LOGGER
-from streamlit.errors import StreamlitAPIException, StreamlitValueError
+from streamlit.errors import (
+    StreamlitAPIException,
+    StreamlitDuplicateElementId,
+    StreamlitValueError,
+)
 from streamlit.proto.Checkbox_pb2 import Checkbox as CheckboxProto
 from streamlit.proto.LabelVisibility_pb2 import LabelVisibility
 from streamlit.runtime.state.widgets import register_widget_from_metadata
@@ -455,3 +459,43 @@ hello
             widget_func("the label", persist_state="session")
 
         assert "must have a unique 'key' parameter" in str(exc.value)
+
+    @parameterized.expand(
+        [
+            ("checkbox", st.checkbox),
+            ("toggle", st.toggle),
+        ]
+    )
+    def test_wrap_default(self, _name: str, widget_func: object) -> None:
+        """By default wrap is left unset (auto) so the frontend resolves it from
+        the layout."""
+        widget_func("the label")
+
+        c = self.get_delta_from_queue().new_element.checkbox
+        assert not c.HasField("wrap")
+
+    @parameterized.expand(
+        [
+            ("checkbox", st.checkbox, True),
+            ("checkbox", st.checkbox, False),
+            ("toggle", st.toggle, True),
+            ("toggle", st.toggle, False),
+        ]
+    )
+    def test_wrap(self, _name: str, widget_func: object, wrap_value: bool) -> None:
+        """The wrap parameter is forwarded to the checkbox proto."""
+        widget_func("the label", wrap=wrap_value)
+
+        c = self.get_delta_from_queue().new_element.checkbox
+        assert c.wrap is wrap_value
+
+    def test_wrap_excluded_from_id(self) -> None:
+        """wrap is layout-only and must not change the element id.
+
+        Two otherwise-identical checkboxes that differ only in wrap collide on
+        the same auto-generated id, proving wrap is excluded from id computation
+        and so preserves widget state when toggled.
+        """
+        st.checkbox("same label")
+        with pytest.raises(StreamlitDuplicateElementId):
+            st.checkbox("same label", wrap=False)

--- a/lib/tests/streamlit/elements/checkbox_test.py
+++ b/lib/tests/streamlit/elements/checkbox_test.py
@@ -480,10 +480,10 @@ hello
 
     @parameterized.expand(
         [
-            ("checkbox", st.checkbox, True),
-            ("checkbox", st.checkbox, False),
-            ("toggle", st.toggle, True),
-            ("toggle", st.toggle, False),
+            ("checkbox_true", st.checkbox, True),
+            ("checkbox_false", st.checkbox, False),
+            ("toggle_true", st.toggle, True),
+            ("toggle_false", st.toggle, False),
         ]
     )
     def test_wrap(self, _name: str, widget_func: object, wrap_value: bool) -> None:

--- a/lib/tests/streamlit/elements/checkbox_test.py
+++ b/lib/tests/streamlit/elements/checkbox_test.py
@@ -462,14 +462,18 @@ hello
 
     @parameterized.expand(
         [
-            ("checkbox", st.checkbox),
-            ("toggle", st.toggle),
+            ("checkbox_default", st.checkbox, {}),
+            ("checkbox_explicit_none", st.checkbox, {"wrap": None}),
+            ("toggle_default", st.toggle, {}),
+            ("toggle_explicit_none", st.toggle, {"wrap": None}),
         ]
     )
-    def test_wrap_default(self, _name: str, widget_func: object) -> None:
-        """By default wrap is left unset (auto) so the frontend resolves it from
-        the layout."""
-        widget_func("the label")
+    def test_wrap_default(
+        self, _name: str, widget_func: object, kwargs: dict[str, object]
+    ) -> None:
+        """Omitting wrap or passing wrap=None leaves the proto field unset (auto),
+        so the frontend resolves wrapping from the layout."""
+        widget_func("the label", **kwargs)
 
         c = self.get_delta_from_queue().new_element.checkbox
         assert not c.HasField("wrap")
@@ -489,13 +493,18 @@ hello
         c = self.get_delta_from_queue().new_element.checkbox
         assert c.wrap is wrap_value
 
-    def test_wrap_excluded_from_id(self) -> None:
-        """wrap is layout-only and must not change the element id.
+    @parameterized.expand(
+        [
+            ("checkbox", st.checkbox),
+            ("toggle", st.toggle),
+        ]
+    )
+    def test_wrap_excluded_from_id(self, _name: str, widget_func: object) -> None:
+        """wrap is layout-only and must not affect the element id (state-preserving).
 
-        Two otherwise-identical checkboxes that differ only in wrap collide on
-        the same auto-generated id, proving wrap is excluded from id computation
-        and so preserves widget state when toggled.
+        Two otherwise-identical widgets that differ only in wrap collide on the
+        same auto-generated id, proving wrap is excluded from id computation.
         """
-        st.checkbox("same label")
+        widget_func("same label")
         with pytest.raises(StreamlitDuplicateElementId):
-            st.checkbox("same label", wrap=False)
+            widget_func("same label", wrap=False)

--- a/lib/tests/streamlit/typing/checkbox_types.py
+++ b/lib/tests/streamlit/typing/checkbox_types.py
@@ -48,6 +48,10 @@ if TYPE_CHECKING:
     assert_type(checkbox("Accept terms", width="content"), bool)
     assert_type(checkbox("Accept terms", width="stretch"), bool)
     assert_type(checkbox("Accept terms", width=200), bool)
+
+    assert_type(checkbox("Accept terms", wrap=True), bool)
+    assert_type(checkbox("Accept terms", wrap=False), bool)
+    assert_type(checkbox("Accept terms", wrap=None), bool)
     assert_type(
         checkbox("Accept terms", key="bind_checkbox", bind="query-params"), bool
     )
@@ -113,6 +117,10 @@ if TYPE_CHECKING:
     assert_type(toggle("Enable feature", width="content"), bool)
     assert_type(toggle("Enable feature", width="stretch"), bool)
     assert_type(toggle("Enable feature", width=150), bool)
+
+    assert_type(toggle("Enable feature", wrap=True), bool)
+    assert_type(toggle("Enable feature", wrap=False), bool)
+    assert_type(toggle("Enable feature", wrap=None), bool)
     assert_type(toggle("Enable feature", key="bind_toggle", bind="query-params"), bool)
     assert_type(
         toggle("Enable feature", key="persist_toggle", persist_state="page"), bool

--- a/proto/streamlit/proto/Checkbox.proto
+++ b/proto/streamlit/proto/Checkbox.proto
@@ -36,4 +36,8 @@ message Checkbox {
   StyleType type = 10;
   // If set, widget value is bound to this query parameter key.
   optional string query_param_key = 11;
+  // If false, the label ellipsizes on one line instead of wrapping.
+  // Absent means the frontend decides the optimal wrapping behavior based on
+  // the layout.
+  optional bool wrap = 12;
 }


### PR DESCRIPTION
## Describe your changes

Adds a keyword-only `wrap: bool | None = None` parameter to `st.checkbox` and `st.toggle`, extending the `wrap` behavior already shipped for `st.button` and the other button-like commands.

- `wrap=False` keeps the control on one row and ellipsizes an overflowing label, exposing the full label via a native `title` tooltip scoped to the label. Unlike a button (whose help tooltip covers the whole control), `help` lives on a separate icon here, so the title stays enabled when `help` is set and the two tooltips do not compete; the checkbox indicator / toggle switch and the help icon stay visible.
- `wrap=None` (default, "auto") resolves from the layout — no-wrap inside a horizontal container, wrap otherwise — matching the `st.markdown(width="auto")` / `st.button` precedent. It is layout-only and excluded from the widget id, so toggling it never resets widget state.
- Extracts the native-title sync into a shared `useLabelTitleTooltip` hook, reused by `DynamicButtonLabel` (behavior-preserving).

Scoped to `st.checkbox` and `st.toggle` from the [horizontal wrap control spec](https://github.com/streamlit/streamlit/blob/develop/specs/2026-07-23-horizontal-wrap-control/product-spec.md); the other commands in that spec are out of scope for this PR.

> [!NOTE]
> The spec's shared tooltip rule ("omit the native `title` when `help` is set") was written for button-like controls, where the help tooltip covers the whole control and would compete with the title. For checkbox/toggle, help is triggered by a separate help icon and the title is scoped to the label element, so both can coexist without competing. This intentional, author-approved refinement is why the title stays enabled when `help` is set here.

## GitHub Issue Link (if applicable)

## Testing Plan

- Unit Tests (JS and/or Python)
  - `lib/tests/streamlit/elements/checkbox_test.py` — `wrap` forwarded to the proto, absent by default, and excluded from the element id (state preserved).
  - `lib/tests/streamlit/typing/checkbox_types.py` — `wrap=True/False/None` typing for both commands.
  - `frontend/lib/src/components/widgets/Checkbox/Checkbox.test.tsx` — native title on `wrap=False`, auto resolution inside/outside horizontal layouts, and title/help coexistence with the title scoped to the label (checkbox and toggle variants).
- E2E Tests
  - `e2e_playwright/st_checkbox_test.py`, `e2e_playwright/st_toggle_test.py` — single-row vs. wrapped height, full-label title exposure, auto-truncation inside a horizontal container, and title/help coexistence.
- Any manual testing needed? No — verified visually via `make debug`.