### PR TITLE
[chore] Add explaining-pull-requests agent skill

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -34,6 +34,7 @@ skills/*
 !skills/generating-changelog/
 !skills/improving-frontend-coverage/
 !skills/improving-python-coverage/
+!skills/explaining-pull-requests/
 
 # Allow agents
 !agents/

--- a/.claude/skills/explaining-pull-requests/SKILL.md
+++ b/.claude/skills/explaining-pull-requests/SKILL.md
@@ -1,0 +1,293 @@
+---
+name: explaining-pull-requests
+description: Turns a pull request into one short, visual, self-contained HTML report that catches a reader up on most of a PR in a fraction of the time reading the diff would take — leading with real before/after Playwright baselines, naming only the non-obvious parts, and ending with a quiz that proves it landed. Also prepares a PR-comment pitch for getting review attention. Use when someone wants to understand, explain, socialise, or get sign-off on a PR: "write up this PR", "explain what this branch does", "catch me up on #16385", "make something I can post on the PR", "quiz me before I approve", "PR report", "PR explainer", "review packet", "this PR went cold and I don't remember it". Also use for triaging a stale community PR. Prefer this over an ad-hoc markdown summary — the HTML report is the expected output.
+---
+
+# Explaining pull requests
+
+**This report competes with reading the code.** If it isn't dramatically faster
+than the diff, it has negative value — it's just one more thing to review. So the
+target is most of the PR in a fraction of the time, and every instruction below
+exists to protect that ratio.
+
+Three consequences worth internalising before you start:
+
+- **A picture does the work of a thousand words, so spend your effort there.** The
+  visual is the payload, not decoration. This repo makes that unusually cheap:
+  `e2e_playwright/__snapshots__/` holds committed baselines, so a PR that changes
+  rendering ships its own before/after pictures.
+- **Length is a cost, not a signal of care.** `scripts/finalize.py` enforces a
+  word budget and fails the build above it. Cut prose, not visuals.
+- **Only include what changes what the reader does.** Completeness is the enemy.
+  The diff is already complete; the report's job is selection.
+
+Explicitly out of scope: **CI status.** Nothing merges without green checks, so
+reporting them is noise. A single dot in the header at most — never a table, a
+stat tile, or a section.
+
+## Output shape
+
+Per PR, in this order and nothing else:
+
+1. **The brief** — four beats, one sentence each: *problem*, *why now*,
+   *approach* (including what was rejected), *how* (the mechanism). This comes
+   before the picture, because a screenshot means far more once the reader knows
+   what problem it solves. Orientation, not explanation.
+2. **The visual** — full width, straight after the brief.
+3. **Two stat chips** — files, and one number specific to this PR.
+4. **What isn't obvious** — two to five items. **This is the section readers value
+   most**, and the irreplaceable content. When you're over budget, trim the brief
+   and the watch-out list before you trim these.
+5. **Watch out for** — only when something real is open or undecided.
+6. **Quiz** — four to six questions.
+
+The PR-comment pitch is **clipboard-only**, behind the copy button. Do not also
+render it as prose — that duplication is the biggest source of bloat.
+
+Several PRs in one report is normal ("do these three"): tabs, one per PR.
+
+## Workflow
+
+### 1. Gather
+
+```bash
+uv run python .claude/skills/explaining-pull-requests/scripts/pr_facts.py <pr-ref> --out work-tmp/pr-report/facts
+```
+
+Accepts a URL, `owner/repo#123`, or a bare number. Writes `meta.json`, `diff.txt`,
+`diffstat.txt`, `commits.txt`, `reviews.md`, `surface.json` and `visuals.json` per
+PR.
+
+`surface.json` classifies the changed files the way a reviewer reads them —
+baselines, e2e tests, protos, elements, runtime, theme, type tests, and an
+`external_risk_surface` bucket — plus any **added proto fields**. Use it for the
+stat chip and as the starting point for step 3.
+
+The script also asserts that its file count matches GitHub's. A fresh worktree has
+no `origin/develop` ref, so a local `git merge-base` returns nothing and a diff
+silently expands to the whole repo — a 3-file PR reads as 870. If that assertion
+fails, stop: every conclusion downstream would be fiction.
+
+For reading surrounding code, fetch **both** the PR head and the base:
+
+```bash
+git fetch origin pull/<N>/head:pr-<N>
+git fetch origin develop:refs/remotes/origin/develop
+```
+
+### 1b. Has it already landed? (ask this first for any stale PR)
+
+```bash
+uv run python .claude/skills/explaining-pull-requests/scripts/superseded.py origin/develop pr-<N>
+```
+
+For a PR that has gone quiet — common on community contributions — the
+highest-value thing you can discover is that its content already merged via
+someone else's PR. Then the honest report is "close it", and everything else you'd
+write is wasted. Check before investing in the rest.
+
+This has its own script because the check is easy to get exactly backwards, and
+backwards is worse than skipping it: it sends the reader off to salvage code that
+is already on `develop`. `git diff A B` reports what changing *from A to B* would
+do, so in `git diff --numstat <base> <head>` the first column is lines the **head**
+has that the base lacks and the second is lines the **base** has that the head
+lacks. Read them the wrong way round and "develop already has this test" becomes
+"this test is all that's left".
+
+So when you write a supersession claim, name the direction in words the reader can
+check — "develop has 22 test lines this branch lacks", not "22 lines of test
+remain". And note that a non-empty `git diff` does **not** mean not-superseded: a
+branch whose only surplus is reworded docstrings is fully superseded. The script
+separates comment-only surplus from executable surplus for exactly that reason.
+
+### 2. Get the visual — this is the main event
+
+**Tier 1: committed baselines.** Nearly always the best option available, and free.
+
+```bash
+uv run python .claude/skills/explaining-pull-requests/scripts/snapshot_pairs.py origin/develop pr-<N> \
+    --out work-tmp/pr-report/<N>/snapshots
+```
+
+Pulls the *merge base* blob and the head blob straight out of git, so no test run
+is needed. It also does the selecting, which is the whole problem: a single feature
+PR can churn 50+ baselines across three engines, and a report showing all of them
+is worse than one showing none. It keeps chromium, treats `[dark_theme-chromium]`
+and `[light_theme-chromium]` as distinct states rather than duplicates, ranks by
+the share of pixels that actually differ, and interleaves changed states with
+newly added ones so a PR whose point is four new states doesn't rank them last.
+
+Read the percentage as **extent, not importance**: a label shifting one pixel
+repaints every glyph edge and scores in double digits. If a staged pair looks
+identical to you, caption it as the subtle shift it is.
+
+If `manifest.json` reports baselines it didn't stage, and the report reads as
+though it covers every visual change, **say how many it left out**.
+
+**Tier 2: images the author already attached.** The repo's PR template has a
+literal `## Screenshot or video (only for visual changes)` heading, so authors are
+prompted and the hit rate is high. `visuals.json` has them.
+
+**Tier 3: capture it.** If the PR touches UI and tiers 1–2 came up empty, run the
+app and drive it to the changed state. Follow
+[debugging-streamlit](../debugging-streamlit/SKILL.md) — `make debug <app.py>` plus
+a throwaway Playwright script in `work-tmp/debug/`, reusing
+`e2e_playwright.shared.app_utils` and `wait_for_app_loaded`. Worth the time; this
+is the highest-value thing you can do.
+
+Note that empty tier 1 on a UI PR is itself a finding: either the change doesn't
+alter rendering, or **the baselines were never regenerated**. Say which, and if
+it's the latter, that belongs under *watch out for*.
+
+Prefer **before/after pairs** and **multiple states** over one hero shot. A reader
+understands a change from the contrast far faster than from a caption. A GIF only
+when the change *is* motion — otherwise a labelled filmstrip.
+
+**Tier 4: no UI exists** (runtime, server, caching, protobuf, config). Do not
+fabricate a mockup, and do not fall back to prose. **Draw the numbers instead**,
+with the form matched to the data's job — `references/design.md` has the table and
+`finalize.py` enforces it:
+
+- Two headline numbers → `.statpair` **stat tiles**. The number is the chart. A
+  two-bar chart of `6.45%` vs `6.90%` makes a 0.45pp gap look like a verdict; stat
+  tiles with the delta stated say what's true, including "inside noise".
+- A paired before/after across items → the `.db` **dumbbell**, where the gap is
+  the point, on an axis with **labelled ticks**. A bar whose track has no declared
+  maximum implies a scale nobody stated.
+
+Never invent an image. A stated absence is fine; a fabricated screenshot is a lie
+the reader cannot detect.
+
+### 3. Find what isn't obvious
+
+Read the diff, then read the code it calls into. You're hunting for a small number
+of specific things, because these are what the diff cannot tell the reader. In this
+codebase they are usually one of:
+
+- **Widget identity.** Widget IDs are computed from the element type plus its
+  parameters, so adding or reordering a widget's proto fields can change the
+  computed ID and silently reset user state on the next rerun. Appears nowhere in
+  the diff, and it's the failure a reviewer most wants flagged.
+- **proto3 scalar defaults.** A new field defaults to `false` / `0` / `""`, so an
+  older frontend — or a host pinned to an earlier version — keeps the previous
+  behaviour even though the diff reads as an unconditional change. Check
+  `surface.json`'s `proto_added_fields`, then find where the frontend reads it.
+- **Derived theme tokens.** Changing one token ripples to elements the diff never
+  names; commit `39676223bc` exists because derived `codeBackgroundColor` and
+  `dataframeHeaderBackgroundColor` were wrong. If `frontend/lib/src/theme/` is
+  touched, work out the blast radius rather than describing the token.
+- **Embedded and host-config behaviour.** Routing, auth, websocket lifecycle, CSP,
+  cross-origin, static asset paths. If `external_risk_surface` in `surface.json`
+  is non-empty, cross-reference
+  [assessing-external-test-risk](../assessing-external-test-risk/SKILL.md).
+- **Public API ripple.** A signature change in `lib/streamlit/elements/` pulls in
+  type tests under `lib/tests/streamlit/typing/`, a docstring that becomes
+  docs.streamlit.io, and `@gather_metrics`, whose metric name is externally
+  visible.
+- **Two things that look like one.** Two guards at different scopes, two config
+  options at different precedence, hide-versus-dismiss. When the diff has a
+  near-duplicate pair, one is load-bearing in a way the names hide. Say which.
+
+Two to five of these, one short paragraph each. If you find eight, you're
+including things that don't change what the reader does — keep the ones that do.
+This section earns the largest share of the budget.
+
+### 4. Watch out for
+
+Only when it's real, and one line each:
+
+- A user-facing change with **no e2e coverage**, or baselines that weren't
+  regenerated. `surface.json` tells you both.
+- **External-test risk** the author didn't assess.
+- An open decision the reader is being asked to make.
+- Something the author couldn't verify. Worth surfacing because "CI is green"
+  doesn't cover it.
+- `impact:users` with a title that won't survive the changelog generator.
+- A figure quoted from the PR description rather than recomputed — give its age.
+- A review finding that is **stale**: filed against an older commit, describing
+  behaviour that no longer exists. Check with
+  `git log -S'<distinctive string>' --format='%h %ad %s'` rather than trusting the
+  comment. Worth a line because it stops the reader re-litigating settled work.
+
+Omit this section entirely when there's nothing in it. An empty "no known risks"
+block is pure bloat.
+
+### 5. Build
+
+Copy `assets/template.html` and fill it in. The CSS and JS are complete — don't
+re-derive them. `references/design.md` has the palette with measured contrast and
+the narrow-viewport rules; read it before changing anything visual.
+
+Two things there that are easy to get wrong: the brand red `#ff4b4b` measures
+3.16:1 on the card surface, so it may **never** be small text (use `--accent-deep`);
+and figures sit on a neutral backing rather than white, because half the baselines
+in this repo are dark-theme shots.
+
+**Assume a narrow viewport.** The template is single-column and fluid, with no
+side-by-side grids. Keep tables to two columns — anything wider is unreadable at
+380px, so use the `.kv` list instead.
+
+### 6. Quiz
+
+Four to six questions. They test *consequences*, so ask what would change the
+reader's decision, and skip anything answerable from the diff's line numbers. The
+material is what you found in step 3 — that's why that step matters.
+
+Phrase each as a scenario with a concrete outcome ("a developer does X under
+condition Y — what happens?"). A scenario forces a mental simulation; a
+definitional question only invites recognition.
+
+Four options. The best distractor is what a smart reader who skimmed would pick,
+and the explanation should say why it was tempting — that's where the learning is.
+Gating behaviour is already implemented: 100% to clear, incomplete attempts aren't
+graded, reset re-arms.
+
+### 7. Finalize
+
+```bash
+uv run python .claude/skills/explaining-pull-requests/scripts/finalize.py <report.html>
+```
+
+Inlines local images as base64, enforces the word budget, and validates the quiz —
+that each answer key agrees with the letter its explanation names, that options are
+well-formed, that counts are right. A mis-keyed quiz is worse than none: it teaches
+the wrong answer and stamps it "cleared". Failures are hard failures.
+
+Inlining is required, not a convenience: the report is viewed through an iframe
+with no base URL, so a relative `<img src>` resolves to nothing.
+
+If it fails on length, cut prose. Do not cut visuals, and do not raise the budget
+to make the error go away — the budget *is* the feature.
+
+### 8. Show it, then offer to share it
+
+Open it locally: `open work-tmp/pr-report/<N>.html`. Point at the one thing most
+worth looking at first.
+
+To put it in front of reviewers, upload it alongside the PR's other artifacts
+following [sharing-pr-agent-artifacts](../sharing-pr-agent-artifacts/SKILL.md) —
+`agent-wiki/pull-requests/<N>/report.html`, which serves at
+`https://issues.streamlit.app/agent_wiki_explorer?file=pull-requests/<N>/report.html`.
+The explorer renders HTML in a sandboxed iframe, so the quiz works there.
+
+Then **stop and ask before posting anything.** Write the pitch to a file and offer
+`gh pr comment <N> --body-file <path>`; never post it unprompted. The wiki is a
+public repo and the PR thread is public, so the report must contain nothing you
+wouldn't put in a GitHub comment.
+
+Finally, say what you haven't verified: you validated the report's structure, not
+its appearance — you can't see the rendered page. Offer to fix what a human
+notices. And if any figure came from a PR description rather than being recomputed,
+give its age, because stale numbers presented as current are the one way this
+report can actively mislead.
+
+## Related skills
+
+- [debugging-streamlit](../debugging-streamlit/SKILL.md): running the app and
+  capturing screenshots when no baseline exists
+- [sharing-pr-agent-artifacts](../sharing-pr-agent-artifacts/SKILL.md): hosting the
+  finished report so it can be linked from the PR
+- [assessing-external-test-risk](../assessing-external-test-risk/SKILL.md): whether
+  a change needs external e2e coverage
+- [addressing-pr-review-comments](../addressing-pr-review-comments/SKILL.md): for
+  acting on feedback rather than explaining the PR

--- a/.claude/skills/explaining-pull-requests/assets/template.html
+++ b/.claude/skills/explaining-pull-requests/assets/template.html
@@ -1,0 +1,567 @@
+<!--
+ Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<!DOCTYPE html>
+<!--
+  PR report template. Copy, then fill in. Markers are {{ }} — finalize.py fails
+  the build if any survive.
+
+  Design contract, in priority order:
+    1. The BRIEF comes first (problem / why / why this way / how), then the visual
+       full width. A screenshot means more once you know what problem it solves.
+    2. The report must be faster to read than the diff. finalize.py enforces a
+       word budget; if it fails, cut prose, never visuals.
+    3. "What isn't obvious" is the section readers value most — give it the room
+       (2-5 points). Everything else earns its space against it.
+    4. Assume a NARROW viewport: this is read on a phone, and inside the wiki
+       explorer's iframe. Single column, fluid, no side-by-side grids, tables
+       never wider than two columns.
+    5. No CI reporting. The dot in the header is the entire allowance.
+
+  Colour rules that are load-bearing, not taste (see references/design.md):
+    * --accent (#ff4b4b) measures 3.16:1 on the card surface. That clears the 3:1
+      floor for borders, marks, dots and large display type, and FAILS the 4.5:1
+      floor for body and small text. Small red text uses --accent-deep.
+    * Snapshot baselines arrive in both light and dark theme. figure img has a
+      neutral backing rather than white so a dark-theme shot doesn't sit in a
+      glowing frame.
+
+  The PR-comment pitch lives ONLY in the <script type="text/markdown"> block,
+  reachable by the copy button. Do not also render it as prose — one narrative.
+
+  One PR: delete the extra tab buttons and sections. Several: duplicate the
+  tab + section pair, keeping ids in sync (pr-a / quiz-a).
+-->
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>{{REPORT_TITLE}}</title>
+<style>
+:root{
+  /* Streamlit light theme tokens, straight from
+     frontend/lib/src/theme/primitives/colors.ts, so the report reads as a
+     Streamlit artifact without inventing a second palette. */
+  --bg:#ffffff; --card:#fafafa; --card-2:#f0f2f6; --rule:#e6eaf1;
+  --fg:#262730; --muted:#555867; --faint:#6e7284;
+  /* --accent is red70, the Streamlit brand red: 3.16:1 on --card. Borders,
+     dots, active tab, hero chip, large display type. NEVER small text.
+     --accent-deep is red90 at 5.06:1 — the one to use for kickers, labels and
+     links, i.e. anything small that has to be red. */
+  --accent:#ff4b4b; --accent-deep:#bd4043;
+  /* Data marks: both clear 3:1 against --card (5.06 and 6.76) and are 2.14:1
+     apart from each other, so they stay distinguishable in greyscale. */
+  --viz-acc:#ff4b4b; --viz-base:#555867; --viz-axis:#d5dae5;
+  /* Semantic, deliberately NOT the brand accent: red means wrong everywhere, so
+     a red "correct" state would fight the reader. green100 is 5.76:1 on --card
+     and 5.37:1 on --card-2, so it holds up as small text on both surfaces. */
+  --ok:#177233; --amber:#b04a00; --red:#7d353b; --blue:#0068c9;
+  --mono:ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,monospace;
+  --body:-apple-system,BlinkMacSystemFont,"Segoe UI","Source Sans Pro",Helvetica,Arial,sans-serif;
+  --disp:var(--body);
+  --r-card:8px; --r-chip:4px;
+  --pad:1.5rem;
+}
+*{box-sizing:border-box}
+html{scroll-behavior:smooth;-webkit-text-size-adjust:100%}
+body{margin:0;background:var(--bg);color:var(--fg);font-family:var(--body);
+  font-size:16.5px;line-height:1.62;-webkit-font-smoothing:antialiased;overflow-wrap:break-word}
+a{color:var(--accent-deep);text-decoration:none;border-bottom:1px solid rgba(189,64,67,.35)}
+a:hover{border-bottom-color:var(--accent-deep)}
+code{font-family:var(--mono);font-size:.82em;background:var(--card-2);border:1px solid var(--rule);
+  padding:.06em .32em;border-radius:var(--r-chip);color:var(--accent-deep)}
+/* Single fluid column. 720px, not 1080 — one column of prose wants a short measure,
+   and the narrow case (phone, iframe) is the common one. */
+.wrap{max-width:720px;margin:0 auto;padding:0 var(--pad)}
+@media(max-width:560px){:root{--pad:1.1rem} body{font-size:16px}}
+
+/* header */
+header.mast{border-bottom:1px solid var(--rule);padding:1.8rem 0 1.2rem}
+.kicker{font-family:var(--mono);font-size:.62rem;letter-spacing:.22em;
+  text-transform:uppercase;color:var(--accent-deep)}
+h1.mast-t{font-family:var(--disp);font-weight:700;font-size:clamp(1.7rem,6vw,2.4rem);
+  line-height:1.12;margin:.5rem 0 .3rem;letter-spacing:-.02em}
+.mast-sub{color:var(--muted);margin:0;font-size:.95rem}
+
+/* tabs + gate. Scrolls sideways rather than wrapping into a tall stack on a phone. */
+nav.gate{position:sticky;top:0;z-index:80;background:rgba(255,255,255,.95);
+  backdrop-filter:blur(10px);border-bottom:1px solid var(--rule)}
+.gate-inner{max-width:720px;margin:0 auto;padding:.55rem var(--pad);display:flex;gap:.4rem;
+  align-items:center;overflow-x:auto;scrollbar-width:none}
+.gate-inner::-webkit-scrollbar{display:none}
+.tab{font-family:var(--mono);font-size:.7rem;color:var(--muted);background:none;
+  border:1px solid var(--rule);border-radius:var(--r-chip);padding:.4rem .65rem;cursor:pointer;
+  display:flex;gap:.45rem;align-items:center;white-space:nowrap;flex:none;min-height:32px}
+.tab.on{color:var(--accent-deep);border-color:var(--accent);background:rgba(255,75,75,.07)}
+.tab .dot{width:6px;height:6px;border-radius:50%;background:var(--faint);flex:none}
+.tab.pass .dot{background:var(--ok)}
+.tab.fail .dot{background:var(--red)}
+.gate-status{font-family:var(--mono);font-size:.65rem;letter-spacing:.1em;text-transform:uppercase;
+  color:var(--faint);margin-left:auto;padding-left:.6rem;white-space:nowrap;flex:none}
+
+/* PR section */
+.pr{display:none;padding:1.6rem 0 4rem}
+.pr.on{display:block}
+.pr-num{font-family:var(--mono);font-size:.65rem;letter-spacing:.14em;color:var(--accent-deep);
+  text-transform:uppercase;display:flex;align-items:center;gap:.5rem;flex-wrap:wrap}
+/* The entire CI allowance: one dot. Nothing merges without green checks, so a
+   table of them is noise. */
+.ci{width:7px;height:7px;border-radius:50%;flex:none}
+.ci.ok{background:var(--viz-base)} .ci.no{background:var(--red)}
+/* The repo's own review vocabulary. Cheap to include, and it tells a reviewer
+   what kind of PR this is before they read a word. */
+.lbl{font-family:var(--mono);font-size:.58rem;letter-spacing:.06em;text-transform:none;
+  border:1px solid var(--rule);background:var(--card-2);color:var(--muted);
+  padding:.14rem .4rem;border-radius:var(--r-chip);white-space:nowrap}
+h2.pr-t{font-family:var(--disp);font-weight:700;font-size:clamp(1.4rem,4.6vw,1.9rem);
+  line-height:1.2;margin:.35rem 0 .8rem;letter-spacing:-.015em}
+.chips{display:flex;flex-wrap:wrap;gap:.4rem;margin:0 0 1.8rem}
+.chip{font-family:var(--mono);font-size:.68rem;border:1px solid var(--rule);
+  border-radius:var(--r-chip);padding:.3rem .55rem;color:var(--muted);white-space:nowrap}
+.chip b{color:var(--fg);font-weight:600}
+.chip.hero{border-color:var(--accent)}
+.chip.hero b{color:var(--accent-deep)}
+
+/* visual — first, full width, no grid so it can't collapse badly. The backing is
+   neutral, not white: half the baselines here are dark-theme shots. */
+figure{margin:0 0 1.2rem}
+figure img{width:100%;display:block;border:1px solid var(--rule);
+  border-radius:var(--r-card);background:var(--card-2)}
+figcaption{font-family:var(--mono);font-size:.64rem;color:var(--faint);margin-top:.5rem;
+  line-height:1.55}
+/* before/after label for a snapshot pair — the contrast is the teaching, so say
+   which is which rather than relying on reading order. */
+.ba{font-family:var(--mono);font-size:.58rem;letter-spacing:.14em;text-transform:uppercase;
+  color:var(--faint);margin:0 0 .3rem}
+
+/* brief — the preamble. Four beats before the picture, because a screenshot
+   means more once you know what problem it solves. */
+.brief{border:1px solid var(--rule);border-left:3px solid var(--viz-acc);
+  border-radius:var(--r-card);background:var(--card);padding:1.1rem 1.2rem;margin:0 0 1.4rem}
+.brief div{display:grid;grid-template-columns:5.2rem 1fr;gap:.3rem .8rem;margin-bottom:.6rem}
+.brief div:last-child{margin-bottom:0}
+.brief dt{font-family:var(--mono);font-size:.6rem;letter-spacing:.14em;text-transform:uppercase;
+  color:var(--accent-deep);padding-top:.25rem}
+.brief dd{margin:0;font-size:.95rem;color:var(--fg)}
+@media(max-width:480px){.brief div{grid-template-columns:1fr;gap:.1rem}}
+
+/* ---- data viz. Forms chosen by the data's job, per the dataviz procedure:
+   two headline numbers -> stat tiles ("the number is the chart"), never a
+   2-bar chart. A paired before/after -> dumbbell on a DECLARED axis. Colour is
+   emphasis (one accent + de-emphasis gray), so a hue never silently changes
+   meaning between charts. Values are direct-labelled, so identity is never
+   colour-alone. */
+.viz{border:1px solid var(--rule);border-radius:var(--r-card);background:var(--card);
+  padding:1.1rem 1.2rem;margin:0 0 1.4rem}
+.viz-t{font-family:var(--mono);font-size:.62rem;letter-spacing:.14em;text-transform:uppercase;
+  color:var(--faint);margin:0 0 1rem}
+.viz-legend{display:flex;gap:1rem;flex-wrap:wrap;font-family:var(--mono);font-size:.62rem;
+  color:var(--muted);margin-top:.9rem}
+.viz-legend span.k{width:9px;height:9px;border-radius:50%;display:inline-block;margin-right:.35rem}
+.viz-legend .k.base{background:var(--viz-base)} .viz-legend .k.acc{background:var(--viz-acc)}
+
+/* stat tiles — proportional figures (tabular-nums would look loose at this size) */
+.statpair{display:flex;flex-wrap:wrap;gap:.6rem}
+.st{flex:1 1 8.5rem;border:1px solid var(--rule);border-radius:var(--r-chip);
+  padding:.7rem .8rem;background:var(--card-2)}
+.st-l{display:block;font-family:var(--mono);font-size:.6rem;letter-spacing:.1em;
+  text-transform:uppercase;color:var(--faint);margin-bottom:.3rem}
+.st-v{font-family:var(--mono);font-size:1.5rem;font-weight:600;color:var(--fg);line-height:1.1}
+.st.acc{border-color:rgba(255,75,75,.45)}
+.st.acc .st-v{color:var(--viz-acc)}
+.st-d{display:block;font-family:var(--mono);font-size:.66rem;color:var(--muted);margin-top:.25rem}
+
+/* dumbbell — one row per item, two dots, gap is the point. 8px+ markers, 2px
+   connector, recessive axis with real ticks so the scale is declared. */
+.db-row{display:grid;grid-template-columns:minmax(4.5rem,7rem) 1fr auto;gap:.7rem;
+  align-items:center;margin-bottom:.85rem}
+.db-lbl{font-family:var(--mono);font-size:.66rem;color:var(--muted);line-height:1.3}
+.db-track{position:relative;height:18px}
+.db-track::before{content:"";position:absolute;left:0;right:0;top:50%;height:1px;
+  background:var(--viz-axis)}
+.db-conn{position:absolute;top:50%;transform:translateY(-50%);height:2px;
+  left:var(--a);width:calc(var(--b) - var(--a));background:var(--viz-base);opacity:.85}
+.db-dot{position:absolute;top:50%;left:var(--p);transform:translate(-50%,-50%);
+  width:10px;height:10px;border-radius:50%;box-shadow:0 0 0 2px var(--card)}
+.db-dot.base{background:var(--viz-base)} .db-dot.acc{background:var(--viz-acc)}
+.db-val{font-family:var(--mono);font-size:.72rem;color:var(--fg);font-variant-numeric:tabular-nums}
+.db-axis{display:flex;justify-content:space-between;font-family:var(--mono);font-size:.58rem;
+  color:var(--faint);border-top:1px solid var(--viz-axis);padding-top:.3rem;
+  margin-left:calc(4.5rem + .7rem)}
+@media(max-width:480px){.db-axis{margin-left:0}}
+
+/* sections */
+h3.sec{font-family:var(--mono);font-size:.66rem;letter-spacing:.18em;text-transform:uppercase;
+  color:var(--accent-deep);margin:2.4rem 0 .7rem}
+.body{max-width:66ch}
+.body p{margin:0 0 .95rem}
+.body strong{color:var(--fg);font-weight:600}
+/* Numbered points — each is one non-obvious thing, one short paragraph. */
+.pt{margin:0 0 1.15rem;padding-left:1.9rem;position:relative}
+.pt::before{content:attr(data-n);position:absolute;left:0;top:.1rem;font-family:var(--mono);
+  font-size:.7rem;color:var(--accent-deep);border:1px solid var(--rule);border-radius:var(--r-chip);
+  width:1.4rem;height:1.4rem;display:grid;place-items:center}
+.pt h4{margin:0 0 .25rem;font-size:1.02rem;font-family:var(--disp);font-weight:600}
+.pt p{margin:0;color:var(--muted);font-size:.94rem}
+.pt p strong{color:var(--fg)}
+
+/* key/value list — use INSTEAD of a table whenever there'd be >2 columns.
+   A 4-column table is unreadable at 380px; this stacks cleanly. */
+.kv{border:1px solid var(--rule);border-radius:var(--r-card);overflow:hidden;margin:0 0 1.4rem}
+.kv > div{padding:.7rem .9rem;border-bottom:1px solid var(--rule)}
+.kv > div:last-child{border-bottom:0}
+.kv dt{font-family:var(--mono);font-size:.68rem;color:var(--fg);margin:0 0 .2rem}
+.kv dd{margin:0;color:var(--muted);font-size:.89rem}
+.tag{font-family:var(--mono);font-size:.58rem;letter-spacing:.08em;text-transform:uppercase;
+  padding:.14rem .4rem;border-radius:var(--r-chip);border:1px solid;white-space:nowrap}
+.tag.stale{color:var(--blue);border-color:rgba(0,104,201,.4)}
+.tag.open{color:var(--amber);border-color:rgba(176,74,0,.4)}
+.tag.risk{color:var(--red);border-color:rgba(125,53,59,.4)}
+table{width:100%;border-collapse:collapse;font-size:.86rem;margin:0 0 1.4rem;
+  border:1px solid var(--rule);border-radius:var(--r-card);overflow:hidden}
+th{font-family:var(--mono);font-size:.58rem;letter-spacing:.12em;text-transform:uppercase;
+  color:var(--faint);text-align:left;padding:.55rem .75rem;font-weight:500;
+  border-bottom:1px solid var(--rule);background:var(--card)}
+td{padding:.55rem .75rem;border-bottom:1px solid rgba(44,44,49,.6);vertical-align:top}
+tr:last-child td{border-bottom:0}
+td.mono{font-family:var(--mono);font-size:.76rem}
+
+/* quiz */
+.quiz{border:1px solid var(--rule);border-radius:var(--r-card);background:var(--card);
+  margin-top:1rem;overflow:hidden}
+.quiz-head{padding:1.1rem 1.2rem;border-bottom:1px solid var(--rule);background:var(--card-2)}
+.quiz-head .t{font-family:var(--disp);font-size:1.25rem;font-weight:600;margin:0}
+.quiz-head .s{font-family:var(--mono);font-size:.62rem;color:var(--faint);margin:.3rem 0 0;
+  text-transform:uppercase;letter-spacing:.08em}
+.q{padding:1.2rem;border-bottom:1px solid var(--rule)}
+.q:last-of-type{border-bottom:0}
+.q .qn{font-family:var(--mono);font-size:.6rem;letter-spacing:.16em;color:var(--accent-deep);
+  text-transform:uppercase}
+.q .qt{margin:.35rem 0 .8rem;font-size:.99rem;line-height:1.5;color:var(--fg)}
+.opts{display:flex;flex-direction:column;gap:.15rem}
+/* min-height keeps these tappable on a phone */
+.opt{display:flex;gap:.6rem;align-items:flex-start;padding:.6rem .7rem;min-height:44px;
+  border:1px solid transparent;border-radius:var(--r-chip);cursor:pointer;font-size:.9rem;
+  line-height:1.45;transition:.14s}
+.opt:hover{background:var(--card-2)}
+.opt input{margin:.3rem 0 0;accent-color:var(--accent);flex:none;width:16px;height:16px}
+.opt .ltr{font-family:var(--mono);font-size:.7rem;color:var(--faint);flex:none;width:1rem}
+.graded .opt{cursor:default}
+.graded .opt:hover{background:none}
+.graded .opt.correct{background:rgba(23,114,51,.1);border-color:rgba(23,114,51,.45)}
+.graded .opt.wrong{background:rgba(125,53,59,.1);border-color:rgba(125,53,59,.45)}
+.why{display:none;margin-top:.9rem;padding:.8rem .95rem;border-left:2px solid var(--rule);
+  font-size:.88rem;color:var(--muted)}
+.graded .why{display:block}
+.why b{color:var(--fg)}
+.why.hit{border-left-color:var(--ok)}
+.why.miss{border-left-color:var(--red)}
+.why .verdict{font-family:var(--mono);font-size:.58rem;letter-spacing:.16em;text-transform:uppercase;
+  display:block;margin-bottom:.35rem}
+.why.hit .verdict{color:var(--ok)}
+.why.miss .verdict{color:var(--red)}
+.quiz-foot{padding:1.1rem 1.2rem;display:flex;gap:.7rem;align-items:center;flex-wrap:wrap;
+  background:var(--card-2)}
+.btn{font-family:var(--mono);font-size:.68rem;letter-spacing:.12em;text-transform:uppercase;
+  padding:.6rem 1.1rem;border-radius:var(--r-chip);cursor:pointer;font-weight:600;min-height:40px;
+  border:1px solid var(--accent-deep);background:var(--accent-deep);color:#fff}
+.btn:hover{filter:brightness(.92)}
+.btn.ghost{background:none;color:var(--muted);border-color:var(--rule);font-weight:400}
+.btn.ghost:hover{color:var(--fg);border-color:var(--faint);background:none}
+.copy{font-family:var(--mono);font-size:.62rem;letter-spacing:.08em;text-transform:uppercase;
+  background:none;color:var(--muted);border:1px solid var(--rule);border-radius:var(--r-chip);
+  padding:.45rem .7rem;cursor:pointer;min-height:34px}
+.copy:hover{color:var(--accent-deep);border-color:var(--accent)}
+.copy.done{color:var(--ok);border-color:var(--ok)}
+.score{font-family:var(--mono);font-size:.72rem;color:var(--muted)}
+.stamp{font-family:var(--mono);font-weight:600;font-size:.66rem;letter-spacing:.16em;
+  text-transform:uppercase;border:2px solid;padding:.4rem .75rem;border-radius:var(--r-chip);
+  transform:rotate(-2deg);opacity:0;transition:.3s}
+.stamp.show{opacity:1}
+.stamp.ok{color:var(--ok);border-color:var(--ok)}
+.stamp.no{color:var(--red);border-color:var(--red)}
+
+footer{border-top:1px solid var(--rule);padding:1.5rem 0 3rem;color:var(--faint);
+  font-family:var(--mono);font-size:.62rem;line-height:1.7;
+  display:flex;gap:.8rem;align-items:center;flex-wrap:wrap}
+</style>
+</head>
+<body>
+
+<header class="mast"><div class="wrap">
+  <div class="kicker">{{KICKER — e.g. "PR report · 2026-07-28"}}</div>
+  <h1 class="mast-t">{{Short headline — what this catches you up on}}</h1>
+  <p class="mast-sub">{{One sentence. What to read first.}}</p>
+</div></header>
+
+<nav class="gate"><div class="gate-inner">
+  <button class="tab on" data-pr="a"><span class="dot"></span>{{short label}}</button>
+  <!-- duplicate per extra PR; delete if only one -->
+  <span class="gate-status" id="gateStatus">0 / {{N}} cleared</span>
+</div></nav>
+
+<section class="pr on" id="pr-a"><div class="wrap">
+
+  <div class="pr-num">
+    <span class="ci ok"></span>{{streamlit/streamlit#N · state}}
+    <span class="lbl">{{impact:users}}</span><span class="lbl">{{change:feature}}</span>
+  </div>
+  <h2 class="pr-t">{{[type] PR title}}</h2>
+
+  <!-- 1. THE BRIEF. Four beats, before the picture. Keep each to one sentence:
+       this is orientation, not the explainer. -->
+  <dl class="brief">
+    <div><dt>Problem</dt><dd>{{What is broken, missing, or unmeasurable today.}}</dd></div>
+    <div><dt>Why</dt><dd>{{Why it's worth solving now — the cost of leaving it.}}</dd></div>
+    <div><dt>Approach</dt><dd>{{Why THIS is the right way — and what was rejected.}}</dd></div>
+    <div><dt>How</dt><dd>{{The mechanism, in one line.}}</dd></div>
+  </dl>
+
+  <!-- 2. THE VISUAL, full width. For a snapshot pair, stack before then after and
+       LABEL each: the contrast is the teaching, and at 380px the two figures are
+       far apart vertically, so reading order alone won't carry it.
+
+       Say which theme a baseline is (the file name tells you), and if the pixel
+       delta was small, caption it as the subtle shift it is rather than implying a
+       dramatic one. -->
+  <figure>
+    <p class="ba">Before · {{develop}}</p>
+    <img src="{{…-before.png — finalize.py inlines it}}" alt="{{what is visible, for screen readers}}">
+  </figure>
+  <figure>
+    <p class="ba">After · {{this PR}}</p>
+    <img src="{{…-after.png}}" alt="{{what is visible}}">
+    <figcaption>{{What changed and why this is the state worth showing. Name the
+    test it came from, e.g. st_text_input_test · dark theme.}}</figcaption>
+  </figure>
+
+  <!-- No UI to screenshot? Use a form matched to the data's job. NEVER a 2-bar
+       chart, and never a bar whose track has no declared maximum.
+
+       (a) Two headline numbers -> stat tiles. The number IS the chart. Say
+       outright when a difference is inside the noise; bars would imply a verdict
+       the data doesn't support. -->
+  <div class="viz">
+    <p class="viz-t">{{what is being compared · basis}}</p>
+    <div class="statpair">
+      <div class="st"><span class="st-l">{{baseline}}</span><b class="st-v">{{6.45%}}</b></div>
+      <div class="st acc"><span class="st-l">{{our cohort}}</span><b class="st-v">{{6.90%}}</b>
+        <span class="st-d">{{+0.45pp — inside noise}}</span></div>
+    </div>
+  </div>
+
+  <!-- (b) A paired before/after across items -> dumbbell. The GAP is the point.
+       Set --p (and --a/--b for the connector) to value ÷ axis-max × 100%, and
+       label the axis so the scale is declared. Accent = the cohort in question,
+       gray = context; that pairing never changes meaning between charts. -->
+  <div class="viz">
+    <p class="viz-t">{{measure · what the axis shows}}</p>
+    <div class="db-row">
+      <span class="db-lbl">{{item}}</span>
+      <span class="db-track">
+        <span class="db-conn" style="--a:61%;--b:90%"></span>
+        <span class="db-dot base" style="--p:61%"></span>
+        <span class="db-dot acc" style="--p:90%"></span>
+      </span>
+      <span class="db-val">{{+8.6pp}}</span>
+    </div>
+    <div class="db-axis"><span>0</span><span>{{10%}}</span><span>{{20%}}</span><span>{{30%}}</span></div>
+    <div class="viz-legend"><span><span class="k base"></span>{{baseline}}</span>
+      <span><span class="k acc"></span>{{our cohort}}</span></div>
+  </div>
+
+  <div class="chips">
+    <span class="chip"><b>{{n}}</b> files</span>
+    <span class="chip hero"><b>{{key number}}</b> {{baselines updated / e2e tests touched / proto fields added}}</span>
+  </div>
+
+  <!-- 3. THE SECTION READERS VALUE MOST: 2-5 things the diff can't tell you.
+       Give this the room. If you're trimming for the word budget, trim
+       elsewhere first. -->
+  <h3 class="sec">What isn't obvious</h3>
+  <div class="body">
+    <div class="pt" data-n="1">
+      <h4>{{The claim, as a short phrase}}</h4>
+      <p>{{One paragraph. A widget id that shifts and silently resets state, a
+      proto3 default that keeps an older client on the old behaviour, a derived
+      theme token that reaches elements the diff never names, a near-duplicate
+      pair where one is load-bearing — and why it changes what the reader does.}}</p>
+    </div>
+    <div class="pt" data-n="2">
+      <h4>{{...}}</h4><p>{{...}}</p>
+    </div>
+  </div>
+
+  <!-- 4. Only if genuinely non-empty. Delete the whole section otherwise. -->
+  <h3 class="sec">Watch out for</h3>
+  <div class="kv">
+    <div><dt>{{the thing}}</dt><dd><span class="tag risk">no e2e</span> {{one line — why, and who can}}</dd></div>
+    <div><dt>{{a stale review finding}}</dt><dd><span class="tag stale">stale</span> {{filed against an older commit; behaviour changed in <code>sha</code>}}</dd></div>
+  </div>
+
+  <!-- 5. Quiz: 4–6 questions. data-a is the 0-based index of the right option,
+       and the explanation must open by naming that letter — finalize.py checks
+       that they agree, so a mis-key can't ship. -->
+  <h3 class="sec">Check yourself</h3>
+  <div class="quiz" id="quiz-a" data-total="{{N}}">
+    <div class="quiz-head">
+      <p class="t">{{N}} questions</p>
+      <p class="s">{{N}}/{{N}} to clear · consequences, not line numbers</p>
+    </div>
+
+    <div class="q" data-a="1">
+      <div class="qn">Q1 · {{facet}}</div>
+      <p class="qt">{{Scenario with a concrete outcome — "X happens under Y; then what?"}}</p>
+      <div class="opts">
+        <label class="opt"><input type="radio" name="qa1" value="0"><span class="ltr">A</span><span>{{plausible miss}}</span></label>
+        <label class="opt"><input type="radio" name="qa1" value="1"><span class="ltr">B</span><span>{{correct}}</span></label>
+        <label class="opt"><input type="radio" name="qa1" value="2"><span class="ltr">C</span><span>{{what a skimmer picks}}</span></label>
+        <label class="opt"><input type="radio" name="qa1" value="3"><span class="ltr">D</span><span>{{plausible miss}}</span></label>
+      </div>
+      <div class="why"><span class="verdict"></span><b>B.</b> {{Why right — and why the tempting option was tempting. The second half is the learning.}}</div>
+    </div>
+
+    <div class="quiz-foot">
+      <button class="btn" data-grade="quiz-a">Submit</button>
+      <button class="btn ghost" data-reset="quiz-a">Reset</button>
+      <span class="score" id="score-quiz-a"></span>
+      <span class="stamp" id="stamp-quiz-a"></span>
+    </div>
+  </div>
+
+  <script type="text/markdown" id="pitch-a">
+{{PR-comment pitch — clipboard only, never rendered above. Real markdown (**bold**),
+because this goes in a GitHub comment. Sharpest true sentence, then why it's cheap
+or safe to merge, then the ask, then the report link. Under ~150 words; a reviewer
+reads it in the notification email.}}
+  </script>
+
+</div></section>
+
+<footer><div class="wrap" style="display:flex;gap:.8rem;align-items:center;flex-wrap:wrap">
+  <button class="copy" data-src="pitch-a">Copy PR comment</button>
+  <span>{{Provenance: PR heads/shas, whether the visuals are committed baselines
+  (and from which merge base) or fresh captures, how many changed baselines were
+  left out, and whether any figure was quoted rather than recomputed (with age).}}</span>
+</div></footer>
+
+<script>
+(function(){
+  var tabs = document.querySelectorAll(".tab");
+  tabs.forEach(function(t){
+    t.addEventListener("click", function(){
+      tabs.forEach(function(x){ x.classList.remove("on"); });
+      t.classList.add("on");
+      document.querySelectorAll(".pr").forEach(function(s){ s.classList.remove("on"); });
+      document.getElementById("pr-" + t.dataset.pr).classList.add("on");
+      window.scrollTo({top:0, behavior:"instant"});
+    });
+  });
+
+  document.querySelectorAll(".copy").forEach(function(b){
+    b.addEventListener("click", function(){
+      var src = document.getElementById(b.dataset.src);
+      if(!src) return;
+      navigator.clipboard.writeText(src.textContent.trim()).then(function(){
+        var old = b.textContent;
+        b.textContent = "Copied ✓"; b.classList.add("done");
+        setTimeout(function(){ b.textContent = old; b.classList.remove("done"); }, 1800);
+      });
+    });
+  });
+
+  var ids = Array.prototype.map.call(tabs, function(t){ return t.dataset.pr; });
+  var passed = {};
+  ids.forEach(function(i){ passed["quiz-" + i] = false; });
+
+  function updateGate(){
+    var n = 0;
+    Object.keys(passed).forEach(function(k){ if(passed[k]) n++; });
+    var el = document.getElementById("gateStatus");
+    if(el) el.textContent = n + " / " + ids.length + " cleared";
+    ids.forEach(function(i){
+      var tab = document.querySelector('.tab[data-pr="' + i + '"]');
+      var q = document.getElementById("quiz-" + i);
+      if(!tab || !q) return;
+      tab.classList.remove("pass","fail");
+      if(passed["quiz-" + i]) tab.classList.add("pass");
+      else if(q.classList.contains("graded")) tab.classList.add("fail");
+    });
+  }
+
+  document.querySelectorAll("[data-grade]").forEach(function(btn){
+    btn.addEventListener("click", function(){
+      var quiz = document.getElementById(btn.dataset.grade);
+      var qs = quiz.querySelectorAll(".q");
+      var scoreEl = document.getElementById("score-" + quiz.id);
+      var blank = 0;
+      qs.forEach(function(q){ if(!q.querySelector("input:checked")) blank++; });
+      // Blanks aren't wrong answers — grading them would teach nothing.
+      if(blank > 0){
+        scoreEl.textContent = blank + " unanswered";
+        scoreEl.style.color = "var(--red)";
+        return;
+      }
+      var right = 0;
+      qs.forEach(function(q){
+        var want = parseInt(q.dataset.a, 10);
+        var got = parseInt(q.querySelector("input:checked").value, 10);
+        var hit = want === got;
+        if(hit) right++;
+        q.querySelectorAll(".opt").forEach(function(o){
+          var v = parseInt(o.querySelector("input").value, 10);
+          o.classList.remove("correct","wrong");
+          if(v === want) o.classList.add("correct");
+          else if(v === got) o.classList.add("wrong");
+          o.querySelector("input").disabled = true;
+        });
+        var why = q.querySelector(".why");
+        why.classList.remove("hit","miss");
+        why.classList.add(hit ? "hit" : "miss");
+        why.querySelector(".verdict").textContent = hit ? "Correct" : "Missed";
+      });
+      quiz.classList.add("graded");
+      var total = parseInt(quiz.dataset.total, 10);
+      var perfect = right === total;
+      scoreEl.textContent = right + " / " + total;
+      scoreEl.style.color = perfect ? "var(--ok)" : "var(--red)";
+      var stamp = document.getElementById("stamp-" + quiz.id);
+      stamp.className = "stamp show " + (perfect ? "ok" : "no");
+      stamp.textContent = perfect ? "Cleared" : "Reread and retry";
+      passed[quiz.id] = perfect;
+      updateGate();
+    });
+  });
+
+  document.querySelectorAll("[data-reset]").forEach(function(btn){
+    btn.addEventListener("click", function(){
+      var quiz = document.getElementById(btn.dataset.reset);
+      quiz.classList.remove("graded");
+      quiz.querySelectorAll("input").forEach(function(i){ i.disabled = false; i.checked = false; });
+      quiz.querySelectorAll(".opt").forEach(function(o){ o.classList.remove("correct","wrong"); });
+      document.getElementById("score-" + quiz.id).textContent = "";
+      document.getElementById("stamp-" + quiz.id).className = "stamp";
+      passed[quiz.id] = false;
+      updateGate();
+      quiz.scrollIntoView({behavior:"smooth", block:"start"});
+    });
+  });
+
+  updateGate();
+})();
+</script>
+</body>
+</html>

--- a/.claude/skills/explaining-pull-requests/references/design.md
+++ b/.claude/skills/explaining-pull-requests/references/design.md
@@ -1,0 +1,177 @@
+# Visual system
+
+Read this before changing anything visual.
+
+The report is a Streamlit artifact that a maintainer may link from a public PR
+thread, so it uses Streamlit's own light theme tokens rather than inventing a
+palette — same surfaces, same brand red, same neutral greys as the app the PR
+changes. The structure is long-form editorial: one column, generous whitespace,
+proportional type.
+
+Every contrast figure below is computed (WCAG 2.1 relative luminance) against the
+card surface `#fafafa`, not estimated. If you add a colour, compute its ratio.
+
+## Narrow first — this is the constraint that breaks layouts
+
+Two of the three ways this gets read are narrow: on a phone, and inside the wiki
+explorer's iframe. So:
+
+- **One column, always.** No side-by-side grids. A two-up figure pair that looks
+  elegant at 1080px is two illegible thumbnails at 380px, so figures stack.
+- **720px measure**, not 1080. One column of prose wants a short line.
+- **Tables: two columns maximum.** Anything wider is unreadable narrow. Use the
+  `.kv` list (stacked label/value rows) instead — it degrades gracefully because
+  it was never depending on horizontal room.
+- **44px minimum tap target** on quiz options and buttons.
+- **The tab strip scrolls sideways** rather than wrapping — wrapping turns four
+  PRs into a four-line block that pushes the content off screen.
+- `--pad` drops from `1.5rem` to `1.1rem` under 560px; body from 16.5px to 16px.
+
+Because figures stack, a before/after pair can end up a screen apart. Label each
+with `.ba` ("Before · develop" / "After · this PR") instead of trusting reading
+order to carry which is which.
+
+## Length is a design constraint
+
+`scripts/finalize.py` fails above **550 words of prose per PR**, excluding the
+quiz — roughly two minutes of reading. The report has to be dramatically faster
+than the diff or it's just more to review. Whitespace and visuals are free; prose
+is not.
+
+The allowance covers the four-beat `.brief` and up to five points under *what
+isn't obvious* — it is not headroom for prose elsewhere. **"What isn't obvious" is
+the section readers value most**, so when you're over budget, trim the brief and
+the watch-out list before you trim points.
+
+The corollary is that the PR-comment pitch is **clipboard-only**, never also
+rendered. Rendering it doubles every claim in a second register, and in the
+original version of this report that was the single largest source of bloat.
+
+## What gets no space at all
+
+**CI status.** Nothing merges without green checks, so reporting them is noise.
+The allowance is one 7px dot in the PR header (`.ci.ok` / `.ci.no`). Never a
+table, a stat tile, or a section.
+
+## Palette
+
+From `frontend/lib/src/theme/primitives/colors.ts`, so the report and the app
+agree. Measured contrast against `--card` `#fafafa`:
+
+| Token | Hex | Streamlit name | vs card | Use |
+|---|---|---|---|---|
+| `--bg` | `#ffffff` | white | — | page |
+| `--card` | `#fafafa` | gray10 | — | brief, viz, quiz, `.kv` |
+| `--card-2` | `#f0f2f6` | gray20 | — | quiz header/footer, stat tiles, `.lbl` |
+| `--rule` | `#e6eaf1` | gray30 | — | hairlines |
+| `--fg` | `#262730` | gray90 | 14.22 | body prose |
+| `--muted` | `#555867` | gray80 | 6.76 | secondary prose, `.pt` paragraphs |
+| `--faint` | `#6e7284` | — | 4.57 | small labels, captions, axis ticks |
+| `--accent` | `#ff4b4b` | red70 | **3.16** | brand red. Borders, dots, active tab, hero chip |
+| `--accent-deep` | `#bd4043` | red90 | 5.06 | kickers, `.brief` labels, links, buttons, `code` |
+| `--ok` | `#177233` | green100 | 5.76 | quiz correct, cleared stamp |
+| `--amber` | `#b04a00` | — | 5.26 | accepted trade-off |
+| `--red` | `#7d353b` | red100 | 8.23 | worse, open, unverified, quiz wrong |
+| `--blue` | `#0068c9` | — | 5.26 | stale / informational |
+
+**The one rule that will bite you: `--accent` is 3.16:1.** That clears the 3:1
+floor for non-text things — borders, chart marks, the status dot, large display
+type — and **fails** the 4.5:1 floor for body and small text. Brand red at 12px is
+the mistake this palette is shaped to prevent, so anything small that must be red
+uses `--accent-deep`. On `--card-2` the accent measures 2.95:1, below even the 3:1
+mark floor, so it must not be the only signal on a stat tile or quiz footer.
+
+`--ok` is deliberately **not** the brand accent. Red means wrong everywhere, so a
+red "correct" state fights the reader; the quiz needs a green regardless of what
+the brand colour is. `--faint` is a custom grey rather than gray70 (`#808495`)
+because gray70 measures 3.56:1 — fine for a border, not for a caption someone has
+to read.
+
+Headings wear `--fg`, not red. Weight and size carry them; colour would be
+redundant and would spend the accent's scarcity on decoration.
+
+## Data marks
+
+| Token | Hex | vs card | Role |
+|---|---|---|---|
+| `--viz-acc` | `#ff4b4b` | 3.16 | the cohort in question |
+| `--viz-base` | `#555867` | 6.76 | context / baseline |
+| `--viz-axis` | `#d5dae5` | — | axis rules, dumbbell track (rule-only, not a mark) |
+
+Both marks clear the 3:1 floor against the card, and they are **2.14:1 apart from
+each other**, which is the check people forget: two marks can each pass against
+the background and still be indistinguishable from one another in greyscale or to
+a reader with achromatopsia. A light grey is not available here — on a near-white
+surface any grey pale enough to read as "de-emphasised" (gray60 `#a3a8b8` is
+2.27:1) fails the mark floor, so de-emphasis is carried by a *dark* neutral beside
+a saturated red.
+
+That pairing is fixed. A hue must never mean one thing in one chart and something
+else in the next.
+
+### Form follows the data's job
+
+| The data | Form | Never |
+|---|---|---|
+| Two headline numbers | `.statpair` stat tiles — the number *is* the chart | a two-bar chart |
+| A paired before/after across items | `.db` dumbbell, gap is the point | grouped bars |
+| One value against a limit | a meter with a same-ramp track | a two-slice pie |
+
+Two rules `finalize.py` enforces: **declare the scale** (a bar whose track has no
+labelled maximum implies a scale nobody stated), and **don't let ink imply a
+verdict the data doesn't support** — 6.45% vs 6.90% is inside the noise, so it gets
+stat tiles and a stated delta, not two nearly-equal bars in accusing colours. The
+`.delta` bars that broke both are retired, and using them is a hard failure.
+
+Direct-label every value. That keeps identity off colour alone, which is also the
+accessibility answer for a report with no tooltip layer.
+
+## Type
+
+System sans throughout (`-apple-system` / `Segoe UI` / `Source Sans Pro`), matching
+the app, with the display face the same stack at weight 700 and tighter tracking.
+No webfont link: the report is opened from disk and from inside a sandboxed iframe,
+and a blocked font request would leave the whole thing in a fallback nobody chose.
+
+Mono is the system mono stack, used for chips, kickers, labels, captions, axis
+ticks and code. Uppercase mono kickers at ~0.62rem with `.22em` tracking are the
+workhorse label; they hold the technical register that keeps the polish from
+reading as marketing.
+
+## Components
+
+- **`figure`** — full width, `--card-2` backing, mono caption. Note the backing is
+  neutral rather than white: roughly half the baselines in this repo are
+  dark-theme shots, and a white frame around a dark screenshot reads as a
+  rendering bug.
+- **`.ba`** — the before/after label on a stacked pair.
+- **`.brief`** — the four-beat preamble (problem / why / approach / how), above the
+  visual. One sentence per beat.
+- **`.lbl`** — the PR's own `impact:*` / `change:*` labels in the header. The
+  repo's review vocabulary, free to include, and it tells a reviewer what kind of
+  change this is before they read a word.
+- **`.viz`** — the picture for a PR with no UI: `.statpair` or the `.db` dumbbell
+  with a labelled axis. `finalize.py` accepts either in place of an image.
+- **`.pt`** — a numbered point: sub-head plus one muted paragraph. Two to five per
+  PR; the section readers value most. The number badge is a `::before` on
+  `data-n`, so no extra markup.
+- **`.kv`** — stacked label/value rows. Use instead of any table wider than two
+  columns.
+- **`.chip`** — at most three per PR. One may be `.hero`.
+
+## Motion and texture
+
+No grain overlay, no glow. Both are dark-surface devices; on white, a glow reads
+as a smudge and grain as a print artefact. The stamp keeps its slight rotation and
+fade, and options animate on grading. No scroll-triggered reveals — this is read
+under time pressure, and content that animates in on scroll actively slows
+reading.
+
+## Keep colour meaning stable
+
+The reader learns the code once: **`--ok`** correct or resolved, **`--blue`** stale
+or informational, **`--amber`** an accepted trade-off, **`--red`** worse, open, or
+unverified, and **`--accent`** brand emphasis that never carries meaning on its
+own. Never colour a number red just because it's the headline. A
+worse-than-baseline number shown in `--red` while the surrounding story is
+positive is the single most credibility-building detail available.

--- a/.claude/skills/explaining-pull-requests/scripts/finalize.py
+++ b/.claude/skills/explaining-pull-requests/scripts/finalize.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Make a PR report self-contained, and refuse to ship a bad one.
+
+Four jobs:
+
+  1. Inline every local image as a base64 data URI. Required, not a convenience:
+     the report is viewed through `components.v1.html` in an iframe with no base
+     URL, so a relative <img src> resolves to nothing. Inlining is also what lets
+     the file survive being moved or attached.
+
+  2. Enforce the length budget and the presence of a visual. This report competes
+     with reading the diff -- if it isn't dramatically faster, it's just one more
+     thing to review. A budget that's merely advisory gets ignored under the
+     pressure to be thorough, so it's checked here instead.
+
+  3. Validate the quiz. A mis-keyed quiz is worse than no quiz -- it teaches the
+     reader the wrong answer and stamps it "cleared". So this checks, per
+     question, that the answer key agrees with the letter the explanation names,
+     that options are well-formed, and that each quiz's declared count is real.
+
+  4. Warn on total size. The wiki explorer inlines the whole file into an iframe
+     srcdoc, so a report carrying a dozen full-page baselines gets slow to open.
+
+Failures are hard failures; only the size check is a warning.
+
+Usage:
+    uv run python scripts/finalize.py report.html [--check-only] [--max-words N]
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import mimetypes
+import re
+import sys
+from pathlib import Path
+
+LETTERS = "ABCDEFGH"
+# The srcdoc payload is roughly the file size; past a few MB the explorer's iframe
+# takes visibly long to paint. Not fatal, so not an error.
+SOFT_SIZE_LIMIT_MB = 4.0
+PLACEHOLDERS = [
+    re.compile(r"__IMG[A-Z_]*__"),
+    re.compile(r"\{\{[A-Z_]+\}\}"),
+    re.compile(r"\bTODO\b"),
+    re.compile(r"\bLOREM\b", re.IGNORECASE),
+]
+
+
+def inline_images(html: str, base: Path) -> tuple[str, list[str], list[str]]:
+    done: list[str] = []
+    missing: list[str] = []
+
+    def sub(m: re.Match[str]) -> str:
+        src = m.group(2)
+        if src.startswith(("data:", "http://", "https://")):
+            return m.group(0)
+        p = Path(src.removeprefix("file://"))
+        if not p.is_absolute():
+            p = base / p
+        if not p.is_file():
+            missing.append(src)
+            return m.group(0)
+        mime = mimetypes.guess_type(p.name)[0] or "image/png"
+        b64 = base64.b64encode(p.read_bytes()).decode()
+        done.append(f"{src} ({p.stat().st_size / 1024:.1f} KB)")
+        return f'{m.group(1)}data:{mime};base64,{b64}"'
+
+    return (
+        re.sub(r'(<img[^>]*?\ssrc=")([^"]+)"', sub, html, flags=re.IGNORECASE),
+        done,
+        missing,
+    )
+
+
+def visible_words(fragment: str) -> int:
+    """Rough word count of rendered text: drop tags, comments, and entities."""
+    t = re.sub(r"<!--.*?-->", " ", fragment, flags=re.DOTALL)
+    t = re.sub(r"<[^>]+>", " ", t)
+    t = re.sub(r"&[a-z#0-9]+;", " ", t)
+    return len([w for w in t.split() if any(c.isalnum() for c in w)])
+
+
+def check_budget(html: str, max_words: int) -> tuple[list[str], list[str]]:
+    """Per-PR: enforce the prose budget and require a visual. -> (errors, notes)."""
+    errors: list[str] = []
+    notes: list[str] = []
+
+    stripped = re.sub(
+        r"<(script|style)\b.*?</\1>", " ", html, flags=re.DOTALL | re.IGNORECASE
+    )
+    sections = re.findall(
+        r'<section class="pr[^"]*" id="(pr-[^"]+)">(.*?)</section>', stripped, re.DOTALL
+    )
+    if not sections:
+        # Fall back to budgeting the whole document rather than skipping. Keying
+        # only on the template's markup would let a hand-rolled report dodge the
+        # budget entirely -- and a silently-skipped check is worse than no check,
+        # because it reads as a pass.
+        body = re.search(r"<body[^>]*>(.*)</body>", stripped, re.DOTALL)
+        sections = [("whole document", body.group(1) if body else stripped)]
+        notes.append(
+            'no <section class="pr" id="pr-…"> found — budgeting the whole document '
+            "instead (was this built from assets/template.html?)"
+        )
+
+    for sid, sec in sections:
+        # Everything before the quiz is the part the reader must *read*. The quiz
+        # is the payoff, not overhead, so it's reported but not budgeted.
+        head, _, quiz = sec.partition('<div class="quiz"')
+        prose = visible_words(head)
+        qwords = visible_words(quiz)
+
+        has_img = bool(re.search(r"<img\b", head, re.IGNORECASE))
+        has_viz = 'class="viz"' in head
+        if not (has_img or has_viz):
+            errors.append(
+                f"[{sid}] no visual. A picture is the payload of this report — add a "
+                f"harvested/captured image, or for a PR with no UI use a .viz block "
+                f"(stat tiles for two headline numbers, dumbbell for a paired "
+                f"before/after)."
+            )
+        if 'class="delta"' in head:
+            errors.append(
+                f"[{sid}] uses the retired .delta bars. A bar whose track has no declared "
+                f"maximum implies a scale nobody stated, and two bars 0.45pp apart read as "
+                f"a verdict the data doesn't support. Use .statpair (two headline numbers) "
+                f"or the .db dumbbell with a labelled axis instead."
+            )
+
+        # The brief is the orientation a screenshot can't give. Its absence is the
+        # difference between "here is a picture" and "here is why you're looking".
+        if 'class="brief"' not in head:
+            errors.append(
+                f"[{sid}] no brief. Add the four-beat preamble (problem / why / approach / "
+                f"how) above the visual — a screenshot means more once the reader knows "
+                f"what problem it solves."
+            )
+
+        pts = len(re.findall(r'<div class="pt"', head))
+        if pts < 2:
+            errors.append(
+                f'[{sid}] only {pts} point(s) under "what isn\'t obvious". That section is '
+                f"the one readers value most; 2-5 is the range."
+            )
+        elif pts > 5:
+            errors.append(
+                f"[{sid}] {pts} points under \"what isn't obvious\", max 5. Past five you're "
+                f"including things that don't change what the reader does — keep the ones "
+                f"that do."
+            )
+
+        if prose > max_words:
+            errors.append(
+                f"[{sid}] {prose} words of prose, budget {max_words}. Cut prose — not "
+                f"visuals, and don't raise the budget. Usual culprits: the PR-comment "
+                f"pitch rendered as well as copied, a file-by-file walkthrough, a brief "
+                f"whose beats ran to a paragraph each, or a testing/CI section that "
+                f"shouldn't exist. Trim the brief and the watch-out list before the points."
+            )
+        else:
+            head_room = max_words - prose
+            notes.append(
+                f"{sid}: {prose} words prose ({head_room} under budget), "
+                f"{qwords} in quiz, visual: {'screenshot' if has_img else 'viz block'}"
+            )
+    return errors, notes
+
+
+def validate_quiz(html: str) -> list[str]:
+    errors: list[str] = []
+
+    quizzes = re.findall(
+        r'<div class="quiz"\s+id="([^"]+)"[^>]*data-total="(\d+)"', html
+    )
+    if not quizzes:
+        errors.append(
+            "no quiz found -- the report is meant to gate on one. Pass --check-only "
+            "deliberately if this report is intentionally quiz-free."
+        )
+
+    blocks = re.findall(
+        r'<div class="q" data-a="(\d+)">(.*?)(?=<div class="q" data-a=|<div class="quiz-foot")',
+        html,
+        re.DOTALL,
+    )
+    if len(blocks) == 0 and quizzes:
+        errors.append(
+            "quiz container present but no question blocks matched -- check markup"
+        )
+
+    for i, (key, body) in enumerate(blocks, 1):
+        label = re.search(r'class="qn">([^<]*)<', body)
+        tag = (label.group(1).strip() if label else f"question {i}")[:48]
+
+        radios = re.findall(r'<input[^>]+type="radio"[^>]*>', body)
+        names = set(re.findall(r'name="([^"]+)"', body))
+        values = sorted(int(v) for v in re.findall(r'<input[^>]+value="(\d+)"', body))
+
+        if len(radios) != 4:
+            errors.append(f"[{tag}] has {len(radios)} options; expected 4")
+        if len(names) != 1:
+            errors.append(f"[{tag}] spans {len(names)} input groups: {sorted(names)}")
+        if values != list(range(len(values))):
+            errors.append(f"[{tag}] option values are {values}; expected 0..n-1")
+
+        k = int(key)
+        if k >= len(radios):
+            errors.append(f"[{tag}] data-a={k} but only {len(radios)} options exist")
+            continue
+
+        named = re.search(r'class="why"[^>]*>.*?<b>([A-H])[.\)]', body, re.DOTALL)
+        if not named:
+            errors.append(
+                f"[{tag}] explanation does not open by naming its answer letter "
+                f'(expected e.g. "<b>{LETTERS[k]}.</b>") -- that naming is what makes '
+                f"the key checkable"
+            )
+        elif named.group(1) != LETTERS[k]:
+            errors.append(
+                f"[{tag}] MIS-KEYED: data-a={k} means {LETTERS[k]}, "
+                f"but the explanation says {named.group(1)}"
+            )
+
+    for qid, total in quizzes:
+        seg = html.split(f'id="{qid}"', 1)[1].split("quiz-foot", 1)[0]
+        found = len(re.findall(r'<div class="q" data-a=', seg))
+        if int(total) != found:
+            errors.append(
+                f"[{qid}] declares data-total={total} but contains {found} questions"
+            )
+
+    for pat in PLACEHOLDERS:
+        errors.extend(
+            f"unfilled placeholder left in output: {hit!r}"
+            for hit in set(pat.findall(html))
+        )
+
+    return errors
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("report")
+    ap.add_argument(
+        "--check-only", action="store_true", help="validate without rewriting"
+    )
+    ap.add_argument(
+        "--max-words",
+        type=int,
+        default=550,
+        help="prose budget per PR section, excluding the quiz (default 550 — roughly "
+        "two minutes of reading. The allowance covers the four-beat brief and up to "
+        "five points; it is not headroom for prose elsewhere)",
+    )
+    args = ap.parse_args()
+
+    path = Path(args.report).resolve()
+    if not path.is_file():
+        print(f"error: {path} not found", file=sys.stderr)
+        return 1
+    html = path.read_text()
+
+    if args.check_only:
+        inlined: list[str] = []
+        missing: list[str] = []
+    else:
+        html, inlined, missing = inline_images(html, path.parent)
+
+    errors = validate_quiz(html)
+    budget_errors, budget_notes = check_budget(html, args.max_words)
+    errors += budget_errors
+    for src in missing:
+        errors.append(f"image not found on disk, left as-is: {src}")
+
+    if errors:
+        print(
+            f"FAIL — {len(errors)} problem(s); {path.name} not written:\n",
+            file=sys.stderr,
+        )
+        for e in errors:
+            print(f"  - {e}", file=sys.stderr)
+        return 1
+
+    if not args.check_only:
+        path.write_text(html)
+
+    n_q = len(re.findall(r'<div class="q" data-a=', html))
+    size_mb = len(html.encode()) / 1_048_576
+    print(f"OK — {path.name}")
+    print(
+        f"  size: {size_mb:.2f} MB   questions: {n_q}   images inlined: {len(inlined)}"
+    )
+    for note in budget_notes:
+        print(f"  {note}")
+    for d in inlined:
+        print(f"    + {d}")
+    if size_mb > SOFT_SIZE_LIMIT_MB:
+        print(
+            f"  warning: {size_mb:.1f} MB is above the {SOFT_SIZE_LIMIT_MB} MB soft limit. "
+            f"The wiki explorer inlines the file into an iframe srcdoc, so this will be "
+            f"slow to open. Drop a figure or downscale the largest baselines."
+        )
+    if re.search(r'<img[^>]+src="https?://', html):
+        print(
+            "  note: remote image URLs remain. They need network to render, and "
+            "GitHub user-attachment URLs can expire — download and re-run if the "
+            "report must work offline or be archived."
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/explaining-pull-requests/scripts/pr_facts.py
+++ b/.claude/skills/explaining-pull-requests/scripts/pr_facts.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Gather everything needed to write a PR report, for one or more PRs.
+
+Exists because doing this by hand is ~10 gh/git calls, and because one of them
+fails *silently* rather than loudly:
+
+    Diffing a PR locally needs a real merge base. A freshly created worktree has
+    no `origin/develop` ref, so `git merge-base` returns empty and the diff
+    silently expands to the entire repository (a 3-file PR reads as 870 files).
+    We take the diff from GitHub instead, then assert its file count matches the
+    count GitHub reports for the PR. A mismatch means the diff is wrong, and
+    every downstream conclusion would be built on fiction.
+
+Also classifies the changed files the way a Streamlit reviewer would, so the
+report's stat chip and its risk notes have something real to stand on:
+baselines, e2e tests, protos, public API surface, theme tokens.
+
+Usage:
+    uv run python scripts/pr_facts.py <pr-ref> [<pr-ref> ...] --out DIR
+
+<pr-ref> may be a full URL, owner/repo#123, owner/repo/123, or a bare number
+(repo inferred from the current directory, so a bare number works inside a
+streamlit/streamlit checkout).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+IMG_PATTERNS = [
+    re.compile(r'<img[^>]+src="([^"]+)"', re.IGNORECASE),
+    re.compile(r"!\[[^\]]*\]\((https?://[^)\s]+)\)"),
+]
+
+# How a Streamlit reviewer reads a file list. Order matters only for reporting.
+FILE_CLASSES: dict[str, re.Pattern[str]] = {
+    "snapshot_baselines": re.compile(r"^e2e_playwright/__snapshots__/.*\.png$"),
+    "e2e_tests": re.compile(r"^e2e_playwright/(?!__snapshots__/).*_test\.py$"),
+    "e2e_apps": re.compile(
+        r"^e2e_playwright/(?!__snapshots__/)(?!.*_test\.py$)[^/]*\.py$"
+    ),
+    "protos": re.compile(r"^proto/streamlit/proto/.*\.proto$"),
+    "python_elements": re.compile(r"^lib/streamlit/elements/"),
+    "python_runtime": re.compile(r"^lib/streamlit/runtime/"),
+    "python_tests": re.compile(r"^lib/tests/"),
+    "type_tests": re.compile(r"^lib/tests/streamlit/typing/"),
+    "frontend_components": re.compile(r"^frontend/(lib|app)/src/components/"),
+    "frontend_theme": re.compile(r"^frontend/lib/src/theme/"),
+    "frontend_tests": re.compile(r"^frontend/.*\.test\.tsx?$"),
+    "config": re.compile(r"^lib/streamlit/config\.py$"),
+}
+
+# Paths whose change puts the PR in the blast radius the assessing-external-test-risk
+# skill exists for: proxies, embedded iframes, CSP, cross-origin, pinned hosts.
+EXTERNAL_RISK = re.compile(
+    r"^(lib/streamlit/web/|lib/streamlit/runtime/(websocket|http|secrets)"
+    r"|frontend/connection/|lib/streamlit/config\.py"
+    r"|.*host_config|.*/Hostframe|.*embed)",
+    re.IGNORECASE,
+)
+
+FIELDS = (
+    "number,title,body,state,isDraft,additions,deletions,changedFiles,labels,"
+    "headRefName,baseRefName,url,reviewDecision,headRefOid,createdAt,updatedAt,commits"
+)
+
+
+def run(cmd: list[str], check: bool = True) -> tuple[int, str, str]:
+    p = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if check and p.returncode != 0:
+        raise RuntimeError(f"{' '.join(cmd)}\n{p.stderr.strip()}")
+    return p.returncode, p.stdout, p.stderr
+
+
+def parse_ref(ref: str) -> tuple[str | None, int]:
+    """-> (owner/repo or None, number)."""
+    m = re.search(r"github\.com/([^/]+/[^/]+)/pull/(\d+)", ref)
+    if m:
+        return m.group(1), int(m.group(2))
+    m = re.match(r"^([^/\s]+/[^/#\s]+)[#/](\d+)$", ref)
+    if m:
+        return m.group(1), int(m.group(2))
+    m = re.match(r"^#?(\d+)$", ref)
+    if m:
+        return None, int(m.group(1))
+    raise SystemExit(f"Cannot parse PR reference: {ref!r}")
+
+
+def harvest_images(text: str) -> list[str]:
+    found: list[str] = []
+    for pat in IMG_PATTERNS:
+        for u in pat.findall(text or ""):
+            if u.startswith("http") and u not in found:
+                found.append(u)
+    return found
+
+
+def collect_reviews(repo: str, num: int) -> tuple[str, list[str]]:
+    """Reviews + issue comments + inline review comments. -> (markdown, image urls)."""
+    urls: list[str] = []
+    lines: list[str] = []
+
+    _, out, _ = run(
+        ["gh", "pr", "view", str(num), "--repo", repo, "--json", "reviews,comments"]
+    )
+    d = json.loads(out)
+
+    lines.append("# Reviews\n")
+    for r in d.get("reviews", []):
+        who = (r.get("author") or {}).get("login", "?")
+        body = (r.get("body") or "").strip()
+        lines.append(f"## review · {who} · {r.get('state')}\n")
+        if body:
+            lines.append(body + "\n")
+            urls += harvest_images(body)
+
+    lines.append("\n# Issue comments\n")
+    for c in d.get("comments", []):
+        who = (c.get("author") or {}).get("login", "?")
+        body = (c.get("body") or "").strip()
+        lines.append(f"## comment · {who}\n{body}\n")
+        urls += harvest_images(body)
+
+    lines.append("\n# Inline review comments (incl. bots)\n")
+    code, out, _ = run(
+        ["gh", "api", f"repos/{repo}/pulls/{num}/comments", "--paginate"], check=False
+    )
+    if code == 0:
+        try:
+            for c in json.loads(out):
+                who = (c.get("user") or {}).get("login", "?")
+                body = (c.get("body") or "").strip()
+                lines.append(
+                    f"## inline · {who} · {c.get('path')}:{c.get('line')} · "
+                    f"{c.get('created_at')} · commit {(c.get('commit_id') or '')[:10]}\n{body}\n"
+                )
+                urls += harvest_images(body)
+        except json.JSONDecodeError:
+            lines.append("_(could not parse inline comments)_\n")
+
+    return "\n".join(lines), urls
+
+
+def diff_files(diff: str) -> list[str]:
+    return re.findall(r"^diff --git a/(\S+)", diff, re.MULTILINE)
+
+
+def classify(files: list[str]) -> dict[str, list[str]]:
+    out = {
+        name: [f for f in files if pat.search(f)] for name, pat in FILE_CLASSES.items()
+    }
+    out["external_risk_surface"] = [f for f in files if EXTERNAL_RISK.search(f)]
+    return {k: v for k, v in out.items() if v}
+
+
+def proto_additions(diff: str) -> dict[str, list[str]]:
+    """Added proto field declarations and added enum values.
+
+    Both are compatibility stories the diff states misleadingly, and they are
+    different stories:
+
+      * a new *field* takes a proto3 scalar default (`false`/`0`/`""`), so an
+        older frontend behaves as it did before rather than as the diff implies;
+      * a new *enum value* is a number an older frontend has no case for, so the
+        question is what its switch statement's default branch does — which is
+        usually not "the new behaviour" and occasionally not "the old" either.
+
+    Field declarations are `<type> <name> = <n>;`; enum values are `NAME = <n>;`
+    with no type. Matching only the former misses every PR that extends an enum,
+    which is a common shape here (adding input types, chart kinds, layouts).
+    """
+    fields: list[str] = []
+    enum_values: list[str] = []
+    in_proto = False
+    for line in diff.splitlines():
+        if line.startswith("diff --git a/"):
+            in_proto = ".proto" in line
+            continue
+        if not (in_proto and line.startswith("+") and not line.startswith("+++")):
+            continue
+        body = line[1:].strip().rstrip(";")
+        m = re.match(
+            r"^(?:optional\s+|repeated\s+)?([A-Za-z_][\w.]*)\s+(\w+)\s*=\s*(\d+)$", body
+        )
+        if m:
+            fields.append(f"{m.group(1)} {m.group(2)} = {m.group(3)}")
+            continue
+        m = re.match(r"^([A-Z][A-Z0-9_]*)\s*=\s*(\d+)$", body)
+        if m:
+            enum_values.append(f"{m.group(1)} = {m.group(2)}")
+    return {"fields": fields, "enum_values": enum_values}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("refs", nargs="+")
+    ap.add_argument("--out", default="work-tmp/pr-report/facts")
+    args = ap.parse_args()
+
+    outroot = Path(args.out)
+    outroot.mkdir(parents=True, exist_ok=True)
+    report: list[str] = []
+
+    for ref in args.refs:
+        repo, num = parse_ref(ref)
+        if not repo:
+            _, out, _ = run(["gh", "repo", "view", "--json", "nameWithOwner"])
+            repo = json.loads(out)["nameWithOwner"]
+
+        code, out, err = run(
+            ["gh", "pr", "view", str(num), "--repo", repo, "--json", FIELDS],
+            check=False,
+        )
+        if code != 0:
+            raise SystemExit(
+                f"Could not read {repo}#{num}: {err.strip()}\n"
+                f"If this is an auth failure rather than a missing PR, check which account "
+                f"is active with `gh auth status`."
+            )
+        meta = json.loads(out)
+        meta["_repo"] = repo
+
+        d = outroot / f"{repo.replace('/', '__')}__{num}"
+        d.mkdir(parents=True, exist_ok=True)
+
+        _, diff, _ = run(["gh", "pr", "diff", str(num), "--repo", repo])
+        (d / "diff.txt").write_text(diff)
+
+        files = diff_files(diff)
+        claimed = meta.get("changedFiles")
+        ok = claimed == len(files)
+        (d / "diffstat.txt").write_text(
+            f"files in diff: {len(files)}\nchangedFiles per GitHub: {claimed}\n"
+            f"additions: {meta.get('additions')}  deletions: {meta.get('deletions')}\n"
+            f"MATCH: {ok}\n\n" + "\n".join(files)
+        )
+
+        commits = meta.pop("commits", []) or []
+        (d / "commits.txt").write_text(
+            "\n".join(
+                f"{(c.get('oid') or '')[:10]} {c.get('committedDate', '')[:10]} "
+                f"{(c.get('messageHeadline') or '').strip()}"
+                for c in commits
+            )
+        )
+
+        reviews_md, urls = collect_reviews(repo, num)
+        urls = harvest_images(meta.get("body") or "") + urls
+        (d / "reviews.md").write_text(reviews_md)
+        (d / "meta.json").write_text(json.dumps(meta, indent=2))
+
+        buckets = classify(files)
+        protos = proto_additions(diff)
+        (d / "surface.json").write_text(
+            json.dumps(
+                {
+                    "counts": {k: len(v) for k, v in buckets.items()},
+                    "files": buckets,
+                    "proto_added_fields": protos["fields"],
+                    "proto_added_enum_values": protos["enum_values"],
+                    "labels": [lbl.get("name") for lbl in meta.get("labels") or []],
+                },
+                indent=2,
+            )
+        )
+
+        (d / "visuals.json").write_text(
+            json.dumps(
+                {
+                    "remote_images": list(dict.fromkeys(urls)),
+                    "snapshot_baselines_in_diff": buckets.get("snapshot_baselines", []),
+                    "note": (
+                        "If snapshot_baselines_in_diff is non-empty, run snapshot_pairs.py — "
+                        "those are real before/after pairs of already-reviewed rendered states, "
+                        "and they cover error/empty states a hand-taken screenshot skips. "
+                        "Otherwise use remote_images (this repo's PR template prompts authors "
+                        "for a screenshot, so the hit rate is high). If both are empty and the "
+                        "PR touches UI, capture with `make debug` per the debugging-streamlit "
+                        "skill. If it has no UI, draw the numbers instead."
+                    ),
+                },
+                indent=2,
+            )
+        )
+
+        labels = (
+            ", ".join(lbl.get("name", "") for lbl in meta.get("labels") or [])
+            or "(none)"
+        )
+        report.append(
+            f"{repo}#{num} [{meta.get('state')}"
+            f"{', draft' if meta.get('isDraft') else ''}] {meta.get('title')}\n"
+            f"  labels: {labels}\n"
+            f"  {len(files)} files, +{meta.get('additions')}/-{meta.get('deletions')}, "
+            f"{len(commits)} commits, base {meta.get('baseRefName')}, head "
+            f"{(meta.get('headRefOid') or '')[:10]}\n"
+            f"  diff/metadata file count match: "
+            f"{'OK' if ok else 'MISMATCH -- do not trust the diff'}\n"
+            f"  surface: "
+            + ", ".join(f"{k}={len(v)}" for k, v in buckets.items())
+            + "\n"
+            f"  remote images: {len(urls)}   "
+            f"snapshot baselines: {len(buckets.get('snapshot_baselines', []))}\n"
+            f"  -> {d}"
+        )
+
+    print("\n".join(report))
+    print(
+        "\nNext: for reading surrounding code and `git log -S`, fetch BOTH the PR head\n"
+        "and its base into your worktree:\n"
+        "  git fetch origin pull/<N>/head:pr-<N>\n"
+        "  git fetch origin develop:refs/remotes/origin/develop   # else merge-base is empty"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except RuntimeError as e:
+        print(f"error: {e}", file=sys.stderr)
+        sys.exit(1)

--- a/.claude/skills/explaining-pull-requests/scripts/snapshot_pairs.py
+++ b/.claude/skills/explaining-pull-requests/scripts/snapshot_pairs.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Turn a PR's Playwright baseline churn into a ranked set of before/after pairs.
+
+Why this exists: `e2e_playwright/__snapshots__/` holds thousands of committed
+baseline PNGs, and a PR that changes rendering updates every one it affects. That
+is the best visual a report can have — real rendered states, already reviewed,
+including the error/empty/success states nobody screenshots by hand — but it
+arrives in the wrong shape. A single feature PR can churn 50+ baselines across
+three browsers, and a report that shows all of them is worse than one that shows
+none.
+
+So this does the selecting:
+
+  * drops the firefox/webkit duplicates of the same state (same picture, 3x the
+    space), keeping chromium
+  * pulls the base-branch blob and the head blob straight out of git, so no test
+    run or CI artifact is needed
+  * ranks pairs by how much actually changed, so the top of the list is the state
+    that best shows what the PR did
+  * distinguishes a *new* baseline (no before — a state that did not exist) from a
+    *changed* one, because captioning a new state as "after" implies a before that
+    the reader will look for and not find
+
+Ranking uses the share of pixels that differ, not byte size: a re-encode with
+identical pixels is a 0% change however many bytes moved, and that is exactly the
+kind of no-op churn that would otherwise crowd out the real state.
+
+Read the percentage as *extent*, not importance. A label shifting one pixel
+repaints every glyph edge and can score 11%, while a changed default that only
+recolours a 20px icon scores under 1%. High-scoring pairs are where a rendering
+change definitely happened — deciding whether it matters is still your job, and a
+pair whose two images look identical to you is worth captioning as the subtle
+shift it is rather than presenting as a dramatic one.
+
+Usage:
+    uv run python scripts/snapshot_pairs.py <base-ref> <head-ref> [--out DIR]
+                                            [--top N] [--browser chromium]
+
+Both refs must exist locally:
+    git fetch origin pull/<N>/head:pr-<N>
+    git fetch origin develop:refs/remotes/origin/develop
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import operator
+import re
+import subprocess
+import sys
+from io import BytesIO
+from pathlib import Path
+from typing import Any
+
+SnapshotEntry = dict[str, Any]
+
+SNAPSHOT_ROOT = "e2e_playwright/__snapshots__"
+# __snapshots__/<platform>/<test_file>_test/<snapshot_name>[<variant>].png
+#
+# The bracket is not just a browser engine. It is `[chromium]` for a default-theme
+# shot but `[dark_theme-chromium]` / `[light_theme-chromium]` when the test is
+# parametrised over themes. Those theme variants are distinct STATES, not
+# duplicates of each other, so the engine filter has to match the suffix and keep
+# the prefix as a caption-worthy variant label. Matching the whole bracket exactly
+# silently throws away every themed shot.
+SNAPSHOT_PATH = re.compile(
+    r"^e2e_playwright/__snapshots__/(?P<platform>[^/]+)/(?P<test>[^/]+)/"
+    r"(?P<name>.+?)\[(?P<variant>[^\]]+)\]\.png$"
+)
+
+try:
+    from PIL import Image, ImageChops
+
+    HAVE_PIL = True
+except ImportError:  # pragma: no cover - depends on the environment
+    HAVE_PIL = False
+
+
+def git(repo: str, *args: str, binary: bool = False) -> bytes | str:
+    p = subprocess.run(["git", "-C", repo, *args], capture_output=True, check=False)
+    if p.returncode != 0:
+        raise SystemExit(
+            f"git {' '.join(args)}\n{p.stderr.decode(errors='replace').strip()}"
+        )
+    return p.stdout if binary else p.stdout.decode(errors="replace")
+
+
+def blob(repo: str, ref: str, path: str) -> bytes | None:
+    """Contents of `path` at `ref`, or None if it does not exist there."""
+    # check=False: a missing path at that ref is the expected "added baseline"
+    # case, not an error.
+    p = subprocess.run(
+        ["git", "-C", repo, "show", f"{ref}:{path}"], capture_output=True, check=False
+    )
+    return p.stdout if p.returncode == 0 else None
+
+
+def changed_snapshots(repo: str, merge_base: str, head: str) -> list[tuple[str, str]]:
+    """-> [(status, path)] for baseline PNGs, status in A/M/D."""
+    out = str(git(repo, "diff", "--name-status", merge_base, head, "--", SNAPSHOT_ROOT))
+    rows: list[tuple[str, str]] = []
+    for line in out.splitlines():
+        parts = line.split("\t")
+        if len(parts) >= 2 and parts[-1].endswith(".png"):
+            rows.append((parts[0][:1], parts[-1]))
+    return rows
+
+
+def split_variant(variant: str) -> tuple[str, str]:
+    """`dark_theme-chromium` -> ("dark_theme", "chromium"); `chromium` -> ("", "chromium")."""
+    prefix, _, engine = variant.rpartition("-")
+    return prefix, engine or variant
+
+
+def pixel_delta(before: bytes | None, after: bytes | None) -> SnapshotEntry:
+    """Share of differing pixels, plus dimensions. Honest about what it could not do."""
+    info: SnapshotEntry = {
+        "pct_changed": None,
+        "before_size": None,
+        "after_size": None,
+        "metric": None,
+    }
+    if not HAVE_PIL:
+        info["metric"] = (
+            "unavailable (Pillow not installed) — ranked by byte delta instead"
+        )
+        return info
+    if before is None or after is None:
+        info["metric"] = "single image — no comparison possible"
+        for key, data in (("before_size", before), ("after_size", after)):
+            if data is not None:
+                with Image.open(_buf(data)) as im:
+                    info[key] = list(im.size)
+        return info
+
+    with Image.open(_buf(before)) as b_im, Image.open(_buf(after)) as a_im:
+        b_rgb, a_rgb = b_im.convert("RGB"), a_im.convert("RGB")
+        info["before_size"], info["after_size"] = list(b_rgb.size), list(a_rgb.size)
+        if b_rgb.size != a_rgb.size:
+            # A dimension change is a layout shift: the most visible kind of change
+            # there is, and not meaningfully expressible as a percentage.
+            info["pct_changed"] = 100.0
+            info["metric"] = "dimensions differ (layout shift) — ranked top"
+            return info
+        diff = ImageChops.difference(b_rgb, a_rgb).convert("L")
+        # Threshold above JPEG-ish/antialiasing noise so a font-hinting wobble does
+        # not outrank a genuinely redrawn component.
+        changed = sum(
+            count for value, count in enumerate(diff.histogram()) if value > 8
+        )
+        total = a_rgb.size[0] * a_rgb.size[1]
+        info["pct_changed"] = round(100.0 * changed / total, 3) if total else 0.0
+        info["metric"] = "share of pixels differing by >8/255 in luminance"
+    return info
+
+
+def _buf(data: bytes) -> BytesIO:
+    return BytesIO(data)
+
+
+def select(entries: list[SnapshotEntry], top: int) -> list[SnapshotEntry]:
+    """Pick the `top` most report-worthy states out of the churn.
+
+    Three rules, in order, each fixing a way a naive "sort by delta" misleads:
+
+    1. One entry per *state* first. A themed test contributes
+       `foo (light_theme)` and `foo (dark_theme)`, which are near-identical
+       pictures; letting both in spends two of four figures saying one thing.
+       Extra theme variants are held back and only used to backfill.
+
+    2. Modified and added are ranked in separate pools and interleaved. A new
+       baseline has no "before", so it has no percentage, and any single numeric
+       ranking buries it under the modified ones — even when the new states *are*
+       the feature (a PR adding four input types adds four baselines and modifies
+       two). Interleaving guarantees the report shows both kinds.
+
+    3. Removed baselines go last. A deleted state is real information but it is
+       rarely the picture that explains a PR.
+    """
+    best_by_state: dict[tuple[str, str], SnapshotEntry] = {}
+    overflow: list[SnapshotEntry] = []
+    for e in entries:
+        key = (e["test"], e["snapshot"])
+        held = best_by_state.get(key)
+        if held is None or _state_score(e) > _state_score(held):
+            if held is not None:
+                overflow.append(held)
+            best_by_state[key] = e
+        else:
+            overflow.append(e)
+
+    states = list(best_by_state.values())
+    modified = sorted(
+        (e for e in states if e["status"] == "modified"),
+        key=lambda e: e["pct_changed"] or 0,
+        reverse=True,
+    )
+    added = sorted(
+        (e for e in states if e["status"] == "added"),
+        key=operator.itemgetter("snapshot"),
+    )
+    removed = sorted(
+        (e for e in states if e["status"] == "removed"),
+        key=operator.itemgetter("snapshot"),
+    )
+
+    picked: list[SnapshotEntry] = []
+    while len(picked) < top and (modified or added):
+        if modified:
+            picked.append(modified.pop(0))
+        if len(picked) < top and added:
+            picked.append(added.pop(0))
+    for pool in (removed, overflow):
+        while len(picked) < top and pool:
+            picked.append(pool.pop(0))
+    return picked
+
+
+def _state_score(e: SnapshotEntry) -> tuple[float, int]:
+    """Which variant best represents a state: biggest change, default theme first."""
+    theme_rank = {"default": 2, "light_theme": 1}.get(e["theme"], 0)
+    return (e["pct_changed"] or 0, theme_rank)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("base", help="e.g. origin/develop")
+    ap.add_argument("head", help="e.g. pr-16385")
+    ap.add_argument("--repo", default=".")
+    ap.add_argument("--out", default="work-tmp/pr-report/snapshots")
+    ap.add_argument("--top", type=int, default=4, help="pairs to stage (default 4)")
+    ap.add_argument(
+        "--browser",
+        default="chromium",
+        help="browser engine to keep (default chromium)",
+    )
+    args = ap.parse_args()
+
+    # The "before" picture is the baseline at the MERGE BASE, not at the base tip.
+    # Using the tip silently produces before == after for any PR whose content has
+    # already landed (a squash-merge leaves the head commit out of develop while
+    # develop's tree already has the change), which reads as "0% changed" and
+    # quietly drops the real pair to the bottom of the ranking.
+    merge_base = str(git(args.repo, "merge-base", args.base, args.head)).strip()
+
+    rows = changed_snapshots(args.repo, merge_base, args.head)
+    if not rows:
+        print("No baseline PNGs changed in this PR.")
+        print(
+            "That is a real signal, not a dead end: either the change does not alter "
+            "rendering, or the baselines were never regenerated. If the PR touches UI, "
+            "say which of those it is — an unregenerated baseline belongs under "
+            '"watch out for".'
+        )
+        return 0
+
+    parsed = []
+    for status, path in rows:
+        m = SNAPSHOT_PATH.match(path)
+        if m:
+            g = m.groupdict()
+            g["theme"], g["engine"] = split_variant(g["variant"])
+            parsed.append((status, path, g))
+
+    engines = sorted({p[2]["engine"] for p in parsed})
+    picked = [p for p in parsed if p[2]["engine"] == args.browser]
+    browser_note = ""
+    if not picked:
+        # Some PRs only touch firefox/webkit baselines (a flaky-test fix, say).
+        # Falling back beats reporting "no visuals" when visuals exist.
+        picked = parsed
+        browser_note = (
+            f"no {args.browser} baselines changed; falling back to all engines "
+            f"({', '.join(engines)})"
+        )
+        print(f"note: {browser_note}")
+
+    outdir = Path(args.out)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    entries = []
+    for status, path, g in picked:
+        before = blob(args.repo, merge_base, path) if status != "A" else None
+        after = blob(args.repo, args.head, path) if status != "D" else None
+        delta = pixel_delta(before, after)
+        entries.append(
+            {
+                "status": {"A": "added", "M": "modified", "D": "removed"}.get(
+                    status, status
+                ),
+                "path": path,
+                "test": g["test"],
+                "snapshot": g["name"],
+                "theme": g["theme"] or "default",
+                "engine": g["engine"],
+                "platform": g["platform"],
+                "_before": before,
+                "_after": after,
+                "byte_delta": abs(len(after or b"") - len(before or b"")),
+                **delta,
+            }
+        )
+
+    staged = select(entries, args.top)
+    staged_paths = {e["path"] for e in staged}
+    rest = [e for e in entries if e["path"] not in staged_paths]
+
+    manifest = []
+    for i, e in enumerate(staged, 1):
+        stem = f"{i:02d}-{e['test']}-{re.sub(r'[^A-Za-z0-9_.-]+', '_', e['snapshot'])}"
+        if e["theme"] != "default":
+            stem += f"-{e['theme']}"
+        written = {}
+        for role, data in (("before", e.pop("_before")), ("after", e.pop("_after"))):
+            if data is not None:
+                fp = outdir / f"{stem}-{role}.png"
+                fp.write_bytes(data)
+                written[role] = str(fp)
+        manifest.append(
+            {
+                "rank": i,
+                **{k: v for k, v in e.items() if not k.startswith("_")},
+                **written,
+            }
+        )
+
+    for e in rest:
+        e.pop("_before", None)
+        e.pop("_after", None)
+
+    doc = {
+        "base": args.base,
+        "merge_base": merge_base,
+        "head": args.head,
+        "engines_changed": engines,
+        "engine_filter": args.browser,
+        "browser_note": browser_note,
+        "total_baselines_changed": len(rows),
+        "distinct_states_after_engine_filter": len(picked),
+        "staged": len(manifest),
+        "pairs": manifest,
+        "not_staged": [
+            {k: v for k, v in e.items() if k in {"path", "status", "pct_changed"}}
+            for e in rest
+        ],
+    }
+    (outdir / "manifest.json").write_text(json.dumps(doc, indent=2))
+
+    print(
+        f"{len(rows)} baseline PNG(s) changed across {len(engines)} engine(s) "
+        f"({', '.join(engines)}); before = merge base {merge_base[:10]}."
+    )
+    print(
+        f"{len(picked)} distinct state(s) after the {args.browser} filter; "
+        f"staging top {len(manifest)}.\n"
+    )
+    for e in manifest:
+        pct = "    n/a" if e["pct_changed"] is None else f"{e['pct_changed']:6.2f}%"
+        roles = "+".join(r for r in ("before", "after") if r in e)
+        theme = "" if e["theme"] == "default" else f" ({e['theme']})"
+        print(
+            f"  {e['rank']:>2}. {pct}  {e['status']:<8} "
+            f"{e['test']}/{e['snapshot']}{theme}  [{roles}]"
+        )
+    if doc["not_staged"]:
+        # Never let a cap look like full coverage.
+        print(
+            f"\n  {len(doc['not_staged'])} further changed baseline(s) NOT staged — see manifest.json."
+        )
+        print(
+            "  If the report implies it covers every visual change, say how many it left out."
+        )
+    if not HAVE_PIL:
+        print(
+            "\n  warning: Pillow unavailable, so ranking fell back to byte size. A re-encode"
+        )
+        print(
+            "  with identical pixels can outrank a real change. Treat the order as a hint."
+        )
+    print(f"\n-> {outdir}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/explaining-pull-requests/scripts/superseded.py
+++ b/.claude/skills/explaining-pull-requests/scripts/superseded.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Has this PR already landed some other way? Answer it without getting the diff direction wrong.
+
+For a PR that has gone quiet, the single most valuable thing you can discover is
+that its content already merged via someone else's PR — the answer is then "close
+it", not "here's how to chase a review". But this check is easy to get exactly
+backwards, and backwards is worse than not checking: it sends someone off to
+salvage code that is already on the base branch.
+
+The trap: `git diff A B` reports what changing *from A to B* would do. So in
+`git diff --numstat <base> <head>`, the first column is lines the HEAD has that
+the base lacks, and the second is lines the BASE has that the head lacks. Read
+those two numbers the wrong way round and "the base already has this test"
+becomes "this test is all that's left".
+
+This script only ever reports in the direction-explicit form: "head-only" and
+"base-only", never "added" or "removed". It also separates comment-only surplus
+from executable surplus, because a branch whose only remaining difference is
+reworded JSDoc is fully superseded even though `git diff` is non-empty.
+
+Usage:
+    uv run python scripts/superseded.py <base-ref> <head-ref> [--repo DIR]
+
+Both refs must exist locally. Fetch them first:
+    git fetch origin pull/<N>/head:pr-<N>
+    git fetch origin develop:refs/remotes/origin/develop
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+
+COMMENT_STARTS = ("//", "/*", "*/", "*", "#", "<!--", "-->", '"""', "'''", "--")
+
+
+def git(repo: str, *args: str) -> str:
+    p = subprocess.run(
+        ["git", "-C", repo, *args], capture_output=True, text=True, check=False
+    )
+    if p.returncode != 0:
+        raise SystemExit(f"git {' '.join(args)}\n{p.stderr.strip()}")
+    return p.stdout
+
+
+def is_comment_or_blank(line: str) -> bool:
+    s = line.strip()
+    return not s or s.startswith(COMMENT_STARTS)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "base", help="e.g. origin/develop — the CURRENT base, not the merge base"
+    )
+    ap.add_argument("head", help="e.g. pr-16042")
+    ap.add_argument("--repo", default=".")
+    args = ap.parse_args()
+
+    mb = git(args.repo, "merge-base", args.head, args.base).strip()
+    files = [
+        f
+        for f in git(args.repo, "diff", "--name-only", mb, args.head).splitlines()
+        if f
+    ]
+    if not files:
+        print("PR touches no files relative to its merge base — nothing to compare.")
+        return 0
+
+    rows = []
+    total_exec_head_only = 0
+    for f in files:
+        # +lines are present in HEAD and absent from BASE. -lines are the reverse.
+        diff = git(args.repo, "diff", args.base, args.head, "--", f).splitlines()
+        head_only = [
+            line[1:]
+            for line in diff
+            if line.startswith("+") and not line.startswith("+++")
+        ]
+        base_only = [
+            line[1:]
+            for line in diff
+            if line.startswith("-") and not line.startswith("---")
+        ]
+        exec_head_only = [line for line in head_only if not is_comment_or_blank(line)]
+        total_exec_head_only += len(exec_head_only)
+        rows.append((f, len(head_only), len(exec_head_only), len(base_only)))
+
+    w = max(len(f.split("/")[-1]) for f, *_ in rows)
+    print(f"base = {args.base}   head = {args.head}   merge-base = {mb[:10]}\n")
+    print(f"{'file':<{w}}  head-only  (of which executable)  base-only")
+    for f, ho, eho, bo in rows:
+        print(f"{f.split('/')[-1]:<{w}}  {ho:>9}  {eho:>20}  {bo:>9}")
+
+    print("\nDirection, spelled out so it cannot be misread:")
+    print(f"  head-only = lines {args.head} has that {args.base} does NOT have")
+    print(f"  base-only = lines {args.base} has that {args.head} does NOT have")
+
+    surplus_base = sum(bo for *_, bo in rows)
+    print()
+    if total_exec_head_only == 0:
+        print(
+            f"VERDICT: fully superseded. {args.head} has 0 executable lines that "
+            f"{args.base} lacks"
+            + (
+                " — its only surplus is comments/blank lines."
+                if any(ho for _, ho, _, _ in rows)
+                else "."
+            )
+        )
+        if surplus_base:
+            print(
+                f"         Note the other direction: {args.base} has {surplus_base} line(s) "
+                f"{args.head} lacks, so the base is AHEAD, not behind. There is nothing "
+                f"here to salvage."
+            )
+    else:
+        print(
+            f"VERDICT: not superseded. {args.head} still has {total_exec_head_only} "
+            f"executable line(s) absent from {args.base}."
+        )
+        if surplus_base:
+            print(
+                f"         {args.base} also has {surplus_base} line(s) {args.head} lacks — "
+                f"the branch is behind as well as ahead, so it needs a rebase, and any "
+                f"'what's left' claim must name both directions."
+            )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,6 +124,7 @@ This repository includes skills and subagents in `.claude/` usable with Claude C
 | `improving-python-coverage` | When you want to systematically improve Python test coverage with high-value test cases |
 | `reviewing-readability` | When reviewing a PR, branch, or changes for comment, docstring, and naming readability — produces findings with concrete proposed rewrites |
 | `reviewing-pr-description` | When reviewing a PR's title and description for clarity and conciseness |
+| `explaining-pull-requests` | When you need to understand, explain, or get sign-off on a PR — builds a short visual HTML report from the PR's before/after Playwright baselines, ending in a quiz |
 
 ### Subagents
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -349,6 +349,14 @@ extend-safe-fixes = ["TC002", "TC003"]
   "TRY",     # Ignore tryceratops rules (simpler exception handling in tests).
 ]
 "scripts/**" = ["T20", "INP", "PERF", "S", "TRY002"]
+".claude/skills/**" = [
+  # Standalone agent-facing CLIs, not importable modules. Same shape as
+  # `scripts/**`: their whole output is `print`, and they drive `git`/`gh`.
+  "EXE001", # Shebang is for documentation; these run via `uv run python`.
+  "INP",
+  "S",
+  "T20",
+]
 "lib/streamlit/.agents/**" = [
   # Each template is a standalone app, not a package. Adding __init__.py would
   # misrepresent them as importable modules.


### PR DESCRIPTION
## Describe your changes

Adds an agent skill, `explaining-pull-requests`, that turns a PR into one short, self-contained HTML report — a four-beat brief, then the visual, the non-obvious parts, and a quiz that gates on understanding. It's a Streamlit-specific adaptation of a generic PR-explainer, not a re-theme.

What makes it specific to this repo:

- **`scripts/snapshot_pairs.py`** mines committed Playwright baselines under `e2e_playwright/__snapshots__/` into ranked before/after pairs, so a rendering PR ships its own screenshots. It pulls the **merge-base** and head blobs from git (no test run needed), keeps one engine, treats theme variants (`[dark_theme-chromium]`) as distinct states, and interleaves changed with newly-added baselines so a feature's new states aren't buried. Selection is the point — a single PR can churn 50+ baselines.
- **`scripts/pr_facts.py`** classifies the diff the way a reviewer reads it (baselines, e2e, protos, elements, runtime, theme, type tests, external-risk surface) and flags added proto fields and enum values.
- **`scripts/finalize.py`** inlines images, enforces a prose budget, and hard-fails a mis-keyed quiz.
- The "what isn't obvious" guidance targets this codebase: widget-identity resets, proto3 defaults under version skew, derived theme tokens, host-config blast radius, public-API ripple.
- Light-theme brand palette built from the repo's own colour primitives, with every contrast ratio measured (brand red is 3.16:1, so it's borders and large type only, never small text).

Reports are hosted via the existing `sharing-pr-agent-artifacts` wiki flow.

Also: registers the skill in `.claude/.gitignore`'s allowlist and the `CONTRIBUTING.md` skills table, and adds a `.claude/skills/**` ruff per-file-ignore mirroring the existing `scripts/**` entry.

## Screenshot or video (only for visual changes)

Skill/tooling only — no user-facing product change. The skill's own output was validated by generating a report for #16385 and rendering it at 380px and 900px.

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- **Explanation of why no additional tests are needed:** this adds an agent skill under `.claude/`, not library code — there's no product surface to unit/e2e test. The scripts were exercised directly against a live PR (#16385) and `origin/develop`.
- Verified: `make check` passes; `finalize.py` accepts a real report and hard-fails a deliberately mis-keyed quiz; the report renders and the quiz grades correctly inside the wiki explorer (with streamlit/st-issues#87).

## Companion PR

The report is meant to be viewed through the agent wiki explorer, which needs streamlit/st-issues#87 to render HTML rather than show source. Until that merges, the report opens locally; the skill notes this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)