### PR TITLE
[fix] Require XSRF token on cross-origin WebSocket handshakes

### DIFF
--- a/.claude/skills/understanding-streamlit-architecture/references/backend.md
+++ b/.claude/skills/understanding-streamlit-architecture/references/backend.md
@@ -185,6 +185,32 @@ Browser connects -> Runtime.connect_session()
                  -> Browser disconnects -> Runtime.disconnect_session()
 ```
 
+The handshake applies two gates before `accept()`, then it binds identity:
+
+- **Origin check** (`_is_origin_allowed`): the handler rejects a handshake when
+  `server.allowedHosts` does not list the `Host` header, or when the `Origin` header is neither
+  same-origin nor allowed by `is_url_from_allowed_origins`. That helper accepts localhost, the
+  machine IP addresses, and `server.corsAllowedOrigins`. When `server.enableCORS=false`, it accepts
+  every origin. Both config lists are empty by default.
+- **XSRF admission**: a cross-origin handshake must send a matching double-submit XSRF token, or
+  the handler closes the socket with code `1008` before `accept()` and before `connect_session()`.
+  This gate runs when XSRF protection is on, which `is_xsrf_enabled()` decides: either
+  `server.enableXsrfProtection` is on, which is the default, or an `[auth]` section exists in
+  secrets. That second path turns the gate on even when the config option is `false`. A same-origin
+  handshake and a handshake without an `Origin` header skip the token check. Browsers set `Origin`
+  and scripts cannot forge it, so same-origin means the app's own page opened the socket, and
+  JavaScript can read the XSRF cookie there anyway. This gate still limits cross-origin handshakes
+  when an operator sets `server.enableCORS=false`.
+- **Identity**: the handler reads the signed user cookie into `user_info` only when the XSRF token
+  validates. A handshake that connects without a valid token stays anonymous. So does every
+  handshake when XSRF protection is off. `server.trustedUserHeaders` still applies in
+  both cases, and it overrides the cookie.
+
+HTTP routes carry the token in the `X-Xsrftoken` header. The handshake carries it in the second
+`Sec-WebSocket-Protocol` entry, because browsers cannot set arbitrary WebSocket headers. The
+frontend puts either a host auth token or the XSRF token in that one entry, so an embed that uses
+`useExternalAuthToken` cannot send both. See `frontend.md` for the effect on `st.user`.
+
 ## Key abstractions
 
 | Interface | Purpose | Default Implementation |

--- a/.claude/skills/understanding-streamlit-architecture/references/frontend.md
+++ b/.claude/skills/understanding-streamlit-architecture/references/frontend.md
@@ -159,6 +159,17 @@ Any state -> DISCONNECTED_FOREVER (on fatal error)
 - Uses `ForwardMsgCache` for message deduplication
 - Maintains message ordering via index queue
 - Handles session reconnection via tokens
+- Sends `hostAuthToken ?? xsrfCookie` in the second `Sec-WebSocket-Protocol` entry
+  (`getSessionTokens`). A host auth token wins that one slot, so an embed that uses
+  `useExternalAuthToken` cannot also send the XSRF token. The server still admits the handshake
+  when the page and the backend share an origin, but it cannot read the signed user cookie. Then
+  `st.user` stays empty unless `server.trustedUserHeaders` supplies the identity. A deployment that
+  points `BACKEND_BASE_URL` at another host makes the handshake cross-origin, so the server closes
+  it with code `1008`. Such a page cannot read the backend's XSRF cookie, so it cannot put the
+  token in the slot, and admission fails whatever `server.xsrfCookieSameSite` allows the browser to
+  send. Those deployments need XSRF protection off, which the file upload routes already require of
+  them. Note that `server.enableXsrfProtection=false` alone does not turn it off when an `[auth]`
+  section exists in secrets, because `is_xsrf_enabled()` honors both paths.
 
 ### ForwardMsgCache (`ForwardMessageCache.ts`)
 

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -1103,9 +1103,32 @@ _create_option(
         Enables support for Cross-Site Request Forgery (XSRF) protection, for
         added security.
 
-        This option does not enable `server.enableCORS`. Streamlit does not
-        need a valid XSRF token to open a WebSocket connection, so this option
-        does not replace `server.enableCORS`.
+        When enabled, a WebSocket handshake that comes from an origin other
+        than the app must send a matching XSRF token. Streamlit rejects such a
+        handshake before it opens a session.
+
+        - A handshake from the app's own origin does not need the token.
+        - A handshake without an ``Origin`` header does not need the token, so
+          programmatic clients still connect.
+        - A page on the app's host but a different port must send the token,
+          and it can. The browser shares the cookie across ports.
+        - A page on a different host cannot read the XSRF cookie, so it cannot
+          put the token in the handshake and the connection fails while XSRF
+          protection is on. The file upload routes already reject that page for
+          the same reason. Serve the page and the server from one host, or turn
+          XSRF protection off. An ``[auth]`` section in your secrets also turns
+          XSRF protection on, so this option alone does not turn it off for an
+          app that uses Streamlit authentication.
+        - An app that receives an external auth token from its host page puts
+          that token in the same ``Sec-WebSocket-Protocol`` entry that carries
+          the XSRF token. Streamlit cannot validate the XSRF token for those
+          connections, so it does not read the signed user cookie and
+          ``st.user`` stays empty.
+
+        This option does not enable ``server.enableCORS``. To limit which
+        origins may attempt a connection, set ``server.enableCORS=true`` and
+        list the origins that you trust in ``server.corsAllowedOrigins``. That
+        allowlist does not exempt an origin from the XSRF token requirement.
     """,
     default_val=True,
     type_=bool,
@@ -3089,14 +3112,16 @@ def _check_conflicts() -> None:
 Streamlit sends the header 'Access-Control-Allow-Origin: *', except on the file
 upload routes, which stay pinned to the app address and still require a valid
 XSRF token.
-Streamlit also accepts a WebSocket connection from any origin.
 Streamlit does not set 'server.enableCORS' to 'true' for you.
-'server.enableXsrfProtection=true' does not stop a cross-origin WebSocket
-connection, because Streamlit does not need a valid XSRF token to open one.
+The Origin check admits a WebSocket handshake from any origin, but
+'server.enableXsrfProtection=true' rejects a cross-origin handshake that has a
+missing or invalid XSRF token.
 
-To limit cross-origin access, do these steps:
+To limit which origins may attempt a connection, do these steps:
   1. Set 'server.enableCORS=true'.
   2. Put the origins that you trust in 'server.corsAllowedOrigins'.
+
+That allowlist does not exempt an origin from the XSRF token requirement.
 
 'server.allowedHosts' can also limit the hostnames that Streamlit accepts on a
 WebSocket connection.

--- a/lib/streamlit/web/server/starlette/starlette_websocket.py
+++ b/lib/streamlit/web/server/starlette/starlette_websocket.py
@@ -145,6 +145,22 @@ def _is_host_allowed(host: str | None) -> bool:
     return False
 
 
+def _is_same_origin(origin: str, host: str | None) -> bool:
+    """Check whether the Origin header names the same host and port as the request.
+
+    The comparison includes the port, so an origin on a different port is
+    cross-origin. It leaves out the scheme on purpose. A proxy that terminates
+    TLS sends the backend an http request for an https origin, so a scheme
+    comparison would call every such deployment cross-origin.
+
+    The comparison does not normalize a default port, because ``urlparse``
+    leaves it out of ``netloc``. An ``https://app.example.com`` origin against
+    an ``app.example.com:443`` host reads as cross-origin, which requires the
+    token rather than skipping it.
+    """
+    return urlparse(origin).netloc == host
+
+
 def _is_origin_allowed(origin: str | None, host: str | None) -> bool:
     """Check if the WebSocket Origin header is allowed.
 
@@ -177,12 +193,7 @@ def _is_origin_allowed(origin: str | None, host: str | None) -> bool:
     if origin is None:
         return True
 
-    # Check same-origin: compare origin host with request host
-    parsed_origin = urlparse(origin)
-    origin_host = parsed_origin.netloc
-
-    # If origin host matches request host, it's same-origin
-    if origin_host == host:
+    if _is_same_origin(origin, host):
         return True
 
     # Delegate to the standard allowed origins check
@@ -411,6 +422,7 @@ def create_websocket_handler(runtime: Runtime) -> Any:
     bidirectional communication between the browser and the Streamlit runtime.
     The handler performs:
     - Origin validation (CORS/XSRF protection)
+    - XSRF admission control for cross-origin handshakes
     - Subprotocol negotiation
     - Session management (connect/disconnect)
     - User authentication via cookies and trusted headers
@@ -447,6 +459,36 @@ def create_websocket_handler(runtime: Runtime) -> Any:
         subprotocol, xsrf_token, existing_session_id = _parse_subprotocols(
             websocket.headers
         )
+
+        # A cross-origin handshake must send a matching double-submit XSRF
+        # token. The HTTP upload and delete routes apply the same check.
+        # A same-origin handshake skips it. Browsers set Origin and scripts
+        # cannot forge it, so a same-origin handshake comes from the app's own
+        # page, where JavaScript can read the XSRF cookie anyway. A cross-origin
+        # page cannot read that cookie, which is what makes the token an
+        # effective control there.
+        # The gate cannot cover a same-origin handshake, because an embed puts
+        # its host auth token in the entry that carries the XSRF token. Issue
+        # 16477 tracks that shared slot.
+        xsrf_valid = False
+        if is_xsrf_enabled() and origin:
+            xsrf_cookie = websocket.cookies.get(XSRF_COOKIE_NAME)
+            xsrf_valid = starlette_app_utils.validate_xsrf_token(
+                xsrf_token, xsrf_cookie
+            )
+            if not xsrf_valid and not _is_same_origin(origin, host):
+                _LOGGER.warning(
+                    "Rejecting cross-origin WebSocket connection with a missing "
+                    "or invalid XSRF token: origin=%s, host=%s, token_present=%s, "
+                    "cookie_present=%s",
+                    origin,
+                    host,
+                    bool(xsrf_token),
+                    bool(xsrf_cookie),
+                )
+                await websocket.close(code=1008)  # 1008 = Policy Violation
+                return
+
         await websocket.accept(subprotocol=subprotocol)
 
         client = StarletteSessionClient(websocket)
@@ -454,52 +496,44 @@ def create_websocket_handler(runtime: Runtime) -> Any:
 
         try:
             user_info: dict[str, Any] = {}
-            if is_xsrf_enabled():
-                xsrf_cookie = websocket.cookies.get(XSRF_COOKIE_NAME)
-                origin_header = websocket.headers.get("Origin")
+            # Read the signed user cookie only when the admission check above
+            # validated the XSRF token. A same-origin handshake without a valid
+            # token connects but stays anonymous.
+            if origin and xsrf_valid:
+                # Read expose_tokens lazily on connect (rather than once at
+                # handler creation) so programmatic secrets from
+                # ``st.App(secrets=...)``, which are merged during the ASGI
+                # lifespan after routes are built, are honored. Resolve it
+                # outside the defensive cookie-parsing block below so an
+                # invalid ``expose_tokens`` config surfaces as a clear error
+                # instead of being silently swallowed as a cookie-parsing
+                # failure.
+                expose_tokens = get_expose_tokens_config()
 
-                # Validate XSRF token before parsing auth cookie:
-                if origin_header and starlette_app_utils.validate_xsrf_token(
-                    xsrf_token, xsrf_cookie
-                ):
-                    # Read expose_tokens lazily on connect (rather than once at
-                    # handler creation) so programmatic secrets from
-                    # ``st.App(secrets=...)``, which are merged during the ASGI
-                    # lifespan after routes are built, are honored. Resolve it
-                    # outside the defensive cookie-parsing block below so an
-                    # invalid ``expose_tokens`` config surfaces as a clear error
-                    # instead of being silently swallowed as a cookie-parsing
-                    # failure.
-                    expose_tokens = get_expose_tokens_config()
-
-                    try:
-                        raw_auth_cookie = _get_signed_cookie_with_chunks(
-                            websocket.cookies, USER_COOKIE_NAME
+                try:
+                    raw_auth_cookie = _get_signed_cookie_with_chunks(
+                        websocket.cookies, USER_COOKIE_NAME
+                    )
+                    if raw_auth_cookie:
+                        user_info.update(
+                            _parse_decoded_user_cookie(raw_auth_cookie, origin)
                         )
-                        if raw_auth_cookie:
-                            user_info.update(
-                                _parse_decoded_user_cookie(
-                                    raw_auth_cookie, origin_header
-                                )
-                            )
 
-                            raw_token_cookie = _get_signed_cookie_with_chunks(
-                                websocket.cookies, TOKENS_COOKIE_NAME
-                            )
-                            if raw_token_cookie:
-                                all_tokens = json.loads(raw_token_cookie)
+                        raw_token_cookie = _get_signed_cookie_with_chunks(
+                            websocket.cookies, TOKENS_COOKIE_NAME
+                        )
+                        if raw_token_cookie:
+                            all_tokens = json.loads(raw_token_cookie)
 
-                                filtered_tokens: dict[str, str] = {}
-                                for token_type in expose_tokens:
-                                    token_key = f"{token_type}_token"
-                                    if token_key in all_tokens:
-                                        filtered_tokens[token_type] = all_tokens[
-                                            token_key
-                                        ]
+                            filtered_tokens: dict[str, str] = {}
+                            for token_type in expose_tokens:
+                                token_key = f"{token_type}_token"
+                                if token_key in all_tokens:
+                                    filtered_tokens[token_type] = all_tokens[token_key]
 
-                                user_info["tokens"] = filtered_tokens
-                    except Exception:  # pragma: no cover - defensive
-                        _LOGGER.exception("Error parsing auth cookie for websocket")
+                            user_info["tokens"] = filtered_tokens
+                except Exception:  # pragma: no cover - defensive
+                    _LOGGER.exception("Error parsing auth cookie for websocket")
 
             # Map in any user-configured headers. Note that these override anything
             # coming from the auth cookie.

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -860,6 +860,29 @@ class ConfigTest(unittest.TestCase):
         assert config.get_option("server.enableCORS") is False
 
     @patch("streamlit.logger.get_logger")
+    def test_check_conflicts_cors_disabled_says_xsrf_still_rejects_cross_origin(
+        self, get_logger
+    ):
+        """The warning must say that XSRF still rejects cross-origin handshakes.
+
+        The WebSocket handler rejects a cross-origin handshake without a valid
+        XSRF token even when CORS is disabled, so the warning must not tell the
+        operator that XSRF leaves those connections open.
+        """
+        config._set_option("server.enableXsrfProtection", True, "test")
+        config._set_option("server.enableCORS", False, "test")
+        config._set_option("global.developmentMode", False, "test")
+        mock_logger = get_logger()
+        config._check_conflicts()
+        warnings = _warning_text(mock_logger)
+        assert "cross-origin" in warnings
+        assert "XSRF token" in warnings
+        assert "does not stop" not in warnings
+        # The allowlist limits which origins may try, but it grants no exemption
+        # from the token, so the warning must not imply that it does.
+        assert "does not exempt" in warnings
+
+    @patch("streamlit.logger.get_logger")
     def test_check_conflicts_cors_disabled_warns_once_in_development_mode(
         self, get_logger
     ):

--- a/lib/tests/streamlit/web/server/starlette/starlette_app_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_app_test.py
@@ -1254,6 +1254,51 @@ def test_websocket_rejects_auth_cookie_without_valid_xsrf(tmp_path: Path) -> Non
 
 @patch_config_options(
     {
+        "server.enableXsrfProtection": True,
+        # CORS is disabled so the Origin check admits every origin and only the
+        # XSRF check can reject the handshake.
+        "server.enableCORS": False,
+        "global.developmentMode": False,
+        "server.cookieSecret": "test-signing-secret",
+    }
+)
+def test_websocket_rejects_cross_origin_handshake_without_valid_xsrf(
+    tmp_path: Path,
+) -> None:
+    """Close a cross-origin handshake that has no valid XSRF token.
+
+    The socket closes with code 1008 and the runtime never opens a session.
+    """
+    component_dir = tmp_path / "component"
+    component_dir.mkdir()
+
+    static_dir = tmp_path / "static"
+    static_dir.mkdir()
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(file_util, "get_static_dir", lambda: str(static_dir))
+
+    runtime = _DummyRuntime(component_dir)
+    app = create_starlette_app(runtime)
+    client = TestClient(app)
+
+    with (
+        pytest.raises(WebSocketDisconnect) as exc_info,
+        client.websocket_connect(
+            "/_stcore/stream",
+            headers={"Origin": "http://evil.example.com"},
+            subprotocols=["streamlit"],  # No XSRF token in second position
+        ),
+    ):
+        pass
+
+    assert exc_info.value.code == 1008
+    assert runtime.last_user_info is None
+
+    monkeypatch.undo()
+
+
+@patch_config_options(
+    {
         "global.developmentMode": False,
         "global.e2eTest": False,
         "server.enableXsrfProtection": False,

--- a/lib/tests/streamlit/web/server/starlette/starlette_websocket_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_websocket_test.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -32,6 +33,7 @@ from streamlit.web.server.starlette.starlette_websocket import (
     _get_signed_cookie_with_chunks,
     _is_host_allowed,
     _is_origin_allowed,
+    _is_same_origin,
     _parse_decoded_user_cookie,
     _parse_subprotocols,
     _parse_user_cookie_signed,
@@ -489,6 +491,41 @@ class TestIsOriginAllowed:
         assert _is_origin_allowed(origin, "localhost:8501") is expected
 
 
+class TestIsSameOrigin:
+    """Tests for _is_same_origin function."""
+
+    @pytest.mark.parametrize(
+        ("origin", "host", "expected"),
+        [
+            ("http://localhost:8501", "localhost:8501", True),
+            ("https://app.example.com", "app.example.com", True),
+            # A different port is a different origin, so the Vite dev server on
+            # port 3000 is cross-origin to the Streamlit server on port 8501.
+            ("http://localhost:3000", "localhost:8501", False),
+            # A host with an explicit default port does not match an origin
+            # that omits it.
+            ("https://app.example.com", "app.example.com:443", False),
+            ("http://evil.com", "localhost:8501", False),
+        ],
+        ids=[
+            "same_host_and_port",
+            "same_host_no_port",
+            "different_port",
+            "explicit_default_port",
+            "different_host",
+        ],
+    )
+    def test_compares_origin_host_to_request_host(
+        self, origin: str, host: str, expected: bool
+    ) -> None:
+        """The comparison includes the port."""
+        assert _is_same_origin(origin, host) is expected
+
+    def test_returns_false_for_missing_host(self) -> None:
+        """A request without a Host header cannot be same-origin."""
+        assert _is_same_origin("http://localhost:8501", None) is False
+
+
 class TestWebsocketHandlerUserInfoPrecedence:
     """Tests for user_info precedence in websocket handler."""
 
@@ -770,6 +807,288 @@ class TestWebsocketHandlerTokenExposure:
 
         # The misconfiguration must abort the connection rather than silently
         # proceeding with an empty token set.
+        mock_runtime.connect_session.assert_not_called()
+
+
+class TestWebsocketHandlerXsrfAdmission:
+    """Tests for XSRF admission control on the WebSocket handshake.
+
+    A cross-origin handshake needs a matching double-submit XSRF token. A
+    same-origin handshake and a handshake without an ``Origin`` header do not.
+    """
+
+    _SAME_ORIGIN = "http://localhost:8501"
+    _CROSS_ORIGIN = "http://evil.com"
+    _SAME_HOST_OTHER_PORT = "http://localhost:3001"
+    _HOST = "localhost:8501"
+
+    @staticmethod
+    def _make_websocket(
+        *,
+        origin: str | None,
+        xsrf_token: str | None = None,
+        cookies: dict[str, str] | None = None,
+    ) -> MagicMock:
+        """Build a mock websocket for admission tests."""
+        from starlette.websockets import WebSocketDisconnect
+
+        protocol = "streamlit" if xsrf_token is None else f"streamlit, {xsrf_token}"
+
+        mock_websocket = MagicMock()
+        mock_websocket.headers = MagicMock()
+        mock_websocket.headers.get.side_effect = lambda key: {
+            "Origin": origin,
+            "Host": TestWebsocketHandlerXsrfAdmission._HOST,
+            "sec-websocket-protocol": protocol,
+        }.get(key)
+        mock_websocket.headers.getlist.return_value = []
+        mock_websocket.cookies = cookies or {}
+        mock_websocket.accept = AsyncMock()
+        mock_websocket.close = AsyncMock()
+        mock_websocket.receive_bytes = AsyncMock(side_effect=WebSocketDisconnect())
+        return mock_websocket
+
+    @staticmethod
+    def _make_runtime() -> MagicMock:
+        """Build a mock runtime that records ``connect_session`` calls."""
+        mock_runtime = MagicMock()
+        mock_runtime.connect_session = MagicMock(return_value="test-session-id")
+        mock_runtime.disconnect_session = MagicMock()
+        return mock_runtime
+
+    @staticmethod
+    def _run_handler(handler: Any, mock_websocket: MagicMock) -> None:
+        """Run the handler with a stubbed session client."""
+        with patch(
+            "streamlit.web.server.starlette.starlette_websocket.StarletteSessionClient"
+        ) as mock_client_class:
+            mock_client = MagicMock()
+            mock_client.aclose = AsyncMock()
+            mock_client_class.return_value = mock_client
+            asyncio.run(handler(mock_websocket))
+
+    @pytest.mark.parametrize(
+        ("xsrf_token", "cookies"),
+        [
+            pytest.param(None, {}, id="no_token_and_no_cookie"),
+            pytest.param(
+                starlette_app_utils.generate_xsrf_token_string(),
+                {},
+                id="token_without_cookie",
+            ),
+            pytest.param(
+                # Two generated tokens decode correctly but hold different bytes.
+                starlette_app_utils.generate_xsrf_token_string(),
+                {"_streamlit_xsrf": starlette_app_utils.generate_xsrf_token_string()},
+                id="mismatched_token",
+            ),
+        ],
+    )
+    # CORS is disabled so _is_origin_allowed admits every origin. Only the XSRF
+    # check can reject here, which is the cross-site hijacking scenario.
+    @patch_config_options(
+        {"server.enableXsrfProtection": True, "server.enableCORS": False}
+    )
+    def test_rejects_cross_origin_handshake_without_valid_xsrf_token(
+        self, xsrf_token: str | None, cookies: dict[str, str]
+    ) -> None:
+        """A cross-origin handshake without a valid token must not open a session."""
+        mock_websocket = self._make_websocket(
+            origin=self._CROSS_ORIGIN, xsrf_token=xsrf_token, cookies=cookies
+        )
+        mock_runtime = self._make_runtime()
+        handler = create_websocket_handler(mock_runtime)
+
+        asyncio.run(handler(mock_websocket))
+
+        mock_websocket.close.assert_called_once_with(code=1008)
+        mock_websocket.accept.assert_not_called()
+        mock_runtime.connect_session.assert_not_called()
+
+    @patch_config_options(
+        {"server.enableXsrfProtection": True, "server.enableCORS": False}
+    )
+    def test_accepts_cross_origin_handshake_with_valid_xsrf_token(self) -> None:
+        """A matching token admits the handshake whatever the origin is.
+
+        The check reads the token, not an origin allowlist. A page on another
+        host cannot reach this state, because it can neither read nor send the
+        XSRF cookie. See ``test_accepts_same_host_other_port_with_valid_token``
+        for the case a real browser can reach.
+        """
+        xsrf_token = starlette_app_utils.generate_xsrf_token_string()
+        mock_websocket = self._make_websocket(
+            origin=self._CROSS_ORIGIN,
+            xsrf_token=xsrf_token,
+            cookies={"_streamlit_xsrf": xsrf_token},
+        )
+        mock_runtime = self._make_runtime()
+        handler = create_websocket_handler(mock_runtime)
+
+        self._run_handler(handler, mock_websocket)
+
+        mock_websocket.accept.assert_called_once()
+        mock_websocket.close.assert_not_called()
+        mock_runtime.connect_session.assert_called_once()
+
+    @patch_config_options(
+        {"server.enableXsrfProtection": True, "server.enableCORS": False}
+    )
+    def test_accepts_same_host_other_port_with_valid_token(self) -> None:
+        """A page on the app's host but another port sends the token and connects.
+
+        The browser shares a cookie across ports, so this page reads the XSRF
+        cookie and fills the token slot. The dev servers run this shape: the
+        frontend serves on port 3001 under ``make debug``, or on port 3000 under
+        ``make frontend-dev``, and the backend listens on port 8501.
+        """
+        xsrf_token = starlette_app_utils.generate_xsrf_token_string()
+        mock_websocket = self._make_websocket(
+            origin=self._SAME_HOST_OTHER_PORT,
+            xsrf_token=xsrf_token,
+            cookies={"_streamlit_xsrf": xsrf_token},
+        )
+        mock_runtime = self._make_runtime()
+        handler = create_websocket_handler(mock_runtime)
+
+        self._run_handler(handler, mock_websocket)
+
+        mock_websocket.accept.assert_called_once()
+        mock_websocket.close.assert_not_called()
+        mock_runtime.connect_session.assert_called_once()
+
+    @patch_config_options(
+        {"server.enableXsrfProtection": True, "server.enableCORS": False}
+    )
+    def test_rejects_same_host_other_port_without_token(self) -> None:
+        """Another port is a different origin, so it still needs the token."""
+        mock_websocket = self._make_websocket(origin=self._SAME_HOST_OTHER_PORT)
+        mock_runtime = self._make_runtime()
+        handler = create_websocket_handler(mock_runtime)
+
+        asyncio.run(handler(mock_websocket))
+
+        mock_websocket.close.assert_called_once_with(code=1008)
+        mock_websocket.accept.assert_not_called()
+        mock_runtime.connect_session.assert_not_called()
+
+    @patch_config_options(
+        {"server.enableXsrfProtection": True, "server.enableCORS": False}
+    )
+    def test_accepts_same_origin_handshake_without_xsrf_token(self) -> None:
+        """A same-origin handshake connects without a token.
+
+        The browser sets Origin and scripts cannot forge it, so a same-origin
+        handshake comes from the app's own page. JavaScript can read the cookie
+        there, so the token would prove nothing.
+        """
+        mock_websocket = self._make_websocket(origin=self._SAME_ORIGIN)
+        mock_runtime = self._make_runtime()
+        handler = create_websocket_handler(mock_runtime)
+
+        self._run_handler(handler, mock_websocket)
+
+        mock_websocket.accept.assert_called_once()
+        mock_websocket.close.assert_not_called()
+        mock_runtime.connect_session.assert_called_once()
+
+    @patch_config_options(
+        {
+            "server.enableXsrfProtection": True,
+            "server.enableCORS": False,
+            "server.cookieSecret": "test-secret",
+        }
+    )
+    def test_same_origin_host_auth_token_connects_but_stays_anonymous(self) -> None:
+        """An embed that sends a host auth token connects with no user info.
+
+        The frontend puts either a host auth token or the XSRF cookie in the
+        second ``Sec-WebSocket-Protocol`` entry. A host auth token there fails
+        XSRF validation, so the session opens without reading the auth cookie.
+        """
+        cookie_payload = json.dumps(
+            {
+                "origin": self._SAME_ORIGIN,
+                "is_logged_in": True,
+                "email": "cookie@example.com",
+            }
+        )
+        signed_cookie = starlette_app_utils.create_signed_value(
+            "test-secret", "_streamlit_user", cookie_payload
+        )
+        mock_websocket = self._make_websocket(
+            origin=self._SAME_ORIGIN,
+            xsrf_token="host-auth-token-not-xsrf",
+            cookies={
+                "_streamlit_user": signed_cookie.decode("utf-8"),
+                "_streamlit_xsrf": starlette_app_utils.generate_xsrf_token_string(),
+            },
+        )
+        mock_runtime = self._make_runtime()
+        handler = create_websocket_handler(mock_runtime)
+
+        self._run_handler(handler, mock_websocket)
+
+        mock_websocket.accept.assert_called_once()
+        mock_runtime.connect_session.assert_called_once()
+        user_info = mock_runtime.connect_session.call_args.kwargs["user_info"]
+        assert user_info.get("email") is None
+        assert user_info.get("is_logged_in") is None
+
+    @patch_config_options(
+        {"server.enableXsrfProtection": True, "server.enableCORS": False}
+    )
+    def test_accepts_handshake_without_origin_header(self) -> None:
+        """No Origin header skips the check so programmatic clients connect."""
+        mock_websocket = self._make_websocket(origin=None)
+        mock_runtime = self._make_runtime()
+        handler = create_websocket_handler(mock_runtime)
+
+        self._run_handler(handler, mock_websocket)
+
+        mock_websocket.accept.assert_called_once()
+        mock_websocket.close.assert_not_called()
+        mock_runtime.connect_session.assert_called_once()
+
+    @patch_config_options(
+        {"server.enableXsrfProtection": False, "server.enableCORS": False}
+    )
+    def test_accepts_cross_origin_handshake_when_xsrf_disabled(self) -> None:
+        """Disabled XSRF protection removes the admission check."""
+        mock_websocket = self._make_websocket(origin=self._CROSS_ORIGIN)
+        mock_runtime = self._make_runtime()
+        handler = create_websocket_handler(mock_runtime)
+
+        self._run_handler(handler, mock_websocket)
+
+        mock_websocket.accept.assert_called_once()
+        mock_websocket.close.assert_not_called()
+        mock_runtime.connect_session.assert_called_once()
+
+    @patch(
+        "streamlit.web.server.starlette.starlette_websocket.is_xsrf_enabled",
+        return_value=True,
+    )
+    @patch_config_options(
+        {"server.enableXsrfProtection": False, "server.enableCORS": False}
+    )
+    def test_rejects_cross_origin_handshake_when_auth_section_enables_xsrf(
+        self, _mock_is_xsrf_enabled: MagicMock
+    ) -> None:
+        """An [auth] secrets section keeps the gate on when the option is false.
+
+        ``is_xsrf_enabled`` reports XSRF protection as on when secrets hold an
+        ``[auth]`` section, so ``server.enableXsrfProtection=false`` alone does
+        not admit a cross-origin handshake.
+        """
+        mock_websocket = self._make_websocket(origin=self._CROSS_ORIGIN)
+        mock_runtime = self._make_runtime()
+        handler = create_websocket_handler(mock_runtime)
+
+        asyncio.run(handler(mock_websocket))
+
+        mock_websocket.close.assert_called_once_with(code=1008)
+        mock_websocket.accept.assert_not_called()
         mock_runtime.connect_session.assert_not_called()
 
 


### PR DESCRIPTION
## Describe your changes

Streamlit now closes a cross-origin WebSocket handshake that sends no matching XSRF token. It closes with code `1008`, before it accepts the socket and before it opens a session.

The handler validated the token before this change but never acted on the result: the token only decided whether the handler read the signed user cookie, so a handshake with a missing or invalid token still reached `Runtime.connect_session`. The HTTP upload and delete routes already hard-reject on a bad token.

What the change does:

- Close a cross-origin handshake with code `1008` before `accept` and before `connect_session` when it has no matching double-submit token.
- Keep admitting a same-origin handshake and a handshake without an `Origin` header.
- Leave identity binding unchanged: the handler reads the signed user cookie only when the token validates, so a same-origin handshake without a valid token connects and stays anonymous.

### Why cross-origin only

Browsers set `Origin` and scripts cannot forge it. When `Origin` equals `Host`, the page that opened the socket is the app's own origin, and the XSRF cookie is readable by JavaScript there, so the token proves nothing. A cross-origin page cannot read that cookie, which is what makes the token an effective control against cross-site WebSocket hijacking.

Requiring the token on every `Origin`-bearing handshake would also break embeds: the frontend puts either a host auth token or the XSRF cookie in one `Sec-WebSocket-Protocol` entry (`hostAuthToken ?? xsrfCookie` in `WebsocketConnection.getSessionTokens`), so an embed that uses `useExternalAuthToken` cannot send both. Scoping admission to cross-origin keeps those embeds connecting with no protocol change and no advice to disable XSRF protection. #16477 tracks the identity gap that remains for those embeds.

### What this closes

The Origin check admits `localhost`, `127.0.0.1`, the machine IPs, and every origin when `server.enableCORS=false`. Verified against a running app with `server.enableCORS=false`:

| Handshake | Before | After |
|---|---|---|
| `Origin: http://evil.example.com`, no token | connects | rejected |
| `Origin: http://evil.example.com`, bad token | connects | rejected |
| same-origin, no token | connects | connects |
| no `Origin`, no token | connects | connects |

### What this changes for cross-origin deployments

A deployment that serves the page from one host and points `BACKEND_BASE_URL` at a Streamlit server on another host now gets `1008` under the default `server.enableXsrfProtection=true`. Such a page cannot read the backend's `_streamlit_xsrf` cookie, so it cannot put the token in the handshake. That holds whatever `server.xsrfCookieSameSite` allows the browser to send, because a double submit needs both halves. Before this change the handshake connected and `st.user` stayed empty. Now it does not connect.

Those deployments need XSRF protection off. That is not new advice: `_check_xsrf` on the file upload and delete routes has no origin exemption, so `st.file_uploader` already fails for the same caller on `develop`. This change makes the handshake agree with the routes instead of being the one surface that let a cross-site caller through. I did not add a `server.corsAllowedOrigins` exemption for the handshake, because that would make WebSocket admission weaker than the HTTP routes it is meant to match. The `server.enableXsrfProtection` help text now states this, so an operator does not have to infer it.

One caveat that the help text also now states: `server.enableXsrfProtection=false` alone does not turn XSRF protection off. `is_xsrf_enabled()` also reports it as on when secrets hold an `[auth]` section. So a cross-host deployment that uses Streamlit authentication cannot open the handshake at all. A unit test locks that path.

A second, narrower case: a reverse proxy that rewrites `Host` without setting `proxy_set_header Host $host` makes same-origin browser traffic look cross-origin. A plain app still connects, because its page can read the cookie. An embed that uses `useExternalAuthToken` does not, because the host auth token occupies the token slot. #16477 covers that slot conflict.

## GitHub Issue Link (if applicable)

- Related: #16477 (the host auth token and the XSRF token share one subprotocol slot). This PR does not close it.

## Testing Plan

- [x] Unit Tests (Python)
  - `starlette_websocket_test.py`: cross-origin with no token, a token without a cookie, and a mismatched token all close with `1008` and open no session; a matching token connects whatever the origin, which locks that the gate reads the token and not an origin allowlist; a page on the app's host but another port connects with a token and is rejected without one, which is the `make debug` shape; same-origin without a token connects; an embed-style host auth token in the shared subprotocol slot connects but stays anonymous; no `Origin` connects; XSRF disabled connects; and a cross-origin handshake is still rejected when an `[auth]` section reports XSRF as on while `server.enableXsrfProtection=false`. Plus `_is_same_origin` cases including port mismatch.
  - `starlette_app_test.py`: `TestClient` cross-origin handshake closes with `1008` and never calls `connect_session`. The existing same-origin identity test is unchanged.
  - `config_test.py`: the `server.enableCORS=false` warning states that XSRF still rejects cross-origin handshakes, and that the `corsAllowedOrigins` allowlist grants no exemption from the token.
- [x] E2E Tests: `web_server_test.py` passes with no changes to the file, including `test_direct_websocket_with_session_id_in_subprotocol`, which sends the literal string `placeholder` in the token slot. No existing handshake contract changes.
- Manual: `make debug` runs the frontend on port 3001 against the backend on 8501, which is a cross-origin handshake. The app reached `CONNECTED` on the first attempt with no rejections logged.

### On external test coverage

No `@pytest.mark.external_test` case here, and this is the part of the plan I am least sure about.

The embedded topology the e2e harness exercises is same-origin, because the iframe `src` is the app URL, so the iframe document is Streamlit-served. That path is unchanged. The cross-origin `BACKEND_BASE_URL` topology described above IS affected, and it is the topology external tests exist to cover. I did not add a marker because the case needs two origins to be meaningful and I could not verify it locally, so a marker would add a case that only runs under `--external-app-url`. If a reviewer who owns that harness wants it, say so and I will add it rather than argue.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | committing-with-conventional-commits | 1 |
| skill | updating-internal-docs | 1 |
| subagent | Explore | 1 |
| subagent | general-purpose | 1 |
| subagent | reviewing-local-changes | 1 |
| subagent | simplifying-local-changes | 1 |

</details>
<!-- agent-metrics-end -->
