### PR TITLE
[fix] Restore color picker interaction in dialogs

### DIFF
--- a/e2e_playwright/st_dialog.py
+++ b/e2e_playwright/st_dialog.py
@@ -381,3 +381,15 @@ def dialog_with_popover() -> None:
 
 if st.button("Open Dialog with Popover"):
     dialog_with_popover()
+
+
+# Regression coverage for #16538: a color picker palette opened inside an
+# st.dialog must stay interactive without dismissing the dialog.
+@st.dialog("Dialog with color picker")
+def dialog_with_color_picker() -> None:
+    color = st.color_picker("Dialog color picker")
+    st.write(f"Selected color: {color}")
+
+
+if st.button("Open Dialog with Color Picker"):
+    dialog_with_color_picker()

--- a/e2e_playwright/st_dialog_test.py
+++ b/e2e_playwright/st_dialog_test.py
@@ -28,6 +28,7 @@ from e2e_playwright.shared.app_utils import (
     expect_no_exception,
     expect_prefixed_markdown,
     get_button,
+    get_color_picker,
     get_markdown,
     is_child_bounding_box_inside_parent,
     select_selectbox_option,
@@ -259,6 +260,30 @@ def test_dialog_allows_interacting_with_widget_in_popover(app: Page):
     expect_markdown(popover_body, "picked: Banana")
 
     # The dialog must not be dismissed by the interaction inside the popover.
+    expect(dialog).to_be_visible()
+
+
+def test_dialog_allows_interacting_with_color_picker(app: Page):
+    """A color picker palette opened inside an st.dialog must stay interactive
+    without dismissing the dialog (regression coverage for #16538).
+    """
+    click_button(app, "Open Dialog with Color Picker")
+    dialog = app.get_by_test_id(modal_test_id)
+    expect(dialog).to_be_visible()
+
+    color_picker = get_color_picker(dialog, "Dialog color picker")
+    color_picker.get_by_test_id("stColorPickerBlock").click()
+
+    popover = app.get_by_test_id("stColorPickerPopover")
+    expect(popover).to_be_visible()
+    popover.locator("input").fill("#1a2b3c")
+
+    # Close the palette with a click that stays inside the dialog, which must
+    # remain open.
+    dialog.get_by_text("Dialog color picker", exact=True).click()
+    wait_for_app_run(app)
+
+    expect_markdown(dialog, "Selected color: #1a2b3c")
     expect(dialog).to_be_visible()
 
 

--- a/frontend/lib/src/components/shared/BaseColorPicker/BaseColorPicker.test.tsx
+++ b/frontend/lib/src/components/shared/BaseColorPicker/BaseColorPicker.test.tsx
@@ -17,6 +17,7 @@
 import { screen } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 
+import { FLOATING_OVERLAY_PORTAL_ID } from "~lib/components/core/Portal/constants"
 import { render } from "~lib/test_util"
 import { LabelVisibilityOptions } from "~lib/util/utils"
 
@@ -98,6 +99,20 @@ describe("ColorPicker widget", () => {
     expect(
       screen.getByRole("button", { name: /label color picker/i })
     ).toHaveAttribute("aria-expanded", "true")
+  })
+
+  it("mounts the popover in the shared floating overlay portal", async () => {
+    const user = userEvent.setup()
+    render(<BaseColorPicker {...getProps()} />)
+
+    await user.click(
+      screen.getByRole("button", { name: /label color picker/i })
+    )
+
+    const portalHost = document.getElementById(FLOATING_OVERLAY_PORTAL_ID)
+    expect(portalHost).toContainElement(
+      screen.getByTestId("stColorPickerPopover")
+    )
   })
 
   it("closes popover and calls onChange when trigger is clicked again", async () => {

--- a/frontend/lib/src/components/shared/BaseColorPicker/BaseColorPicker.tsx
+++ b/frontend/lib/src/components/shared/BaseColorPicker/BaseColorPicker.tsx
@@ -20,6 +20,7 @@ import { FloatingFocusManager, FloatingPortal } from "@floating-ui/react"
 import { ChromePicker, ColorResult } from "react-color"
 import SaturationComponent from "react-color/es/components/common/Saturation"
 
+import { FLOATING_OVERLAY_PORTAL_ID } from "~lib/components/core/Portal/constants"
 import { Placement } from "~lib/components/shared/Tooltip/Tooltip"
 import { WidgetLabel } from "~lib/components/widgets/BaseWidget/WidgetLabel"
 import { WidgetLabelHelpIconInline } from "~lib/components/widgets/BaseWidget/WidgetLabelHelpIconInline"
@@ -139,8 +140,9 @@ const BaseColorPicker = (props: BaseColorPickerProps): React.ReactElement => {
 
   // Custom dismissal via document-level DOM listeners.
   //
-  // The popover is portalled to document.body, so we implement outside-click,
-  // Escape, and Tab-out dismissal ourselves.
+  // The popover is portalled into the shared overlay host (a document.body
+  // sibling of the dialog), so we handle outside-click, Escape, and Tab-out
+  // ourselves.
   //
   // We use `click` (not `pointerdown`) so that a focused input inside the
   // popover fires its blur/change handlers before we close, ensuring the
@@ -281,7 +283,7 @@ const BaseColorPicker = (props: BaseColorPickerProps): React.ReactElement => {
         )}
       </StyledColorPreview>
       {isOpen && (
-        <FloatingPortal>
+        <FloatingPortal id={FLOATING_OVERLAY_PORTAL_ID}>
           <FloatingFocusManager
             context={floatingContext}
             modal={false}

--- a/frontend/lib/src/components/shared/BaseColorPicker/BaseColorPicker.tsx
+++ b/frontend/lib/src/components/shared/BaseColorPicker/BaseColorPicker.tsx
@@ -141,8 +141,8 @@ const BaseColorPicker = (props: BaseColorPickerProps): React.ReactElement => {
   // Custom dismissal via document-level DOM listeners.
   //
   // The popover is portalled into the shared overlay host (a document.body
-  // sibling of the dialog), so we handle outside-click, Escape, and Tab-out
-  // ourselves.
+  // sibling of the dialog). We handle outside-click, Escape, and Tab-out
+  // ourselves rather than via Floating UI dismiss middleware.
   //
   // We use `click` (not `pointerdown`) so that a focused input inside the
   // popover fires its blur/change handlers before we close, ensuring the


### PR DESCRIPTION
## Describe your changes

Routes the `st.color_picker` palette through the shared floating overlay host so it stays interactive inside `st.dialog`.

Without that host, React Aria treated the portaled palette as outside the modal and often marked it inert. This is the same overlay-host pattern already used for date input, selectbox, and popover-in-dialog.

## GitHub Issue Link (if applicable)

- Closes #16538

## Testing Plan

- [x] Unit Tests (JS and/or Python)
- [x] E2E Tests

- `frontend/lib/src/components/shared/BaseColorPicker/BaseColorPicker.test.tsx` — Asserts the palette mounts in the shared overlay portal
- `e2e_playwright/st_dialog_test.py` — Opens a color picker inside a dialog, edits the palette, and confirms the dialog stays open

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

Made with [Cursor](https://cursor.com)