### PR TITLE
[chore] Update AI workflow model defaults

### DIFF
--- a/.github/workflows/ai-fix-flaky-e2e-tests.yml
+++ b/.github/workflows/ai-fix-flaky-e2e-tests.yml
@@ -20,7 +20,7 @@ on:
         description: "Model to use for flaky test fixing"
         required: false
         type: string
-        default: "cursor-grok-4.5-high"
+        default: "cursor-grok-4.6-xhigh"
       dry_run:
         description: "Run without creating PR"
         type: boolean
@@ -28,7 +28,7 @@ on:
         default: false
 
 env:
-  MODEL: ${{ inputs.model || 'cursor-grok-4.5-high' }}
+  MODEL: ${{ inputs.model || 'cursor-grok-4.6-xhigh' }}
   TOP_N: ${{ inputs.top_n || 10 }}
   DAYS: ${{ inputs.days || 4 }}
 

--- a/.github/workflows/ai-issue-triage.yml
+++ b/.github/workflows/ai-issue-triage.yml
@@ -14,12 +14,12 @@ on:
         description: "Model to use for the triage"
         required: false
         type: string
-        default: "cursor-grok-4.5-high"
+        default: "cursor-grok-4.6-xhigh"
 
 # Computed issue number and model for use in jobs
 env:
   ISSUE_NUMBER: ${{ github.event.inputs.issue_number || github.event.issue.number }}
-  MODEL: ${{ github.event.inputs.model || 'cursor-grok-4.5-high' }}
+  MODEL: ${{ github.event.inputs.model || 'cursor-grok-4.6-xhigh' }}
 
 jobs:
   # Job 1: AI performs the triage analysis with READ-ONLY access

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -20,8 +20,8 @@ on:
 env:
   PR_NUMBER: ${{ github.event.inputs.pr_number || github.event.pull_request.number }}
   MODEL_INPUT: ${{ github.event.inputs.model || '' }}
-  DEFAULT_AI_PR_REVIEW_MODELS: ${{ vars.AI_PR_REVIEW_MODELS || 'gpt-5.3-codex-high,claude-4.6-opus-high-thinking,cursor-grok-4.5-high' }}
-  FINAL_AI_PR_REVIEW_MODELS: "gpt-5.4-xhigh,cursor-grok-4.5-high,claude-opus-4-8-thinking-xhigh"
+  DEFAULT_AI_PR_REVIEW_MODELS: ${{ vars.AI_PR_REVIEW_MODELS || 'gpt-5.6-terra-xhigh,claude-opus-5-thinking-high,cursor-grok-4.6-xhigh' }}
+  FINAL_AI_PR_REVIEW_MODELS: "gpt-5.6-sol-xhigh,cursor-grok-4.6-xhigh,claude-opus-5-thinking-xhigh"
 
 jobs:
   # Job 1: Parse model list and check for API key

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -21,7 +21,7 @@ env:
   PR_NUMBER: ${{ github.event.inputs.pr_number || github.event.pull_request.number }}
   MODEL_INPUT: ${{ github.event.inputs.model || '' }}
   DEFAULT_AI_PR_REVIEW_MODELS: ${{ vars.AI_PR_REVIEW_MODELS || 'gpt-5.6-terra-xhigh,claude-opus-5-thinking-high,cursor-grok-4.6-xhigh' }}
-  FINAL_AI_PR_REVIEW_MODELS: "gpt-5.6-sol-xhigh,cursor-grok-4.6-xhigh,claude-opus-5-thinking-xhigh"
+  FINAL_AI_PR_REVIEW_MODELS: "gpt-5.6-sol-xhigh,claude-opus-5-thinking-xhigh,cursor-grok-4.6-xhigh"
 
 jobs:
   # Job 1: Parse model list and check for API key

--- a/.github/workflows/ai-qa-testing.yml
+++ b/.github/workflows/ai-qa-testing.yml
@@ -14,11 +14,11 @@ on:
         description: "Model to use for QA testing"
         required: false
         type: string
-        default: "cursor-grok-4.5-high"
+        default: "cursor-grok-4.6-xhigh"
 
 env:
   PR_NUMBER: ${{ github.event.inputs.pr_number || github.event.pull_request.number }}
-  MODEL: ${{ github.event.inputs.model || 'cursor-grok-4.5-high' }}
+  MODEL: ${{ github.event.inputs.model || 'cursor-grok-4.6-xhigh' }}
 
 jobs:
   check-secrets:

--- a/.github/workflows/ai-test-coverage.yml
+++ b/.github/workflows/ai-test-coverage.yml
@@ -11,7 +11,7 @@ on:
         description: "Model to use for coverage improvement"
         required: false
         type: string
-        default: "cursor-grok-4.5-high"
+        default: "cursor-grok-4.6-xhigh"
       dry_run:
         description: "Run without creating PR"
         type: boolean
@@ -19,7 +19,7 @@ on:
         default: false
 
 env:
-  MODEL: ${{ inputs.model || 'cursor-grok-4.5-high' }}
+  MODEL: ${{ inputs.model || 'cursor-grok-4.6-xhigh' }}
 
 jobs:
   check-secrets:

--- a/.github/workflows/ai-update-docs.yml
+++ b/.github/workflows/ai-update-docs.yml
@@ -15,7 +15,7 @@ on:
         description: "Model to use for documentation review"
         required: false
         type: string
-        default: "cursor-grok-4.5-high"
+        default: "cursor-grok-4.6-xhigh"
       dry_run:
         description: "Run without creating PR"
         type: boolean
@@ -23,7 +23,7 @@ on:
         default: false
 
 env:
-  MODEL: ${{ inputs.model || 'cursor-grok-4.5-high' }}
+  MODEL: ${{ inputs.model || 'cursor-grok-4.6-xhigh' }}
   PR_NUMBER: ${{ inputs.pr_number || '' }}
 
 jobs:


### PR DESCRIPTION
## Describe your changes

Updates the Cursor CLI model defaults in the six AI GitHub Actions workflows to the current GPT 5.6, Claude Opus 5, and Grok 4.6 generations. Also raises the default reasoning effort from `high` to `xhigh` for the Grok-based workflows (and for the GPT default-review entry), which increases per-run cost and runtime in exchange for better output on the automation tasks.

- Ordinary AI jobs default to `cursor-grok-4.6-xhigh`.
- PR review defaults to Terra xhigh / Opus 5 thinking-high / Grok 4.6 xhigh.
- Final review uses Sol xhigh / Opus 5 thinking-xhigh / Grok 4.6 xhigh, with Grok last so it is the consolidation judge (cheaper than a second Opus 5 pass).

Note that `ai-pr-review` reads the `AI_PR_REVIEW_MODELS` repository variable first, so that variable needs the same update for the new default to take effect on labeled PRs if it is set.

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

Workflow YAML model-id updates only; no product behavior change. Verified the new slugs against `cursor-agent models`, and the default review models are exercised by this PR's own `ai-review` run.

- [ ] Unit Tests (JS and/or Python)
- [ ] E2E Tests
- [ ] Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

Made with [Cursor](https://cursor.com)