### PR TITLE
[fix] Restore metric sparkline after empty chart data

### DIFF
--- a/e2e_playwright/st_metric.py
+++ b/e2e_playwright/st_metric.py
@@ -203,3 +203,13 @@ st.metric(
     icon=":material/thermostat:",
     border=True,
 )
+
+# Empty → data sparkline remount (https://github.com/streamlit/streamlit/issues/16539)
+show_sparkline = st.toggle("Show sparkline data", value=True)
+st.metric(
+    "Sparkline toggle",
+    value=42 if show_sparkline else 0,
+    delta=5 if show_sparkline else 0,
+    chart_data=generate_sparkline_data() if show_sparkline else None,
+    chart_type="bar",
+)

--- a/e2e_playwright/st_metric_test.py
+++ b/e2e_playwright/st_metric_test.py
@@ -355,7 +355,7 @@ def test_metric_with_icon(themed_app: Page, assert_snapshot: ImageCompareFunctio
 
 
 def test_metric_chart_renders_after_empty_to_data_transition(app: Page):
-    """Chart SVG remounts after chart_data is cleared then restored.
+    """Empty→data chart_data left the sparkline missing without remount.
 
     Regression test for https://github.com/streamlit/streamlit/issues/16539
     """

--- a/e2e_playwright/st_metric_test.py
+++ b/e2e_playwright/st_metric_test.py
@@ -18,6 +18,7 @@ from playwright.sync_api import Page, expect
 from e2e_playwright.conftest import ImageCompareFunction
 from e2e_playwright.shared.app_utils import (
     check_top_level_class,
+    click_toggle,
     expect_help_tooltip,
     get_element_by_key,
     get_metric,
@@ -351,3 +352,24 @@ def test_metric_with_icon(themed_app: Page, assert_snapshot: ImageCompareFunctio
     metric = get_metric(themed_app, "Temperature")
     expect(metric.get_by_test_id("stMetricIcon")).to_be_visible()
     assert_snapshot(metric, name="st_metric-with_icon")
+
+
+def test_metric_chart_renders_after_empty_to_data_transition(app: Page):
+    """Chart SVG remounts after chart_data is cleared then restored.
+
+    Regression test for https://github.com/streamlit/streamlit/issues/16539
+    """
+    metric = get_metric(app, "Sparkline toggle")
+    chart_svg = metric.get_by_test_id("stMetricChart").locator("svg")
+    expect(chart_svg).to_be_visible()
+    expect(metric.get_by_test_id("stMetricValue")).to_have_text("42")
+
+    click_toggle(app, "Show sparkline data")
+    expect(metric.get_by_test_id("stMetricChart")).to_have_count(0)
+    expect(metric.get_by_test_id("stMetricValue")).to_have_text("0")
+
+    click_toggle(app, "Show sparkline data")
+    expect(metric.get_by_test_id("stMetricValue")).to_have_text("42")
+    expect(chart_svg).to_be_visible()
+    # One sparkline, not missing or duplicated.
+    expect(chart_svg).to_have_count(1)

--- a/frontend/lib/src/components/elements/Metric/Metric.test.tsx
+++ b/frontend/lib/src/components/elements/Metric/Metric.test.tsx
@@ -361,6 +361,14 @@ describe("Metric element", () => {
 
   // Chart feature tests
   describe("Chart feature", () => {
+    const mockFinalize = vi.fn()
+
+    beforeEach(() => {
+      vi.mocked(embed).mockResolvedValue({
+        finalize: mockFinalize,
+      } as unknown as Awaited<ReturnType<typeof embed>>)
+    })
+
     it("renders chart when chartData is provided", () => {
       const props = getProps({
         chartData: [1, 2, 3, 4, 5],
@@ -417,6 +425,90 @@ describe("Metric element", () => {
             }),
           })
         )
+      })
+    })
+
+    it("re-embeds and finalizes after chartData is cleared then restored", async () => {
+      const chartData = [1, 2, 3, 4, 5]
+      const withChart = getProps({
+        chartData,
+        chartType: MetricProto.ChartType.LINE,
+      })
+      const withoutChart = getProps({
+        chartData: [],
+        chartType: MetricProto.ChartType.LINE,
+      })
+      const { rerender } = render(<Metric {...withChart} />)
+
+      await waitFor(() => {
+        expect(vi.mocked(embed)).toHaveBeenCalledTimes(1)
+      })
+
+      rerender(<Metric {...withoutChart} />)
+      expect(screen.queryByTestId("stMetricChart")).not.toBeInTheDocument()
+      await waitFor(() => {
+        expect(mockFinalize).toHaveBeenCalledTimes(1)
+      })
+
+      rerender(<Metric {...withChart} />)
+
+      await waitFor(() => {
+        expect(vi.mocked(embed)).toHaveBeenCalledTimes(2)
+      })
+      expect(screen.getByTestId("stMetricChart")).toBeVisible()
+    })
+
+    it("passes chart data presence to useCalculatedDimensions", () => {
+      const withChart = getProps({
+        chartData: [1, 2, 3],
+        chartType: MetricProto.ChartType.LINE,
+      })
+      const withoutChart = getProps({
+        chartData: [],
+        chartType: MetricProto.ChartType.LINE,
+      })
+      const { rerender } = render(<Metric {...withChart} />)
+
+      expect(vi.mocked(useCalculatedDimensions)).toHaveBeenLastCalledWith([
+        true,
+      ])
+
+      rerender(<Metric {...withoutChart} />)
+      expect(vi.mocked(useCalculatedDimensions)).toHaveBeenLastCalledWith([
+        false,
+      ])
+
+      rerender(<Metric {...withChart} />)
+      expect(vi.mocked(useCalculatedDimensions)).toHaveBeenLastCalledWith([
+        true,
+      ])
+    })
+
+    it("finalizes vega-embed if it resolves after unmount", async () => {
+      const lateFinalize = vi.fn()
+      const { promise, resolve } = Promise.withResolvers<{
+        finalize: () => void
+      }>()
+      vi.mocked(embed).mockReturnValue(promise as ReturnType<typeof embed>)
+
+      const { unmount } = render(
+        <Metric
+          {...getProps({
+            chartData: [1, 2, 3],
+            chartType: MetricProto.ChartType.LINE,
+          })}
+        />
+      )
+
+      await waitFor(() => {
+        expect(vi.mocked(embed)).toHaveBeenCalled()
+      })
+      unmount()
+
+      resolve({ finalize: lateFinalize })
+
+      await waitFor(() => {
+        expect(lateFinalize).toHaveBeenCalledTimes(1)
       })
     })
 

--- a/frontend/lib/src/components/elements/Metric/Metric.tsx
+++ b/frontend/lib/src/components/elements/Metric/Metric.tsx
@@ -19,6 +19,7 @@ import { memo, ReactElement, useEffect, useId, useRef } from "react"
 import { Global } from "@emotion/react"
 import { EmotionIcon } from "@emotion-icons/emotion-icon"
 import { ArrowDownward, ArrowUpward } from "@emotion-icons/material-outlined"
+import { getLogger } from "loglevel"
 import embed from "vega-embed"
 import { expressionInterpreter } from "vega-interpreter"
 import { TopLevelSpec } from "vega-lite"
@@ -50,6 +51,8 @@ import {
   StyledMetricLabelText,
   StyledMetricValueText,
 } from "./styled-components"
+
+const LOG = getLogger("Metric")
 
 const LARGE_DATASET_POINT_THRESHOLD = 1000
 
@@ -301,8 +304,6 @@ export interface MetricProps {
 function Metric({ element }: Readonly<MetricProps>): ReactElement {
   const theme = useEmotionTheme()
   const chartRef = useRef<HTMLDivElement>(null)
-  const { width: chartWidth, elementRef: chartContainerRef } =
-    useCalculatedDimensions()
 
   const { MetricDirection } = MetricProto
   const {
@@ -320,6 +321,12 @@ function Metric({ element }: Readonly<MetricProps>): ReactElement {
     deltaDescription,
     icon,
   } = element
+
+  const hasChartData = Boolean(chartData?.length)
+  // Re-attach ResizeObserver when the chart container remounts. Otherwise an
+  // empty-to-data transition keeps width at the -1 fallback and vega-embed never runs.
+  const { width: chartWidth, elementRef: chartContainerRef } =
+    useCalculatedDimensions([hasChartData])
 
   // Apply number formatting if a format is specified and the value is numeric
   const formattedMetricValue =
@@ -352,36 +359,58 @@ function Metric({ element }: Readonly<MetricProps>): ReactElement {
 
   useEffect(() => {
     if (
-      chartData &&
-      chartData.length > 0 &&
-      chartRef.current &&
+      !chartData?.length ||
+      !chartRef.current ||
       // Having a chart width <= 0 causes issues with vega-embed:
-      chartWidth > 0
+      chartWidth <= 0
     ) {
-      const spec = getMetricChartSpec(
-        chartData,
-        chartType,
-        chartWidth,
-        theme,
-        color
-      )
-
-      void embed(chartRef.current, spec, {
-        actions: false,
-        renderer: "svg",
-        ast: true,
-        expr: expressionInterpreter,
-        tooltip: {
-          theme: "custom",
-          formatTooltip: (value: { y: number }) => {
-            // Only show the y value in the tooltip since
-            // the x value is just the numeric index of the point:
-            return `${value.y}`
-          },
-        },
-      })
+      return
     }
-  }, [chartData, color, theme, chartWidth, chartType, chartRef])
+
+    const spec = getMetricChartSpec(
+      chartData,
+      chartType,
+      chartWidth,
+      theme,
+      color
+    )
+
+    let isCancelled = false
+    let finalizeEmbed: (() => void) | undefined
+
+    void embed(chartRef.current, spec, {
+      actions: false,
+      renderer: "svg",
+      ast: true,
+      expr: expressionInterpreter,
+      tooltip: {
+        theme: "custom",
+        formatTooltip: (value: { y: number }) => {
+          // Only show the y value in the tooltip since
+          // the x value is just the numeric index of the point:
+          return `${value.y}`
+        },
+      },
+    })
+      .then(result => {
+        if (isCancelled) {
+          // Embed resolved after this effect was cancelled; drop the view.
+          result.finalize()
+        } else {
+          finalizeEmbed = result.finalize
+        }
+      })
+      .catch((error: unknown) => {
+        // Embed can reject if this effect cleaned up mid-flight. Log so a bad
+        // spec is still visible in development without surfacing it to users.
+        LOG.debug("Failed to embed metric chart:", error)
+      })
+
+    return () => {
+      isCancelled = true
+      finalizeEmbed?.()
+    }
+  }, [chartData, color, theme, chartWidth, chartType])
 
   return (
     <StyledMetricContainer
@@ -476,7 +505,7 @@ function Metric({ element }: Readonly<MetricProps>): ReactElement {
           </StyledDeltaContainer>
         )}
       </StyledMetricContent>
-      {chartData && chartData.length > 0 && (
+      {hasChartData && (
         <div ref={chartContainerRef}>
           <Global styles={StyledVegaLiteChartTooltips} />
           <StyledMetricChart

--- a/frontend/lib/src/components/elements/Metric/Metric.tsx
+++ b/frontend/lib/src/components/elements/Metric/Metric.tsx
@@ -401,8 +401,8 @@ function Metric({ element }: Readonly<MetricProps>): ReactElement {
         }
       })
       .catch((error: unknown) => {
-        // Embed can reject if this effect cleaned up mid-flight. Log so a bad
-        // spec is still visible in development without surfacing it to users.
+        // Ignore embed rejections so teardown races do not throw. LOG.debug
+        // records the error only when debug logging is enabled.
         LOG.debug("Failed to embed metric chart:", error)
       })
 

--- a/frontend/lib/src/hooks/useResizeObserver.test.tsx
+++ b/frontend/lib/src/hooks/useResizeObserver.test.tsx
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 
-import { MutableRefObject, ReactElement, useCallback } from "react"
+import {
+  DependencyList,
+  MutableRefObject,
+  ReactElement,
+  useCallback,
+} from "react"
 
 import { act, screen } from "@testing-library/react"
 
@@ -31,12 +36,20 @@ function TestComponent({
   properties,
   throttleMs,
   dimensionsRef,
+  dependencies = [],
+  mounted = true,
 }: {
   properties: DOMRectKeys[]
   throttleMs: number
   dimensionsRef: MutableRefObject<{ width: number; height: number }>
-}): ReactElement {
-  const { values, elementRef } = useResizeObserver(properties, [], throttleMs)
+  dependencies?: DependencyList
+  mounted?: boolean
+}): ReactElement | null {
+  const { values, elementRef } = useResizeObserver(
+    properties,
+    dependencies,
+    throttleMs
+  )
 
   // Use a ref callback to set up getBoundingClientRect before ResizeObserver is attached
   const setRef = useCallback(
@@ -59,6 +72,10 @@ function TestComponent({
     },
     [elementRef, dimensionsRef]
   )
+
+  if (!mounted) {
+    return null
+  }
 
   return (
     <div ref={setRef} data-testid="observed-element">
@@ -184,5 +201,47 @@ describe("useResizeObserver", () => {
       resizeCallback?.([{} as ResizeObserverEntry])
     })
     expect(screen.getByTestId("values")).toHaveTextContent("[250,350]")
+  })
+
+  it("reobserves when dependencies change after the element remounts", () => {
+    const properties: DOMRectKeys[] = ["width"]
+    const dimensionsRef = { current: { width: 100, height: 50 } }
+
+    const { rerender } = render(
+      <TestComponent
+        mounted
+        dependencies={[true]}
+        properties={properties}
+        throttleMs={0}
+        dimensionsRef={dimensionsRef}
+      />
+    )
+
+    expect(mockObserve).toHaveBeenCalledTimes(1)
+    expect(screen.getByTestId("observed-element")).toBeVisible()
+
+    rerender(
+      <TestComponent
+        mounted={false}
+        dependencies={[false]}
+        properties={properties}
+        throttleMs={0}
+        dimensionsRef={dimensionsRef}
+      />
+    )
+    expect(mockDisconnect).toHaveBeenCalled()
+    expect(screen.queryByTestId("observed-element")).not.toBeInTheDocument()
+
+    rerender(
+      <TestComponent
+        mounted
+        dependencies={[true]}
+        properties={properties}
+        throttleMs={0}
+        dimensionsRef={dimensionsRef}
+      />
+    )
+    expect(mockObserve).toHaveBeenCalledTimes(2)
+    expect(screen.getByTestId("observed-element")).toBeVisible()
   })
 })


### PR DESCRIPTION
## Describe your changes

Restores `st.metric` sparklines after `chart_data` goes empty and then populated again. Clearing the chart unmounted the container without re-attaching ResizeObserver, so width stayed at the fallback and vega-embed never ran.

- Re-attaches the chart size observer when sparkline data presence changes, matching Vega-Lite charts
- Finalizes the Vega embed on teardown so views do not leak across remounts

## GitHub Issue Link (if applicable)

- Closes #16539

## Testing Plan

- [x] Unit Tests (JS and/or Python)
- [x] E2E Tests

- `frontend/lib/src/components/elements/Metric/Metric.test.tsx` — re-embed and finalize after empty→data; observer deps follow chart presence
- `frontend/lib/src/hooks/useResizeObserver.test.tsx` — observer rebinds when deps change across remount
- `e2e_playwright/st_metric_test.py` — sparkline SVG disappears then remounts after toggling chart data


Made with [Cursor](https://cursor.com)