### PR TITLE
Remove `react-focus-lock` dependency from `MainMenu`

### DIFF
--- a/NOTICES
+++ b/NOTICES
@@ -11406,32 +11406,6 @@ SOFTWARE.
 
 -----
 
-The following software may be included in this product: react-focus-lock. A copy of the source code may be downloaded from git+https://github.com/theKashey/react-focus-lock.git. This software contains the following license and notice below:
-
-MIT License
-
-Copyright (c) 2017 Anton
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
------
-
 The following software may be included in this product: react-helmet-async. A copy of the source code may be downloaded from http://github.com/staylor/react-helmet-async. This software contains the following license and notice below:
 
 Apache License

--- a/e2e_playwright/main_menu_test.py
+++ b/e2e_playwright/main_menu_test.py
@@ -152,9 +152,9 @@ def test_keyboard_activates_menu_item(app: Page):
 
 
 # WebKit (Safari) does not allow programmatic .focus() on buttons outside a
-# user-activation context. Our focus-return fires from react-focus-lock's
-# returnFocus callback (during FocusLock's unmount cleanup), which
-# Chromium/Firefox accept but WebKit silently ignores.
+# user-activation context. Our focus-return fires from a useLayoutEffect
+# (synchronously after the popover unmounts), which Chromium/Firefox accept
+# but WebKit silently ignores.
 @pytest.mark.skip_browser("webkit")
 def test_focus_returns_to_menu_button_after_close(app: Page):
     """Test that focus returns to the menu button after the popover closes."""
@@ -175,7 +175,7 @@ def test_tab_closes_menu(app: Page):
     """Test that pressing Tab from the menu eventually closes the popover.
 
     The first Tab moves focus from the menu items to the version CopyButton
-    (which lives outside role="menu" but inside the popover's focus-lock).
+    (which lives outside role="menu" but inside the popover's focus cycle).
     The second Tab closes the popover and advances focus.
     """
     menu_button = app.get_by_test_id("stMainMenuButton")

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -52,7 +52,6 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-feather": "^2.0.10",
-    "react-focus-lock": "^2.13.2",
     "react-helmet-async": "^3.0.0",
     "react-hot-keys": "^3.0.0",
     "react-transition-group": "^4.4.5",

--- a/frontend/app/src/components/MainMenu/MainMenu.test.tsx
+++ b/frontend/app/src/components/MainMenu/MainMenu.test.tsx
@@ -44,36 +44,6 @@ vi.mock("@streamlit/app/src/util/ScreenCastRecorder", () => ({
   },
 }))
 
-// Simulate FocusLock without its real implementation. The real library restores
-// focus via an internal setTimeout that fires outside act() in tests, causing
-// spurious React warnings. This mock invokes returnFocus synchronously during
-// useLayoutEffect cleanup (same commit-phase timing) to keep updates in act().
-vi.mock("react-focus-lock", async () => {
-  const { useLayoutEffect, useRef, createElement, Fragment } =
-    await import("react")
-  type ReactNode = ReturnType<typeof createElement> | string | null | undefined
-  function MockFocusLock({
-    children,
-    returnFocus,
-  }: {
-    children: ReactNode
-    returnFocus?: ((returnTo: Element) => false) | boolean
-  }): ReturnType<typeof createElement> {
-    const returnFocusRef = useRef(returnFocus)
-    returnFocusRef.current = returnFocus
-    useLayoutEffect(() => {
-      return () => {
-        const fn = returnFocusRef.current
-        if (typeof fn === "function") {
-          fn(document.activeElement ?? document.body)
-        }
-      }
-    }, [])
-    return createElement(Fragment, null, children)
-  }
-  return { default: MockFocusLock }
-})
-
 const mockCopyToClipboard = vi.fn()
 vi.mock("~lib/hooks/useCopyToClipboard", () => ({
   useCopyToClipboard: () => ({

--- a/frontend/app/src/components/MainMenu/MainMenu.tsx
+++ b/frontend/app/src/components/MainMenu/MainMenu.tsx
@@ -721,7 +721,9 @@ const MenuContent = memo(function MenuContent({
           // Footer with CopyButton exists — both Tab and Shift+Tab route to
           // CopyButton (2-element contained cycle: menu item ↔ CopyButton).
           // Forward Tab from CopyButton exits via handleFooterKeyDown.
-          footerRef.current?.querySelector<HTMLElement>("button")?.focus()
+          footerRef.current
+            ?.querySelector<HTMLElement>(".stMenuVersionCopyButton")
+            ?.focus()
         } else {
           closeMenu(event.shiftKey ? "shift-tab" : "tab")
         }

--- a/frontend/app/src/components/MainMenu/MainMenu.tsx
+++ b/frontend/app/src/components/MainMenu/MainMenu.tsx
@@ -718,7 +718,9 @@ const MenuContent = memo(function MenuContent({
       case "Tab": {
         event.preventDefault()
         if (streamlitVersion) {
-          // Footer with CopyButton exists — cycle focus within the popover.
+          // Footer with CopyButton exists — both Tab and Shift+Tab route to
+          // CopyButton (2-element contained cycle: menu item ↔ CopyButton).
+          // Forward Tab from CopyButton exits via handleFooterKeyDown.
           footerRef.current?.querySelector<HTMLElement>("button")?.focus()
         } else {
           closeMenu(event.shiftKey ? "shift-tab" : "tab")

--- a/frontend/app/src/components/MainMenu/MainMenu.tsx
+++ b/frontend/app/src/components/MainMenu/MainMenu.tsx
@@ -721,9 +721,14 @@ const MenuContent = memo(function MenuContent({
           // Footer with CopyButton exists — both Tab and Shift+Tab route to
           // CopyButton (2-element contained cycle: menu item ↔ CopyButton).
           // Forward Tab from CopyButton exits via handleFooterKeyDown.
-          footerRef.current
-            ?.querySelector<HTMLElement>(".stMenuVersionCopyButton")
-            ?.focus()
+          const copyBtn = footerRef.current?.querySelector<HTMLElement>(
+            ".stMenuVersionCopyButton"
+          )
+          if (copyBtn) {
+            copyBtn.focus()
+          } else {
+            closeMenu(event.shiftKey ? "shift-tab" : "tab")
+          }
         } else {
           closeMenu(event.shiftKey ? "shift-tab" : "tab")
         }

--- a/frontend/app/src/components/MainMenu/MainMenu.tsx
+++ b/frontend/app/src/components/MainMenu/MainMenu.tsx
@@ -21,6 +21,7 @@ import {
   ReactElement,
   useCallback,
   useContext,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -28,9 +29,7 @@ import {
 
 import { MoreVert } from "@emotion-icons/material-rounded"
 import { FloatingPortal } from "@floating-ui/react"
-import { focusNextElement, focusPrevElement } from "focus-lock"
 import { getLogger } from "loglevel"
-import FocusLock from "react-focus-lock"
 
 import type { Steps } from "@streamlit/app/src/hocs/withScreencast/withScreencast"
 import { MetricsManager } from "@streamlit/app/src/MetricsManager"
@@ -51,6 +50,7 @@ import {
 } from "@streamlit/lib"
 import { Config, PageConfig } from "@streamlit/protobuf"
 
+import { focusNextTabbable, focusPrevTabbable } from "./focusTabbable"
 import {
   StyledMainMenuContainer,
   StyledMainMenuPopoverBody,
@@ -624,6 +624,7 @@ const MenuContent = memo(function MenuContent({
   const theme = useEmotionTheme()
   // Store button refs so roving tabindex can move focus without DOM queries.
   const menuItemButtonsRef = useRef<Array<HTMLElement | null>>([])
+  const footerRef = useRef<HTMLDivElement>(null)
   // Flatten sections to preserve visual grouping but allow linear navigation.
   // All items are focusable, including disabled ones (WAI-ARIA: every menuitem
   // in a menu is focusable, whether or not it is disabled).
@@ -715,15 +716,13 @@ const MenuContent = memo(function MenuContent({
         break
       }
       case "Tab": {
-        if (streamlitVersion) {
-          // A CopyButton exists in the version footer outside role="menu"
-          // but inside the popover's focus-lock.  Let focus-lock move
-          // focus there instead of closing the menu immediately.
-          break
-        }
-        // No footer — close the menu and advance focus per WAI-ARIA.
         event.preventDefault()
-        closeMenu(event.shiftKey ? "shift-tab" : "tab")
+        if (streamlitVersion) {
+          // Footer with CopyButton exists — cycle focus within the popover.
+          footerRef.current?.querySelector<HTMLElement>("button")?.focus()
+        } else {
+          closeMenu(event.shiftKey ? "shift-tab" : "tab")
+        }
         break
       }
       default:
@@ -732,14 +731,13 @@ const MenuContent = memo(function MenuContent({
   }
 
   const handleFooterKeyDown = (event: KeyboardEvent<HTMLDivElement>): void => {
-    if (event.key === "Tab" && !event.shiftKey) {
-      // Forward Tab from the footer: close menu and advance focus
-      // past the trigger, same as Tab from a bare menu.
-      // Escape is handled by the capture-phase document listener in MainMenu.
-      event.preventDefault()
+    if (event.key !== "Tab") return
+    event.preventDefault()
+    if (event.shiftKey) {
+      menuItemButtonsRef.current[clampedIndex]?.focus()
+    } else {
       closeMenu("tab")
     }
-    // Shift+Tab: focus-lock moves focus back into the menu.
   }
 
   // Render sections with dividers between non-empty sections.
@@ -836,7 +834,10 @@ const MenuContent = memo(function MenuContent({
         {elements}
       </StyledMenuContainer>
       {streamlitVersion && (
-        <StyledMenuVersionFooter onKeyDown={handleFooterKeyDown}>
+        <StyledMenuVersionFooter
+          ref={footerRef}
+          onKeyDown={handleFooterKeyDown}
+        >
           <StyledMenuVersionRow>
             <StyledMenuVersionText>
               Made with Streamlit v{formatDisplayVersion(streamlitVersion)}
@@ -938,7 +939,6 @@ function MainMenu(props: Readonly<Props>): ReactElement | null {
   // Track popover open state for aria-expanded on the menu button.
   const [isMenuOpen, setIsMenuOpen] = useState(false)
 
-  // triggerRef is still needed by handleReturnFocus for Tab/Shift+Tab focus routing.
   const triggerRef = useRef<HTMLButtonElement | null>(null)
 
   const { refs, floatingStyles } = useFloatingOverlay({
@@ -947,8 +947,6 @@ function MainMenu(props: Readonly<Props>): ReactElement | null {
     offsetPx: convertRemToPx(theme.spacing.twoXS),
   })
 
-  // Tracks *why* the menu was closed so handleReturnFocus can route focus.
-  // Set by closeMenu, read + reset in handleReturnFocus.
   const closeReasonRef = useRef<CloseReason>("other")
 
   // Stable close callback — MenuContent holds a stable reference so its memo
@@ -962,37 +960,27 @@ function MainMenu(props: Readonly<Props>): ReactElement | null {
     setIsMenuOpen(prev => !prev)
   }, [])
 
-  // Passed to FocusLock's returnFocus prop. FocusLock internally uses a
-  // setTimeout to restore focus after unmount; this callback intercepts that
-  // restoration to route focus correctly.
-  //
-  // - Escape / item click / outside-click ("other"): focus returns to trigger.
-  // - Tab: focus advances to the next tabbable element after the trigger.
-  // - Shift+Tab: focus moves to the previous tabbable element.
-  //
-  // Returning false prevents FocusLock's default restoration (which targets
-  // the wrong element due to DOM ordering).
-  const handleReturnFocus = useCallback((_returnTo: Element): false => {
-    const reason = closeReasonRef.current
-    closeReasonRef.current = "other"
-
-    const button = triggerRef.current
-    if (button) {
-      if (reason === "tab") {
-        focusNextElement(button)
-      } else if (reason === "shift-tab") {
-        focusPrevElement(button)
-      } else {
-        button.focus()
+  // Route focus when the menu closes. Runs in useLayoutEffect so it fires
+  // synchronously after the portal unmounts (no flash of focus on body).
+  const prevOpenRef = useRef(false)
+  useLayoutEffect(() => {
+    if (prevOpenRef.current && !isMenuOpen) {
+      const reason = closeReasonRef.current
+      closeReasonRef.current = "other"
+      const button = triggerRef.current
+      if (button) {
+        if (reason === "tab") {
+          focusNextTabbable(button)
+        } else if (reason === "shift-tab") {
+          focusPrevTabbable(button)
+        } else {
+          button.focus()
+        }
       }
     }
-    return false
-  }, [])
+    prevOpenRef.current = isMenuOpen
+  }, [isMenuOpen])
 
-  // FocusLock's handleReturnFocus manages focus restoration — omit restoreFocusFn.
-  // useOverlayDismissal calls onClose() without a reason argument, so closeMenu()
-  // defaults to reason "other". handleReturnFocus routes "other" to button.focus(),
-  // the same as "escape", so the focus behaviour is identical.
   const { setFloatingRef, setReferenceRef } = useOverlayDismissal({
     isOpen: isMenuOpen,
     onClose: closeMenu,
@@ -1000,7 +988,6 @@ function MainMenu(props: Readonly<Props>): ReactElement | null {
     referenceSetFn: refs.setReference,
   })
 
-  // Attach triggerRef (for handleReturnFocus focus routing) alongside setReferenceRef.
   const setTriggerAndReferenceRef = useCallback(
     (node: HTMLButtonElement | null): void => {
       triggerRef.current = node
@@ -1047,14 +1034,12 @@ function MainMenu(props: Readonly<Props>): ReactElement | null {
             data-testid="stMainMenuPopover"
             className="stMainMenuPopover"
           >
-            <FocusLock returnFocus={handleReturnFocus}>
-              <MenuContent
-                sections={sections}
-                closeMenu={closeMenu}
-                metricsMgr={metricsMgr}
-                streamlitVersion={streamlitVersion}
-              />
-            </FocusLock>
+            <MenuContent
+              sections={sections}
+              closeMenu={closeMenu}
+              metricsMgr={metricsMgr}
+              streamlitVersion={streamlitVersion}
+            />
           </StyledMainMenuPopoverBody>
         </FloatingPortal>
       )}

--- a/frontend/app/src/components/MainMenu/focusTabbable.test.ts
+++ b/frontend/app/src/components/MainMenu/focusTabbable.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { focusNextTabbable, focusPrevTabbable } from "./focusTabbable"
+
+function setup(html: string): void {
+  document.body.innerHTML = html
+}
+
+describe("focusNextTabbable", () => {
+  afterEach(() => {
+    document.body.innerHTML = ""
+  })
+
+  it("focuses the next tabbable element in document order", () => {
+    setup(`
+      <button id="a">A</button>
+      <button id="b">B</button>
+      <button id="c">C</button>
+    `)
+    const a = document.getElementById("a") as HTMLElement
+    const b = document.getElementById("b") as HTMLElement
+
+    focusNextTabbable(a)
+    expect(document.activeElement).toBe(b)
+  })
+
+  it("skips elements with negative tabIndex", () => {
+    setup(`
+      <button id="a">A</button>
+      <button id="b" tabindex="-1">B</button>
+      <button id="c">C</button>
+    `)
+    const a = document.getElementById("a") as HTMLElement
+    const c = document.getElementById("c") as HTMLElement
+
+    focusNextTabbable(a)
+    expect(document.activeElement).toBe(c)
+  })
+
+  it("skips disabled buttons", () => {
+    setup(`
+      <button id="a">A</button>
+      <button id="b" disabled>B</button>
+      <button id="c">C</button>
+    `)
+    const a = document.getElementById("a") as HTMLElement
+    const c = document.getElementById("c") as HTMLElement
+
+    focusNextTabbable(a)
+    expect(document.activeElement).toBe(c)
+  })
+
+  it("skips hidden elements", () => {
+    setup(`
+      <button id="a">A</button>
+      <button id="b" hidden>B</button>
+      <button id="c">C</button>
+    `)
+    const a = document.getElementById("a") as HTMLElement
+    const c = document.getElementById("c") as HTMLElement
+
+    focusNextTabbable(a)
+    expect(document.activeElement).toBe(c)
+  })
+
+  it("skips elements inside an inert subtree", () => {
+    setup(`
+      <button id="a">A</button>
+      <div inert><button id="b">B</button></div>
+      <button id="c">C</button>
+    `)
+    const a = document.getElementById("a") as HTMLElement
+    const c = document.getElementById("c") as HTMLElement
+
+    focusNextTabbable(a)
+    expect(document.activeElement).toBe(c)
+  })
+
+  it("does nothing when no next tabbable element exists", () => {
+    setup(`
+      <button id="a">A</button>
+    `)
+    const a = document.getElementById("a") as HTMLElement
+    a.focus()
+
+    focusNextTabbable(a)
+    // Focus stays where it was (on body, since next?.focus() is a no-op)
+    expect(document.activeElement).toBe(a)
+  })
+})
+
+describe("focusPrevTabbable", () => {
+  afterEach(() => {
+    document.body.innerHTML = ""
+  })
+
+  it("focuses the previous tabbable element in document order", () => {
+    setup(`
+      <button id="a">A</button>
+      <button id="b">B</button>
+      <button id="c">C</button>
+    `)
+    const b = document.getElementById("b") as HTMLElement
+    const c = document.getElementById("c") as HTMLElement
+
+    focusPrevTabbable(c)
+    expect(document.activeElement).toBe(b)
+  })
+
+  it("skips disabled elements going backwards", () => {
+    setup(`
+      <button id="a">A</button>
+      <button id="b" disabled>B</button>
+      <button id="c">C</button>
+    `)
+    const a = document.getElementById("a") as HTMLElement
+    const c = document.getElementById("c") as HTMLElement
+
+    focusPrevTabbable(c)
+    expect(document.activeElement).toBe(a)
+  })
+
+  it("does nothing when no previous tabbable element exists", () => {
+    setup(`
+      <button id="a">A</button>
+    `)
+    const a = document.getElementById("a") as HTMLElement
+    a.focus()
+
+    focusPrevTabbable(a)
+    expect(document.activeElement).toBe(a)
+  })
+})

--- a/frontend/app/src/components/MainMenu/focusTabbable.test.ts
+++ b/frontend/app/src/components/MainMenu/focusTabbable.test.ts
@@ -90,6 +90,18 @@ describe("focusNextTabbable", () => {
     expect(document.activeElement).toBe(c)
   })
 
+  it("descends into non-tabbable wrapper elements", () => {
+    setup(`
+      <button id="a">A</button>
+      <div><span><button id="b">B</button></span></div>
+    `)
+    const a = document.getElementById("a") as HTMLElement
+    const b = document.getElementById("b") as HTMLElement
+
+    focusNextTabbable(a)
+    expect(document.activeElement).toBe(b)
+  })
+
   it("does nothing when no next tabbable element exists", () => {
     setup(`
       <button id="a">A</button>

--- a/frontend/app/src/components/MainMenu/focusTabbable.test.ts
+++ b/frontend/app/src/components/MainMenu/focusTabbable.test.ts
@@ -98,7 +98,7 @@ describe("focusNextTabbable", () => {
     a.focus()
 
     focusNextTabbable(a)
-    // Focus stays where it was (on body, since next?.focus() is a no-op)
+    // No next candidate — focus stays on a
     expect(document.activeElement).toBe(a)
   })
 })

--- a/frontend/app/src/components/MainMenu/focusTabbable.ts
+++ b/frontend/app/src/components/MainMenu/focusTabbable.ts
@@ -16,7 +16,8 @@
 
 /**
  * TreeWalker filter that accepts tabbable elements: non-negative tabIndex,
- * not disabled, not hidden, and not inside an inert subtree.
+ * not disabled, not hidden, and not inside an inert subtree (FILTER_REJECT
+ * prunes the entire inert subtree so descendants are never visited).
  *
  * This intentionally checks only HTML attributes (hidden, disabled, inert) —
  * not CSS visibility (display:none, visibility:hidden) or aria-hidden. This is
@@ -30,7 +31,7 @@ function acceptTabbableNode(node: Node): number {
   if ("disabled" in node && (node as HTMLButtonElement).disabled)
     return NodeFilter.FILTER_SKIP
   if (node.hidden) return NodeFilter.FILTER_SKIP
-  if (node.closest("[inert]")) return NodeFilter.FILTER_SKIP
+  if (node.closest("[inert]")) return NodeFilter.FILTER_REJECT
   return NodeFilter.FILTER_ACCEPT
 }
 

--- a/frontend/app/src/components/MainMenu/focusTabbable.ts
+++ b/frontend/app/src/components/MainMenu/focusTabbable.ts
@@ -16,14 +16,14 @@
 
 /**
  * TreeWalker filter that accepts tabbable elements: non-negative tabIndex,
- * not disabled, not hidden, and not inside an inert subtree (FILTER_REJECT
+ * not disabled, not hidden, visible (checkVisibility gate for display:none /
+ * visibility:hidden ancestors), and not inside an inert subtree (FILTER_REJECT
  * prunes the entire inert subtree so descendants are never visited).
  *
- * This intentionally checks only HTML attributes (hidden, disabled, inert) —
- * not CSS visibility (display:none, visibility:hidden) or aria-hidden. This is
- * sufficient for MainMenu's focus routing (header-bar neighbors are always
- * visible) but should not be reused as a general-purpose tabbable check
- * without adding a visibility gate (e.g. el.offsetParent !== null).
+ * Note: this uses document order, not tab order — positive tabIndex values
+ * are not visited first. This is sufficient for MainMenu's focus routing
+ * (header-bar neighbors use no positive tabIndex) but should not be reused
+ * as a general-purpose tab-order utility without sorting by tabIndex.
  */
 function acceptTabbableNode(node: Node): number {
   if (!(node instanceof HTMLElement)) return NodeFilter.FILTER_SKIP
@@ -32,6 +32,8 @@ function acceptTabbableNode(node: Node): number {
     return NodeFilter.FILTER_SKIP
   if (node.hidden) return NodeFilter.FILTER_SKIP
   if (node.closest("[inert]")) return NodeFilter.FILTER_REJECT
+  if ("checkVisibility" in node && !node.checkVisibility())
+    return NodeFilter.FILTER_SKIP
   return NodeFilter.FILTER_ACCEPT
 }
 

--- a/frontend/app/src/components/MainMenu/focusTabbable.ts
+++ b/frontend/app/src/components/MainMenu/focusTabbable.ts
@@ -14,7 +14,17 @@
  * limitations under the License.
  */
 
-function isTabbable(node: Node): number {
+/**
+ * TreeWalker filter that accepts tabbable elements: non-negative tabIndex,
+ * not disabled, not hidden, and not inside an inert subtree.
+ *
+ * This intentionally checks only HTML attributes (hidden, disabled, inert) —
+ * not CSS visibility (display:none, visibility:hidden) or aria-hidden. This is
+ * sufficient for MainMenu's focus routing (header-bar neighbors are always
+ * visible) but should not be reused as a general-purpose tabbable check
+ * without adding a visibility gate (e.g. el.offsetParent !== null).
+ */
+function acceptTabbableNode(node: Node): number {
   if (!(node instanceof HTMLElement)) return NodeFilter.FILTER_SKIP
   if (node.tabIndex < 0) return NodeFilter.FILTER_SKIP
   if ("disabled" in node && (node as HTMLButtonElement).disabled)
@@ -29,7 +39,7 @@ export function focusNextTabbable(fromElement: HTMLElement): void {
   const walker = document.createTreeWalker(
     document.body,
     NodeFilter.SHOW_ELEMENT,
-    { acceptNode: isTabbable }
+    { acceptNode: acceptTabbableNode }
   )
   walker.currentNode = fromElement
   const next = walker.nextNode() as HTMLElement | null
@@ -41,7 +51,7 @@ export function focusPrevTabbable(fromElement: HTMLElement): void {
   const walker = document.createTreeWalker(
     document.body,
     NodeFilter.SHOW_ELEMENT,
-    { acceptNode: isTabbable }
+    { acceptNode: acceptTabbableNode }
   )
   walker.currentNode = fromElement
   const prev = walker.previousNode() as HTMLElement | null

--- a/frontend/app/src/components/MainMenu/focusTabbable.ts
+++ b/frontend/app/src/components/MainMenu/focusTabbable.ts
@@ -32,7 +32,10 @@ function acceptTabbableNode(node: Node): number {
     return NodeFilter.FILTER_SKIP
   if (node.hidden) return NodeFilter.FILTER_SKIP
   if (node.closest("[inert]")) return NodeFilter.FILTER_REJECT
-  if ("checkVisibility" in node && !node.checkVisibility())
+  if (
+    "checkVisibility" in node &&
+    !node.checkVisibility({ visibilityProperty: true })
+  )
     return NodeFilter.FILTER_SKIP
   return NodeFilter.FILTER_ACCEPT
 }

--- a/frontend/app/src/components/MainMenu/focusTabbable.ts
+++ b/frontend/app/src/components/MainMenu/focusTabbable.ts
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+function isTabbable(node: Node): number {
+  if (!(node instanceof HTMLElement)) return NodeFilter.FILTER_SKIP
+  if (node.tabIndex < 0) return NodeFilter.FILTER_SKIP
+  if ("disabled" in node && (node as HTMLButtonElement).disabled)
+    return NodeFilter.FILTER_SKIP
+  if (node.hidden) return NodeFilter.FILTER_SKIP
+  if (node.closest("[inert]")) return NodeFilter.FILTER_SKIP
+  return NodeFilter.FILTER_ACCEPT
+}
+
+/** Focus the next tabbable element in document order after `fromElement`. */
+export function focusNextTabbable(fromElement: HTMLElement): void {
+  const walker = document.createTreeWalker(
+    document.body,
+    NodeFilter.SHOW_ELEMENT,
+    { acceptNode: isTabbable }
+  )
+  walker.currentNode = fromElement
+  const next = walker.nextNode() as HTMLElement | null
+  next?.focus()
+}
+
+/** Focus the previous tabbable element in document order before `fromElement`. */
+export function focusPrevTabbable(fromElement: HTMLElement): void {
+  const walker = document.createTreeWalker(
+    document.body,
+    NodeFilter.SHOW_ELEMENT,
+    { acceptNode: isTabbable }
+  )
+  walker.currentNode = fromElement
+  const prev = walker.previousNode() as HTMLElement | null
+  prev?.focus()
+}

--- a/frontend/app/src/components/MainMenu/styled-components.ts
+++ b/frontend/app/src/components/MainMenu/styled-components.ts
@@ -326,8 +326,8 @@ export const StyledToggleKnob = styled.div<StyledToggleProps>(
  * Footer container for the version string.
  * Lives outside the role="menu" container (as a sibling within the
  * popover) so the CopyButton is not an invalid child of role="menu".
- * Keyboard users reach the CopyButton via Tab; focus-lock keeps
- * focus within the popover.
+ * Keyboard users reach the CopyButton via Tab; explicit handlers in
+ * MenuContent keep focus cycling within the popover.
  */
 export const StyledMenuVersionFooter = styled.div(({ theme }) => ({
   paddingLeft: theme.spacing.sm,

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3437,7 +3437,6 @@ __metadata:
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
     react-feather: "npm:^2.0.10"
-    react-focus-lock: "npm:^2.13.2"
     react-helmet-async: "npm:^3.0.0"
     react-hot-keys: "npm:^3.0.0"
     react-transition-group: "npm:^4.4.5"
@@ -15170,7 +15169,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-focus-lock@npm:^2.13.2, react-focus-lock@npm:^2.7.1":
+"react-focus-lock@npm:^2.7.1":
   version: 2.13.7
   resolution: "react-focus-lock@npm:2.13.7"
   dependencies:


### PR DESCRIPTION
## Describe your changes
- Remove `react-focus-lock` + `focus-lock` from the `MainMenu` component, replacing with explicit Tab/Shift+Tab handlers and a small `focusTabbable` utility using native `TreeWalker`
- Removes ~15.6KB gzip from initial page load (the library moves entirely into the lazy `DateTimeInput` chunk, its only remaining consumer via `baseui` - which will be removed shortly)
- Drops `react-focus-lock` as a direct dependency from `app/package.json`

### Motivation
After removing BaseWeb's `DateTimeInput` as a consumer (PR #16502), `MainMenu` became the sole entry-chunk importer of `react-focus-lock`. Vite inlines single-consumer modules into their consumer's chunk, bloating the entry. Removing this import eliminates both packages from the entry entirely.

### Changes
The menu's existing keyboard handling already intercepted all Tab events — FocusLock's containment only did real work for one case (Shift+Tab wrapping from menu items to the CopyButton footer). The replacement:

1. Focus containment — explicit `preventDefault` + programmatic focus in Tab handlers creates the same 2-element cycle (menu items ↔ CopyButton)
2. Focus restoration — `useLayoutEffect` detects close transitions and routes focus based on close reason (Tab → next, Shift+Tab → prev, other → trigger)
3. Tabbable element discovery — `focusTabbable.ts` (~30 lines) uses native `document.createTreeWalker` to find next/prev tabbable elements

## Testing Plan

- [x] All 110 MainMenu unit tests pass
- [x] All 24 MainMenu e2e functional tests pass
- [x] Manual testing & QA

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Keyboard focus and tab order in the main menu are security-adjacent for accessibility; behavior is reimplemented without the library but covered by existing MainMenu unit and e2e tests.
> 
> **Overview**
> **MainMenu** no longer wraps the popover in `react-focus-lock` or depends on `focus-lock`; `react-focus-lock` is removed from `app/package.json` and its NOTICES entry is dropped.
> 
> Focus behavior is reimplemented in place: **Tab / Shift+Tab** on menu items and the version **CopyButton** use explicit handlers to cycle between the focused menu item and the footer copy button (when a version footer exists), then close and advance focus on forward Tab from the copy button. On close, a **`useLayoutEffect`** restores focus to the trigger, or moves to the next/previous tabbable element when the menu was dismissed via Tab, using new **`focusTabbable`** helpers (`TreeWalker` over the document).
> 
> The **`react-focus-lock` unit-test mock** in `MainMenu.test.tsx` is removed; **`focusTabbable.test.ts`** adds coverage for the new utility. E2e comments are updated to describe `useLayoutEffect` focus return instead of FocusLock.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b95356d4f7c48a8da9653c4ab954e0bd64b6d6e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->