### PR TITLE
[fix] Keep menu and JSON overlays clickable in `st.dialog`

### DIFF
--- a/e2e_playwright/st_dialog.py
+++ b/e2e_playwright/st_dialog.py
@@ -395,8 +395,8 @@ if st.button("Open Dialog with Color Picker"):
     dialog_with_color_picker()
 
 
-# Regression coverage for inert portal bug: a menu button dropdown opened inside
-# an st.dialog must stay interactive (the portal body must not be marked inert).
+# Regression coverage: a menu button dropdown opened inside an st.dialog
+# must stay interactive without dismissing the dialog.
 @st.dialog("Dialog with menu button")
 def dialog_with_menu_button() -> None:
     selected = st.menu_button(
@@ -410,8 +410,8 @@ if st.button("Open Dialog with Menu Button"):
     dialog_with_menu_button()
 
 
-# Regression coverage for inert portal bug: a JSON path tooltip opened inside
-# an st.dialog must stay interactive (the portal body must not be marked inert).
+# Regression coverage: a JSON path tooltip opened inside an st.dialog
+# must stay interactive without dismissing the dialog.
 @st.dialog("Dialog with JSON path tooltip")
 def dialog_with_json_path_tooltip() -> None:
     st.json({"level1": {"level2": "value"}}, expanded=True)

--- a/e2e_playwright/st_dialog.py
+++ b/e2e_playwright/st_dialog.py
@@ -395,8 +395,8 @@ if st.button("Open Dialog with Color Picker"):
     dialog_with_color_picker()
 
 
-# Regression coverage: a menu button dropdown opened inside an st.dialog
-# must stay interactive without dismissing the dialog.
+# Regression coverage (#16005): a menu button dropdown opened inside an
+# st.dialog must stay interactive without dismissing the dialog.
 @st.dialog("Dialog with menu button")
 def dialog_with_menu_button() -> None:
     selected = st.menu_button(
@@ -410,8 +410,8 @@ if st.button("Open Dialog with Menu Button"):
     dialog_with_menu_button()
 
 
-# Regression coverage: a JSON path tooltip opened inside an st.dialog
-# must stay interactive without dismissing the dialog.
+# Regression coverage (#16005): a JSON path tooltip opened inside an
+# st.dialog must stay interactive without dismissing the dialog.
 @st.dialog("Dialog with JSON path tooltip")
 def dialog_with_json_path_tooltip() -> None:
     st.json({"level1": {"level2": "value"}}, expanded=True)

--- a/e2e_playwright/st_dialog.py
+++ b/e2e_playwright/st_dialog.py
@@ -393,3 +393,29 @@ def dialog_with_color_picker() -> None:
 
 if st.button("Open Dialog with Color Picker"):
     dialog_with_color_picker()
+
+
+# Regression coverage for inert portal bug: a menu button dropdown opened inside
+# an st.dialog must stay interactive (the portal body must not be marked inert).
+@st.dialog("Dialog with menu button")
+def dialog_with_menu_button() -> None:
+    selected = st.menu_button(
+        "Dialog menu",
+        options=["Alpha", "Beta", "Gamma"],
+    )
+    st.write(f"menu selected: {selected}")
+
+
+if st.button("Open Dialog with Menu Button"):
+    dialog_with_menu_button()
+
+
+# Regression coverage for inert portal bug: a JSON path tooltip opened inside
+# an st.dialog must stay interactive (the portal body must not be marked inert).
+@st.dialog("Dialog with JSON path tooltip")
+def dialog_with_json_path_tooltip() -> None:
+    st.json({"level1": {"level2": "value"}}, expanded=True)
+
+
+if st.button("Open Dialog with JSON Path Tooltip"):
+    dialog_with_json_path_tooltip()

--- a/e2e_playwright/st_dialog_test.py
+++ b/e2e_playwright/st_dialog_test.py
@@ -287,6 +287,54 @@ def test_dialog_allows_interacting_with_color_picker(app: Page):
     expect(dialog).to_be_visible()
 
 
+def test_dialog_allows_interacting_with_menu_button(app: Page):
+    """A menu button dropdown opened inside an st.dialog must stay interactive
+    without dismissing the dialog (regression coverage for inert portal bug).
+    """
+    click_button(app, "Open Dialog with Menu Button")
+    dialog = app.get_by_test_id(modal_test_id)
+    expect(dialog).to_be_visible()
+
+    # Open the menu button dropdown
+    dialog.get_by_test_id("stMenuButtonButton").click()
+    menu_body = app.get_by_test_id("stMenuButtonBody")
+    expect(menu_body).to_be_visible()
+
+    # Click a menu option — this verifies the menu items are not inert
+    menu_body.get_by_text("Beta", exact=True).click()
+    wait_for_app_run(app)
+
+    expect_markdown(dialog, "menu selected: Beta")
+    expect(dialog).to_be_visible()
+
+
+def test_dialog_allows_interacting_with_json_path_tooltip(app: Page):
+    """A JSON path tooltip opened inside an st.dialog must stay interactive
+    without dismissing the dialog (regression coverage for inert portal bug).
+    """
+    click_button(app, "Open Dialog with JSON Path Tooltip")
+    dialog = app.get_by_test_id(modal_test_id)
+    expect(dialog).to_be_visible()
+
+    # Click on a string value to trigger the path tooltip
+    json_element = dialog.get_by_test_id("stJson")
+    expect(json_element).to_be_visible()
+    string_value = json_element.locator(".string-value").first
+    string_value.click()
+
+    # Verify the path tooltip appears and is interactable
+    tooltip = app.get_by_test_id("stJsonPathTooltip")
+    expect(tooltip).to_be_visible()
+
+    # The copy button inside the tooltip must be clickable (not inert)
+    copy_button = tooltip.get_by_role("button", name="Copy to clipboard")
+    expect(copy_button).to_be_visible()
+    copy_button.click()
+
+    # The dialog must not be dismissed by the interaction
+    expect(dialog).to_be_visible()
+
+
 def test_dialog_stays_dismissed_when_interacting_with_different_fragment(app: Page):
     """Dismissing a dialog is a UI-only interaction as of today (the Python backend does
     not know about this). We use a deltaMsgReceivedAt to differentiate React renders

--- a/e2e_playwright/st_dialog_test.py
+++ b/e2e_playwright/st_dialog_test.py
@@ -295,13 +295,12 @@ def test_dialog_allows_interacting_with_menu_button(app: Page):
     dialog = app.get_by_test_id(modal_test_id)
     expect(dialog).to_be_visible()
 
-    # Open the menu button dropdown
     dialog.get_by_test_id("stMenuButtonButton").click()
     menu_body = app.get_by_test_id("stMenuButtonBody")
     expect(menu_body).to_be_visible()
 
     # Click a menu option — this verifies the menu items are not inert
-    menu_body.get_by_text("Beta", exact=True).click()
+    menu_body.get_by_role("menuitem", name="Beta").click()
     wait_for_app_run(app)
 
     expect_markdown(dialog, "menu selected: Beta")
@@ -316,13 +315,11 @@ def test_dialog_allows_interacting_with_json_path_tooltip(app: Page):
     dialog = app.get_by_test_id(modal_test_id)
     expect(dialog).to_be_visible()
 
-    # Click on a string value to trigger the path tooltip
     json_element = dialog.get_by_test_id("stJson")
     expect(json_element).to_be_visible()
     string_value = json_element.locator(".string-value").first
     string_value.click()
 
-    # Verify the path tooltip appears and is interactable
     tooltip = app.get_by_test_id("stJsonPathTooltip")
     expect(tooltip).to_be_visible()
 

--- a/e2e_playwright/st_dialog_test.py
+++ b/e2e_playwright/st_dialog_test.py
@@ -289,7 +289,7 @@ def test_dialog_allows_interacting_with_color_picker(app: Page):
 
 def test_dialog_allows_interacting_with_menu_button(app: Page):
     """A menu button dropdown opened inside an st.dialog must stay interactive
-    without dismissing the dialog (regression coverage for inert portal bug).
+    without dismissing the dialog.
     """
     click_button(app, "Open Dialog with Menu Button")
     dialog = app.get_by_test_id(modal_test_id)
@@ -310,7 +310,7 @@ def test_dialog_allows_interacting_with_menu_button(app: Page):
 
 def test_dialog_allows_interacting_with_json_path_tooltip(app: Page):
     """A JSON path tooltip opened inside an st.dialog must stay interactive
-    without dismissing the dialog (regression coverage for inert portal bug).
+    without dismissing the dialog.
     """
     click_button(app, "Open Dialog with JSON Path Tooltip")
     dialog = app.get_by_test_id(modal_test_id)

--- a/frontend/lib/src/components/elements/Json/JsonPathTooltip.test.tsx
+++ b/frontend/lib/src/components/elements/Json/JsonPathTooltip.test.tsx
@@ -17,6 +17,7 @@
 import { screen, waitFor } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 
+import { FLOATING_OVERLAY_PORTAL_ID } from "~lib/components/core/Portal/constants"
 import { render } from "~lib/test_util"
 
 import JsonPathTooltip, {
@@ -49,6 +50,15 @@ describe("JsonPathTooltip", () => {
 
   afterEach(() => {
     vi.restoreAllMocks()
+  })
+
+  it("mounts the tooltip in the shared floating overlay portal", () => {
+    render(<JsonPathTooltip {...getProps()} />)
+
+    const portalHost = document.getElementById(FLOATING_OVERLAY_PORTAL_ID)
+    expect(portalHost).toContainElement(
+      screen.getByTestId("stJsonPathTooltipBody")
+    )
   })
 
   it("renders the path text", () => {

--- a/frontend/lib/src/components/elements/Json/JsonPathTooltip.tsx
+++ b/frontend/lib/src/components/elements/Json/JsonPathTooltip.tsx
@@ -18,6 +18,7 @@ import { memo, ReactElement, useCallback, useEffect, useRef } from "react"
 
 import { FloatingPortal } from "@floating-ui/react"
 
+import { FLOATING_OVERLAY_PORTAL_ID } from "~lib/components/core/Portal/constants"
 import { DynamicIcon } from "~lib/components/shared/Icon/DynamicIcon"
 import { useCopyToClipboard } from "~lib/hooks/useCopyToClipboard"
 import { useFloatingOverlay } from "~lib/hooks/useFloatingOverlay"
@@ -144,7 +145,7 @@ function JsonPathTooltip({
   }, [copyToClipboard, path])
 
   return (
-    <FloatingPortal>
+    <FloatingPortal id={FLOATING_OVERLAY_PORTAL_ID}>
       <StyledJsonPathTooltipBody
         ref={setFloatingRef}
         data-testid="stJsonPathTooltipBody"

--- a/frontend/lib/src/components/widgets/MenuButton/MenuButton.test.tsx
+++ b/frontend/lib/src/components/widgets/MenuButton/MenuButton.test.tsx
@@ -20,6 +20,7 @@ import { vi } from "vitest"
 
 import { MenuButton as MenuButtonProto } from "@streamlit/protobuf"
 
+import { FLOATING_OVERLAY_PORTAL_ID } from "~lib/components/core/Portal/constants"
 import { BaseButtonKind } from "~lib/components/shared/BaseButton/styled-components"
 import { render } from "~lib/test_util"
 import { WidgetStateManager } from "~lib/WidgetStateManager"
@@ -80,6 +81,17 @@ describe("MenuButton widget", () => {
     await waitFor(() => {
       expect(screen.queryByTestId("stMenuButtonBody")).not.toBeInTheDocument()
     })
+  })
+
+  it("mounts the menu popover in the shared floating overlay portal", async () => {
+    const user = userEvent.setup()
+    const props = getProps()
+    render(<MenuButton {...props} />)
+
+    await user.click(screen.getByTestId("stMenuButtonButton"))
+
+    const portalHost = document.getElementById(FLOATING_OVERLAY_PORTAL_ID)
+    expect(portalHost).toContainElement(screen.getByTestId("stMenuButtonBody"))
   })
 
   it("selects an option and triggers widget manager", async () => {

--- a/frontend/lib/src/components/widgets/MenuButton/MenuButton.test.tsx
+++ b/frontend/lib/src/components/widgets/MenuButton/MenuButton.test.tsx
@@ -89,9 +89,10 @@ describe("MenuButton widget", () => {
     render(<MenuButton {...props} />)
 
     await user.click(screen.getByTestId("stMenuButtonButton"))
+    const menuBody = await screen.findByTestId("stMenuButtonBody")
 
     const portalHost = document.getElementById(FLOATING_OVERLAY_PORTAL_ID)
-    expect(portalHost).toContainElement(screen.getByTestId("stMenuButtonBody"))
+    expect(portalHost).toContainElement(menuBody)
   })
 
   it("selects an option and triggers widget manager", async () => {

--- a/frontend/lib/src/components/widgets/MenuButton/MenuButton.tsx
+++ b/frontend/lib/src/components/widgets/MenuButton/MenuButton.tsx
@@ -29,6 +29,7 @@ import { type Key } from "react-aria-components"
 
 import { MenuButton as MenuButtonProto } from "@streamlit/protobuf"
 
+import { FLOATING_OVERLAY_PORTAL_ID } from "~lib/components/core/Portal/constants"
 import { Box } from "~lib/components/shared/Base/styled-components"
 import BaseButton, {
   BaseButtonKind,
@@ -198,7 +199,7 @@ function MenuButton(props: Props): ReactElement {
         </BaseButton>
       </BaseButtonTooltip>
       {isOpen && (
-        <FloatingPortal>
+        <FloatingPortal id={FLOATING_OVERLAY_PORTAL_ID}>
           <StyledMenuPopover
             ref={setFloatingRef}
             data-testid="stMenuButtonBody"


### PR DESCRIPTION
## Describe your changes
- Route `<FloatingPortal>` in `MenuButton` and `JsonPathTooltip` through the shared overlay portal host (`FLOATING_OVERLAY_PORTAL_ID`), preventing React Aria's `ModalOverlay` from marking their content inert when rendered inside `st.dialog`
- Add unit tests verifying both components mount their overlays in the shared portal host
- Add E2E tests confirming menu button dropdown and JSON path tooltip remain interactive inside a dialog

**Context**
When st.dialog opens, React Aria's ModalOverlay marks all document.body siblings as inert. Components using a bare <FloatingPortal> create their own div directly under document.body, which gets marked inert — making overlay content unclickable.

This was previously fixed for st.popover (#16067) and st.color_picker (#16541). This PR applies the same fix to the remaining affected components.

Fixes the same class of bug as #16005 and #15599.

## Testing Plan
- [x] Unit test: `MenuButton` — "mounts the menu popover in the shared floating overlay portal"
- [x] Unit test: `JsonPathTooltip` — "mounts the tooltip in the shared floating overlay portal"
- [x] E2E test: `test_dialog_allows_interacting_with_menu_button`
- [x] E2E test: `test_dialog_allows_interacting_with_json_path_tooltip`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized frontend portal-target change with established pattern and regression tests; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes **unclickable overlays inside `st.dialog`** for `st.menu_button` dropdowns and `st.json` path tooltips by routing their `FloatingPortal` mounts through **`FLOATING_OVERLAY_PORTAL_ID`**, matching earlier fixes for popovers and color pickers.
> 
> Without this, React Aria’s dialog overlay marks default `document.body` portal siblings as **inert**, so menu items and the JSON path copy control could not receive clicks while a dialog is open.
> 
> **Tests:** unit checks that both components render into the shared portal host; Playwright regressions open each widget in a dialog and assert selection/copy works and the dialog stays open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d70c0489d74a2384a6005ffc8be86be01c9c413. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->