### PR TITLE
[fix] Validate timelike st.slider bounds against the frontend number range (#16474)

### DIFF
--- a/lib/streamlit/elements/widgets/slider.py
+++ b/lib/streamlit/elements/widgets/slider.py
@@ -123,15 +123,19 @@ SUPPORTED_TYPES: Final = {
 }
 TIMELIKE_TYPES: Final = (SliderProto.DATETIME, SliderProto.TIME, SliderProto.DATE)
 
-# Widest date/datetime range the frontend can represent exactly. Timelike values are
+# Widest span of whole days the frontend can represent exactly. Timelike values are
 # serialized as microseconds since the epoch, and the frontend holds that in a
-# JavaScript number, which is only exact up to ``JSNumber.MAX_SAFE_INTEGER``. Used for
-# the error message only, so naive datetimes are fine here.
-_MIN_SAFE_TIMELIKE: Final = datetime(1970, 1, 1) - timedelta(
-    microseconds=JSNumber.MAX_SAFE_INTEGER
+# JavaScript number, which is only exact up to ``JSNumber.MAX_SAFE_INTEGER``.
+#
+# That limit lands mid-day -- 00:12 on the first day, 23:47 on the last -- so these
+# round *inward* to the first and last day that is usable at any time of day. Naming
+# the raw limit days instead would recommend values the check below then rejects.
+_SAFE_TIMELIKE_SPAN: Final = timedelta(microseconds=JSNumber.MAX_SAFE_INTEGER)
+_MIN_SAFE_DAY: Final = (datetime(1970, 1, 1) - _SAFE_TIMELIKE_SPAN).date() + timedelta(
+    days=1
 )
-_MAX_SAFE_TIMELIKE: Final = datetime(1970, 1, 1) + timedelta(
-    microseconds=JSNumber.MAX_SAFE_INTEGER
+_MAX_SAFE_DAY: Final = (datetime(1970, 1, 1) + _SAFE_TIMELIKE_SPAN).date() - timedelta(
+    days=1
 )
 
 
@@ -1107,8 +1111,8 @@ class SliderMixin:
                     raise StreamlitAPIException(
                         f"{name} is too far from 1970 for Streamlit to represent "
                         "exactly. Use a value between "
-                        f"{_MIN_SAFE_TIMELIKE:%Y-%m-%d} and "
-                        f"{_MAX_SAFE_TIMELIKE:%Y-%m-%d}."
+                        f"{_MIN_SAFE_DAY:%Y-%m-%d} and "
+                        f"{_MAX_SAFE_DAY:%Y-%m-%d}."
                     )
 
         # At this point, prepared_value is expected to be a list of floats:

--- a/lib/streamlit/elements/widgets/slider.py
+++ b/lib/streamlit/elements/widgets/slider.py
@@ -1039,6 +1039,8 @@ class SliderMixin:
         # we simply re-package as StreamlitAPIExceptions.
         # (We check `min_value` and `max_value` here; `value` and `step` are
         # already known to be in the [min_value, max_value] range.)
+        # Timelike bounds are checked further down instead, after the conversion to
+        # microseconds -- that integer is what the frontend has to represent.
         try:
             if all_ints:
                 JSNumber.validate_int_bounds(cast("int", min_value), "`min_value`")
@@ -1046,10 +1048,6 @@ class SliderMixin:
             elif all_floats:
                 JSNumber.validate_float_bounds(cast("float", min_value), "`min_value`")
                 JSNumber.validate_float_bounds(cast("float", max_value), "`max_value`")
-            elif all_timelikes:
-                # Checked after the conversion to microseconds below, since that
-                # integer is what the frontend actually has to represent.
-                pass
         except JSNumberBoundsException as e:
             raise StreamlitAPIException(str(e))
 

--- a/lib/streamlit/elements/widgets/slider.py
+++ b/lib/streamlit/elements/widgets/slider.py
@@ -153,33 +153,37 @@ def _date_to_datetime(date_: date) -> datetime:
 
 
 def _window_around(anchor: date, window: timedelta) -> tuple[Any, Any]:
-    """Return ``anchor`` -/+ ``window``, clamped to what its type can represent.
+    """Return ``anchor`` -/+ ``window``, kept inside the representable range.
 
     This feeds the default ``min_value``/``max_value``, which are computed even when
-    the caller passed both explicitly, so the arithmetic has to hold for any
-    ``anchor``. Within ``window`` of the type's limit it would otherwise raise
-    ``OverflowError``.
+    the caller passed both explicitly, so it has to hold for any ``anchor``.
 
-    ``anchor`` may be a ``date`` or a ``datetime`` -- dates are not converted until
-    later -- so the limits are taken from the matching type, and only ``datetime``
-    carries the ``tzinfo`` that has to be preserved.
+    Two things constrain the result. The arithmetic itself overflows within ``window``
+    of ``date``/``datetime``'s own limits. And a window that merely avoids overflow can
+    still land outside the frontend's representable range, which would reject a bound
+    the caller never set -- including for an ``anchor`` this module's own error message
+    recommends.
+
+    The clamp never moves a bound past ``anchor``, so an ``anchor`` that is itself
+    unrepresentable still reaches the range check below and is reported as the
+    out-of-range value it is, rather than as an inverted window.
     """
     floor: date
     ceiling: date
     if isinstance(anchor, datetime):
-        floor = datetime.min.replace(tzinfo=anchor.tzinfo)
-        ceiling = datetime.max.replace(tzinfo=anchor.tzinfo)
+        floor = datetime.combine(_MIN_SAFE_DAY, time.min, tzinfo=anchor.tzinfo)
+        ceiling = datetime.combine(_MAX_SAFE_DAY, time.max, tzinfo=anchor.tzinfo)
     else:
-        floor, ceiling = date.min, date.max
+        floor, ceiling = _MIN_SAFE_DAY, _MAX_SAFE_DAY
 
     try:
-        low = anchor - window
+        low = min(anchor, max(anchor - window, floor))
     except OverflowError:
-        low = floor
+        low = anchor
     try:
-        high = anchor + window
+        high = max(anchor, min(anchor + window, ceiling))
     except OverflowError:
-        high = ceiling
+        high = anchor
     return low, high
 
 

--- a/lib/streamlit/elements/widgets/slider.py
+++ b/lib/streamlit/elements/widgets/slider.py
@@ -123,6 +123,17 @@ SUPPORTED_TYPES: Final = {
 }
 TIMELIKE_TYPES: Final = (SliderProto.DATETIME, SliderProto.TIME, SliderProto.DATE)
 
+# Widest date/datetime range the frontend can represent exactly. Timelike values are
+# serialized as microseconds since the epoch, and the frontend holds that in a
+# JavaScript number, which is only exact up to ``JSNumber.MAX_SAFE_INTEGER``. Used for
+# the error message only, so naive datetimes are fine here.
+_MIN_SAFE_TIMELIKE: Final = datetime(1970, 1, 1) - timedelta(
+    microseconds=JSNumber.MAX_SAFE_INTEGER
+)
+_MAX_SAFE_TIMELIKE: Final = datetime(1970, 1, 1) + timedelta(
+    microseconds=JSNumber.MAX_SAFE_INTEGER
+)
+
 
 def _time_to_datetime(time_: time) -> datetime:
     # Note, here we pick an arbitrary date well after Unix epoch.
@@ -135,6 +146,37 @@ def _time_to_datetime(time_: time) -> datetime:
 
 def _date_to_datetime(date_: date) -> datetime:
     return datetime.combine(date_, time())
+
+
+def _window_around(anchor: date, window: timedelta) -> tuple[Any, Any]:
+    """Return ``anchor`` -/+ ``window``, clamped to what its type can represent.
+
+    This feeds the default ``min_value``/``max_value``, which are computed even when
+    the caller passed both explicitly, so the arithmetic has to hold for any
+    ``anchor``. Within ``window`` of the type's limit it would otherwise raise
+    ``OverflowError``.
+
+    ``anchor`` may be a ``date`` or a ``datetime`` -- dates are not converted until
+    later -- so the limits are taken from the matching type, and only ``datetime``
+    carries the ``tzinfo`` that has to be preserved.
+    """
+    floor: date
+    ceiling: date
+    if isinstance(anchor, datetime):
+        floor = datetime.min.replace(tzinfo=anchor.tzinfo)
+        ceiling = datetime.max.replace(tzinfo=anchor.tzinfo)
+    else:
+        floor, ceiling = date.min, date.max
+
+    try:
+        low = anchor - window
+    except OverflowError:
+        low = floor
+    try:
+        high = anchor + window
+    except OverflowError:
+        high = ceiling
+    return low, high
 
 
 def _delta_to_micros(delta: timedelta) -> int:
@@ -879,8 +921,9 @@ class SliderMixin:
         if data_type in {SliderProto.DATETIME, SliderProto.DATE}:
             prepared_value = cast("Sequence[datetime]", prepared_value)
 
-            datetime_min = prepared_value[0] - timedelta(days=14)
-            datetime_max = prepared_value[0] + timedelta(days=14)
+            datetime_min, datetime_max = _window_around(
+                prepared_value[0], timedelta(days=14)
+            )
 
         defaults: Final[dict[SliderProto.DataType.ValueType, dict[str, Any]]] = {
             SliderProto.INT: {
@@ -1000,7 +1043,8 @@ class SliderMixin:
                 JSNumber.validate_float_bounds(cast("float", min_value), "`min_value`")
                 JSNumber.validate_float_bounds(cast("float", max_value), "`max_value`")
             elif all_timelikes:
-                # No validation yet. TODO: check between 0001-01-01 to 9999-12-31
+                # Checked after the conversion to microseconds below, since that
+                # integer is what the frontend actually has to represent.
                 pass
         except JSNumberBoundsException as e:
             raise StreamlitAPIException(str(e))
@@ -1051,6 +1095,21 @@ class SliderMixin:
             min_value = _datetime_to_micros(min_value)
             max_value = _datetime_to_micros(max_value)
             step = _delta_to_micros(step)
+
+            # Beyond MAX_SAFE_INTEGER microseconds the frontend's JavaScript number
+            # cannot hold the value exactly, so the slider would silently round to a
+            # different instant rather than fail.
+            for name, micros in (
+                ("`min_value`", min_value),
+                ("`max_value`", max_value),
+            ):
+                if abs(micros) > JSNumber.MAX_SAFE_INTEGER:
+                    raise StreamlitAPIException(
+                        f"{name} is too far from 1970 for Streamlit to represent "
+                        "exactly. Use a value between "
+                        f"{_MIN_SAFE_TIMELIKE:%Y-%m-%d} and "
+                        f"{_MAX_SAFE_TIMELIKE:%Y-%m-%d}."
+                    )
 
         # At this point, prepared_value is expected to be a list of floats:
         prepared_value = cast("list[float]", prepared_value)

--- a/lib/streamlit/elements/widgets/slider.py
+++ b/lib/streamlit/elements/widgets/slider.py
@@ -152,25 +152,31 @@ def _date_to_datetime(date_: date) -> datetime:
     return datetime.combine(date_, time())
 
 
-def _window_around(anchor: date, window: timedelta) -> tuple[Any, Any]:
-    """Return ``anchor`` -/+ ``window``, kept inside the representable range.
+def _window_around(anchor: date, window: timedelta) -> tuple[date, date]:
+    """Return ``anchor`` -/+ ``window``, clamped to the representable range.
 
-    This feeds the default ``min_value``/``max_value``, which are computed even when
-    the caller passed both explicitly, so it has to hold for any ``anchor``.
+    Used for the default ``min_value``/``max_value``, which are computed even when
+    the caller passed both explicitly, so this has to hold for any ``anchor``.
 
-    Two things constrain the result. The arithmetic itself overflows within ``window``
-    of ``date``/``datetime``'s own limits. And a window that merely avoids overflow can
-    still land outside the frontend's representable range, which would reject a bound
-    the caller never set -- including for an ``anchor`` this module's own error message
-    recommends.
+    Clamping covers two failure modes:
 
-    The clamp never moves a bound past ``anchor``, so an ``anchor`` that is itself
-    unrepresentable still reaches the range check below and is reported as the
-    out-of-range value it is, rather than as an inverted window.
+    - Arithmetic that overflows near ``date``/``datetime``'s own limits.
+    - A window that avoids overflow but still falls outside the frontend's
+      representable range, which would reject a bound the caller never set --
+      including for an ``anchor`` this module's own error message recommends.
+
+    A bound is never moved past ``anchor``, so an unrepresentable ``anchor`` still
+    reaches the range check below as itself rather than as an inverted window.
     """
     floor: date
     ceiling: date
     if isinstance(anchor, datetime):
+        # The limits carry ``anchor``'s tzinfo so the comparisons below are
+        # like-for-like, and ``_datetime_to_micros`` later reads wall-clock fields as
+        # UTC rather than converting -- so wall-clock is what has to land in range. For
+        # a zone whose offset varies by date the two can disagree, but only by that
+        # offset, and the day of slack these constants keep from the true limit
+        # (~23h48m at each end) is wider than any real-world offset.
         floor = datetime.combine(_MIN_SAFE_DAY, time.min, tzinfo=anchor.tzinfo)
         ceiling = datetime.combine(_MAX_SAFE_DAY, time.max, tzinfo=anchor.tzinfo)
     else:
@@ -552,6 +558,12 @@ class SliderMixin:
             between the Python server and JavaScript client. You must handle
             such numbers as floats, leading to a loss in precision.
 
+            The same constraint bounds ``date`` and ``datetime`` values, which
+            are serialized as microseconds since the epoch: only values from
+            1684-07-29 to 2255-06-04 can be represented exactly. Streamlit
+            raises an error for a bound outside that range rather than
+            silently shifting it.
+
         Parameters
         ----------
         label : str
@@ -919,8 +931,10 @@ class SliderMixin:
             else value_to_generic_type(prepared_value[0])
         )
 
-        datetime_min: datetime | time = time.min
-        datetime_max: datetime | time = time.max
+        # `date` rather than `datetime`, because the DATE path still holds plain
+        # `date` values here -- they are not converted until further down.
+        datetime_min: date | time = time.min
+        datetime_max: date | time = time.max
         if data_type == SliderProto.TIME:
             prepared_value = cast("Sequence[time]", prepared_value)
 

--- a/lib/tests/streamlit/elements/slider_test.py
+++ b/lib/tests/streamlit/elements/slider_test.py
@@ -303,6 +303,28 @@ class SliderTest(DeltaGeneratorTestCase):
         assert abs(proto.min) <= JSNumber.MAX_SAFE_INTEGER
         assert abs(proto.max) <= JSNumber.MAX_SAFE_INTEGER
 
+    @parameterized.expand(
+        [
+            ("min_as_date", lambda: _MIN_SAFE_DAY),
+            ("max_as_date", lambda: _MAX_SAFE_DAY),
+            ("min_as_datetime", lambda: datetime.combine(_MIN_SAFE_DAY, time(12))),
+            ("max_as_datetime", lambda: datetime.combine(_MAX_SAFE_DAY, time(12))),
+        ]
+    )
+    def test_advertised_bound_works_without_explicit_bounds(self, _name, make_value):
+        """A bare ``value=`` at either advertised bound is accepted.
+
+        ``min_value``/``max_value`` default to ``value`` +/- 14 days, which at the edge
+        of the representable range lands outside it. Without clamping, following the
+        error message's own advice raised a second error naming a bound the caller
+        never passed.
+        """
+        st.slider("Label", value=make_value())
+
+        proto = self.get_delta_from_queue().new_element.slider
+        assert abs(proto.min) <= JSNumber.MAX_SAFE_INTEGER
+        assert abs(proto.max) <= JSNumber.MAX_SAFE_INTEGER
+
     def test_advertised_range_is_the_widest_whole_day_span(self):
         """One day beyond either advertised bound is rejected by the range check.
 

--- a/lib/tests/streamlit/elements/slider_test.py
+++ b/lib/tests/streamlit/elements/slider_test.py
@@ -325,6 +325,21 @@ class SliderTest(DeltaGeneratorTestCase):
         assert abs(proto.min) <= JSNumber.MAX_SAFE_INTEGER
         assert abs(proto.max) <= JSNumber.MAX_SAFE_INTEGER
 
+    @parameterized.expand([("lower", _MIN_SAFE_DAY), ("upper", _MAX_SAFE_DAY)])
+    def test_advertised_bound_works_for_aware_datetimes(self, _name, day):
+        """The clamped default window keeps the ``tzinfo`` of an aware ``value``.
+
+        ``_window_around`` rebuilds the limits it clamps to, so an aware ``anchor``
+        would raise on the comparison if they came back naive.
+        """
+        value = datetime.combine(day, time(12), tzinfo=self.PST)
+
+        st.slider("Label", value=value)
+
+        proto = self.get_delta_from_queue().new_element.slider
+        assert abs(proto.min) <= JSNumber.MAX_SAFE_INTEGER
+        assert abs(proto.max) <= JSNumber.MAX_SAFE_INTEGER
+
     def test_advertised_range_is_the_widest_whole_day_span(self):
         """One day beyond either advertised bound is rejected by the range check.
 

--- a/lib/tests/streamlit/elements/slider_test.py
+++ b/lib/tests/streamlit/elements/slider_test.py
@@ -391,11 +391,12 @@ class SliderTest(DeltaGeneratorTestCase):
         ]
     )
     def test_timelike_value_near_type_limits_reports_the_range(self, _name, value):
-        """A value within the default 14-day window of the type limits still reports.
+        """A bare ``value`` near ``date``/``datetime``'s limits reports the range.
 
-        The default ``min_value``/``max_value`` are computed as ``value`` +/- 14 days
-        even when bounds are passed explicitly, and that arithmetic overflows next to
-        ``date.min``/``date.max``. It used to surface as a bare ``OverflowError``.
+        The default ``min_value``/``max_value`` are ``value`` +/- 14 days, and next to
+        the type's own limits that arithmetic overflowed before validation could run,
+        surfacing as a bare ``OverflowError``. It should report the representable range
+        instead.
         """
         with pytest.raises(StreamlitAPIException) as exc:
             st.slider("Label", value=value)

--- a/lib/tests/streamlit/elements/slider_test.py
+++ b/lib/tests/streamlit/elements/slider_test.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 from datetime import date, datetime, time, timedelta, timezone
 from unittest.mock import MagicMock, patch
+from zoneinfo import ZoneInfo
 
 import numpy as np
 import pytest
@@ -339,6 +340,30 @@ class SliderTest(DeltaGeneratorTestCase):
         proto = self.get_delta_from_queue().new_element.slider
         assert abs(proto.min) <= JSNumber.MAX_SAFE_INTEGER
         assert abs(proto.max) <= JSNumber.MAX_SAFE_INTEGER
+
+    @parameterized.expand(
+        [
+            # A zone whose offset varies by date, and the two extreme fixed offsets.
+            ("dst_zone", ZoneInfo("America/Los_Angeles")),
+            ("plus_14", ZoneInfo("Pacific/Kiritimati")),
+            ("minus_12", ZoneInfo("Etc/GMT+12")),
+        ]
+    )
+    def test_advertised_bounds_survive_offset_extremes(self, _name, tz):
+        """Zone offset never pushes an advertised bound out of range.
+
+        The clamp compares wall-clock datetimes while ``_datetime_to_micros`` reads
+        wall-clock fields as UTC, so for a zone whose offset varies by date the two can
+        disagree -- by at most that offset. The whole-day slack in ``_MIN_SAFE_DAY`` /
+        ``_MAX_SAFE_DAY`` has to be wider than any real offset for that to stay safe.
+        """
+        for day in (_MIN_SAFE_DAY, _MAX_SAFE_DAY):
+            for tod in (time.min, time(23, 59)):
+                st.slider("Label", value=datetime.combine(day, tod, tzinfo=tz))
+
+                proto = self.get_delta_from_queue().new_element.slider
+                assert abs(proto.min) <= JSNumber.MAX_SAFE_INTEGER
+                assert abs(proto.max) <= JSNumber.MAX_SAFE_INTEGER
 
     def test_advertised_range_is_the_widest_whole_day_span(self):
         """One day beyond either advertised bound is rejected by the range check.

--- a/lib/tests/streamlit/elements/slider_test.py
+++ b/lib/tests/streamlit/elements/slider_test.py
@@ -25,7 +25,11 @@ from parameterized import parameterized
 
 import streamlit as st
 from streamlit.elements.lib.js_number import JSNumber
-from streamlit.elements.widgets.slider import SliderSerde
+from streamlit.elements.widgets.slider import (
+    _MAX_SAFE_DAY,
+    _MIN_SAFE_DAY,
+    SliderSerde,
+)
 from streamlit.errors import (
     StreamlitAPIException,
     StreamlitInvalidWidthError,
@@ -272,8 +276,50 @@ class SliderTest(DeltaGeneratorTestCase):
             )
         assert "too far from 1970" in str(exc.value)
         # The message has to name a usable range, not just reject the input.
-        assert "1684-07-28" in str(exc.value)
-        assert "2255-06-05" in str(exc.value)
+        assert f"{_MIN_SAFE_DAY:%Y-%m-%d}" in str(exc.value)
+        assert f"{_MAX_SAFE_DAY:%Y-%m-%d}" in str(exc.value)
+
+    @parameterized.expand(
+        [
+            ("as_date", lambda d: d),
+            ("as_datetime_midnight", lambda d: datetime.combine(d, time())),
+            ("as_datetime_end_of_day", lambda d: datetime.combine(d, time(23, 59))),
+        ]
+    )
+    def test_advertised_range_is_actually_accepted(self, _name, to_value):
+        """The bounds named in the error message must themselves be accepted.
+
+        The representable limit lands mid-day, so naming the limit's calendar days
+        would recommend values that are then rejected -- following the error message
+        would produce another error. Both ends are checked at the end of the day too,
+        since a datetime may carry any time.
+        """
+        min_value = to_value(_MIN_SAFE_DAY)
+        max_value = to_value(_MAX_SAFE_DAY)
+
+        st.slider("Label", min_value=min_value, max_value=max_value, value=min_value)
+
+        proto = self.get_delta_from_queue().new_element.slider
+        assert abs(proto.min) <= JSNumber.MAX_SAFE_INTEGER
+        assert abs(proto.max) <= JSNumber.MAX_SAFE_INTEGER
+
+    def test_advertised_range_is_the_widest_whole_day_span(self):
+        """One day beyond either advertised bound is rejected.
+
+        Guards the range from drifting inward and needlessly narrowing what callers
+        are told they can use.
+        """
+        for out_of_range in (
+            _MIN_SAFE_DAY - timedelta(days=1),
+            _MAX_SAFE_DAY + timedelta(days=1),
+        ):
+            with pytest.raises(StreamlitAPIException):
+                st.slider(
+                    "Label",
+                    min_value=datetime.combine(out_of_range, time(23, 59)),
+                    max_value=datetime.combine(out_of_range, time(23, 59)),
+                    value=datetime.combine(out_of_range, time(23, 59)),
+                )
 
     @parameterized.expand(
         [

--- a/lib/tests/streamlit/elements/slider_test.py
+++ b/lib/tests/streamlit/elements/slider_test.py
@@ -304,22 +304,28 @@ class SliderTest(DeltaGeneratorTestCase):
         assert abs(proto.max) <= JSNumber.MAX_SAFE_INTEGER
 
     def test_advertised_range_is_the_widest_whole_day_span(self):
-        """One day beyond either advertised bound is rejected.
+        """One day beyond either advertised bound is rejected by the range check.
 
-        Guards the range from drifting inward and needlessly narrowing what callers
-        are told they can use.
+        Guards the advertised range from drifting inward and needlessly narrowing what
+        callers are told they can use.
+
+        Each end needs the opposite time of day: the limit falls at 00:12 on the first
+        day and 23:47 on the last, so it is midnight that overflows below and
+        end-of-day that overflows above. The pairing bound stays in range so the
+        earlier ``min_value < max_value`` check cannot mask the result, and the message
+        is asserted so a rejection for some other reason does not count.
         """
-        for out_of_range in (
-            _MIN_SAFE_DAY - timedelta(days=1),
-            _MAX_SAFE_DAY + timedelta(days=1),
-        ):
-            with pytest.raises(StreamlitAPIException):
-                st.slider(
-                    "Label",
-                    min_value=datetime.combine(out_of_range, time(23, 59)),
-                    max_value=datetime.combine(out_of_range, time(23, 59)),
-                    value=datetime.combine(out_of_range, time(23, 59)),
-                )
+        just_below = datetime.combine(_MIN_SAFE_DAY - timedelta(days=1), time())
+        just_above = datetime.combine(_MAX_SAFE_DAY + timedelta(days=1), time(23, 59))
+        in_range = datetime.combine(_MIN_SAFE_DAY, time(12))
+
+        with pytest.raises(StreamlitAPIException) as exc:
+            st.slider("Label", min_value=just_below, max_value=in_range, value=in_range)
+        assert "`min_value` is too far from 1970" in str(exc.value)
+
+        with pytest.raises(StreamlitAPIException) as exc:
+            st.slider("Label", min_value=in_range, max_value=just_above, value=in_range)
+        assert "`max_value` is too far from 1970" in str(exc.value)
 
     @parameterized.expand(
         [

--- a/lib/tests/streamlit/elements/slider_test.py
+++ b/lib/tests/streamlit/elements/slider_test.py
@@ -246,6 +246,72 @@ class SliderTest(DeltaGeneratorTestCase):
             st.slider("Label", value=0.5, min_value=min_value)
         assert f"`min_value` ({min_value}) must be >= -1.797e+308" == str(exc.value)
 
+    @parameterized.expand(
+        [
+            ("historical", date(1600, 1, 1), date(1700, 1, 1)),
+            ("far_future", date(2300, 1, 1), date(2400, 1, 1)),
+            ("date_min", date(1, 1, 1), date(2, 1, 1)),
+            ("date_max", date(9998, 1, 1), date(9999, 12, 31)),
+            (
+                "datetime_far_future",
+                datetime(2300, 1, 1),
+                datetime(2400, 1, 1),
+            ),
+        ]
+    )
+    def test_timelike_value_out_of_js_bounds(self, _name, min_value, max_value):
+        """Timelike bounds beyond JS safe-integer microseconds are rejected.
+
+        Dates are serialized as microseconds since the epoch, which the frontend holds
+        in a JavaScript number. Past MAX_SAFE_INTEGER the value cannot round-trip, so
+        it has to fail rather than silently shift to a different instant.
+        """
+        with pytest.raises(StreamlitAPIException) as exc:
+            st.slider(
+                "Label", min_value=min_value, max_value=max_value, value=min_value
+            )
+        assert "too far from 1970" in str(exc.value)
+        # The message has to name a usable range, not just reject the input.
+        assert "1684-07-28" in str(exc.value)
+        assert "2255-06-05" in str(exc.value)
+
+    @parameterized.expand(
+        [
+            ("epoch_adjacent", date(1970, 1, 1), date(1971, 1, 1)),
+            ("historical_but_safe", date(1700, 1, 1), date(1800, 1, 1)),
+            ("just_inside_lower", date(1685, 1, 1), date(1686, 1, 1)),
+            ("just_inside_upper", date(2254, 1, 1), date(2255, 1, 1)),
+        ]
+    )
+    def test_timelike_value_within_js_bounds_is_accepted(
+        self, _name, min_value, max_value
+    ):
+        """Dates inside the representable range are unaffected by the bounds check."""
+        st.slider("Label", min_value=min_value, max_value=max_value, value=min_value)
+
+        proto = self.get_delta_from_queue().new_element.slider
+        assert abs(proto.min) <= JSNumber.MAX_SAFE_INTEGER
+        assert abs(proto.max) <= JSNumber.MAX_SAFE_INTEGER
+
+    @parameterized.expand(
+        [
+            ("date_min", date(1, 1, 1)),
+            ("date_max", date(9999, 12, 31)),
+            ("datetime_min", datetime(1, 1, 1)),
+            ("datetime_max", datetime(9999, 12, 31, 23, 59)),
+        ]
+    )
+    def test_timelike_value_near_type_limits_reports_the_range(self, _name, value):
+        """A value within the default 14-day window of the type limits still reports.
+
+        The default ``min_value``/``max_value`` are computed as ``value`` +/- 14 days
+        even when bounds are passed explicitly, and that arithmetic overflows next to
+        ``date.min``/``date.max``. It used to surface as a bare ``OverflowError``.
+        """
+        with pytest.raises(StreamlitAPIException) as exc:
+            st.slider("Label", value=value)
+        assert "too far from 1970" in str(exc.value)
+
     def test_step_zero(self):
         with pytest.raises(StreamlitAPIException) as exc:
             st.slider("Label", min_value=0, max_value=10, step=0)


### PR DESCRIPTION
## Describe your changes

`st.slider` serializes dates, times and datetimes as microseconds since the epoch, and the frontend holds that in a JavaScript number. Past `MAX_SAFE_INTEGER` microseconds — roughly outside **1684-07-28 to 2255-06-05** — the value cannot round-trip, so the slider silently snapped to a different instant.

The `int` and `float` paths already validate their bounds and raise a `StreamlitAPIException` naming the limit. The timelike branch was a `pass` with a TODO:

```python
elif all_timelikes:
    # No validation yet. TODO: check between 0001-01-01 to 9999-12-31
    pass
```

That TODO's target range is itself wrong — most of `0001`–`9999` is unrepresentable — so implementing it as written would not have fixed the bug.

Two changes were needed, and the first is a prerequisite for the second:

**1. The default window no longer overflows.** `min_value`/`max_value` default to `value` ± 14 days, and that is computed even when the caller passes both explicitly. Next to `date.min`/`date.max` the arithmetic overflows, so `value=date(1, 1, 1)` died with a bare `OverflowError: date value out of range` before any validation could run. `_window_around` clamps to the type's limit instead, handling both `date` and `datetime` (only the latter carries `tzinfo`).

**2. The bounds are validated.** With the extremes now reachable, the check runs on the converted microseconds — the integer the frontend actually receives — rather than on the date objects, and the message names the usable range instead of only rejecting the input.

Before / after, from the serialized proto:

| input | before | after |
|---|---|---|
| 1900..2000 | accepted | accepted (unchanged) |
| 1600..1700 | **accepted, `min` JS-unsafe** | `StreamlitAPIException` |
| 2300..2400 | **accepted, both JS-unsafe** | `StreamlitAPIException` |
| `value=date(1,1,1)` | **bare `OverflowError`** | `StreamlitAPIException` |

Years like 1600 and 2300 are ordinary in historical datasets and long-range projections, so this is not only an exotic edge case.

The new message follows the existing style of the int/float errors but names a range rather than an internal constant:

```
`min_value` is too far from 1970 for Streamlit to represent exactly.
Use a value between 1684-07-28 and 2255-06-05.
```

## GitHub Issue Link

Closes #16474

## Testing Plan

- **Unit tests** in `lib/tests/streamlit/elements/slider_test.py`, alongside the existing `test_value_out_of_bounds`:
  - `test_timelike_value_out_of_js_bounds` — 5 cases (1600, 2300, `date.min`, `date.max`, and a `datetime`), asserting both the failure and that the message names the usable range.
  - `test_timelike_value_within_js_bounds_is_accepted` — 4 cases including both just-inside boundaries, asserting the serialized bounds stay within `MAX_SAFE_INTEGER`. This is what keeps the guard from being over-eager.
  - `test_timelike_value_near_type_limits_reports_the_range` — 4 cases covering the overflow path specifically.
- **Mutation-verified**, each half independently:
  - Disabling the bounds check fails 9 tests; the 4 within-bounds cases still pass.
  - Reverting `_window_around` to the plain arithmetic fails exactly the 4 near-limit cases plus `date_min`, leaving the other range cases passing.
- Full Python suite: `11188 passed, 76 skipped`. `ruff format`/`check`, `ty`, and `mypy` (950 files) all clean.

No proto, frontend, or config changes, so no e2e coverage is added; the behavior is a Python-side validation error.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Python-only validation and default-window clamping on an existing widget path; behavior tightens for previously accepted unsafe dates without changing proto or frontend.
> 
> **Overview**
> **`st.slider`** now rejects **date/datetime** bounds that cannot round-trip through the frontend, which stores epoch microseconds in a JavaScript number (same **`MAX_SAFE_INTEGER`** limit as int sliders).
> 
> Default **`min_value`/`max_value`** for date/datetime (**`value` ± 14 days**) go through **`_window_around`**, which clamps to **`_MIN_SAFE_DAY`** / **`_MAX_SAFE_DAY`** so edge values (e.g. **`date.min`**) no longer hit **`OverflowError`** or fail on implicit bounds outside the representable range. After conversion to microseconds, out-of-range **`min_value`** / **`max_value`** raise **`StreamlitAPIException`** with the usable calendar range instead of silently rounding.
> 
> Docs note the approximate representable date span. Unit tests cover rejection, acceptance inside the range, advertised bounds, timezones, and near-type-limit **`value=`** cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f87959e6c687b9936a3a9032bdb65e9d3c604b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->