### PR TITLE
[chore] Replace tenacity dependency with internal retry helper

### DIFF
--- a/e2e_playwright/lazy_loaded_modules.py
+++ b/e2e_playwright/lazy_loaded_modules.py
@@ -34,7 +34,6 @@ lazy_loaded_modules = [
     "pyarrow",
     "pydeck",
     "rich",
-    "tenacity",
     # toml is automatically loaded if there is a secret.toml, config.toml or
     # a local credentials.toml file. So, we cannot test this here.
     # Internal modules:

--- a/e2e_playwright/lazy_loaded_modules_test.py
+++ b/e2e_playwright/lazy_loaded_modules_test.py
@@ -20,6 +20,6 @@ from playwright.sync_api import Page, expect
 def test_lazy_loaded_modules_are_not_imported(app: Page):
     """Test that lazy loaded modules are not imported when the page is loaded."""
     markdown_elements = app.get_by_test_id("stMarkdown")
-    expect(markdown_elements).to_have_count(15)
+    expect(markdown_elements).to_have_count(14)
     for element in markdown_elements.all():
         expect(element).to_have_text(re.compile(r".*not loaded.*"))

--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -78,7 +78,6 @@ dependencies = [
   # See https://github.com/apache/arrow/issues/50471.
   "pyarrow>=7.0,<25",
   "requests>=2.27,<3",
-  "tenacity>=8.1.0,<10",
   # Starting from Python 3.11, Python has built in support for reading TOML files.
   # Let's make sure to remove this "toml" library when we stop supporting Python 3.10.
   "toml>=0.10.1,<2",

--- a/lib/streamlit/connections/retry_util.py
+++ b/lib/streamlit/connections/retry_util.py
@@ -14,29 +14,9 @@
 
 """A small retry helper for Streamlit's database connections.
 
-This replaces the tiny subset of the ``tenacity`` library that
-``SQLConnection.query`` and ``SnowflakeConnection.query`` relied on, so that
-``tenacity`` is no longer a required runtime dependency.
-
-The single :func:`retry` decorator retries a function a fixed number of times,
-sleeping a fixed number of seconds between attempts, and only retries
-exceptions for which a caller-supplied predicate returns ``True``. This mirrors
-tenacity's behavior for the specific options the connections use (``stop=
-stop_after_attempt``, ``wait=wait_fixed``, ``retry=retry_if_exception[_type]``,
-``after``, and ``reraise=True``):
-
-- On success, the result is returned immediately.
-- After every failed *retryable* attempt, the optional ``after`` callback runs
-  (including the final attempt, right before the exception is re-raised).
-- When all attempts are exhausted, the exception from the final attempt is
-  re-raised unchanged (tenacity's ``reraise=True``).
-- An exception the predicate rejects is re-raised immediately, without any
-  retry, wait, or ``after`` callback.
-
-This is not a fully general tenacity drop-in: only ``Exception`` subclasses are
-considered for retrying, so non-``Exception`` ``BaseException``s (e.g.
-``KeyboardInterrupt``) always propagate immediately. This matches the observable
-behavior at both call sites, whose predicates only ever match ``Exception``s.
+Replaces the tiny subset of ``tenacity`` that ``SQLConnection.query`` and
+``SnowflakeConnection.query`` used, so ``tenacity`` is no longer a required
+runtime dependency.
 """
 
 from __future__ import annotations
@@ -58,11 +38,14 @@ def retry(
     *,
     max_attempts: int,
     wait_seconds: float,
-    retry_on_exception: Callable[[BaseException], bool],
+    retry_on_exception: Callable[[Exception], bool],
     after: Callable[[], None] | None = None,
     sleep: Callable[[float], None] = time.sleep,
 ) -> Callable[[Callable[_P, _R]], Callable[_P, _R]]:
     """Retry a function on retryable exceptions.
+
+    Only ``Exception`` subclasses are considered; other ``BaseException``s
+    (e.g. ``KeyboardInterrupt``) propagate immediately.
 
     Parameters
     ----------
@@ -105,7 +88,7 @@ def retry(
             while True:
                 try:
                     return func(*args, **kwargs)
-                except Exception as exc:  # noqa: PERF203
+                except Exception as exc:  # noqa: PERF203 — retry loop must catch per-iteration
                     # The predicate rejected this exception: re-raise it
                     # immediately with no wait or `after` callback.
                     if not retry_on_exception(exc):

--- a/lib/streamlit/connections/retry_util.py
+++ b/lib/streamlit/connections/retry_util.py
@@ -1,0 +1,118 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A small retry helper for Streamlit's database connections.
+
+This replaces the tiny subset of the ``tenacity`` library that
+``SQLConnection.query`` and ``SnowflakeConnection.query`` relied on, so that
+``tenacity`` is no longer a required runtime dependency.
+
+The single :func:`retry` decorator retries a function a fixed number of times,
+sleeping a fixed number of seconds between attempts, and only retries
+exceptions for which a caller-supplied predicate returns ``True``. This mirrors
+tenacity's behavior for the specific options the connections use (``stop=
+stop_after_attempt``, ``wait=wait_fixed``, ``retry=retry_if_exception[_type]``,
+``after``, and ``reraise=True``):
+
+- On success, the result is returned immediately.
+- After every failed *retryable* attempt, the optional ``after`` callback runs
+  (including the final attempt, right before the exception is re-raised).
+- When all attempts are exhausted, the exception from the final attempt is
+  re-raised unchanged (tenacity's ``reraise=True``).
+- An exception the predicate rejects is re-raised immediately, without any
+  retry, wait, or ``after`` callback.
+
+This is not a fully general tenacity drop-in: only ``Exception`` subclasses are
+considered for retrying, so non-``Exception`` ``BaseException``s (e.g.
+``KeyboardInterrupt``) always propagate immediately. This matches the observable
+behavior at both call sites, whose predicates only ever match ``Exception``s.
+"""
+
+from __future__ import annotations
+
+import functools
+import time
+from typing import TYPE_CHECKING, TypeVar
+
+from typing_extensions import ParamSpec
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
+
+
+def retry(
+    *,
+    max_attempts: int,
+    wait_seconds: float,
+    retry_on_exception: Callable[[BaseException], bool],
+    after: Callable[[], None] | None = None,
+    sleep: Callable[[float], None] = time.sleep,
+) -> Callable[[Callable[_P, _R]], Callable[_P, _R]]:
+    """Retry a function on retryable exceptions.
+
+    Parameters
+    ----------
+    max_attempts
+        The maximum number of times the wrapped function is called (must be at
+        least ``1``).
+    wait_seconds
+        The number of seconds to sleep between attempts.
+    retry_on_exception
+        A predicate called with the raised exception. If it returns ``True``,
+        the function is retried until ``max_attempts`` is reached; if it returns
+        ``False``, the exception is re-raised immediately.
+    after
+        An optional callback invoked after every failed, retryable attempt,
+        including the final one before the exception is re-raised. The
+        connections use this to reset the connection between attempts.
+    sleep
+        The function used to sleep between attempts. Injectable for testing;
+        defaults to :func:`time.sleep`.
+
+    Returns
+    -------
+    Callable
+        A decorator that wraps a function with the configured retry behavior.
+    """
+
+    def decorator(func: Callable[_P, _R]) -> Callable[_P, _R]:
+        @functools.wraps(func)
+        def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
+            attempt = 1
+            while True:
+                try:
+                    return func(*args, **kwargs)
+                except Exception as exc:  # noqa: PERF203
+                    # Exceptions the predicate rejects (and non-Exception
+                    # BaseExceptions like KeyboardInterrupt) propagate
+                    # immediately without any retry or `after` callback.
+                    if not retry_on_exception(exc):
+                        raise
+
+                    if after is not None:
+                        after()
+
+                    if attempt >= max_attempts:
+                        # Out of attempts: re-raise the final exception.
+                        raise
+
+                    sleep(wait_seconds)
+                    attempt += 1
+
+        return wrapper
+
+    return decorator

--- a/lib/streamlit/connections/retry_util.py
+++ b/lib/streamlit/connections/retry_util.py
@@ -87,7 +87,16 @@ def retry(
     -------
     Callable
         A decorator that wraps a function with the configured retry behavior.
+
+    Raises
+    ------
+    ValueError
+        If ``max_attempts`` is less than ``1`` or ``wait_seconds`` is negative.
     """
+    if max_attempts < 1:
+        raise ValueError(f"max_attempts must be at least 1, got {max_attempts!r}.")
+    if wait_seconds < 0:
+        raise ValueError(f"wait_seconds must be non-negative, got {wait_seconds!r}.")
 
     def decorator(func: Callable[_P, _R]) -> Callable[_P, _R]:
         @functools.wraps(func)
@@ -97,9 +106,8 @@ def retry(
                 try:
                     return func(*args, **kwargs)
                 except Exception as exc:  # noqa: PERF203
-                    # Exceptions the predicate rejects (and non-Exception
-                    # BaseExceptions like KeyboardInterrupt) propagate
-                    # immediately without any retry or `after` callback.
+                    # The predicate rejected this exception: re-raise it
+                    # immediately with no wait or `after` callback.
                     if not retry_on_exception(exc):
                         raise
 

--- a/lib/streamlit/connections/snowflake_connection.py
+++ b/lib/streamlit/connections/snowflake_connection.py
@@ -121,22 +121,19 @@ class BaseSnowflakeConnection(BaseConnection["InternalSnowflakeConnection"]):
         >>> st.dataframe(df)
 
         """
-        from tenacity import retry, retry_if_exception, stop_after_attempt, wait_fixed
+        from streamlit.connections import retry_util
 
-        @retry(
-            after=lambda _: self.reset(),
-            stop=stop_after_attempt(3),
-            reraise=True,
+        @retry_util.retry(
+            max_attempts=3,
+            wait_seconds=1,
             # We don't have to implement retries ourself for most error types as the
             # `snowflake-connector-python` library already implements retries for
             # retryable HTTP errors.
-            retry=retry_if_exception(
-                lambda e: (
-                    hasattr(e, "sqlstate")
-                    and e.sqlstate == SQLSTATE_CONNECTION_WAS_NOT_ESTABLISHED
-                )
+            retry_on_exception=lambda exc: (
+                hasattr(exc, "sqlstate")
+                and exc.sqlstate == SQLSTATE_CONNECTION_WAS_NOT_ESTABLISHED
             ),
-            wait=wait_fixed(1),
+            after=self.reset,
         )
         # `params` must be an explicit parameter (not captured from closure) so that
         # `@st.cache_data` includes it in the cache key.

--- a/lib/streamlit/connections/sql_connection.py
+++ b/lib/streamlit/connections/sql_connection.py
@@ -295,21 +295,16 @@ class SQLConnection(BaseConnection["Engine"]):
 
         from sqlalchemy import text
         from sqlalchemy.exc import DatabaseError, InternalError, OperationalError
-        from tenacity import (
-            retry,
-            retry_if_exception_type,
-            stop_after_attempt,
-            wait_fixed,
-        )
 
-        @retry(
-            after=lambda _: self.reset(),
-            stop=stop_after_attempt(3),
-            reraise=True,
-            retry=retry_if_exception_type(
-                (DatabaseError, InternalError, OperationalError)
+        from streamlit.connections import retry_util
+
+        @retry_util.retry(
+            max_attempts=3,
+            wait_seconds=1,
+            retry_on_exception=lambda exc: isinstance(
+                exc, (DatabaseError, InternalError, OperationalError)
             ),
-            wait=wait_fixed(1),
+            after=self.reset,
         )
         def _query(
             # Dummy parameter to retain per-instance caching.

--- a/lib/tests/streamlit/connections/retry_util_test.py
+++ b/lib/tests/streamlit/connections/retry_util_test.py
@@ -243,3 +243,24 @@ def test_preserves_wrapped_function_metadata() -> None:
     # `functools.wraps` exposes the original function so `inspect.signature`
     # (used by `st.cache_data` to build cache keys) resolves the true params.
     assert wrapped.__wrapped__ is original
+
+
+@pytest.mark.parametrize("max_attempts", [0, -1])
+def test_rejects_max_attempts_below_one(max_attempts: int) -> None:
+    """Constructing the decorator with fewer than one attempt fails fast."""
+    with pytest.raises(ValueError, match="max_attempts must be at least 1"):
+        retry_util.retry(
+            max_attempts=max_attempts,
+            wait_seconds=1,
+            retry_on_exception=_retry_only_retryable,
+        )
+
+
+def test_rejects_negative_wait_seconds() -> None:
+    """Constructing the decorator with a negative wait time fails fast."""
+    with pytest.raises(ValueError, match="wait_seconds must be non-negative"):
+        retry_util.retry(
+            max_attempts=3,
+            wait_seconds=-1,
+            retry_on_exception=_retry_only_retryable,
+        )

--- a/lib/tests/streamlit/connections/retry_util_test.py
+++ b/lib/tests/streamlit/connections/retry_util_test.py
@@ -1,0 +1,245 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the internal retry helper (tenacity replacement)."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+
+from streamlit.connections import retry_util
+
+
+class _RetryableError(Exception):
+    """An exception the retry predicate treats as retryable."""
+
+
+class _NonRetryableError(Exception):
+    """An exception the retry predicate treats as non-retryable."""
+
+
+def _retry_only_retryable(exc: BaseException) -> bool:
+    """Retry predicate that only retries ``_RetryableError`` instances."""
+    return isinstance(exc, _RetryableError)
+
+
+def test_returns_result_without_retrying_on_success() -> None:
+    """A function that succeeds is called once and its result is returned."""
+    sleep = Mock()
+    after = Mock()
+    inner = Mock(return_value="result")
+
+    wrapped = retry_util.retry(
+        max_attempts=3,
+        wait_seconds=1,
+        retry_on_exception=_retry_only_retryable,
+        after=after,
+        sleep=sleep,
+    )(inner)
+
+    assert wrapped() == "result"
+    assert inner.call_count == 1
+    # No failure occurred, so neither the sleep nor the `after` hook should run.
+    sleep.assert_not_called()
+    after.assert_not_called()
+
+
+def test_reraises_final_exception_after_exhausting_attempts() -> None:
+    """When every attempt fails, the final exception is re-raised unchanged."""
+    sleep = Mock()
+    after = Mock()
+    final_error = _RetryableError("kaboom")
+    inner = Mock(
+        side_effect=[_RetryableError("first"), _RetryableError("second"), final_error]
+    )
+
+    wrapped = retry_util.retry(
+        max_attempts=3,
+        wait_seconds=1,
+        retry_on_exception=_retry_only_retryable,
+        after=after,
+        sleep=sleep,
+    )(inner)
+
+    with pytest.raises(_RetryableError) as exc_info:
+        wrapped()
+
+    # The exception from the last attempt is propagated (tenacity reraise=True).
+    assert exc_info.value is final_error
+    assert inner.call_count == 3
+    # `after` runs after every failed attempt, including the final one.
+    assert after.call_count == 3
+    # We sleep between attempts, i.e. one fewer time than the number of attempts.
+    assert sleep.call_count == 2
+
+
+def test_succeeds_after_transient_failures() -> None:
+    """A function that fails then succeeds returns its eventual result."""
+    sleep = Mock()
+    after = Mock()
+    inner = Mock(side_effect=[_RetryableError("boom"), "recovered"])
+
+    wrapped = retry_util.retry(
+        max_attempts=3,
+        wait_seconds=1,
+        retry_on_exception=_retry_only_retryable,
+        after=after,
+        sleep=sleep,
+    )(inner)
+
+    assert wrapped() == "recovered"
+    assert inner.call_count == 2
+    assert after.call_count == 1
+    assert sleep.call_count == 1
+
+
+def test_non_retryable_exception_is_reraised_immediately() -> None:
+    """An exception the predicate rejects is raised without any retry."""
+    sleep = Mock()
+    after = Mock()
+    inner = Mock(side_effect=_NonRetryableError("nope"))
+
+    wrapped = retry_util.retry(
+        max_attempts=3,
+        wait_seconds=1,
+        retry_on_exception=_retry_only_retryable,
+        after=after,
+        sleep=sleep,
+    )(inner)
+
+    with pytest.raises(_NonRetryableError):
+        wrapped()
+
+    # Non-retryable failures fail fast: a single call, no wait, no `after` hook.
+    assert inner.call_count == 1
+    sleep.assert_not_called()
+    after.assert_not_called()
+
+
+def test_base_exception_propagates_without_after() -> None:
+    """A non-``Exception`` ``BaseException`` propagates immediately without retry."""
+    sleep = Mock()
+    after = Mock()
+    inner = Mock(side_effect=KeyboardInterrupt())
+
+    wrapped = retry_util.retry(
+        max_attempts=3,
+        wait_seconds=1,
+        retry_on_exception=lambda _exc: True,
+        after=after,
+        sleep=sleep,
+    )(inner)
+
+    with pytest.raises(KeyboardInterrupt):
+        wrapped()
+
+    assert inner.call_count == 1
+    sleep.assert_not_called()
+    after.assert_not_called()
+
+
+def test_after_hook_is_optional() -> None:
+    """The retry logic works when no ``after`` callback is provided."""
+    sleep = Mock()
+    inner = Mock(side_effect=_RetryableError("boom"))
+
+    wrapped = retry_util.retry(
+        max_attempts=2,
+        wait_seconds=1,
+        retry_on_exception=_retry_only_retryable,
+        sleep=sleep,
+    )(inner)
+
+    with pytest.raises(_RetryableError):
+        wrapped()
+
+    assert inner.call_count == 2
+    assert sleep.call_count == 1
+
+
+def test_single_attempt_does_not_sleep() -> None:
+    """With ``max_attempts=1`` the function is tried once and never waits."""
+    sleep = Mock()
+    after = Mock()
+    inner = Mock(side_effect=_RetryableError("boom"))
+
+    wrapped = retry_util.retry(
+        max_attempts=1,
+        wait_seconds=1,
+        retry_on_exception=_retry_only_retryable,
+        after=after,
+        sleep=sleep,
+    )(inner)
+
+    with pytest.raises(_RetryableError):
+        wrapped()
+
+    assert inner.call_count == 1
+    # `after` still runs for the failed attempt, but there is nothing to wait for.
+    assert after.call_count == 1
+    sleep.assert_not_called()
+
+
+def test_sleeps_configured_wait_seconds_between_attempts() -> None:
+    """The wait strategy sleeps for exactly ``wait_seconds`` between attempts."""
+    sleep = Mock()
+    inner = Mock(side_effect=[_RetryableError("boom"), "done"])
+
+    wrapped = retry_util.retry(
+        max_attempts=3,
+        wait_seconds=2.5,
+        retry_on_exception=_retry_only_retryable,
+        sleep=sleep,
+    )(inner)
+
+    assert wrapped() == "done"
+    sleep.assert_called_once_with(2.5)
+
+
+def test_forwards_args_and_kwargs() -> None:
+    """Positional and keyword arguments are passed through to the function."""
+    sleep = Mock()
+    inner = Mock(return_value="ok")
+
+    wrapped = retry_util.retry(
+        max_attempts=3,
+        wait_seconds=1,
+        retry_on_exception=_retry_only_retryable,
+        sleep=sleep,
+    )(inner)
+
+    assert wrapped("a", 2, key="value") == "ok"
+    inner.assert_called_once_with("a", 2, key="value")
+
+
+def test_preserves_wrapped_function_metadata() -> None:
+    """The decorator preserves the wrapped function's identity metadata."""
+
+    def original(x: int) -> int:
+        """Original docstring."""
+        return x
+
+    wrapped = retry_util.retry(
+        max_attempts=3,
+        wait_seconds=1,
+        retry_on_exception=_retry_only_retryable,
+    )(original)
+
+    assert wrapped.__name__ == "original"
+    assert wrapped.__doc__ == "Original docstring."
+    # `functools.wraps` exposes the original function so `inspect.signature`
+    # (used by `st.cache_data` to build cache keys) resolves the true params.
+    assert wrapped.__wrapped__ is original

--- a/lib/tests/streamlit/connections/retry_util_test.py
+++ b/lib/tests/streamlit/connections/retry_util_test.py
@@ -31,7 +31,7 @@ class _NonRetryableError(Exception):
     """An exception the retry predicate treats as non-retryable."""
 
 
-def _retry_only_retryable(exc: BaseException) -> bool:
+def _retry_only_retryable(exc: Exception) -> bool:
     """Retry predicate that only retries ``_RetryableError`` instances."""
     return isinstance(exc, _RetryableError)
 

--- a/scripts/assets/min-constraints-gen.txt
+++ b/scripts/assets/min-constraints-gen.txt
@@ -14,7 +14,6 @@ pydeck==0.8.0b4
 python-multipart==0.0.10
 requests==2.27
 starlette==0.46.0
-tenacity==8.1.0
 toml==0.10.1
 typing-extensions==4.10.0
 uvicorn==0.30.0

--- a/uv.lock
+++ b/uv.lock
@@ -4430,7 +4430,6 @@ dependencies = [
     { name = "python-multipart" },
     { name = "requests" },
     { name = "starlette" },
-    { name = "tenacity" },
     { name = "toml" },
     { name = "typing-extensions" },
     { name = "uvicorn" },
@@ -4493,7 +4492,6 @@ requires-dist = [
     { name = "starlette", specifier = ">=0.46.0,<2" },
     { name = "streamlit", extras = ["auth", "charts", "snowflake", "sql", "pdf", "performance"], marker = "extra == 'all'" },
     { name = "streamlit-pdf", marker = "extra == 'pdf'", specifier = ">=1.0.0" },
-    { name = "tenacity", specifier = ">=8.1.0,<10" },
     { name = "toml", specifier = ">=0.10.1,<2" },
     { name = "typing-extensions", specifier = ">=4.10.0,<5" },
     { name = "uvicorn", specifier = ">=0.30.0,<1" },
@@ -4767,15 +4765,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
-]
-
-[[package]]
-name = "tenacity"
-version = "9.1.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Describe your changes

Removes the required `tenacity` runtime dependency, replacing the small slice used by the SQL/Snowflake connection retry logic with a focused internal `connections/retry_util.py` helper. This shrinks the installed dependency footprint (supply-chain reduction) with no behavior change.

- New `connections/retry_util.py`: a single `retry` decorator with capped attempts, fixed wait, an exception predicate, an optional `after` callback, and re-raise of the final exception — exactly the subset of tenacity the connections used (`stop_after_attempt`, `wait_fixed`, `retry_if_exception[_type]`, `after`, `reraise=True`).
- Retry/reset semantics are preserved exactly: `after` (connection reset) runs after every retryable failed attempt **including the final one** before re-raising, non-retryable exceptions fail fast (no `after`/wait), and the final exception is re-raised on exhaustion. Verified by the existing connection retry tests (reset called 3×, fail-fast).
- `pip install streamlit` no longer installs `tenacity` transitively. Note: persisted `cache_data` (`persist="disk"`) entries recompute once after upgrade — a benign internal cache-key change, equivalent to the prior tenacity situation.

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- `lib/tests/streamlit/connections/retry_util_test.py` — new unit tests: success without retry, exhaustion + reraise, transient-then-success, non-retryable fast-fail, non-`Exception` `BaseException` propagation, optional `after`, single attempt (no sleep), exact wait value, arg/kwarg forwarding, and `__wrapped__` metadata preservation (keeps `st.cache_data` key resolution intact).
- Existing `sql_connection_test.py` / `snowflake_connection_test.py` retry tests validate behavioral parity (reset called 3×, fail-fast) — pass unchanged.
- `e2e_playwright/lazy_loaded_modules_test.py` — updated expected markdown count (15 → 14) after dropping `tenacity`; passes.

Made with [Cursor](https://cursor.com)