### PR TITLE
[docs] Point users to streamlit.typing imports

### DIFF
--- a/lib/streamlit/.agents/skills/developing-with-streamlit/SKILL.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/SKILL.md
@@ -92,6 +92,8 @@ streamlit docs st.<command>
 
 Run this with the Streamlit installation relevant to the app being edited. Use `references/api-reference.md` to discover available public `st` commands and namespaces, then use `streamlit docs st.<command>` for exact signatures, parameters, and docstrings.
 
+When annotating Streamlit-owned values returned by commands or stored in Session State, import the curated public types from `streamlit.typing` (also available as `st.typing`) instead of their internal implementation modules. See `references/api-reference.md` for the available types.
+
 ### Best practices quick reference
 
 Apply these defaults unless the user's app or request clearly needs a different approach. For examples, read `references/best-practices.md`.
@@ -134,7 +136,7 @@ Use this routing table to select reference(s). **Always read the reference file*
 | **Displaying or editing tabular data** — `st.dataframe` column configuration, `st.data_editor` for editable tables, chart selection, and best practices for large datasets | read `references/data-display.md` |
 | **Multi-page app architecture** — `st.navigation`, `st.Page`, page routing, shared state across pages, and structuring apps with multiple views | read `references/multipage-apps.md` |
 | **Persisting values across reruns** — `st.session_state`, widget keys, callbacks (`on_change`, `on_click`), and patterns for stateful interactions | read `references/session-state.md` |
-| **Discovering available Streamlit public APIs, looking up `st.<command>` commands, exact parameters, docstrings, signatures, or choosing the right top-level command** — quick table of public `st` commands and related public objects plus CLI instructions for inspecting local docstrings | read `references/api-reference.md` |
+| **Discovering available Streamlit public APIs, looking up `st.<command>` commands, exact parameters, docstrings, signatures, public annotation types, or choosing the right top-level command** — quick table of public `st` commands, related public objects, and `streamlit.typing` exports plus CLI instructions for inspecting local docstrings | read `references/api-reference.md` |
 | **Rich text formatting** — Markdown in `st.markdown` and widget labels, colored text (`:red[...]`), badges, Material Symbols icons (`:material/icon_name:`), LaTeX math, and Mermaid diagrams | read `references/markdown.md` |
 | **Chat and conversational UIs** — `st.chat_message`, `st.chat_input`, streaming responses with `st.write_stream`, and building AI assistant interfaces | read `references/chat-ui.md` |
 | **Connecting to Snowflake** — `st.connection("snowflake")`, secrets configuration, querying data, and Snowflake-specific patterns | read `references/snowflake-connection.md` |

--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/api-reference.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/api-reference.md
@@ -169,3 +169,25 @@ Run this command with the Streamlit installation relevant to the code being edit
 | **Public namespaces** | |
 | `st.column_config` | Namespace of column configuration helpers for `st.dataframe` and `st.data_editor`. See the `st.column_config` helper rows above and inspect helpers such as `st.column_config.NumberColumn` for exact parameters. |
 | `st.components` | Namespace for custom components. Prefer `st.components.v2.component()` for new HTML/JS components; `st.components.v1` is deprecated for new work. |
+| `st.typing` | Curated namespace of public Streamlit-owned types for annotations. Prefer imports from `streamlit.typing` over internal implementation modules. |
+
+## Public annotation types
+
+Import Streamlit-owned return and state types from `streamlit.typing`, not from modules under `streamlit.elements` or `streamlit.runtime`:
+
+```python
+from streamlit.typing import DataframeState, UploadedFile
+```
+
+| Type | Produced by |
+|------|-------------|
+| `UploadedFile` | `st.file_uploader`, `st.camera_input`, `st.audio_input`, and file/audio fields from `st.chat_input` |
+| `ChatInputValue` | `st.chat_input` when file or audio input is enabled |
+| `DataframeState` | `st.dataframe` when selection events are enabled |
+| `PlotlyState` | `st.plotly_chart` when selection events are enabled |
+| `VegaLiteState` | `st.altair_chart` and `st.vega_lite_chart` when selection events are enabled |
+| `PydeckState` | `st.pydeck_chart` when selection events are enabled |
+| `DataEditorState` | Session State for a keyed `st.data_editor` |
+| `ButtonColumnClickState` | Session State for a keyed `st.column_config.ButtonColumn` click |
+
+These are the runtime classes returned by Streamlit, so they work in annotations and `isinstance` checks. Obtain their values from the corresponding command or Session State entry instead of constructing them directly.

--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/chat-ui.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/chat-ui.md
@@ -142,6 +142,16 @@ if prompt:
 
 Use `accept_file="multiple"` to allow multiple files.
 
+For typed helpers, import `ChatInputValue` and `UploadedFile` from the public `streamlit.typing` namespace instead of Streamlit's internal modules:
+
+```python
+from streamlit.typing import ChatInputValue, UploadedFile
+
+
+def first_file(submission: ChatInputValue) -> UploadedFile | None:
+    return submission.files[0] if submission.files else None
+```
+
 ## Audio input
 
 Enable voice recording with `accept_audio`. The recorded audio is available as a WAV file:

--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/chat-ui.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/chat-ui.md
@@ -149,7 +149,11 @@ from streamlit.typing import ChatInputValue, UploadedFile
 
 
 def first_file(submission: ChatInputValue) -> UploadedFile | None:
-    return submission.files[0] if submission.files else None
+    return (
+        submission.files[0]
+        if "files" in submission and submission.files
+        else None
+    )
 ```
 
 ## Audio input

--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/chat-ui.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/chat-ui.md
@@ -149,11 +149,7 @@ from streamlit.typing import ChatInputValue, UploadedFile
 
 
 def first_file(submission: ChatInputValue) -> UploadedFile | None:
-    return (
-        submission.files[0]
-        if "files" in submission and submission.files
-        else None
-    )
+    return submission.files[0] if "files" in submission and submission.files else None
 ```
 
 ## Audio input

--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/data-display.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/data-display.md
@@ -160,6 +160,7 @@ st.dataframe(
 **Key points:**
 
 - **`key` is required** to enable clicks/callbacks. Click info lives in `st.session_state[key]` as a dict-like object with `row` and `label` attributes (also supports key access) — only during the click rerun, then resets to `None`.
+- Import `ButtonColumnClickState` from `streamlit.typing` when annotating this click value.
 - Use `on_click` (with optional `args`/`kwargs`) for the action; read the clicked row/label inside the callback.
 - Always **read-only** — even in `st.data_editor`, the cell values can't be edited, but clicks still fire.
 - Style with `type="primary" | "secondary" | "tertiary"` and `alignment`.
@@ -218,6 +219,8 @@ edited_df = st.data_editor(
 
 Access edit details via `st.session_state["my_editor"]["edited_rows"]`.
 
+Import `DataEditorState` from `streamlit.typing` when annotating the pending edit state stored at this Session State key.
+
 **Preserving edits on data refresh** — With a `key` and `num_rows="fixed"`, edits are kept when the data's *values* change and only reset when its structure changes (columns, dtypes, row count, or index labels). An edit is dropped once its value matches the new data. Edits are matched by row position, so use a meaningful index if edits should follow specific rows when the data is reordered. Omit `key` to reset edits on every data change.
 
 **Double-input anti-pattern** — assigning the result back to the same session state used as input causes every other edit to disappear:
@@ -244,6 +247,8 @@ selected_data = df.iloc[selected_indices]
 ```
 
 Selection modes: `"single-row"`, `"multi-row"`, `"single-column"`, `"multi-column"`, `"single-cell"`, `"multi-cell"`.
+
+Import `DataframeState` from `streamlit.typing` when annotating the returned event. The same public namespace exposes `PlotlyState`, `VegaLiteState`, and `PydeckState` for selection events from `st.plotly_chart`, `st.altair_chart`/`st.vega_lite_chart`, and `st.pydeck_chart`, respectively. Do not import these types from Streamlit's internal modules.
 
 ## Empty DataFrames
 

--- a/lib/streamlit/elements/arrow.py
+++ b/lib/streamlit/elements/arrow.py
@@ -246,6 +246,8 @@ class DataframeState(ReadOnlyAttributeDictionary):
     """
     The schema for the dataframe event state.
 
+    To use this type in an annotation, import it from ``streamlit.typing``.
+
     The event state is stored in a dictionary-like object that supports both
     key and attribute notation. Event states can be programmatically set
     through session state by assigning a dictionary with the same schema to the
@@ -923,12 +925,13 @@ class ArrowMixin:
 
         Returns
         -------
-        element or dict
+        element or DataframeState
             If ``on_select`` is ``"ignore"`` (default), this command returns an
             internal placeholder for the dataframe element. Otherwise, this
-            command returns a dictionary-like object that supports both key and
-            attribute notation. The attributes are described by the
-            ``DataframeState`` class.
+            command returns a ``DataframeState`` object. This object is
+            dictionary-like and supports both key and attribute notation. To
+            use this type in an annotation, import it from
+            ``streamlit.typing``.
 
         Examples
         --------

--- a/lib/streamlit/elements/deck_gl_json_chart.py
+++ b/lib/streamlit/elements/deck_gl_json_chart.py
@@ -236,6 +236,8 @@ class PydeckState(ReadOnlyAttributeDictionary):
     """
     The schema for the PyDeck event state.
 
+    To use this type in an annotation, import it from ``streamlit.typing``.
+
     The event state is stored in a read-only dictionary-like object that
     supports both key and attribute notation. Event states cannot be
     programmatically changed or set through Session State.
@@ -474,12 +476,12 @@ class PydeckMixin:
 
         Returns
         -------
-        element or dict
+        element or PydeckState
             If ``on_select`` is ``"ignore"`` (default), this command returns an
             internal placeholder for the chart element. Otherwise, this method
-            returns a dictionary-like object that supports both key and
-            attribute notation. The attributes are described by the
-            ``PydeckState`` class.
+            returns a ``PydeckState`` object. This object is dictionary-like
+            and supports both key and attribute notation. To use this type in
+            an annotation, import it from ``streamlit.typing``.
 
         Examples
         --------

--- a/lib/streamlit/elements/lib/column_config_utils.py
+++ b/lib/streamlit/elements/lib/column_config_utils.py
@@ -444,6 +444,8 @@ ButtonColumnMapping: TypeAlias = dict[str, ButtonColumnResult]
 class ButtonColumnClickState(ReadOnlyAttributeDictionary):
     """The schema for button click state in ButtonColumn.
 
+    To use this type in an annotation, import it from ``streamlit.typing``.
+
     Read-only dict-like click payload with attribute and key access
     (``click.row`` / ``click["row"]``). Both fields are always present when a
     button click occurs.

--- a/lib/streamlit/elements/lib/column_types.py
+++ b/lib/streamlit/elements/lib/column_types.py
@@ -3371,9 +3371,11 @@ def ButtonColumn(
     key : str or None
         A session state key for the click trigger value. When a button is
         clicked, the click information is stored under this key in Session
-        State as a dictionary-like object with ``row`` (int) and ``label``
-        (str) entries that support both key and attribute notation. For
-        example, if ``key="my_click"``, you can access the clicked row with
+        State as a ``ButtonColumnClickState`` object with ``row`` (int) and
+        ``label`` (str) entries that support both key and attribute notation.
+        To use this type in an annotation, import it from
+        ``streamlit.typing``. For example, if ``key="my_click"``, you can
+        access the clicked row with
         ``st.session_state.my_click.row`` or
         ``st.session_state["my_click"]["row"]``. The value is only present
         during the rerun triggered by the click; it resets to ``None`` on

--- a/lib/streamlit/elements/lib/column_types.py
+++ b/lib/streamlit/elements/lib/column_types.py
@@ -3373,13 +3373,12 @@ def ButtonColumn(
         clicked, the click information is stored under this key in Session
         State as a ``ButtonColumnClickState`` object with ``row`` (int) and
         ``label`` (str) entries that support both key and attribute notation.
-        To use this type in an annotation, import it from
-        ``streamlit.typing``. For example, if ``key="my_click"``, you can
-        access the clicked row with
+        For example, if ``key="my_click"``, you can access the clicked row with
         ``st.session_state.my_click.row`` or
         ``st.session_state["my_click"]["row"]``. The value is only present
         during the rerun triggered by the click; it resets to ``None`` on
-        subsequent reruns.
+        subsequent reruns. To use ``ButtonColumnClickState`` in an annotation,
+        import it from ``streamlit.typing``.
 
         ``key`` is required to enable button clicks and callbacks.
 

--- a/lib/streamlit/elements/plotly_chart.py
+++ b/lib/streamlit/elements/plotly_chart.py
@@ -196,6 +196,8 @@ class PlotlyState(ReadOnlyAttributeDictionary):
     """
     The schema for the Plotly chart event state.
 
+    To use this type in an annotation, import it from ``streamlit.typing``.
+
     The event state is stored in a read-only dictionary-like object that
     supports both key and attribute notation. Event states cannot be
     programmatically changed or set through Session State.
@@ -610,12 +612,12 @@ class PlotlyMixin:
 
         Returns
         -------
-        element or dict
+        element or PlotlyState
             If ``on_select`` is ``"ignore"`` (default), this command returns an
             internal placeholder for the chart element. Otherwise, this command
-            returns a dictionary-like object that supports both key and
-            attribute notation. The attributes are described by the
-            ``PlotlyState`` class.
+            returns a ``PlotlyState`` object. This object is dictionary-like
+            and supports both key and attribute notation. To use this type in
+            an annotation, import it from ``streamlit.typing``.
 
         Examples
         --------

--- a/lib/streamlit/elements/vega_charts.py
+++ b/lib/streamlit/elements/vega_charts.py
@@ -88,6 +88,8 @@ class VegaLiteState(ReadOnlyAttributeDictionary):
     """
     The schema for the Vega-Lite event state.
 
+    To use this type in an annotation, import it from ``streamlit.typing``.
+
     The event state is stored in a read-only dictionary-like object that
     supports both key and attribute notation. Event states cannot be
     programmatically changed or set through Session State.
@@ -1951,12 +1953,12 @@ class VegaChartsMixin:
 
         Returns
         -------
-        element or dict
+        element or VegaLiteState
             If ``on_select`` is ``"ignore"`` (default), this command returns an
             internal placeholder for the chart element. Otherwise, this command
-            returns a dictionary-like object that supports both key and attribute
-            notation. The attributes are described by the ``VegaLiteState``
-            class.
+            returns a ``VegaLiteState`` object. This object is dictionary-like
+            and supports both key and attribute notation. To use this type in
+            an annotation, import it from ``streamlit.typing``.
 
         Examples
         --------
@@ -2183,12 +2185,12 @@ class VegaChartsMixin:
 
         Returns
         -------
-        element or dict
+        element or VegaLiteState
             If ``on_select`` is ``"ignore"`` (default), this command returns an
             internal placeholder for the chart element. Otherwise, this command
-            returns a dictionary-like object that supports both key and attribute
-            notation. The attributes are described by the ``VegaLiteState``
-            class.
+            returns a ``VegaLiteState`` object. This object is dictionary-like
+            and supports both key and attribute notation. To use this type in
+            an annotation, import it from ``streamlit.typing``.
 
         Examples
         --------

--- a/lib/streamlit/elements/widgets/audio_input.py
+++ b/lib/streamlit/elements/widgets/audio_input.py
@@ -199,7 +199,8 @@ class AudioInputMixin:
             The ``UploadedFile`` class is a subclass of ``BytesIO``, and
             therefore is "file-like". This means you can pass an instance of it
             anywhere a file is expected. The MIME type for the audio data is
-            ``audio/wav``.
+            ``audio/wav``. To use this type in an annotation, import it from
+            ``streamlit.typing``.
 
             .. Note::
                 The resulting ``UploadedFile`` is subject to the size

--- a/lib/streamlit/elements/widgets/camera_input.py
+++ b/lib/streamlit/elements/widgets/camera_input.py
@@ -209,9 +209,10 @@ class CameraInputMixin:
         Returns
         -------
         None or UploadedFile
-            The UploadedFile class is a subclass of BytesIO, and therefore is
-            "file-like". This means you can pass an instance of it anywhere a
-            file is expected.
+            The ``UploadedFile`` class is a subclass of ``BytesIO``, and
+            therefore is "file-like". This means you can pass an instance of it
+            anywhere a file is expected. To use this type in an annotation,
+            import it from ``streamlit.typing``.
 
         Examples
         --------

--- a/lib/streamlit/elements/widgets/chat.py
+++ b/lib/streamlit/elements/widgets/chat.py
@@ -813,8 +813,9 @@ class ChatMixin:
               rerun, the widget returns the user's message as a string.
             - A ``ChatInputValue`` object: When the widget is configured to
               accept files or audio recordings, and the user submitted any
-              content in the last rerun, the widget returns a dictionary-like
-              object.
+              content in the last rerun, the widget returns a ``ChatInputValue``
+              object. This object is dictionary-like and supports both key and
+              attribute notation.
               The object always includes the ``text`` attribute, and
               optionally includes ``files`` and/or ``audio`` attributes depending
               on the ``accept_file`` and ``accept_audio`` parameters.

--- a/lib/streamlit/elements/widgets/chat.py
+++ b/lib/streamlit/elements/widgets/chat.py
@@ -97,6 +97,8 @@ _ChatInputValueItem: TypeAlias = str | list[UploadedFile] | UploadedFile | None
 class ChatInputValue(MutableMapping[str, _ChatInputValueItem]):
     """Represents the value returned by `st.chat_input` after user interaction.
 
+    To use this type in an annotation, import it from ``streamlit.typing``.
+
     This dataclass contains the user's input text, any files uploaded, and optionally
     an audio recording. It provides a dict-like interface for accessing and modifying
     its attributes.
@@ -801,7 +803,7 @@ class ChatMixin:
 
         Returns
         -------
-        None, str, or dict-like
+        None, str, or ChatInputValue
             The user's submission. This is one of the following types:
 
             - ``None``: If the user didn't submit a message, file, or audio
@@ -809,12 +811,16 @@ class ChatMixin:
             - A string: When the widget isn't configured to accept files or
               audio recordings, and the user submitted a message in the last
               rerun, the widget returns the user's message as a string.
-            - A dict-like object: When the widget is configured to accept files
-              or audio recordings, and the user submitted any content in the
-              last rerun, the widget returns a dict-like object.
+            - A ``ChatInputValue`` object: When the widget is configured to
+              accept files or audio recordings, and the user submitted any
+              content in the last rerun, the widget returns a dictionary-like
+              object.
               The object always includes the ``text`` attribute, and
               optionally includes ``files`` and/or ``audio`` attributes depending
               on the ``accept_file`` and ``accept_audio`` parameters.
+
+            To use ``ChatInputValue`` or ``UploadedFile`` in an annotation,
+            import them from ``streamlit.typing``.
 
             When the widget is configured to accept files or audio recordings,
             and the user submitted content in the last rerun, you can access

--- a/lib/streamlit/elements/widgets/data_editor.py
+++ b/lib/streamlit/elements/widgets/data_editor.py
@@ -116,6 +116,8 @@ DataTypes: TypeAlias = Union[
 class DataEditorState(ReadOnlyAttributeDictionary):
     """The schema for the data editor state.
 
+    To use this type in an annotation, import it from ``streamlit.typing``.
+
     The state is stored in a read-only dictionary-like object that
     supports both key and attribute notation. Top-level assignment and
     nested dict mutation raise ``TypeError``. List fields (``added_rows``,
@@ -956,6 +958,10 @@ class DataEditorMixin:
             ``st.session_state[key]`` (read-only). For more details, see
             `Widget behavior
             <https://docs.streamlit.io/develop/concepts/architecture/widget-behavior>`_.
+
+            The value in Session State is a ``DataEditorState`` object that
+            describes the pending edits. To use this type in an annotation,
+            import it from ``streamlit.typing``.
 
             Additionally, if ``key`` is provided, it will be used as a
             CSS class name prefixed with ``st-key-``.

--- a/lib/streamlit/elements/widgets/file_uploader.py
+++ b/lib/streamlit/elements/widgets/file_uploader.py
@@ -420,7 +420,8 @@ class FileUploaderMixin:
 
             The ``UploadedFile`` class is a subclass of ``BytesIO``, and
             therefore is "file-like". This means you can pass an instance of it
-            anywhere a file is expected.
+            anywhere a file is expected. To use this type in an annotation,
+            import it from ``streamlit.typing``.
 
         Examples
         --------

--- a/lib/streamlit/runtime/uploaded_file_manager.py
+++ b/lib/streamlit/runtime/uploaded_file_manager.py
@@ -61,6 +61,8 @@ class DeletedFile(NamedTuple):
 class UploadedFile(io.BytesIO):
     """A mutable uploaded file.
 
+    To use this type in an annotation, import it from ``streamlit.typing``.
+
     This class extends BytesIO, which has copy-on-write semantics when
     initialized with `bytes`.
     """


### PR DESCRIPTION
## Describe your changes

Document that Streamlit-owned return/state types should be imported from `streamlit.typing` (not internal modules). Completes the Documentation follow-up from `specs/2026-07-21-public-typing` (command return docs + agent skill).

- Updates command and class docstrings for selection state, upload, chat input, and data editor types
- Updates the developing-with-streamlit agent skill with the same public import guidance

## GitHub Issue Link (if applicable)

Follow-up to the public `streamlit.typing` namespace (#16295).

## Testing Plan

- [x] No additional tests needed — docstring and agent-skill documentation only
- [x] `make check` passed on changed files

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

Made with [Cursor](https://cursor.com)