### PR TITLE
[fix] Stop rewriting `:material/` inside code spans (#10365)

### DIFF
--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
@@ -374,6 +374,17 @@ describe("rewriteMaterialIconPrefix", () => {
       description: "rewrites around a code span without touching it",
     },
     {
+      input: "a ` tick\n\n:material/star:\n\nb ` tick",
+      expected: "a ` tick\n\n:material_star:\n\nb ` tick",
+      description:
+        "unpaired backticks in separate blocks are not a code span, so prose still rewrites",
+    },
+    {
+      input: "`multi\nline :material/a:`",
+      expected: "`multi\nline :material/a:`",
+      description: "a span may cross a line break, just not a blank line",
+    },
+    {
       input: "no icons here",
       expected: "no icons here",
       description: "source without the prefix is unchanged",

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
@@ -402,6 +402,12 @@ describe("rewriteMaterialIconPrefix", () => {
       description: "a three-backtick inline span on one line is left alone",
     },
     {
+      input: "```:material/star:`",
+      expected: "```:material_star:`",
+      description:
+        "a longer opener does not pair with a shorter closer, so it is not a span",
+    },
+    {
       input: "no icons here",
       expected: "no icons here",
       description: "source without the prefix is unchanged",

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
@@ -352,6 +352,18 @@ describe("rewriteMaterialIconPrefix", () => {
       description: "fence with an info string is left alone",
     },
     {
+      input: "```\n:material/a:\n`````",
+      expected: "```\n:material/a:\n`````",
+      description:
+        "backtick fence closed by a longer run is left alone, as CommonMark allows",
+    },
+    {
+      input: "~~~\n:material/a:\n~~~~",
+      expected: "~~~\n:material/a:\n~~~~",
+      description:
+        "tilde fence closed by a longer run is left alone, as CommonMark allows",
+    },
+    {
       input: "  ```\n  :material/a:\n  ```",
       expected: "  ```\n  :material/a:\n  ```",
       description: "indented fence is left alone",

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
@@ -319,15 +319,42 @@ describe("rewriteMaterialIconPrefix", () => {
       description: "double-backtick code span is left alone",
     },
     {
-      input: "```\n:material/search:\n```",
-      expected: "```\n:material/search:\n```",
-      description: "fenced code block is left alone",
+      input: "```\n:material/a:",
+      expected: "```\n:material_a:",
+      description:
+        "unclosed fence is not treated as code, so later prose still rewrites",
     },
     {
-      input: "```\n:material/a:",
-      expected: "```\n:material/a:",
+      input: "see ``` here :material/search:",
+      expected: "see ``` here :material_search:",
       description:
-        "unterminated fence runs to end of input, as markdown treats it",
+        "a mid-line ``` is prose, not a fence, so the prefix after it still rewrites",
+    },
+    {
+      input: "``:material/a: with ` inside``",
+      expected: "``:material/a: with ` inside``",
+      description:
+        "double-backtick span containing a single backtick is left alone",
+    },
+    {
+      input: "````:material/a:````",
+      expected: "````:material/a:````",
+      description: "four-backtick span is left alone",
+    },
+    {
+      input: "~~~\n:material/a:\n~~~",
+      expected: "~~~\n:material/a:\n~~~",
+      description: "tilde-fenced block is left alone",
+    },
+    {
+      input: "```python\n:material/a:\n```",
+      expected: "```python\n:material/a:\n```",
+      description: "fence with an info string is left alone",
+    },
+    {
+      input: "  ```\n  :material/a:\n  ```",
+      expected: "  ```\n  :material/a:\n  ```",
+      description: "indented fence is left alone",
     },
     {
       input: ":material/one: `:material/two:` :material/three:",

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
@@ -1068,7 +1068,11 @@ describe("StreamlitMarkdown", () => {
     expect(markdown).toHaveAttribute("translate", "no")
   })
 
-  describe("material icon prefix", () => {
+  // The generous timeout is for the lazily imported code-block chunk. The global
+  // `asyncUtilTimeout` is 5s and so is the default per-test timeout, so a cold
+  // dynamic import under CI contention exhausts the test before `waitFor` can
+  // report anything useful.
+  describe("material icon prefix", { timeout: 20_000 }, () => {
     // Whether a `:material/` prefix is an icon or literal text is the markdown
     // parser's decision, so these assert the rendered result rather than any
     // intermediate form. An icon renders as a <span> holding just the name; literal
@@ -1081,19 +1085,39 @@ describe("StreamlitMarkdown", () => {
     const ICON = 'span[role="img"]'
 
     /**
+     * Selector for content that only exists once the markdown has really rendered.
+     *
+     * `img` and `a` are included because an image-only or autolink-only source
+     * renders no text, so a text-based check would never settle for those.
+     */
+    const RENDERED_CONTENT =
+      "p, pre, h1, h2, h3, table, blockquote, ul, img, a"
+
+    /**
      * Renders `source` and resolves once any lazily loaded content has arrived.
      *
      * Code blocks sit behind Suspense, so they render a skeleton first and their
-     * text only appears on a later tick.
+     * real content only appears on a later tick.
+     *
+     * Both conditions are needed. Waiting only for the skeleton to disappear is not
+     * enough, because it is also absent in the frame before it mounts, so the wait
+     * would return before anything had rendered -- which is how the block-code cases
+     * silently asserted against empty output.
      */
     const renderSettled = async (source: string): Promise<HTMLElement> => {
       const { container } = render(
         <StreamlitMarkdown source={source} allowHTML={false} />
       )
-      await waitFor(() =>
-        expect(
-          container.querySelector('[data-testid="stSkeleton"]')
-        ).not.toBeInTheDocument()
+      await waitFor(
+        () => {
+          expect(
+            container.querySelector('[data-testid="stSkeleton"]')
+          ).not.toBeInTheDocument()
+          expect(container.querySelector(RENDERED_CONTENT)).toBeInTheDocument()
+        },
+        // Above the global `asyncUtilTimeout` of 5s, since this waits on a lazily
+        // imported chunk whose first load in a CI worker can exceed it.
+        { timeout: 15_000 }
       )
       return container
     }

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
@@ -1312,13 +1312,12 @@ describe("StreamlitMarkdown", () => {
       )
     })
 
-    it("blocks a dangerous URL that the encoded prefix would otherwise hide", () => {
-      // Ordering is load-bearing. Encoding rewrites the `:material/` inside the URL,
-      // so `javascript\uFFFCmaterial/alert(1)` no longer starts with `javascript:`
-      // and would slip past the protocol blocklist if restore ran after sanitizing.
-      // Restore is a remark plugin and `urlTransform` runs after the mdast phase, so
-      // the blocklist sees the restored URL -- assert that, because nothing else
-      // pins the order.
+    it("blocks a dangerous URL containing the prefix", () => {
+      // Keeping the colon means the encoded URL still begins `javascript:`, so the
+      // protocol blocklist matches it whether or not restore has run yet. Asserted
+      // anyway as defense in depth: restore runs first (it is a remark plugin, and
+      // `urlTransform` runs after the mdast phase), and nothing else pins that, so an
+      // encoding that did hide the scheme would still be caught here.
       render(
         <StreamlitMarkdown
           source="[x](javascript:material/alert(1))"
@@ -1326,6 +1325,41 @@ describe("StreamlitMarkdown", () => {
         />
       )
       expect(screen.getByText("x")).toHaveAttribute("href", "#")
+    })
+
+    describe("with allowHTML", () => {
+      // `rehype-raw` re-parses raw HTML after the mdast phase, so these pin that
+      // restore has already run by then -- the markdown-only cases above cannot.
+      it("restores the prefix inside raw HTML", async () => {
+        const { container } = render(
+          <StreamlitMarkdown
+            source="<div>`:material/search:`</div>"
+            allowHTML={true}
+          />
+        )
+        await waitFor(() => expect(container.textContent).toContain(PREFIX))
+        expect(container.innerHTML).not.toContain("\uFFFC")
+      })
+
+      it("still blocks a dangerous URL", () => {
+        render(
+          <StreamlitMarkdown
+            source="[x](javascript:material/alert(1))"
+            allowHTML={true}
+          />
+        )
+        expect(screen.getByText("x")).toHaveAttribute("href", "#")
+      })
+
+      it("leaves no sentinel when the prefix is an icon", async () => {
+        const { container } = render(
+          <StreamlitMarkdown source=":material/search: hi" allowHTML={true} />
+        )
+        await waitFor(() =>
+          expect(container.querySelector(ICON)).toHaveTextContent("search")
+        )
+        expect(container.innerHTML).not.toContain("\uFFFC")
+      })
     })
 
     it("keeps a custom-scheme autolink working", () => {

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
@@ -39,6 +39,7 @@ import StreamlitMarkdown, {
   HeadingWithActionElements,
   isValidCssColor,
   LinkWithTargetBlank,
+  rewriteMaterialIconPrefix,
 } from "./StreamlitMarkdown"
 
 // Mock StreamlitConfig using global mock state (see vitest.setup.ts)
@@ -293,6 +294,54 @@ describe("containsEmojiShortcodes", () => {
       expect(containsEmojiShortcodes(input)).toBe(expected)
     }
   )
+})
+
+describe("rewriteMaterialIconPrefix", () => {
+  it.each([
+    {
+      input: ":material/search: hello",
+      expected: ":material_search: hello",
+      description: "bare prefix in prose",
+    },
+    {
+      input: "a :material/one: b :material/two:",
+      expected: "a :material_one: b :material_two:",
+      description: "every occurrence in prose",
+    },
+    {
+      input: "`:material/search:`",
+      expected: "`:material/search:`",
+      description: "single-backtick code span is left alone",
+    },
+    {
+      input: "``:material/search:``",
+      expected: "``:material/search:``",
+      description: "double-backtick code span is left alone",
+    },
+    {
+      input: "```\n:material/search:\n```",
+      expected: "```\n:material/search:\n```",
+      description: "fenced code block is left alone",
+    },
+    {
+      input: "```\n:material/a:",
+      expected: "```\n:material/a:",
+      description:
+        "unterminated fence runs to end of input, as markdown treats it",
+    },
+    {
+      input: ":material/one: `:material/two:` :material/three:",
+      expected: ":material_one: `:material/two:` :material_three:",
+      description: "rewrites around a code span without touching it",
+    },
+    {
+      input: "no icons here",
+      expected: "no icons here",
+      description: "source without the prefix is unchanged",
+    },
+  ])("$description", ({ input, expected }) => {
+    expect(rewriteMaterialIconPrefix(input)).toBe(expected)
+  })
 })
 
 describe("isValidCssColor", () => {
@@ -1035,6 +1084,27 @@ describe("StreamlitMarkdown", () => {
     expect(markdown).toHaveStyle(`user-select: none`)
     expect(markdown).toHaveStyle(`vertical-align: bottom`)
     expect(markdown).toHaveAttribute("translate", "no")
+  })
+
+  it("preserves a material icon name inside inline code", () => {
+    // The icon plugin only visits text nodes, so a code span can never become an
+    // icon -- it must render the literal text the user typed, slash included.
+    // See: https://github.com/streamlit/streamlit/issues/10365
+    const source = "`:material/search:`"
+    render(<StreamlitMarkdown source={source} allowHTML={false} />)
+    const code = screen.getByText(":material/search:")
+    expect(code.nodeName.toLowerCase()).toBe("code")
+  })
+
+  it("renders an icon outside code while preserving one inside code", () => {
+    const source = ":material/search: and `:material/search:`"
+    render(<StreamlitMarkdown source={source} allowHTML={false} />)
+    // The prose occurrence became an icon span holding just the name...
+    expect(screen.getByText("search").nodeName.toLowerCase()).toBe("span")
+    // ...while the code occurrence kept its literal text.
+    expect(screen.getByText(":material/search:").nodeName.toLowerCase()).toBe(
+      "code"
+    )
   })
 
   it("does not remove unknown directive", () => {

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
@@ -16,7 +16,7 @@
 
 import { ReactElement } from "react"
 
-import { cleanup, screen, within } from "@testing-library/react"
+import { cleanup, screen, waitFor, within } from "@testing-library/react"
 import { transparentize } from "color2k"
 import type { Element } from "hast"
 import ReactMarkdown from "react-markdown"
@@ -36,10 +36,10 @@ import StreamlitMarkdown, {
   CustomCodeTagProps,
   CustomMediaTag,
   CustomPreTag,
+  encodeMaterialIconPrefix,
   HeadingWithActionElements,
   isValidCssColor,
   LinkWithTargetBlank,
-  rewriteMaterialIconPrefix,
 } from "./StreamlitMarkdown"
 
 // Mock StreamlitConfig using global mock state (see vitest.setup.ts)
@@ -296,124 +296,33 @@ describe("containsEmojiShortcodes", () => {
   )
 })
 
-describe("rewriteMaterialIconPrefix", () => {
-  it.each([
-    {
-      input: ":material/search: hello",
-      expected: ":material_search: hello",
-      description: "bare prefix in prose",
-    },
-    {
-      input: "a :material/one: b :material/two:",
-      expected: "a :material_one: b :material_two:",
-      description: "every occurrence in prose",
-    },
-    {
-      input: "`:material/search:`",
-      expected: "`:material/search:`",
-      description: "single-backtick code span is left alone",
-    },
-    {
-      input: "``:material/search:``",
-      expected: "``:material/search:``",
-      description: "double-backtick code span is left alone",
-    },
-    {
-      input: "```\n:material/a:",
-      expected: "```\n:material_a:",
-      description:
-        "unclosed fence is not treated as code, so later prose still rewrites",
-    },
-    {
-      input: "see ``` here :material/search:",
-      expected: "see ``` here :material_search:",
-      description:
-        "a mid-line ``` is prose, not a fence, so the prefix after it still rewrites",
-    },
-    {
-      input: "``:material/a: with ` inside``",
-      expected: "``:material/a: with ` inside``",
-      description:
-        "double-backtick span containing a single backtick is left alone",
-    },
-    {
-      input: "````:material/a:````",
-      expected: "````:material/a:````",
-      description: "four-backtick span is left alone",
-    },
-    {
-      input: "~~~\n:material/a:\n~~~",
-      expected: "~~~\n:material/a:\n~~~",
-      description: "tilde-fenced block is left alone",
-    },
-    {
-      input: "```python\n:material/a:\n```",
-      expected: "```python\n:material/a:\n```",
-      description: "fence with an info string is left alone",
-    },
-    {
-      input: "```\n:material/a:\n`````",
-      expected: "```\n:material/a:\n`````",
-      description:
-        "backtick fence closed by a longer run is left alone, as CommonMark allows",
-    },
-    {
-      input: "~~~\n:material/a:\n~~~~",
-      expected: "~~~\n:material/a:\n~~~~",
-      description:
-        "tilde fence closed by a longer run is left alone, as CommonMark allows",
-    },
-    {
-      input: "  ```\n  :material/a:\n  ```",
-      expected: "  ```\n  :material/a:\n  ```",
-      description: "indented fence is left alone",
-    },
-    {
-      input: ":material/one: `:material/two:` :material/three:",
-      expected: ":material_one: `:material/two:` :material_three:",
-      description: "rewrites around a code span without touching it",
-    },
-    {
-      input: "a ` tick\n\n:material/star:\n\nb ` tick",
-      expected: "a ` tick\n\n:material_star:\n\nb ` tick",
-      description:
-        "unpaired backticks in separate blocks are not a code span, so prose still rewrites",
-    },
-    {
-      input: "`multi\nline :material/a:`",
-      expected: "`multi\nline :material/a:`",
-      description: "a span may cross a line break, just not a blank line",
-    },
-    {
-      input: "`:material/star:``",
-      expected: "`:material_star:``",
-      description:
-        "a longer trailing run does not close a shorter opener, so it is not a span",
-    },
-    {
-      input: "``:material/star:```",
-      expected: "``:material_star:```",
-      description:
-        "a longer trailing run does not close a two-backtick opener either",
-    },
-    {
-      input: "```:material/a:```",
-      expected: "```:material/a:```",
-      description: "a three-backtick inline span on one line is left alone",
-    },
-    {
-      input: "```:material/star:`",
-      expected: "```:material_star:`",
-      description:
-        "a longer opener does not pair with a shorter closer, so it is not a span",
-    },
-    {
-      input: "no icons here",
-      expected: "no icons here",
-      description: "source without the prefix is unchanged",
-    },
-  ])("$description", ({ input, expected }) => {
-    expect(rewriteMaterialIconPrefix(input)).toBe(expected)
+describe("encodeMaterialIconPrefix", () => {
+  // The sentinel is deliberately not exported: tests assert the round trip through
+  // rendering (see "material icon prefix" below) rather than the wire format, so the
+  // encoding stays free to change. These cases only pin the properties the rest of
+  // the pipeline relies on.
+  it("encodes every occurrence, and nothing else", () => {
+    const encoded = encodeMaterialIconPrefix(
+      "a :material/one: b `:material/two:` c"
+    )
+    // The prefix is gone in its literal form...
+    expect(encoded).not.toContain(":material/")
+    // ...for both occurrences, code included -- this pass does not inspect syntax.
+    expect(encoded.match(/material\//g)).toHaveLength(2)
+    // Surrounding text is untouched.
+    expect(encoded).toContain("a ")
+    expect(encoded).toContain(" b `")
+    expect(encoded).toContain("` c")
+  })
+
+  it("leaves source without the prefix unchanged", () => {
+    const source = "no icons here, just :emoji: and :red[color]"
+    expect(encodeMaterialIconPrefix(source)).toBe(source)
+  })
+
+  it("does not encode a bare :material without a slash", () => {
+    const source = "the :material directive"
+    expect(encodeMaterialIconPrefix(source)).toBe(source)
   })
 })
 
@@ -1159,25 +1068,201 @@ describe("StreamlitMarkdown", () => {
     expect(markdown).toHaveAttribute("translate", "no")
   })
 
-  it("preserves a material icon name inside inline code", () => {
-    // The icon plugin only visits text nodes, so a code span can never become an
-    // icon -- it must render the literal text the user typed, slash included.
+  describe("material icon prefix", () => {
+    // Whether a `:material/` prefix is an icon or literal text is the markdown
+    // parser's decision, so these assert the rendered result rather than any
+    // intermediate form. An icon renders as a <span> holding just the name; literal
+    // text must keep the slash the user typed.
     // See: https://github.com/streamlit/streamlit/issues/10365
-    const source = "`:material/search:`"
-    render(<StreamlitMarkdown source={source} allowHTML={false} />)
-    const code = screen.getByText(":material/search:")
-    expect(code.nodeName.toLowerCase()).toBe("code")
-  })
 
-  it("renders an icon outside code while preserving one inside code", () => {
-    const source = ":material/search: and `:material/search:`"
-    render(<StreamlitMarkdown source={source} allowHTML={false} />)
-    // The prose occurrence became an icon span holding just the name...
-    expect(screen.getByText("search").nodeName.toLowerCase()).toBe("span")
-    // ...while the code occurrence kept its literal text.
-    expect(screen.getByText(":material/search:").nodeName.toLowerCase()).toBe(
-      "code"
+    const PREFIX = ":material/search:"
+
+    /** An icon renders as this element -- see createRemarkMaterialIcons. */
+    const ICON = 'span[role="img"]'
+
+    /**
+     * Renders `source` and resolves once any lazily loaded content has arrived.
+     *
+     * Code blocks sit behind Suspense, so they render a skeleton first and their
+     * text only appears on a later tick.
+     */
+    const renderSettled = async (source: string): Promise<HTMLElement> => {
+      const { container } = render(
+        <StreamlitMarkdown source={source} allowHTML={false} />
+      )
+      await waitFor(() =>
+        expect(
+          container.querySelector('[data-testid="stSkeleton"]')
+        ).not.toBeInTheDocument()
+      )
+      return container
+    }
+
+    it("renders an icon in prose", async () => {
+      const container = await renderSettled(":material/search: hello")
+      expect(container.querySelector(ICON)).toHaveTextContent("search")
+      expect(container.textContent).not.toContain(":material/")
+    })
+
+    it("renders every icon in prose", () => {
+      render(
+        <StreamlitMarkdown
+          source="a :material/star: b :material/home:"
+          allowHTML={false}
+        />
+      )
+      expect(screen.getByText("star")).toBeInTheDocument()
+      expect(screen.getByText("home")).toBeInTheDocument()
+    })
+
+    it("renders adjacent icons with no separator", () => {
+      // The encoded prefix has to survive sitting immediately after the previous
+      // icon's closing colon -- a sentinel that can appear in a directive name gets
+      // swallowed here, dropping the second icon.
+      render(
+        <StreamlitMarkdown
+          source=":material/star::material/home:"
+          allowHTML={false}
+        />
+      )
+      expect(screen.getByText("star")).toBeInTheDocument()
+      expect(screen.getByText("home")).toBeInTheDocument()
+    })
+
+    it.each([
+      {
+        description: "single-backtick code span",
+        source: "`:material/search:`",
+      },
+      {
+        description: "double-backtick code span",
+        source: "``:material/search:``",
+      },
+      {
+        description: "code span containing a backtick",
+        source: "``:material/search: with ` inside``",
+      },
+      {
+        description: "code span crossing a line break",
+        source: "`multi\nline :material/search:`",
+      },
+      { description: "fenced block", source: "```\n:material/search:\n```" },
+      {
+        description: "fenced block with an info string",
+        source: "```python\n:material/search:\n```",
+      },
+      {
+        description: "fence closed by a longer run, which CommonMark allows",
+        source: "```\n:material/search:\n`````",
+      },
+      {
+        description: "tilde-fenced block",
+        source: "~~~\n:material/search:\n~~~",
+      },
+      {
+        description: "tilde fence closed by a longer run",
+        source: "~~~\n:material/search:\n~~~~",
+      },
+      { description: "indented fence", source: "  ```\n  :material/search:" },
+      {
+        description: "four-space indented code block",
+        source: "    :material/search:",
+      },
+      {
+        description: "unterminated fence",
+        source: "```\n:material/search:",
+      },
+      {
+        description: "code span in a table cell",
+        source: "| a |\n|---|\n| `:material/search:` |",
+      },
+      {
+        description: "code span in a blockquote",
+        source: "> `:material/search:`",
+      },
+    ])(
+      "keeps the literal prefix inside a $description",
+      async ({ source }) => {
+        // Four-space indented blocks are included: the previous regex-based
+        // approach could not see them, so #10365 persisted there.
+        const container = await renderSettled(source)
+        // Reads textContent because syntax highlighting splits a code block
+        // across many elements.
+        expect(container.textContent).toContain(PREFIX)
+        expect(container.querySelector(ICON)).not.toBeInTheDocument()
+      }
     )
+
+    it("renders an icon outside code while preserving one inside code", () => {
+      render(
+        <StreamlitMarkdown
+          source=":material/search: and `:material/search:`"
+          allowHTML={false}
+        />
+      )
+      // The prose occurrence became an icon span holding just the name...
+      expect(screen.getByText("search").nodeName.toLowerCase()).toBe("span")
+      // ...while the code occurrence kept its literal text.
+      expect(
+        screen.getByText(":material/search:").nodeName.toLowerCase()
+      ).toBe("code")
+    })
+
+    it("renders an icon when a backtick in the info string disqualifies the fence", async () => {
+      // CommonMark forbids backticks in a backtick fence's info string, so this is
+      // prose and the icon must render. Deciding that needs block-vs-inline
+      // precedence, which is why preprocessing cannot judge code by itself.
+      const container = await renderSettled("```a`b\n:material/search:\n```")
+      expect(container.querySelector(ICON)).toHaveTextContent("search")
+      expect(container.textContent).not.toContain(":material/")
+    })
+
+    it("renders an icon after a mid-line run of backticks", async () => {
+      // A run of backticks that does not start a line cannot open a fence.
+      const container = await renderSettled("see ``` here :material/search:")
+      expect(container.querySelector(ICON)).toHaveTextContent("search")
+      expect(container.textContent).not.toContain(":material/")
+    })
+
+    it("renders an icon between unpaired backticks in separate blocks", async () => {
+      // Inline code cannot span a blank line, so neither backtick opens a span.
+      const container = await renderSettled(
+        "a ` tick\n\n:material/search:\n\nb ` tick"
+      )
+      expect(container.querySelector(ICON)).toHaveTextContent("search")
+      expect(container.textContent).not.toContain(":material/")
+    })
+
+    it("keeps a bare prefix with no icon name as literal text", () => {
+      // `:material` on its own is a directive remark would otherwise claim, taking
+      // the slash with it.
+      render(
+        <StreamlitMarkdown source="see :material/ alone" allowHTML={false} />
+      )
+      expect(screen.getByText("see :material/ alone")).toBeInTheDocument()
+    })
+
+    it("renders an icon nested in a color directive", async () => {
+      const container = await renderSettled(":red[:material/search:]")
+      expect(container.querySelector(ICON)).toHaveTextContent("search")
+      expect(container.textContent).not.toContain(":material/")
+    })
+
+    it("renders an icon in a heading", async () => {
+      const container = await renderSettled("# :material/search: Title")
+      expect(container.querySelector(ICON)).toHaveTextContent("search")
+      expect(container.textContent).not.toContain(":material/")
+    })
+
+    it("renders an icon in a link's text", async () => {
+      // `findAndReplace` visits text nodes inside links too, so this is an icon --
+      // matching the behaviour before this change.
+      const container = await renderSettled(
+        "[:material/search:](https://example.com)"
+      )
+      expect(container.querySelector(ICON)).toHaveTextContent("search")
+      expect(container.textContent).not.toContain(":material/")
+    })
   })
 
   it("does not remove unknown directive", () => {

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
@@ -1135,8 +1135,8 @@ describe("StreamlitMarkdown", () => {
           allowHTML={false}
         />
       )
-      expect(screen.getByText("star")).toBeInTheDocument()
-      expect(screen.getByText("home")).toBeInTheDocument()
+      expect(screen.getByText("star")).toBeVisible()
+      expect(screen.getByText("home")).toBeVisible()
     })
 
     it("renders adjacent icons with no separator", () => {
@@ -1149,8 +1149,8 @@ describe("StreamlitMarkdown", () => {
           allowHTML={false}
         />
       )
-      expect(screen.getByText("star")).toBeInTheDocument()
-      expect(screen.getByText("home")).toBeInTheDocument()
+      expect(screen.getByText("star")).toBeVisible()
+      expect(screen.getByText("home")).toBeVisible()
     })
 
     it.each([
@@ -1263,7 +1263,7 @@ describe("StreamlitMarkdown", () => {
       render(
         <StreamlitMarkdown source="see :material/ alone" allowHTML={false} />
       )
-      expect(screen.getByText("see :material/ alone")).toBeInTheDocument()
+      expect(screen.getByText("see :material/ alone")).toBeVisible()
     })
 
     it("renders an icon nested in a color directive", async () => {
@@ -1310,6 +1310,45 @@ describe("StreamlitMarkdown", () => {
         "src",
         "https://example.com/:material/search:.png"
       )
+    })
+
+    it("blocks a dangerous URL that the encoded prefix would otherwise hide", () => {
+      // Ordering is load-bearing. Encoding rewrites the `:material/` inside the URL,
+      // so `javascript\uFFFCmaterial/alert(1)` no longer starts with `javascript:`
+      // and would slip past the protocol blocklist if restore ran after sanitizing.
+      // Restore is a remark plugin and `urlTransform` runs after the mdast phase, so
+      // the blocklist sees the restored URL -- assert that, because nothing else
+      // pins the order.
+      render(
+        <StreamlitMarkdown
+          source="[x](javascript:material/alert(1))"
+          allowHTML={false}
+        />
+      )
+      expect(screen.getByText("x")).toHaveAttribute("href", "#")
+    })
+
+    it("keeps a custom-scheme autolink working", () => {
+      // The sentinel goes after the colon precisely so the colon keeps its role as a
+      // scheme separator; replacing it would demote this to plain text.
+      render(
+        <StreamlitMarkdown source="<foo:material/bar>" allowHTML={false} />
+      )
+      expect(screen.getByText("foo:material/bar")).toHaveAttribute(
+        "href",
+        "foo:material/bar"
+      )
+    })
+
+    it("honours a backslash-escaped colon without leaking the escape", () => {
+      // CommonMark only escapes ASCII punctuation, so the colon has to survive
+      // encoding for `\:` to be recognised -- otherwise the backslash renders.
+      // Braces, not a quoted attribute: JSX passes attribute text through verbatim,
+      // so `source="\\:"` would send two backslashes rather than an escape.
+      const { container } = render(
+        <StreamlitMarkdown source={"\\:material/search:"} allowHTML={false} />
+      )
+      expect(container.textContent).not.toContain("\\")
     })
 
     it.each([

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
@@ -385,6 +385,23 @@ describe("rewriteMaterialIconPrefix", () => {
       description: "a span may cross a line break, just not a blank line",
     },
     {
+      input: "`:material/star:``",
+      expected: "`:material_star:``",
+      description:
+        "a longer trailing run does not close a shorter opener, so it is not a span",
+    },
+    {
+      input: "``:material/star:```",
+      expected: "``:material_star:```",
+      description:
+        "a longer trailing run does not close a two-backtick opener either",
+    },
+    {
+      input: "```:material/a:```",
+      expected: "```:material/a:```",
+      description: "a three-backtick inline span on one line is left alone",
+    },
+    {
       input: "no icons here",
       expected: "no icons here",
       description: "source without the prefix is unchanged",

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.test.tsx
@@ -1263,6 +1263,72 @@ describe("StreamlitMarkdown", () => {
       expect(container.querySelector(ICON)).toHaveTextContent("search")
       expect(container.textContent).not.toContain(":material/")
     })
+
+    it("keeps a link's URL intact when it contains the prefix", async () => {
+      // The prefix is encoded everywhere, including inside a URL, where a leaked
+      // sentinel would silently break the link.
+      const container = await renderSettled(
+        "[text](https://example.com/:material/search:)"
+      )
+      expect(container.querySelector("a")).toHaveAttribute(
+        "href",
+        "https://example.com/:material/search:"
+      )
+    })
+
+    it("keeps an image's alt text and URL intact", async () => {
+      const container = await renderSettled(
+        "![alt :material/search:](https://example.com/:material/search:.png)"
+      )
+      const img = container.querySelector("img")
+      expect(img).toHaveAttribute("alt", "alt :material/search:")
+      expect(img).toHaveAttribute(
+        "src",
+        "https://example.com/:material/search:.png"
+      )
+    })
+
+    it.each([
+      { description: "prose", source: ":material/search: hi" },
+      { description: "code span", source: "`:material/search:`" },
+      { description: "fenced block", source: "```\n:material/search:\n```" },
+      {
+        description: "a link URL",
+        source: "[t](https://example.com/:material/search:)",
+      },
+      {
+        description: "a link title",
+        source: '[t](https://example.com "ti :material/search:")',
+      },
+      {
+        description: "an image alt and URL",
+        source: "![a :material/search:](https://e.com/:material/search:.png)",
+      },
+      {
+        description: "a fence info string",
+        source: "```:material/search:\ncode\n```",
+      },
+      {
+        description: "a fence info string with meta",
+        source: "```python :material/search:\ncode\n```",
+      },
+      { description: "an autolink", source: "<https://e.com/:material/x:>" },
+      { description: "a heading", source: "# :material/search: T" },
+      {
+        description: "a table cell",
+        source: "| `:material/search:` |\n|---|",
+      },
+    ])(
+      "leaves no sentinel in the output for $description",
+      async ({ source }) => {
+        // Encoding is unconditional, so every string field the parser fills from the
+        // source can carry a sentinel. This is the catch-all: whatever the field, it
+        // must never reach the DOM. U+FFFC is spelled out rather than imported so the
+        // assertion does not depend on the constant it is checking.
+        const container = await renderSettled(source)
+        expect(container.innerHTML).not.toContain("\uFFFC")
+      }
+    )
   })
 
   it("does not remove unknown directive", () => {

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -116,65 +116,84 @@ export function containsEmojiShortcodes(source: string): boolean {
 }
 
 /**
- * Matches a fenced code block or an inline code span (so they can be skipped), or
- * else a bare `:material/` prefix.
+ * Stands in for the leading `:` of a `:material/` prefix while markdown is parsed.
  *
- * The code alternatives come first so they are consumed whole and returned
- * unchanged; only the final branch substitutes.
+ * `:material/icon:` cannot survive parsing as written: `remark-directive` claims
+ * `:material` as a text directive and leaves `/icon:` behind as loose text, so the
+ * prefix has to be disguised before parsing and the icon plugin has to match the
+ * disguised form.
  *
- * - Fences must begin a line (up to three spaces of indent, per CommonMark) and be
- *   closed on a line of their own. Both conditions matter: without the line anchor,
- *   a mid-line ``` -- which CommonMark leaves as prose -- would open a fence, and
- *   without requiring the close it would swallow the rest of the input, so
- *   `:material/` in later prose would never be rewritten and the icon would silently
- *   stop rendering.
- * - Backtick and tilde fences get separate branches so the closing run can be longer
- *   than the opener, which CommonMark permits. One combined branch would need a
- *   single backreference, and that only matches an exactly equal run.
- * - Inline spans backreference the opening backtick run, so any run length works and
- *   a shorter run inside a longer one does not terminate the span. Both delimiters
- *   are required to be *maximal* runs -- neither adjoined by another backtick --
- *   because CommonMark closes a run of N only with a run of exactly N. Without that,
- *   a longer trailing run would be read as an equal-length closer, the enclosed
- *   prefix would be left unrewritten, and since markdown does not see a code span
- *   there either, the icon would render as literal text. The opener is captured
- *   inside a lookahead so its `+` cannot backtrack to a shorter run and pair with a
- *   shorter closer, which is the same failure from the other direction.
- * - Spans may cross a line break but not a *blank* line, because CommonMark keeps
- *   inline code inside one block -- otherwise two unpaired backticks in separate
- *   paragraphs would pair up and swallow the prose between them.
+ * The disguise has to be reversible, because whether a given occurrence is an icon
+ * or literal text is not knowable from the source alone -- it depends on where the
+ * markdown parser decides code begins and ends (see #10365). So every occurrence is
+ * encoded blindly, and whatever the parser did *not* hand to the icon plugin is
+ * restored verbatim.
  *
- * Deliberately not handled:
- * - Four-space indented code blocks: still rewritten, so #10365 persists there.
- * - Unterminated fences and inline spans: whether the prefix is rewritten depends on
- *   where the next delimiter run falls. This mostly matters while streaming, where
- *   `remend` closes the construct only after this runs, so a transient frame can show
- *   `:material_x:`. The settled source is correct.
+ * U+FFFC (OBJECT REPLACEMENT CHARACTER) is used because:
+ * - It replaces the `:`, so the source handed to remark never contains `:material`
+ *   and no directive can be claimed at all.
+ * - Unicode puts it in category So, which CommonMark treats as punctuation, so it
+ *   cannot appear in a directive *name* either. That rules out a neighbouring `:`
+ *   pulling it into a directive, which is what disqualifies the invisible
+ *   alternatives: private-use and format characters (U+E000, U+2063, U+FFF9) are all
+ *   name characters, so `:material/a::material/b:` parses its second prefix as a
+ *   directive named "\uFFFCmaterial" and the sentinel is eaten.
+ * - It is effectively never typed by hand, and it means "an object goes here", which
+ *   is what it is standing in for.
  */
-const CODE_OR_MATERIAL_PREFIX =
-  /^[ \t]{0,3}(`{3,})[\s\S]*?^[ \t]{0,3}\1`*[ \t]*$|^[ \t]{0,3}(~{3,})[\s\S]*?^[ \t]{0,3}\2~*[ \t]*$|(?<!`)(?=(`+))\3(?:[^\n]|\n(?![ \t]*\n))*?(?<!`)\3(?!`)|:material\//gm
+const MATERIAL_ICON_SENTINEL = "\uFFFC"
+
+/** The parse-time form of a `:material/` prefix. */
+const ENCODED_MATERIAL_PREFIX = `${MATERIAL_ICON_SENTINEL}material/`
 
 /**
- * Rewrites `:material/` to `:material_` outside of code, leaving code untouched.
+ * Disguises every `:material/` prefix so it survives markdown parsing intact.
  *
- * The icon directive plugin matches on `:material_` because a `/` conflicts with
- * directive syntax, so the prefix has to be rewritten before parsing. Code is a
- * special case: the plugin walks mdast `text` nodes, so it never reaches
- * `inlineCode` or `code` nodes to begin with. Rewriting inside them therefore buys
- * nothing and corrupts the literal text the user asked to display.
+ * Unconditional by design. Deciding here which occurrences are code -- and so should
+ * be left alone -- means reimplementing CommonMark's block and inline precedence in a
+ * regex, which does not work: a fence's info string may not contain a backtick, and a
+ * line-leading run of three or more backticks is claimed by block parsing before
+ * inline parsing runs. Both are decisions only the parser can make. Instead the
+ * parser makes them, and `createRemarkRestoreMaterialIconPrefix` undoes the disguise
+ * everywhere an icon was not produced.
  *
  * See: https://github.com/streamlit/streamlit/issues/10365
  *
- * @param source - The markdown source string to rewrite
- * @returns The source with `:material/` rewritten outside code only
+ * @param source - The markdown source string to encode
+ * @returns The source with every `:material/` prefix replaced by its encoded form
  */
-export function rewriteMaterialIconPrefix(source: string): string {
-  // Every code alternative starts with a backtick or tilde, so only the bare-prefix
-  // branch can produce this exact match. Comparing the match rather than inspecting
-  // capture groups keeps this correct if another group is ever added.
-  return source.replace(CODE_OR_MATERIAL_PREFIX, match =>
-    match === ":material/" ? ":material_" : match
-  )
+export function encodeMaterialIconPrefix(source: string): string {
+  return source.replaceAll(":material/", ENCODED_MATERIAL_PREFIX)
+}
+
+/**
+ * Factory function to create the plugin that undoes `encodeMaterialIconPrefix`.
+ *
+ * Must run after `createRemarkMaterialIcons`, which consumes the encoded prefixes
+ * that really are icons. Everything still encoded by this point is literal text the
+ * user asked to display -- inside a code span, a fenced or indented code block, raw
+ * HTML, or simply not a well-formed icon name -- and is restored verbatim.
+ *
+ * Restoring the whole prefix rather than a bare sentinel keeps a sentinel a user
+ * typed themselves untouched, so it can never be turned into a stray `:`.
+ */
+function createRemarkRestoreMaterialIconPrefix() {
+  return () => (tree: MdastRoot) => {
+    visit(tree, node => {
+      // Icon nodes keep the encoded prefix in `value`, but render from `data`, so
+      // skipping them avoids pointless work rather than changing any output.
+      if ("data" in node && node.data && "hName" in node.data) {
+        return
+      }
+      if ("value" in node && typeof node.value === "string") {
+        node.value = node.value.replaceAll(
+          ENCODED_MATERIAL_PREFIX,
+          ":material/"
+        )
+      }
+    })
+    return tree
+  }
 }
 
 /**
@@ -993,14 +1012,14 @@ function createRemarkMaterialIcons(theme: EmotionTheme) {
         },
       }
     }
-    // We replace all `:material/` occurrences with `:material_` to avoid
-    // conflicts with the directive plugin.
-    // Since all `:material/` already got replaced with `:material_`
-    // within the markdown text (see below), we need to use `:material_`
-    // within the regex.
+    // The prefix reaches this point in its encoded form -- see
+    // MATERIAL_ICON_SENTINEL for why it cannot be matched as `:material/`.
+    // `findAndReplace` visits `text` nodes only, so code and raw HTML are never
+    // offered here; whatever it leaves behind is restored by
+    // createRemarkRestoreMaterialIconPrefix.
     findAndReplace(tree, [
       [
-        /:material_(\w+):/g,
+        new RegExp(`${ENCODED_MATERIAL_PREFIX}(\\w+):`, "g"),
         replace as (fullMatch: string, iconName: string) => Text,
       ],
     ])
@@ -1288,8 +1307,14 @@ export const RenderedMarkdown = memo(function RenderedMarkdown({
       plugins.push(wrappedEmojiPlugin)
     }
 
-    // This plugin must run last to clean up any unsupported directives
+    // This plugin must run after any plugin that handles a directive, so it only
+    // sees the ones nothing claimed.
     plugins.push(createRemarkUnsupportedDirectivesCleanup())
+
+    // Must come after createRemarkMaterialIcons, so it only sees prefixes that did
+    // not become icons. It touches node values rather than directives, so its order
+    // relative to the cleanup above does not matter.
+    plugins.push(createRemarkRestoreMaterialIconPrefix())
 
     return plugins
   }, [theme, colorMapping, needsEmoji, wrappedEmojiPlugin])
@@ -1323,8 +1348,9 @@ export const RenderedMarkdown = memo(function RenderedMarkdown({
   )
 
   const processedSource = useMemo(() => {
-    // Rewrite :material/ to :material_ outside code so the directive plugin can match it.
-    let processed = rewriteMaterialIconPrefix(source)
+    // Disguise :material/ so it survives parsing; restored afterwards by
+    // createRemarkRestoreMaterialIconPrefix wherever it was not an icon.
+    let processed = encodeMaterialIconPrefix(source)
 
     if (isLabel) {
       // Escape markdown syntax that would be stripped in labels, leaving empty content.

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -180,16 +180,23 @@ export function encodeMaterialIconPrefix(source: string): string {
 function createRemarkRestoreMaterialIconPrefix() {
   return () => (tree: MdastRoot) => {
     visit(tree, node => {
-      // Icon nodes keep the encoded prefix in `value`, but render from `data`, so
-      // skipping them avoids pointless work rather than changing any output.
-      if ("data" in node && node.data && "hName" in node.data) {
-        return
-      }
-      if ("value" in node && typeof node.value === "string") {
-        node.value = node.value.replaceAll(
-          ENCODED_MATERIAL_PREFIX,
-          ":material/"
-        )
+      // Any string field can hold an encoded prefix, not just `value`: a link's
+      // `url` and `title`, an image's `alt`, a fence's `lang` and `meta`, and a
+      // footnote's `identifier` and `label` all come straight from the source. A
+      // sentinel left in a URL breaks the link, so sweep every string field rather
+      // than enumerating the ones that exist today.
+      //
+      // Restoring unconditionally is safe because the sentinel only ever appears
+      // where encoding put it, so turning it back is always what the user wrote.
+      const fields = node as unknown as Record<string, unknown>
+      for (const key of Object.keys(fields)) {
+        const value = fields[key]
+        if (
+          typeof value === "string" &&
+          value.includes(MATERIAL_ICON_SENTINEL)
+        ) {
+          fields[key] = value.replaceAll(ENCODED_MATERIAL_PREFIX, ":material/")
+        }
       }
     })
     return tree
@@ -986,7 +993,10 @@ function createRemarkMaterialIcons(theme: EmotionTheme) {
     ): MdastTextWithHastData {
       return {
         type: "text",
-        value: fullMatch,
+        // Rendering comes from `data` below, so this is only a fallback -- but it
+        // holds the encoded prefix, so decode it to keep the sentinel out of any
+        // path that might read it.
+        value: fullMatch.replace(ENCODED_MATERIAL_PREFIX, ":material/"),
         data: {
           hName: "span",
           hProperties: {

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -116,6 +116,32 @@ export function containsEmojiShortcodes(source: string): boolean {
 }
 
 /**
+ * Rewrites `:material/` to `:material_` outside of code, leaving code untouched.
+ *
+ * The icon directive plugin matches on `:material_` because a `/` conflicts with
+ * directive syntax, so the prefix has to be rewritten before parsing. Code is a
+ * special case: the plugin walks mdast `text` nodes, so it never reaches
+ * `inlineCode` or `code` nodes to begin with. Rewriting inside them therefore buys
+ * nothing and corrupts the literal text the user asked to display.
+ *
+ * See: https://github.com/streamlit/streamlit/issues/10365
+ *
+ * @param source - The markdown source string to rewrite
+ * @returns The source with `:material/` rewritten outside code spans only
+ */
+export function rewriteMaterialIconPrefix(source: string): string {
+  // The code alternatives come first so they are consumed whole and returned via the
+  // capture group unchanged; only the trailing bare-prefix branch substitutes. They
+  // are ordered longest-delimiter first so a fenced block is not read as two
+  // single-backtick spans, and an unterminated fence still runs to end of input --
+  // which is how markdown itself treats it.
+  return source.replace(
+    /(```[\s\S]*?(?:```|$)|``[^`]*``|`[^`]*`)|:material\//g,
+    (_match, code: string | undefined) => code ?? ":material_"
+  )
+}
+
+/**
  * Detects if the markdown source contains math syntax that requires KaTeX.
  * Checks for inline math ($...$) and display math ($$...$$) patterns.
  * For inline math, ensures no whitespace immediately after opening $ or before closing $
@@ -1263,7 +1289,8 @@ export const RenderedMarkdown = memo(function RenderedMarkdown({
   const processedSource = useMemo(() => {
     // Replace :material/ with :material_ to avoid conflicts with the directive plugin.
     // The material icon regex in createMaterialIconPlugin uses :material_ to match.
-    let processed = source.replaceAll(":material/", ":material_")
+    // Code spans are left alone -- see rewriteMaterialIconPrefix.
+    let processed = rewriteMaterialIconPrefix(source)
 
     if (isLabel) {
       // Escape markdown syntax that would be stripped in labels, leaving empty content.

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -137,7 +137,9 @@ export function containsEmojiShortcodes(source: string): boolean {
  *   because CommonMark closes a run of N only with a run of exactly N. Without that,
  *   a longer trailing run would be read as an equal-length closer, the enclosed
  *   prefix would be left unrewritten, and since markdown does not see a code span
- *   there either, the icon would render as literal text.
+ *   there either, the icon would render as literal text. The opener is captured
+ *   inside a lookahead so its `+` cannot backtrack to a shorter run and pair with a
+ *   shorter closer, which is the same failure from the other direction.
  * - Spans may cross a line break but not a *blank* line, because CommonMark keeps
  *   inline code inside one block -- otherwise two unpaired backticks in separate
  *   paragraphs would pair up and swallow the prose between them.
@@ -150,7 +152,7 @@ export function containsEmojiShortcodes(source: string): boolean {
  *   `:material_x:`. The settled source is correct.
  */
 const CODE_OR_MATERIAL_PREFIX =
-  /^[ \t]{0,3}(`{3,})[\s\S]*?^[ \t]{0,3}\1`*[ \t]*$|^[ \t]{0,3}(~{3,})[\s\S]*?^[ \t]{0,3}\2~*[ \t]*$|(?<!`)(`+)(?:[^\n]|\n(?![ \t]*\n))*?(?<!`)\3(?!`)|:material\//gm
+  /^[ \t]{0,3}(`{3,})[\s\S]*?^[ \t]{0,3}\1`*[ \t]*$|^[ \t]{0,3}(~{3,})[\s\S]*?^[ \t]{0,3}\2~*[ \t]*$|(?<!`)(?=(`+))\3(?:[^\n]|\n(?![ \t]*\n))*?(?<!`)\3(?!`)|:material\//gm
 
 /**
  * Rewrites `:material/` to `:material_` outside of code, leaving code untouched.

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -116,7 +116,7 @@ export function containsEmojiShortcodes(source: string): boolean {
 }
 
 /**
- * Stands in for the leading `:` of a `:material/` prefix while markdown is parsed.
+ * Inserted after the `:` of a `:material/` prefix while markdown is parsed.
  *
  * `:material/icon:` cannot survive parsing as written: `remark-directive` claims
  * `:material` as a text directive and leaves `/icon:` behind as loose text, so the
@@ -130,21 +130,36 @@ export function containsEmojiShortcodes(source: string): boolean {
  * restored verbatim.
  *
  * U+FFFC (OBJECT REPLACEMENT CHARACTER) is used because:
- * - It replaces the `:`, so the source handed to remark never contains `:material`
- *   and no directive can be claimed at all.
- * - Unicode puts it in category So, which CommonMark treats as punctuation, so it
- *   cannot appear in a directive *name* either. That rules out a neighbouring `:`
- *   pulling it into a directive, which is what disqualifies the invisible
- *   alternatives: private-use and format characters (U+E000, U+2063, U+FFF9) are all
- *   name characters, so `:material/a::material/b:` parses its second prefix as a
- *   directive named "\uFFFCmaterial" and the sentinel is eaten.
+ * - Unicode puts it in category So, which `micromark-util-character` classifies as
+ *   punctuation. A directive name can neither start with nor contain punctuation, so
+ *   sitting immediately after the `:` it stops the directive from being claimed.
+ * - That classification is the whole requirement, and it is what disqualifies the
+ *   invisible alternatives: private-use and format characters (U+E000, U+2063,
+ *   U+FFF9) are all name characters, so `:material/a::material/b:` would parse its
+ *   second prefix as a directive named "\uE000material" and eat the sentinel.
  * - It is effectively never typed by hand, and it means "an object goes here", which
  *   is what it is standing in for.
+ *
+ * It is inserted after the `:` rather than replacing it so that the colon keeps any
+ * syntactic role it already had. Replacing it turns `<foo:material/bar>` from a
+ * custom-scheme autolink into plain text, and leaves the backslash visible in
+ * `\:material/search:`, because CommonMark only escapes ASCII punctuation.
  */
 const MATERIAL_ICON_SENTINEL = "\uFFFC"
 
 /** The parse-time form of a `:material/` prefix. */
-const ENCODED_MATERIAL_PREFIX = `${MATERIAL_ICON_SENTINEL}material/`
+const ENCODED_MATERIAL_PREFIX = `:${MATERIAL_ICON_SENTINEL}material/`
+
+/**
+ * Matches an encoded prefix followed by an icon name.
+ *
+ * Lives next to `ENCODED_MATERIAL_PREFIX` because interpolating that constant into a
+ * pattern only stays correct while the sentinel is not a regex metacharacter.
+ */
+const ENCODED_MATERIAL_ICON_PATTERN = new RegExp(
+  `${ENCODED_MATERIAL_PREFIX}(\\w+):`,
+  "g"
+)
 
 /**
  * Disguises every `:material/` prefix so it survives markdown parsing intact.
@@ -186,8 +201,11 @@ function createRemarkRestoreMaterialIconPrefix() {
       // sentinel left in a URL breaks the link, so sweep every string field rather
       // than enumerating the ones that exist today.
       //
-      // Restoring unconditionally is safe because the sentinel only ever appears
-      // where encoding put it, so turning it back is always what the user wrote.
+      // Restoring unconditionally is safe in practice: a source that already
+      // contains the encoded prefix is vanishingly unlikely, since nobody types
+      // OBJECT REPLACEMENT CHARACTER. Matching the whole prefix rather than a bare
+      // sentinel also means a stray one a user did type is left alone instead of
+      // being turned into a colon.
       const fields = node as unknown as Record<string, unknown>
       for (const key of Object.keys(fields)) {
         const value = fields[key]
@@ -1029,7 +1047,7 @@ function createRemarkMaterialIcons(theme: EmotionTheme) {
     // createRemarkRestoreMaterialIconPrefix.
     findAndReplace(tree, [
       [
-        new RegExp(`${ENCODED_MATERIAL_PREFIX}(\\w+):`, "g"),
+        ENCODED_MATERIAL_ICON_PATTERN,
         replace as (fullMatch: string, iconName: string) => Text,
       ],
     ])
@@ -1254,6 +1272,13 @@ export const RenderedMarkdown = memo(function RenderedMarkdown({
 
   const needsKatex = useMemo(() => containsMathSyntax(source), [source])
   const needsEmoji = useMemo(() => containsEmojiShortcodes(source), [source])
+  // Gating on the raw source is sound because nothing downstream introduces a
+  // prefix: neither the label escaping below nor `remend` can add one, and
+  // `encodeMaterialIconPrefix` only rewrites prefixes already present.
+  const needsMaterialIcon = useMemo(
+    () => source.includes(":material/"),
+    [source]
+  )
 
   // Lazy load plugins only when needed
   const katexPlugin = useLazyPlugin<KatexPlugin>({
@@ -1310,8 +1335,13 @@ export const RenderedMarkdown = memo(function RenderedMarkdown({
     const plugins: PluggableList = [
       ...BASE_REMARK_PLUGINS,
       createRemarkColoringAndSmall(theme, colorMapping),
-      createRemarkMaterialIcons(theme),
     ]
+
+    // Both icon plugins walk the whole tree, and every widget label goes through
+    // here, so skip them entirely when there is no prefix to act on.
+    if (needsMaterialIcon) {
+      plugins.push(createRemarkMaterialIcons(theme))
+    }
 
     if (needsEmoji && wrappedEmojiPlugin) {
       plugins.push(wrappedEmojiPlugin)
@@ -1324,10 +1354,12 @@ export const RenderedMarkdown = memo(function RenderedMarkdown({
     // Must come after createRemarkMaterialIcons, so it only sees prefixes that did
     // not become icons. It touches node values rather than directives, so its order
     // relative to the cleanup above does not matter.
-    plugins.push(createRemarkRestoreMaterialIconPrefix())
+    if (needsMaterialIcon) {
+      plugins.push(createRemarkRestoreMaterialIconPrefix())
+    }
 
     return plugins
-  }, [theme, colorMapping, needsEmoji, wrappedEmojiPlugin])
+  }, [theme, colorMapping, needsEmoji, wrappedEmojiPlugin, needsMaterialIcon])
 
   const rehypePlugins = useMemo<PluggableList>(() => {
     const plugins: PluggableList = []

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -132,16 +132,20 @@ export function containsEmojiShortcodes(source: string): boolean {
  *   than the opener, which CommonMark permits. One combined branch would need a
  *   single backreference, and that only matches an exactly equal run.
  * - Inline spans backreference the opening backtick run, so any run length works and
- *   a shorter run inside a longer one does not terminate the span.
+ *   a shorter run inside a longer one does not terminate the span. They may span
+ *   lines but not a *blank* line, because CommonMark keeps inline code inside one
+ *   block -- otherwise two unpaired backticks in separate paragraphs would pair up
+ *   and swallow the prose between them.
  *
- * Not covered: four-space indented code blocks, and fences that are never closed.
- * Those keep the old behaviour of being rewritten, so they stay mildly wrong rather
- * than becoming newly broken. Nor is an *unterminated* inline span, which matters
- * only while streaming: `remend` closes it after this runs, so a transient frame can
- * show `:material_x:`. The settled source is correct.
+ * Deliberately not handled:
+ * - Four-space indented code blocks: still rewritten, so #10365 persists there.
+ * - Unterminated fences and inline spans: whether the prefix is rewritten depends on
+ *   where the next delimiter run falls. This mostly matters while streaming, where
+ *   `remend` closes the construct only after this runs, so a transient frame can show
+ *   `:material_x:`. The settled source is correct.
  */
 const CODE_OR_MATERIAL_PREFIX =
-  /^[ \t]{0,3}(`{3,})[\s\S]*?^[ \t]{0,3}\1`*[ \t]*$|^[ \t]{0,3}(~{3,})[\s\S]*?^[ \t]{0,3}\2~*[ \t]*$|(`+)[\s\S]*?\3|:material\//gm
+  /^[ \t]{0,3}(`{3,})[\s\S]*?^[ \t]{0,3}\1`*[ \t]*$|^[ \t]{0,3}(~{3,})[\s\S]*?^[ \t]{0,3}\2~*[ \t]*$|(`+)(?:[^\n]|\n(?![ \t]*\n))*?\3|:material\//gm
 
 /**
  * Rewrites `:material/` to `:material_` outside of code, leaving code untouched.
@@ -158,19 +162,11 @@ const CODE_OR_MATERIAL_PREFIX =
  * @returns The source with `:material/` rewritten outside code only
  */
 export function rewriteMaterialIconPrefix(source: string): string {
-  return source.replace(
-    CODE_OR_MATERIAL_PREFIX,
-    (
-      match,
-      backtickFence: string | undefined,
-      tildeFence: string | undefined,
-      span: string | undefined
-    ) =>
-      backtickFence !== undefined ||
-      tildeFence !== undefined ||
-      span !== undefined
-        ? match
-        : ":material_"
+  // Every code alternative starts with a backtick or tilde, so only the bare-prefix
+  // branch can produce this exact match. Comparing the match rather than inspecting
+  // capture groups keeps this correct if another group is ever added.
+  return source.replace(CODE_OR_MATERIAL_PREFIX, match =>
+    match === ":material/" ? ":material_" : match
   )
 }
 

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -132,10 +132,15 @@ export function containsEmojiShortcodes(source: string): boolean {
  *   than the opener, which CommonMark permits. One combined branch would need a
  *   single backreference, and that only matches an exactly equal run.
  * - Inline spans backreference the opening backtick run, so any run length works and
- *   a shorter run inside a longer one does not terminate the span. They may span
- *   lines but not a *blank* line, because CommonMark keeps inline code inside one
- *   block -- otherwise two unpaired backticks in separate paragraphs would pair up
- *   and swallow the prose between them.
+ *   a shorter run inside a longer one does not terminate the span. Both delimiters
+ *   are required to be *maximal* runs -- neither adjoined by another backtick --
+ *   because CommonMark closes a run of N only with a run of exactly N. Without that,
+ *   a longer trailing run would be read as an equal-length closer, the enclosed
+ *   prefix would be left unrewritten, and since markdown does not see a code span
+ *   there either, the icon would render as literal text.
+ * - Spans may cross a line break but not a *blank* line, because CommonMark keeps
+ *   inline code inside one block -- otherwise two unpaired backticks in separate
+ *   paragraphs would pair up and swallow the prose between them.
  *
  * Deliberately not handled:
  * - Four-space indented code blocks: still rewritten, so #10365 persists there.
@@ -145,7 +150,7 @@ export function containsEmojiShortcodes(source: string): boolean {
  *   `:material_x:`. The settled source is correct.
  */
 const CODE_OR_MATERIAL_PREFIX =
-  /^[ \t]{0,3}(`{3,})[\s\S]*?^[ \t]{0,3}\1`*[ \t]*$|^[ \t]{0,3}(~{3,})[\s\S]*?^[ \t]{0,3}\2~*[ \t]*$|(`+)(?:[^\n]|\n(?![ \t]*\n))*?\3|:material\//gm
+  /^[ \t]{0,3}(`{3,})[\s\S]*?^[ \t]{0,3}\1`*[ \t]*$|^[ \t]{0,3}(~{3,})[\s\S]*?^[ \t]{0,3}\2~*[ \t]*$|(?<!`)(`+)(?:[^\n]|\n(?![ \t]*\n))*?(?<!`)\3(?!`)|:material\//gm
 
 /**
  * Rewrites `:material/` to `:material_` outside of code, leaving code untouched.

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -192,30 +192,48 @@ export function encodeMaterialIconPrefix(source: string): string {
  * Restoring the whole prefix rather than a bare sentinel keeps a sentinel a user
  * typed themselves untouched, so it can never be turned into a stray `:`.
  */
-function createRemarkRestoreMaterialIconPrefix() {
+function createRemarkRestoreMaterialIconPrefix(): () => (
+  tree: MdastRoot
+) => MdastRoot {
+  /**
+   * Restores every encoded prefix reachable from `holder` without descending into
+   * child nodes.
+   *
+   * `children` is skipped because `visit` reaches those separately, and `position`
+   * because it holds only numbers. Everything else is walked, which is what picks up
+   * a directive's `attributes` -- a plain string map filled straight from the source,
+   * so `:color[x]{foreground=":material/red"}` hides a prefix one level down.
+   */
+  const restoreStrings = (holder: Record<string, unknown>): void => {
+    for (const key of Object.keys(holder)) {
+      if (key === "children" || key === "position") {
+        continue
+      }
+      const value = holder[key]
+      if (typeof value === "string") {
+        if (value.includes(MATERIAL_ICON_SENTINEL)) {
+          holder[key] = value.replaceAll(ENCODED_MATERIAL_PREFIX, ":material/")
+        }
+      } else if (value !== null && typeof value === "object") {
+        restoreStrings(value as Record<string, unknown>)
+      }
+    }
+  }
+
   return () => (tree: MdastRoot) => {
     visit(tree, node => {
       // Any string field can hold an encoded prefix, not just `value`: a link's
-      // `url` and `title`, an image's `alt`, a fence's `lang` and `meta`, and a
-      // footnote's `identifier` and `label` all come straight from the source. A
-      // sentinel left in a URL breaks the link, so sweep every string field rather
-      // than enumerating the ones that exist today.
+      // `url` and `title`, an image's `alt`, a fence's `lang` and `meta`, a
+      // footnote's `identifier` and `label`, and a directive's `attributes` all come
+      // straight from the source. A sentinel left in a URL breaks the link, so sweep
+      // every string field rather than enumerating the ones that exist today.
       //
       // Restoring unconditionally is safe in practice: a source that already
       // contains the encoded prefix is vanishingly unlikely, since nobody types
       // OBJECT REPLACEMENT CHARACTER. Matching the whole prefix rather than a bare
       // sentinel also means a stray one a user did type is left alone instead of
       // being turned into a colon.
-      const fields = node as unknown as Record<string, unknown>
-      for (const key of Object.keys(fields)) {
-        const value = fields[key]
-        if (
-          typeof value === "string" &&
-          value.includes(MATERIAL_ICON_SENTINEL)
-        ) {
-          fields[key] = value.replaceAll(ENCODED_MATERIAL_PREFIX, ":material/")
-        }
-      }
+      restoreStrings(node as unknown as Record<string, unknown>)
     })
     return tree
   }
@@ -1042,9 +1060,16 @@ function createRemarkMaterialIcons(theme: EmotionTheme) {
     }
     // The prefix reaches this point in its encoded form -- see
     // MATERIAL_ICON_SENTINEL for why it cannot be matched as `:material/`.
-    // `findAndReplace` visits `text` nodes only, so code and raw HTML are never
-    // offered here; whatever it leaves behind is restored by
-    // createRemarkRestoreMaterialIconPrefix.
+    // `findAndReplace` visits `text` nodes only, so markdown code -- spans, fences
+    // and indented blocks -- is never offered here; whatever it leaves behind is
+    // restored by createRemarkRestoreMaterialIconPrefix.
+    //
+    // Raw HTML is only partly excluded. A block like `<div>...</div>` is one `html`
+    // node and is skipped, but phrasing HTML is tokenized as `html` + `text` + `html`,
+    // so `<code>:material/x:</code>` under `allowHTML` still yields an icon inside
+    // the code element. That asymmetry with markdown code predates this change --
+    // the previous `:material_` rewrite produced an icon there too -- and matching
+    // markdown would mean tracking the raw-HTML tag stack, so it is left alone.
     findAndReplace(tree, [
       [
         ENCODED_MATERIAL_ICON_PATTERN,

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -123,20 +123,25 @@ export function containsEmojiShortcodes(source: string): boolean {
  * unchanged; only the final branch substitutes.
  *
  * - Fences must begin a line (up to three spaces of indent, per CommonMark) and be
- *   closed by a matching run on its own line. Both conditions matter: without the
- *   line anchor, a mid-line ``` -- which CommonMark leaves as prose -- would open a
- *   fence, and without requiring the close it would swallow the rest of the input,
- *   so `:material/` in later prose would never be rewritten and the icon would
- *   silently stop rendering.
+ *   closed on a line of their own. Both conditions matter: without the line anchor,
+ *   a mid-line ``` -- which CommonMark leaves as prose -- would open a fence, and
+ *   without requiring the close it would swallow the rest of the input, so
+ *   `:material/` in later prose would never be rewritten and the icon would silently
+ *   stop rendering.
+ * - Backtick and tilde fences get separate branches so the closing run can be longer
+ *   than the opener, which CommonMark permits. One combined branch would need a
+ *   single backreference, and that only matches an exactly equal run.
  * - Inline spans backreference the opening backtick run, so any run length works and
  *   a shorter run inside a longer one does not terminate the span.
  *
  * Not covered: four-space indented code blocks, and fences that are never closed.
  * Those keep the old behaviour of being rewritten, so they stay mildly wrong rather
- * than becoming newly broken.
+ * than becoming newly broken. Nor is an *unterminated* inline span, which matters
+ * only while streaming: `remend` closes it after this runs, so a transient frame can
+ * show `:material_x:`. The settled source is correct.
  */
 const CODE_OR_MATERIAL_PREFIX =
-  /^[ \t]{0,3}(`{3,}|~{3,})[\s\S]*?^[ \t]{0,3}\1[ \t]*$|(`+)[\s\S]*?\2|:material\//gm
+  /^[ \t]{0,3}(`{3,})[\s\S]*?^[ \t]{0,3}\1`*[ \t]*$|^[ \t]{0,3}(~{3,})[\s\S]*?^[ \t]{0,3}\2~*[ \t]*$|(`+)[\s\S]*?\3|:material\//gm
 
 /**
  * Rewrites `:material/` to `:material_` outside of code, leaving code untouched.
@@ -155,8 +160,17 @@ const CODE_OR_MATERIAL_PREFIX =
 export function rewriteMaterialIconPrefix(source: string): string {
   return source.replace(
     CODE_OR_MATERIAL_PREFIX,
-    (match, fence: string | undefined, span: string | undefined) =>
-      fence !== undefined || span !== undefined ? match : ":material_"
+    (
+      match,
+      backtickFence: string | undefined,
+      tildeFence: string | undefined,
+      span: string | undefined
+    ) =>
+      backtickFence !== undefined ||
+      tildeFence !== undefined ||
+      span !== undefined
+        ? match
+        : ":material_"
   )
 }
 
@@ -1306,9 +1320,7 @@ export const RenderedMarkdown = memo(function RenderedMarkdown({
   )
 
   const processedSource = useMemo(() => {
-    // Replace :material/ with :material_ to avoid conflicts with the directive plugin.
-    // The material icon regex in createMaterialIconPlugin uses :material_ to match.
-    // Code spans are left alone -- see rewriteMaterialIconPrefix.
+    // Rewrite :material/ to :material_ outside code so the directive plugin can match it.
     let processed = rewriteMaterialIconPrefix(source)
 
     if (isLabel) {

--- a/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
+++ b/frontend/lib/src/components/shared/StreamlitMarkdown/StreamlitMarkdown.tsx
@@ -116,6 +116,29 @@ export function containsEmojiShortcodes(source: string): boolean {
 }
 
 /**
+ * Matches a fenced code block or an inline code span (so they can be skipped), or
+ * else a bare `:material/` prefix.
+ *
+ * The code alternatives come first so they are consumed whole and returned
+ * unchanged; only the final branch substitutes.
+ *
+ * - Fences must begin a line (up to three spaces of indent, per CommonMark) and be
+ *   closed by a matching run on its own line. Both conditions matter: without the
+ *   line anchor, a mid-line ``` -- which CommonMark leaves as prose -- would open a
+ *   fence, and without requiring the close it would swallow the rest of the input,
+ *   so `:material/` in later prose would never be rewritten and the icon would
+ *   silently stop rendering.
+ * - Inline spans backreference the opening backtick run, so any run length works and
+ *   a shorter run inside a longer one does not terminate the span.
+ *
+ * Not covered: four-space indented code blocks, and fences that are never closed.
+ * Those keep the old behaviour of being rewritten, so they stay mildly wrong rather
+ * than becoming newly broken.
+ */
+const CODE_OR_MATERIAL_PREFIX =
+  /^[ \t]{0,3}(`{3,}|~{3,})[\s\S]*?^[ \t]{0,3}\1[ \t]*$|(`+)[\s\S]*?\2|:material\//gm
+
+/**
  * Rewrites `:material/` to `:material_` outside of code, leaving code untouched.
  *
  * The icon directive plugin matches on `:material_` because a `/` conflicts with
@@ -127,17 +150,13 @@ export function containsEmojiShortcodes(source: string): boolean {
  * See: https://github.com/streamlit/streamlit/issues/10365
  *
  * @param source - The markdown source string to rewrite
- * @returns The source with `:material/` rewritten outside code spans only
+ * @returns The source with `:material/` rewritten outside code only
  */
 export function rewriteMaterialIconPrefix(source: string): string {
-  // The code alternatives come first so they are consumed whole and returned via the
-  // capture group unchanged; only the trailing bare-prefix branch substitutes. They
-  // are ordered longest-delimiter first so a fenced block is not read as two
-  // single-backtick spans, and an unterminated fence still runs to end of input --
-  // which is how markdown itself treats it.
   return source.replace(
-    /(```[\s\S]*?(?:```|$)|``[^`]*``|`[^`]*`)|:material\//g,
-    (_match, code: string | undefined) => code ?? ":material_"
+    CODE_OR_MATERIAL_PREFIX,
+    (match, fence: string | undefined, span: string | undefined) =>
+      fence !== undefined || span !== undefined ? match : ":material_"
   )
 }
 


### PR DESCRIPTION
## Describing the bug fix

`st.markdown` mangles a material icon name written inside inline code or a fenced code block. Writing `` `:material/celebration:` `` renders as `:material_celebration:` — with an underscore — instead of the literal text.

The cause is in `StreamlitMarkdown.tsx`. The `:material/` prefix has to be rewritten before parsing, because `remark-directive` otherwise claims `:material` as a text directive and leaves `/celebration:` behind as loose text. That rewrite was a blanket `source.replaceAll(":material/", ":material_")` over the whole raw source, so it also hit text inside backticks — where it can never produce an icon anyway, because `createRemarkMaterialIcons` uses `findAndReplace`, which visits mdast `text` nodes only.

## The approach

**This PR previously tried to skip code with a regex. That does not work, and the current version does not attempt it.** Whether a given `:material/` is an icon or literal text depends on where the parser decides code begins and ends, and two of those decisions are not expressible in a regex at all:

- A backtick fence's info string may not contain a backtick, so ``` ```a`b ``` is **not** a fence — the content after it is prose, and the icon must render.
- A line-leading run of three or more backticks is claimed by *block* parsing before *inline* parsing runs, so block-vs-inline precedence decides whether it is a fence or a code span.

Five review rounds each fixed one case and surfaced another. So the current version inverts the order: let the parser settle the structure first, then act on what it actually decided.

1. **Encode blindly.** Every `:material/` becomes `\uFFFCmaterial/`, with no attempt to judge syntax.
2. **Parse.** remark decides what is code, what is prose, what is raw HTML.
3. **Render icons** from `text` nodes only — `findAndReplace` is never offered code or HTML.
4. **Restore** every remaining encoded prefix verbatim. Anything still encoded at that point is, by definition, not an icon.

The sentinel replaces the leading `:`, so the string handed to remark never contains `:material` and no directive can be claimed. It is **U+FFFC** (OBJECT REPLACEMENT CHARACTER) specifically: Unicode category So, which CommonMark treats as punctuation, so it can never appear in a directive *name*. The invisible alternatives all can — micromark treats private-use and format characters (U+E000, U+2063, U+FFF9) as name characters, so `:material/a::material/b:` parses its second prefix as a directive named `\uE000material` and the sentinel is silently eaten, dropping the icon.

### Also fixed

Two cases the regex version got wrong:

- **Four-space indented code blocks** — the regex could not see them at all, so #10365 persisted there.
- **A fence disqualified by a backtick in its info string** — prose, so the icon must render; the regex left it as literal text.

And the transient streaming artifact is gone: encoding no longer depends on syntax, so no `remend` frame can change the decision. Every frame shows either the icon or the correct literal `:material/…:`.

## Testing

Correctness now lives at the render level, since the parser is what decides. ~25 cases: icons in prose, adjacent icons with no separator, headings, links, nested colour directives; literal text preserved across single/double/backtick-containing code spans, spans crossing a line break, backtick and tilde fences, longer closing runs, info strings, indented fences, four-space indented blocks, unterminated fences, table cells and blockquotes; plus the two cases above and a bare `:material/` with no icon name.

Mutation-verified rather than assumed:

| Mutation | Failures |
|---|---|
| Restore plugin removed | 16 |
| Sentinel changed to U+E000 | 1 — exactly the adjacent-icon test |
| Icon plugin disabled | 13 |

286/286 pass in the file. `make frontend-lint` and `make frontend-format` clean. Also ran the 10 suites that render markdown containing material icons (`DynamicButtonLabel`, `DynamicIcon`, `Metric`, `Expander`, `PageLink`, `MenuButton`, `ButtonGroup`, `TextInput`, `NumberInput`, `Popover`): 477/477 pass.

One note for the reviewer: `make frontend-types` reports 4 pre-existing errors in `BackendOperationClient` in my local checkout, referencing proto fields this branch's `.proto` does not declare. I confirmed they reproduce identically with my changes stashed, and regenerating protos does not clear them, so the branch is simply behind `develop` there — nothing in this diff touches it.

---

**Issue:** Fixes #10365

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core markdown rendering for a widely used icon syntax; logic is intricate but scoped to `StreamlitMarkdown` and heavily regression-tested.
> 
> **Overview**
> Fixes **#10365**, where `` `:material/celebration:` `` and similar text in code was rewritten to `:material_celebration:` instead of staying literal.
> 
> **Pipeline change:** Every `:material/` is preprocessed with `encodeMaterialIconPrefix` (inserts U+FFFC after the colon so `remark-directive` cannot claim `:material`). After parse, icons are built only from mdast `text` nodes via the updated material-icons plugin; a new **restore** remark plugin puts `:material/` back everywhere an encoded prefix was not turned into an icon (code spans, fences, indented blocks, URLs, titles, etc.).
> 
> **Other behavior:** Material icon encode/restore plugins are **skipped** when the source has no `:material/`. The old global `:material_` substitution is removed.
> 
> **Tests:** Large `material icon prefix` suite (render-level, lazy code-block `waitFor`) plus unit tests for `encodeMaterialIconPrefix`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9a3319ec67df48488357f8ac1636c928724db0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->