### PR TITLE
[chore] Make httptools an optional dependency

### DIFF
--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -129,7 +129,7 @@ sql = ["SQLAlchemy>=2.0.0"]
 # Optional dependency for better performance:
 performance = [
   # httptools provides faster HTTP parsing for the Starlette server:
-  "httptools>=0.6.3,<1",
+  "httptools>=0.6.3",
   # orjson speeds up large plotly figure processing by 5-10x:
   "orjson>=3.5.0",
   # uvloop speeds up the event loop:

--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -128,7 +128,8 @@ charts = [
 sql = ["SQLAlchemy>=2.0.0"]
 # Optional dependency for better performance:
 performance = [
-  # httptools provides faster HTTP parsing for the Starlette server:
+  # httptools speeds up HTTP parsing in uvicorn. Without it, uvicorn falls back
+  # to its pure-Python h11 parser:
   "httptools>=0.6.3",
   # orjson speeds up large plotly figure processing by 5-10x:
   "orjson>=3.5.0",

--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -89,8 +89,6 @@ dependencies = [
   "starlette>=0.46.0,<2",
   # ASGI server:
   "uvicorn>=0.30.0,<1",
-  # Faster http parsing for Starlette server:
-  "httptools>=0.6.3,<1",
   # Required by starlette:
   "anyio>=4.0.0,<5",
   # Required for file-upload support:
@@ -130,6 +128,8 @@ charts = [
 sql = ["SQLAlchemy>=2.0.0"]
 # Optional dependency for better performance:
 performance = [
+  # httptools provides faster HTTP parsing for the Starlette server:
+  "httptools>=0.6.3,<1",
   # orjson speeds up large plotly figure processing by 5-10x:
   "orjson>=3.5.0",
   # uvloop speeds up the event loop:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,7 +138,7 @@ test = [
   #   - auth -> Authlib, httpx
   #   - charts -> matplotlib, graphviz, plotly, orjson
   #   - pdf -> streamlit-pdf
-  #   - performance -> orjson, uvloop
+  #   - performance -> httptools, orjson, uvloop
   "streamlit[auth,charts,pdf,performance]",
   # Test-only packages not provided by any extra:
   "seaborn",

--- a/scripts/assets/min-constraints-gen.txt
+++ b/scripts/assets/min-constraints-gen.txt
@@ -2,7 +2,6 @@ altair==5.0.0
 anyio==4.0.0
 blinker==1.5.0
 click==7.0
-httptools==0.6.3
 itsdangerous==2.1.2
 numpy==1.23
 packaging==20

--- a/uv.lock
+++ b/uv.lock
@@ -4490,7 +4490,6 @@ dependencies = [
     { name = "anyio" },
     { name = "blinker" },
     { name = "click" },
-    { name = "httptools" },
     { name = "itsdangerous" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.15'" },
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.15'" },
@@ -4527,6 +4526,7 @@ pdf = [
     { name = "streamlit-pdf" },
 ]
 performance = [
+    { name = "httptools" },
     { name = "orjson" },
     { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'" },
 ]
@@ -4543,7 +4543,7 @@ requires-dist = [
     { name = "blinker", specifier = ">=1.5.0,<2" },
     { name = "click", specifier = ">=7.0,<9" },
     { name = "graphviz", marker = "extra == 'charts'", specifier = ">=0.19.0" },
-    { name = "httptools", specifier = ">=0.6.3,<1" },
+    { name = "httptools", marker = "extra == 'performance'", specifier = ">=0.6.3,<1" },
     { name = "httpx", marker = "extra == 'auth'", specifier = ">=0.24.1" },
     { name = "itsdangerous", specifier = ">=2.1.2,<3" },
     { name = "matplotlib", marker = "extra == 'charts'", specifier = ">=3.0.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -4543,7 +4543,7 @@ requires-dist = [
     { name = "blinker", specifier = ">=1.5.0,<2" },
     { name = "click", specifier = ">=7.0,<9" },
     { name = "graphviz", marker = "extra == 'charts'", specifier = ">=0.19.0" },
-    { name = "httptools", marker = "extra == 'performance'", specifier = ">=0.6.3,<1" },
+    { name = "httptools", marker = "extra == 'performance'", specifier = ">=0.6.3" },
     { name = "httpx", marker = "extra == 'auth'", specifier = ">=0.24.1" },
     { name = "itsdangerous", specifier = ">=2.1.2,<3" },
     { name = "matplotlib", marker = "extra == 'charts'", specifier = ">=3.0.0" },


### PR DESCRIPTION
## Describe your changes

Moves `httptools`, the faster HTTP parser used by Uvicorn, from Streamlit's required dependencies to the `performance` extra so default installations no longer require it.

## GitHub Issue Link (if applicable)

## Testing Plan

- No additional tests are needed because this only changes package dependency metadata.
- [x] `make check`
- [x] `uv lock --check`
- [ ] Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
