### PR TITLE
[fix] Clamp date/datetime input default bounds at date.min/max

### DIFF
--- a/lib/streamlit/elements/widgets/time_widgets.py
+++ b/lib/streamlit/elements/widgets/time_widgets.py
@@ -86,6 +86,22 @@ ALLOWED_DATE_FORMATS: Final = re.compile(
 )
 _DATETIME_LEGACY_FORMAT: Final = "%Y/%m/%d, %H:%M"
 _DATETIME_ISO_FORMAT: Final = "%Y-%m-%dT%H:%M"
+
+
+def _date_to_proto_string(value: date) -> str:
+    """Serialize a date to ISO 8601 with a guaranteed four-digit year.
+
+    ``strftime("%Y-...")`` does not zero-pad years below 1000 on Linux/glibc,
+    but the frontend requires exactly four digits.
+    """
+    return f"{value.year:04d}-{value.month:02d}-{value.day:02d}"
+
+
+def _datetime_to_iso_string(value: datetime) -> str:
+    """Serialize a datetime to ISO 8601 with a guaranteed four-digit year."""
+    return f"{value.year:04d}-{value.month:02d}-{value.day:02d}T{value.hour:02d}:{value.minute:02d}"
+
+
 _DEFAULT_MIN_BOUND_TIME: Final = time(hour=0, minute=0)
 _DEFAULT_MAX_BOUND_TIME: Final = time(hour=23, minute=59)
 
@@ -301,7 +317,8 @@ def _default_max_datetime(base_date: date) -> datetime:
 
 
 def _datetime_to_proto_string(value: datetime) -> str:
-    return _normalize_datetime_value(value).strftime(_DATETIME_ISO_FORMAT)
+    normalized = _normalize_datetime_value(value)
+    return _datetime_to_iso_string(normalized)
 
 
 @dataclass(frozen=True)
@@ -665,7 +682,7 @@ class DateInputSerde:
             return []
 
         to_serialize = list(v) if isinstance(v, Sequence) else [v]
-        return [date.strftime(d, "%Y-%m-%d") for d in to_serialize]  # ty: ignore[invalid-argument-type]
+        return [_date_to_proto_string(d) for d in to_serialize]  # ty: ignore[invalid-argument-type]
 
 
 class TimeWidgetsMixin:
@@ -1904,9 +1921,9 @@ class TimeWidgetsMixin:
                 # For ID purposes, no need to parse the input string.
                 return v
             if isinstance(v, datetime):
-                return date.strftime(v.date(), "%Y-%m-%d")
+                return _date_to_proto_string(v.date())
             if isinstance(v, date):
-                return date.strftime(v, "%Y-%m-%d")
+                return _date_to_proto_string(v)
 
             return None
 
@@ -1989,10 +2006,10 @@ class TimeWidgetsMixin:
             date_input_proto.default[:] = []
         else:
             date_input_proto.default[:] = [
-                date.strftime(v, "%Y-%m-%d") for v in parsed_values.value
+                _date_to_proto_string(v) for v in parsed_values.value
             ]
-        date_input_proto.min = date.strftime(parsed_values.min, "%Y-%m-%d")
-        date_input_proto.max = date.strftime(parsed_values.max, "%Y-%m-%d")
+        date_input_proto.min = _date_to_proto_string(parsed_values.min)
+        date_input_proto.max = _date_to_proto_string(parsed_values.max)
         date_input_proto.form_id = current_form_id(self.dg)
 
         if help is not None:

--- a/lib/streamlit/elements/widgets/time_widgets.py
+++ b/lib/streamlit/elements/widgets/time_widgets.py
@@ -86,6 +86,8 @@ ALLOWED_DATE_FORMATS: Final = re.compile(
 )
 _DATETIME_LEGACY_FORMAT: Final = "%Y/%m/%d, %H:%M"
 _DATETIME_ISO_FORMAT: Final = "%Y-%m-%dT%H:%M"
+_DEFAULT_MIN_BOUND_TIME: Final = time(hour=0, minute=0)
+_DEFAULT_MAX_BOUND_TIME: Final = time(hour=23, minute=59)
 
 
 def _date_to_proto_string(value: date) -> str:
@@ -99,11 +101,7 @@ def _date_to_proto_string(value: date) -> str:
 
 def _datetime_to_iso_string(value: datetime) -> str:
     """Serialize a datetime to ISO 8601 with a guaranteed four-digit year."""
-    return f"{value.year:04d}-{value.month:02d}-{value.day:02d}T{value.hour:02d}:{value.minute:02d}"
-
-
-_DEFAULT_MIN_BOUND_TIME: Final = time(hour=0, minute=0)
-_DEFAULT_MAX_BOUND_TIME: Final = time(hour=23, minute=59)
+    return f"{_date_to_proto_string(value)}T{value.hour:02d}:{value.minute:02d}"
 
 
 def _convert_timelike_to_time(value: TimeValue) -> time:

--- a/lib/streamlit/time_util.py
+++ b/lib/streamlit/time_util.py
@@ -22,10 +22,10 @@ from streamlit.errors import StreamlitAPIException, StreamlitBadTimeStringError
 
 
 def adjust_years(input_date: date, years: int) -> date:
-    """Add or subtract years from a date, clamped to ``date.min`` / ``date.max``.
+    """Add or subtract years from a date, clamping at ``date.min`` / ``date.max``.
 
-    Only used to derive default widget bounds, where a clamped bound beats the
-    ``ValueError`` that ``replace()`` raises outside years 1-9999.
+    A target year outside 1-9999 saturates at the calendar endpoint
+    (``0001-01-01`` / ``9999-12-31``) rather than raising.
     """
     target_year = input_date.year + years
     if target_year > date.max.year:

--- a/lib/streamlit/time_util.py
+++ b/lib/streamlit/time_util.py
@@ -22,7 +22,7 @@ from streamlit.errors import StreamlitAPIException, StreamlitBadTimeStringError
 
 
 def adjust_years(input_date: date, years: int) -> date:
-    """Add or subtract years from a date."""
+    """Add or subtract years from a date, saturating at ``date.min`` / ``date.max``."""
     target_year = input_date.year + years
     if target_year > date.max.year:
         return date.max

--- a/lib/streamlit/time_util.py
+++ b/lib/streamlit/time_util.py
@@ -22,7 +22,11 @@ from streamlit.errors import StreamlitAPIException, StreamlitBadTimeStringError
 
 
 def adjust_years(input_date: date, years: int) -> date:
-    """Add or subtract years from a date, saturating at ``date.min`` / ``date.max``."""
+    """Add or subtract years from a date, clamped to ``date.min`` / ``date.max``.
+
+    Only used to derive default widget bounds, where a clamped bound beats the
+    ``ValueError`` that ``replace()`` raises outside years 1-9999.
+    """
     target_year = input_date.year + years
     if target_year > date.max.year:
         return date.max

--- a/lib/streamlit/time_util.py
+++ b/lib/streamlit/time_util.py
@@ -23,17 +23,21 @@ from streamlit.errors import StreamlitAPIException, StreamlitBadTimeStringError
 
 def adjust_years(input_date: date, years: int) -> date:
     """Add or subtract years from a date."""
+    target_year = input_date.year + years
+    if target_year > date.max.year:
+        return date.max
+    if target_year < date.min.year:
+        return date.min
     try:
-        # Attempt to directly add/subtract years
-        return input_date.replace(year=input_date.year + years)
+        return input_date.replace(year=target_year)
     except ValueError as err:
         # Handle case for leap year date (February 29) that doesn't exist in the target year
         # by moving the date to February 28
         if input_date.month == 2 and input_date.day == 29:
-            return input_date.replace(year=input_date.year + years, month=2, day=28)
+            return input_date.replace(year=target_year, month=2, day=28)
 
         raise StreamlitAPIException(  # pragma: no cover - defensive
-            f"Date {input_date} does not exist in the target year {input_date.year + years}. "
+            f"Date {input_date} does not exist in the target year {target_year}. "
             "This should never happen. Please report this bug."
         ) from err
 

--- a/lib/tests/streamlit/elements/date_input_test.py
+++ b/lib/tests/streamlit/elements/date_input_test.py
@@ -133,6 +133,8 @@ class DateInputTest(DeltaGeneratorTestCase):
             #       Add test for empty value list case
             ([date(2021, 4, 26)], "2011-04-26", "2031-04-26"),
             ([date(2007, 2, 4), date(2012, 1, 3)], "1997-02-04", "2022-01-03"),
+            # GH#7427: date.max clamps instead of overflowing
+            (date.max, "9989-12-31", "9999-12-31"),
         ]
     )
     def test_min_max_values(self, arg_value, min_date_value, max_date_value):

--- a/lib/tests/streamlit/elements/date_input_test.py
+++ b/lib/tests/streamlit/elements/date_input_test.py
@@ -133,8 +133,9 @@ class DateInputTest(DeltaGeneratorTestCase):
             #       Add test for empty value list case
             ([date(2021, 4, 26)], "2011-04-26", "2031-04-26"),
             ([date(2007, 2, 4), date(2012, 1, 3)], "1997-02-04", "2022-01-03"),
-            # GH#7427: date.max clamps instead of overflowing
+            # GH#7427: date.max / date.min clamp instead of overflowing
             (date.max, "9989-12-31", "9999-12-31"),
+            (date.min, "0001-01-01", "0011-01-01"),
         ]
     )
     def test_min_max_values(self, arg_value, min_date_value, max_date_value):

--- a/lib/tests/streamlit/elements/datetime_input_test.py
+++ b/lib/tests/streamlit/elements/datetime_input_test.py
@@ -117,6 +117,14 @@ class DateTimeInputTest(DeltaGeneratorTestCase):
         assert proto.min == min_value.strftime(DATETIME_FORMAT)
         assert proto.max == max_value.strftime(DATETIME_FORMAT)
 
+    def test_min_max_values_clamp_at_year_limits(self):
+        """Test that default bounds clamp and serialize with a four-digit year (GH#7427)."""
+        st.datetime_input("the label", datetime.min)
+
+        proto = self.get_delta_from_queue().new_element.date_time_input
+        assert proto.min == "0001-01-01T00:00"
+        assert proto.max == "0011-01-01T23:59"
+
     def test_label_visibility(self):
         """Test that label visibility works."""
         st.datetime_input("the label", label_visibility="hidden")

--- a/lib/tests/streamlit/elements/time_widgets_test.py
+++ b/lib/tests/streamlit/elements/time_widgets_test.py
@@ -25,6 +25,7 @@ from streamlit.elements.widgets.time_widgets import (
     TimeInputSerde,
     _convert_datetimelike_to_datetime,
     _DateInputValues,
+    _DateTimeInputValues,
     _parse_max_date,
     _parse_min_date,
 )
@@ -99,6 +100,24 @@ def test_parse_date_bound_clamps_at_year_limits(
 ) -> None:
     """Test that default bounds clamp instead of overflowing the year range (GH#7427)."""
     assert parse_fn(None, parsed_dates) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected_min", "expected_max"),
+    [
+        (datetime.max, datetime(9989, 12, 31, 0, 0), datetime(9999, 12, 31, 23, 59)),
+        (datetime.min, datetime(1, 1, 1, 0, 0), datetime(11, 1, 1, 23, 59)),
+    ],
+)
+def test_datetime_input_bounds_clamp_at_year_limits(
+    value: datetime, expected_min: datetime, expected_max: datetime
+) -> None:
+    """Test that default datetime bounds clamp instead of overflowing (GH#7427)."""
+    values = _DateTimeInputValues.from_raw_values(
+        value=value, min_value=None, max_value=None
+    )
+    assert values.min == expected_min
+    assert values.max == expected_max
 
 
 @pytest.mark.parametrize(

--- a/lib/tests/streamlit/elements/time_widgets_test.py
+++ b/lib/tests/streamlit/elements/time_widgets_test.py
@@ -85,6 +85,31 @@ def test_date_input_values_rejects_min_after_max() -> None:
         )
 
 
+def test_parse_max_date_clamps_to_date_max() -> None:
+    """Test that _parse_max_date clamps to date.max when value is near the maximum year."""
+    result = _parse_max_date(None, [date(9999, 12, 31)])
+    assert result == date.max
+
+
+def test_parse_min_date_clamps_to_date_min() -> None:
+    """Test that _parse_min_date clamps to date.min when value is near the minimum year."""
+    result = _parse_min_date(None, [date(1, 1, 1)])
+    assert result == date.min
+
+
+def test_parse_max_date_does_not_crash_with_datetime_max() -> None:
+    """Test that using datetime.max as a date_input value does not raise (GH#7427)."""
+    max_as_date = datetime.max.date()
+    result = _parse_max_date(None, [date.today(), max_as_date])
+    assert result == date.max
+
+
+def test_parse_min_date_does_not_crash_with_date_min() -> None:
+    """Test that using date.min as a date_input value does not raise."""
+    result = _parse_min_date(None, [date.min, date.today()])
+    assert result == date.min
+
+
 @pytest.mark.parametrize(
     ("value", "expected"),
     [

--- a/lib/tests/streamlit/elements/time_widgets_test.py
+++ b/lib/tests/streamlit/elements/time_widgets_test.py
@@ -85,29 +85,20 @@ def test_date_input_values_rejects_min_after_max() -> None:
         )
 
 
-def test_parse_max_date_clamps_to_date_max() -> None:
-    """Test that _parse_max_date clamps to date.max when value is near the maximum year."""
-    result = _parse_max_date(None, [date(9999, 12, 31)])
-    assert result == date.max
-
-
-def test_parse_min_date_clamps_to_date_min() -> None:
-    """Test that _parse_min_date clamps to date.min when value is near the minimum year."""
-    result = _parse_min_date(None, [date(1, 1, 1)])
-    assert result == date.min
-
-
-def test_parse_max_date_does_not_crash_with_datetime_max() -> None:
-    """Test that using datetime.max as a date_input value does not raise (GH#7427)."""
-    max_as_date = datetime.max.date()
-    result = _parse_max_date(None, [date.today(), max_as_date])
-    assert result == date.max
-
-
-def test_parse_min_date_does_not_crash_with_date_min() -> None:
-    """Test that using date.min as a date_input value does not raise."""
-    result = _parse_min_date(None, [date.min, date.today()])
-    assert result == date.min
+@pytest.mark.parametrize(
+    ("parse_fn", "parsed_dates", "expected"),
+    [
+        (_parse_max_date, [date.max], date.max),
+        (_parse_max_date, [date.today(), datetime.max.date()], date.max),
+        (_parse_min_date, [date.min], date.min),
+        (_parse_min_date, [date.min, date.today()], date.min),
+    ],
+)
+def test_parse_date_bound_clamps_at_year_limits(
+    parse_fn: Callable[..., date], parsed_dates: list[date], expected: date
+) -> None:
+    """Test that default bounds clamp instead of overflowing the year range (GH#7427)."""
+    assert parse_fn(None, parsed_dates) == expected
 
 
 @pytest.mark.parametrize(

--- a/lib/tests/streamlit/time_util_test.py
+++ b/lib/tests/streamlit/time_util_test.py
@@ -58,6 +58,8 @@ TIME_STRING_TO_SECONDS_PARAMS = [
         (date(2019, 12, 31), 1, date(2020, 12, 31)),
         # Clamp to date.max when target year exceeds 9999:
         (date(9995, 6, 15), 10, date.max),
+        # Leap day whose target year overflows (pre-check short-circuits before Feb-29 fallback):
+        (date(9996, 2, 29), 10, date.max),
         # Clamp to date.min when target year falls below 1:
         (date(5, 6, 15), -10, date.min),
     ]

--- a/lib/tests/streamlit/time_util_test.py
+++ b/lib/tests/streamlit/time_util_test.py
@@ -56,10 +56,18 @@ TIME_STRING_TO_SECONDS_PARAMS = [
         (date(1920, 4, 10), 100, date(2020, 4, 10)),
         # End of year date
         (date(2019, 12, 31), 1, date(2020, 12, 31)),
+        # Clamp to date.max when target year exceeds 9999:
+        (date(9999, 12, 31), 10, date.max),
+        (date(9999, 6, 15), 1, date.max),
+        (date(9995, 6, 15), 10, date.max),
+        # Clamp to date.min when target year falls below 1:
+        (date(1, 1, 1), -1, date.min),
+        (date(1, 3, 15), -5, date.min),
+        (date(5, 6, 15), -10, date.min),
     ]
 )
 def test_adjust_years(input_date: date, years: int, expected_date: date):
-    """Test that `adjust_years` correctly` adjusts the year of a date."""
+    """Test that `adjust_years` correctly adjusts the year of a date."""
     assert adjust_years(input_date, years) == expected_date
 
 

--- a/lib/tests/streamlit/time_util_test.py
+++ b/lib/tests/streamlit/time_util_test.py
@@ -67,7 +67,7 @@ TIME_STRING_TO_SECONDS_PARAMS = [
     ]
 )
 def test_adjust_years(input_date: date, years: int, expected_date: date):
-    """Test that `adjust_years` correctly adjusts the year of a date."""
+    """Test that `adjust_years` shifts the year and saturates at `date.min` / `date.max`."""
     assert adjust_years(input_date, years) == expected_date
 
 

--- a/lib/tests/streamlit/time_util_test.py
+++ b/lib/tests/streamlit/time_util_test.py
@@ -57,17 +57,13 @@ TIME_STRING_TO_SECONDS_PARAMS = [
         # End of year date
         (date(2019, 12, 31), 1, date(2020, 12, 31)),
         # Clamp to date.max when target year exceeds 9999:
-        (date(9999, 12, 31), 10, date.max),
-        (date(9999, 6, 15), 1, date.max),
         (date(9995, 6, 15), 10, date.max),
         # Clamp to date.min when target year falls below 1:
-        (date(1, 1, 1), -1, date.min),
-        (date(1, 3, 15), -5, date.min),
         (date(5, 6, 15), -10, date.min),
     ]
 )
 def test_adjust_years(input_date: date, years: int, expected_date: date):
-    """Test that `adjust_years` shifts the year and saturates at `date.min` / `date.max`."""
+    """Test that `adjust_years` shifts the year and clamps at `date.min` / `date.max`."""
     assert adjust_years(input_date, years) == expected_date
 
 


### PR DESCRIPTION
## Describe your changes
Clamp `adjust_years()` at `date.min`/`date.max` so `st.date_input` and `st.datetime_input` no longer crash when a value near Python's date limits is passed without explicit `min_value`/`max_value`.

Default bounds remain value ± 10 years. If that year is outside 1–9999, the bound saturates at the calendar endpoint (GH#7427). `st.slider` solves the same overflow in `_window_around`, but to the narrower range its microsecond wire format can represent. `st.datetime_input` shares the same helper via `_default_min_datetime`/`_default_max_datetime`.

Additionally, replaces `date.strftime("%Y-%m-%d")` with a format-string helper (`_date_to_proto_string`) that guarantees four-digit year padding — `strftime` does not zero-pad years below 1000 on Linux/glibc, which would cause the frontend parser to reject the serialized bound.

## Problem

```python
# All of these crash without an explicit max_value/min_value:
st.date_input('test', value=datetime.max)       # year 10009 overflow
st.date_input('test', value=date.max)           # year 10009 overflow
st.date_input('test', value=datetime.min)       # year -9 underflow
st.date_input('test', value=date.min)           # year -9 underflow
```

The widget internally computes default bounds by adding/subtracting 10 years from the provided value via `adjust_years()`. For values near Python's `date.max` (9999-12-31) or `date.min` (0001-01-01), this arithmetic overflows.

## GitHub Issue Link (if applicable)
Closes #7427

## Testing Plan
- Unit tests cover `adjust_years` overflow/underflow and the derived `date_input`/`datetime_input` bounds
- Proto-level assertions for both `date.max` and `date.min` verify correct wire serialization
- No e2e test: the overflow was server-side bound arithmetic with no frontend change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted fix in shared `adjust_years` and date proto serialization for time widgets; behavior change only at extreme dates, with unit tests covering clamping and wire format.
> 
> **Overview**
> Fixes crashes when **`st.date_input`** / **`st.datetime_input`** use **`date.min`**, **`date.max`**, or nearby values without explicit **`min_value`** / **`max_value`**. Default bounds are still value ± 10 years, but **`adjust_years()`** now **clamps** to **`0001-01-01`** / **`9999-12-31`** instead of overflowing the year range (GH#7427).
> 
> Date/datetime wire strings for the frontend no longer use **`strftime("%Y-%m-%d")`**, which can emit unpadded years on Linux/glibc. Serialization goes through **`_date_to_proto_string`** / **`_datetime_to_iso_string`** so proto min/max/default always use a **four-digit** ISO year.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bae5eaea0146a75348f4a95727f88d7da34a5ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->