### PR TITLE
[fix] Compare E2E test counts against the PR's merge base

### DIFF
--- a/.cursor/rules/workflows.mdc
+++ b/.cursor/rules/workflows.mdc
@@ -96,7 +96,7 @@ runner's system Python.
 | `python-tests.yml` | Push/PR to `develop` | Python unit tests, linting, type checking across all supported Python versions |
 | `js-tests.yml` | Push/PR to `develop` | Frontend TypeScript linting, type checking, Knip dependency analysis (PR-blocking), and Vitest unit tests with coverage |
 | `js-unit-tests.yml` | `workflow_call` | Reusable JS unit test workflow (called by other workflows) |
-| `playwright.yml` | Push/PR to `develop` | Full E2E test suite across webkit, chromium, and firefox |
+| `playwright.yml` | Push/PR to `develop` | Full E2E test suite across webkit, chromium, and firefox. On PRs, a second job counts how many E2E test cases the PR adds relative to its merge base (via `scripts/compare_e2e_test_counts.py`) and comments if the increase is significant |
 | `playwright-changed-files.yml` | PR | Runs E2E tests only for changed test files (faster feedback) |
 | `playwright-custom-components.yml` | Push/PR to `develop` | E2E tests specifically for custom components |
 | `cli-regression.yml` | Push/PR to `develop` | CLI regression tests (builds package and runs CLI tests) |

--- a/.github/instructions/workflows.instructions.md
+++ b/.github/instructions/workflows.instructions.md
@@ -94,7 +94,7 @@ runner's system Python.
 | `python-tests.yml` | Push/PR to `develop` | Python unit tests, linting, type checking across all supported Python versions |
 | `js-tests.yml` | Push/PR to `develop` | Frontend TypeScript linting, type checking, Knip dependency analysis (PR-blocking), and Vitest unit tests with coverage |
 | `js-unit-tests.yml` | `workflow_call` | Reusable JS unit test workflow (called by other workflows) |
-| `playwright.yml` | Push/PR to `develop` | Full E2E test suite across webkit, chromium, and firefox |
+| `playwright.yml` | Push/PR to `develop` | Full E2E test suite across webkit, chromium, and firefox. On PRs, a second job counts how many E2E test cases the PR adds relative to its merge base (via `scripts/compare_e2e_test_counts.py`) and comments if the increase is significant |
 | `playwright-changed-files.yml` | PR | Runs E2E tests only for changed test files (faster feedback) |
 | `playwright-custom-components.yml` | Push/PR to `develop` | E2E tests specifically for custom components |
 | `cli-regression.yml` | Push/PR to `develop` | CLI regression tests (builds package and runs CLI tests) |

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -88,7 +88,7 @@ runner's system Python.
 | `python-tests.yml` | Push/PR to `develop` | Python unit tests, linting, type checking across all supported Python versions |
 | `js-tests.yml` | Push/PR to `develop` | Frontend TypeScript linting, type checking, Knip dependency analysis (PR-blocking), and Vitest unit tests with coverage |
 | `js-unit-tests.yml` | `workflow_call` | Reusable JS unit test workflow (called by other workflows) |
-| `playwright.yml` | Push/PR to `develop` | Full E2E test suite across webkit, chromium, and firefox |
+| `playwright.yml` | Push/PR to `develop` | Full E2E test suite across webkit, chromium, and firefox. On PRs, a second job counts how many E2E test cases the PR adds relative to its merge base (via `scripts/compare_e2e_test_counts.py`) and comments if the increase is significant |
 | `playwright-changed-files.yml` | PR | Runs E2E tests only for changed test files (faster feedback) |
 | `playwright-custom-components.yml` | Push/PR to `develop` | E2E tests specifically for custom components |
 | `cli-regression.yml` | Push/PR to `develop` | CLI regression tests (builds package and runs CLI tests) |

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -73,174 +73,148 @@ jobs:
           name: playwright_test_results_${{ steps.short_sha.outputs.sha_short }}
           path: e2e_playwright/test-results
 
+  # Reports how many E2E test cases a PR adds, by collecting test IDs on the PR
+  # and on its merge base. This deliberately does not compare against the test
+  # counts of a develop CI run: those runs drift with every merge, so the diff
+  # would include tests added by other PRs.
   check-e2e-test-count:
     runs-on: ubuntu-latest
-    needs: playwright-e2e-tests
+    timeout-minutes: 20
+    # A merge base only exists for pull_request events.
     if: github.event_name == 'pull_request' && github.repository == 'streamlit/streamlit'
     continue-on-error: true
 
     permissions:
       contents: read
       pull-requests: write
-      actions: read
+
+    defaults:
+      run:
+        shell: bash
 
     env:
       NEW_TEST_THRESHOLD: 30
+      SUMMARY_PATH: ${{ runner.temp }}/e2e-test-count-summary.json
 
     steps:
       - name: Checkout Streamlit code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ inputs.ref }}
           persist-credentials: false
-
-      - name: Download current test stats
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        continue-on-error: true
+          submodules: "recursive"
+          # For pull_request events, the checked out HEAD is the merge commit
+          # GitHub creates for the PR, so depth 2 also gets us its parents.
+          fetch-depth: 2
+      # Everything below relies on HEAD being that merge commit. If it is not
+      # (for example because the PR has conflicts), HEAD^1 would be the previous
+      # commit of the PR branch instead of the merge base, and the reported
+      # numbers would be nonsense. Skip the check rather than guess.
+      - name: Check for a PR merge commit
+        id: merge_commit
+        run: |
+          set -euo pipefail
+          if git rev-parse --verify --quiet HEAD^2 > /dev/null; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::HEAD is not a PR merge commit, skipping the E2E test count check."
+          fi
+      - name: Set Python version vars
+        if: steps.merge_commit.outputs.found
+        uses: ./.github/actions/build_info
+      - name: Setup virtual env
+        if: steps.merge_commit.outputs.found
+        uses: ./.github/actions/make_init
         with:
-          name: playwright_test_stats
-          path: current_stats
+          python_version: ${{ env.PYTHON_MAX_VERSION }}
+      - name: Collect test IDs for the PR and its merge base
+        if: steps.merge_commit.outputs.found
+        env:
+          COLLECT_DIR: ${{ runner.temp }}
+        run: |
+          set -euo pipefail
+          # Collection args mirror the `playwright-e2e-tests` job above so that
+          # we count the tests that actually run in CI. Playwright browsers are
+          # not needed: collection never launches one. `addopts` is cleared
+          # because e2e_playwright/pytest.ini enables verbose output, which
+          # would replace the test IDs with human-readable lines.
+          collect() {
+            (cd e2e_playwright && uv run pytest --collect-only -q -o addopts= \
+              --no-stats --ignore ./custom_components --ignore ./load_testing \
+              --browser webkit --browser chromium --browser firefox \
+              -m "not performance") > "$1"
+          }
 
-      - name: Find latest develop test stats
-        id: get-latest-run
-        uses: ./.github/actions/find_latest_workflow_artifact
-        with:
-          workflow: playwright.yml
-          artifact_name: playwright_test_stats
+          collect "$COLLECT_DIR/head-test-ids.txt"
 
-      - name: Download develop test stats
-        if: steps.get-latest-run.outputs.run_id != ''
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        continue-on-error: true
-        with:
-          repository: streamlit/streamlit
-          run-id: ${{ steps.get-latest-run.outputs.run_id }}
-          name: playwright_test_stats
-          path: develop_stats
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # HEAD^1 of the merge commit is the develop commit this PR merges
+          # into, i.e. exactly the baseline the PR is responsible for changing.
+          git rev-parse --short HEAD^1 > "$COLLECT_DIR/base-ref.txt"
+          # Swap in the merge base's tests: restoring tracked files is not
+          # enough, because files the PR added would linger and inflate the
+          # baseline. `--no-renames` keeps a renamed file from being missed
+          # here (it would otherwise be reported as a rename, not an addition).
+          git diff --name-only -z --diff-filter=A --no-renames HEAD^1 HEAD \
+            -- e2e_playwright | xargs -0 -r rm -f
+          git checkout HEAD^1 -- e2e_playwright
 
-      - name: Compare test counts and comment
-        if: steps.get-latest-run.outputs.run_id != ''
+          collect "$COLLECT_DIR/base-test-ids.txt"
+      - name: Compare test counts
+        if: steps.merge_commit.outputs.found
+        env:
+          COLLECT_DIR: ${{ runner.temp }}
+        run: |
+          set -euo pipefail
+          uv run python scripts/compare_e2e_test_counts.py \
+            --base "$COLLECT_DIR/base-test-ids.txt" \
+            --head "$COLLECT_DIR/head-test-ids.txt" \
+            --base-ref "$(cat "$COLLECT_DIR/base-ref.txt")" \
+            --threshold "$NEW_TEST_THRESHOLD" \
+            --output "$SUMMARY_PATH"
+      - name: Comment on the PR
+        if: steps.merge_commit.outputs.found
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs');
-            const path = require('path');
-            const threshold = +process.env.NEW_TEST_THRESHOLD;
+            const summary = JSON.parse(fs.readFileSync(process.env.SUMMARY_PATH, 'utf8'));
 
-            const loadStats = (dir) => {
-              try {
-                const jsonPath = path.join(process.cwd(), dir, 'test-stats.json');
-                if (fs.existsSync(jsonPath)) {
-                  return JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
-                }
-                console.log(`File not found: ${jsonPath}`);
-                return null;
-              } catch (e) {
-                console.log(`Error loading stats from ${dir}:`, e.message);
-                return null;
-              }
-            };
-
-            const currentStats = loadStats('current_stats');
-            const developStats = loadStats('develop_stats');
-
-            if (!currentStats) {
-              console.log('Missing current test stats, skipping comparison.');
-              return;
-            }
-
-            if (!developStats) {
-              console.log('Missing develop test stats, skipping comparison.');
-              return;
-            }
-
-            const currentTotal = currentStats.summary?.total_tests || 0;
-            const developTotal = developStats.summary?.total_tests || 0;
-            const newTests = currentTotal - developTotal;
-
-            console.log(`Current PR test count: ${currentTotal}`);
-            console.log(`Develop test count: ${developTotal}`);
-            console.log(`New tests: ${newTests}`);
-            console.log(`Threshold: ${threshold}`);
-
-            // Check if this PR is from a fork
-            const isForkPR = context.payload.pull_request?.head?.repo?.fork === true;
-            if (isForkPR) {
+            // Fork PRs get a read-only token, so commenting would fail. The
+            // numbers are in the job logs of the previous step either way.
+            if (context.payload.pull_request?.head?.repo?.fork === true) {
               console.log('PR is from a fork - skipping comment (insufficient permissions)');
-              console.log('Test count information is available in the job logs above.');
               return;
             }
 
-            const isSignificant = newTests > threshold;
-            const commentIdentifier = '<!-- STREAMLIT-E2E-TEST-COUNT-CHECK -->';
-
-            // Find existing comment
-            const { data: comments } = await github.rest.issues.listComments({
+            // Paginate: on a busy PR our comment can be well past the first page.
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
+              per_page: 100,
             });
-            const existingComment = comments.find(comment => comment.body.includes(commentIdentifier));
+            const existingComment = comments.find(comment => comment.body.includes(summary.marker));
 
-            // Only comment if tests increased significantly (> threshold)
-            if (isSignificant || existingComment) {
-              let header;
-              let message;
-              if (isSignificant) {
-                header = `### 🧪 Significant E2E test count increase detected`;
-                message = `This PR has **added ${newTests} E2E test cases** (threshold: ${threshold})`;
-              } else {
-                // Previous comment exists but change is now within range
-                header = `### ✅ E2E test count change is within normal range`;
-                if (newTests === 0) {
-                  message = `This PR has **no change** in E2E test count`;
-                } else if (newTests > 0) {
-                  message = `This PR has **added ${newTests} E2E test cases**`;
-                } else {
-                  message = `This PR has **removed ${Math.abs(newTests)} E2E test cases**`;
-                }
-              }
+            // Only speak up about a significant increase, or to correct a
+            // comment we already left on an earlier commit of this PR.
+            if (!summary.is_significant && !existingComment) {
+              console.log('Test count change is not significant, skipping comment');
+              return;
+            }
 
-              const lines = [
-                header,
-                '',
-                message,
-                '',
-                `- Current PR: ${currentTotal} tests`,
-                `- Latest develop: ${developTotal} tests`,
-              ];
-
-              if (isSignificant) {
-                lines.push(
-                  '',
-                  '> ⚠️ **Note:** E2E tests are expensive to run. Please ensure you\'re following best practices:',
-                  '> - Prefer aggregated scenario tests over many micro-tests',
-                  '> - Add tests to existing files when they fit the scope',
-                  '> - Test each aspect only once per browser run'
-                );
-              }
-
-              const commentBody = lines.join('\n');
-              const fullCommentBody = `${commentIdentifier}\n${commentBody}`;
-
-              if (existingComment) {
-                await github.rest.issues.updateComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  comment_id: existingComment.id,
-                  body: fullCommentBody
-                });
-                console.log('Updated existing E2E test count comment');
-              } else {
-                await github.rest.issues.createComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: context.issue.number,
-                  body: fullCommentBody
-                });
-                console.log('Created new E2E test count comment');
-              }
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existingComment.id,
+                body: summary.body,
+              });
+              console.log('Updated existing E2E test count comment');
             } else {
-              console.log('Test count change is not significant (added <= threshold), skipping comment');
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: summary.body,
+              });
+              console.log('Created new E2E test count comment');
             }

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -127,10 +127,11 @@ jobs:
           # For pull_request events, the checked out HEAD is the merge commit
           # GitHub creates for the PR, so depth 2 also gets us its parents.
           fetch-depth: 2
-      # Everything below relies on HEAD being that merge commit. If it is not
-      # (for example because the PR has conflicts), HEAD^1 would be the previous
-      # commit of the PR branch instead of the base branch, and the reported
-      # numbers would be nonsense. Skip the check rather than guess.
+      # Everything below relies on HEAD being that merge commit: otherwise HEAD^1
+      # is the PR branch's own previous commit rather than the base branch, and
+      # the numbers would be nonsense. Skip rather than guess. Conflicted PRs are
+      # not this case — GitHub keeps a stale merge ref for them, so the check
+      # still runs, comparing against that ref's own (older) base parent.
       - name: Check for a PR merge commit
         id: merge_commit
         run: |

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -19,6 +19,15 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-playwright
   cancel-in-progress: true
 
+# Which tests the suite runs. Shared with the `check-e2e-test-count` job below so
+# that the counts it reports stay in sync with what actually runs; keep both jobs
+# reading these instead of spelling the arguments out again. The marker
+# expression is separate because it contains a space and has to stay quoted,
+# while the flags rely on word splitting.
+env:
+  E2E_SELECTION_FLAGS: --ignore ./custom_components --ignore ./load_testing --browser webkit --browser chromium --browser firefox
+  E2E_MARKER_EXPR: not performance
+
 jobs:
   playwright-e2e-tests:
     runs-on: ubuntu-latest-64-cores
@@ -58,7 +67,8 @@ jobs:
         # With psutil installed, pytest-xdist's `-n auto` uses physical cores (32 on 64-core runner)
         run: |
           cd e2e_playwright && rm -rf ./test-results
-          uv run pytest --ignore ./custom_components --ignore ./load_testing --browser webkit --browser chromium --browser firefox -n auto --reruns 1 -m "not performance"
+          # shellcheck disable=SC2086  # E2E_SELECTION_FLAGS must word split
+          uv run pytest $E2E_SELECTION_FLAGS -m "$E2E_MARKER_EXPR" -n auto --reruns 1
       - name: Upload test statistics
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
@@ -118,30 +128,48 @@ jobs:
           else
             echo "::warning::HEAD is not a PR merge commit, skipping the E2E test count check."
           fi
-      - name: Set Python version vars
+      # Most PRs touch no E2E test at all, and no E2E test imports `streamlit`,
+      # so nothing outside this directory can change what gets collected. Skip
+      # the environment setup and collection for those PRs; the comment step
+      # still runs, to clear a comment left on an earlier commit.
+      - name: Check for E2E test changes
+        id: e2e_changes
         if: steps.merge_commit.outputs.found
+        run: |
+          set -euo pipefail
+          if git diff --quiet HEAD^1 HEAD -- e2e_playwright; then
+            echo "No changes under e2e_playwright/, the test count cannot have changed."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Set Python version vars
+        if: steps.e2e_changes.outputs.changed
         uses: ./.github/actions/build_info
       - name: Setup virtual env
-        if: steps.merge_commit.outputs.found
+        if: steps.e2e_changes.outputs.changed
         uses: ./.github/actions/make_init
         with:
           python_version: ${{ env.PYTHON_MAX_VERSION }}
       - name: Collect test IDs for the PR and its merge base
-        if: steps.merge_commit.outputs.found
+        if: steps.e2e_changes.outputs.changed
         env:
           COLLECT_DIR: ${{ runner.temp }}
         run: |
           set -euo pipefail
-          # Collection args mirror the `playwright-e2e-tests` job above so that
-          # we count the tests that actually run in CI. Playwright browsers are
-          # not needed: collection never launches one. `addopts` is cleared
-          # because e2e_playwright/pytest.ini enables verbose output, which
-          # would replace the test IDs with human-readable lines.
+          # Counts the tests that CI actually runs: the selection comes from the
+          # same variables as the suite job above, and the plugin drops the tests
+          # Playwright would skip for their browser. The plugin lives in
+          # scripts/, which is never swapped out below, so both collections apply
+          # the PR's rules. Playwright browsers are not needed, since collection
+          # never launches one. `addopts` is cleared because
+          # e2e_playwright/pytest.ini turns on verbose output, which would
+          # replace the test IDs with human-readable lines.
           collect() {
-            (cd e2e_playwright && uv run pytest --collect-only -q -o addopts= \
-              --no-stats --ignore ./custom_components --ignore ./load_testing \
-              --browser webkit --browser chromium --browser firefox \
-              -m "not performance") > "$1"
+            # shellcheck disable=SC2086  # E2E_SELECTION_FLAGS must word split
+            (cd e2e_playwright && PYTHONPATH="$GITHUB_WORKSPACE/scripts" \
+              uv run pytest -p e2e_executable_tests_plugin --collect-only -q \
+              -o addopts= --no-stats $E2E_SELECTION_FLAGS \
+              -m "$E2E_MARKER_EXPR") > "$1"
           }
 
           collect "$COLLECT_DIR/head-test-ids.txt"
@@ -159,7 +187,7 @@ jobs:
 
           collect "$COLLECT_DIR/base-test-ids.txt"
       - name: Compare test counts
-        if: steps.merge_commit.outputs.found
+        if: steps.e2e_changes.outputs.changed
         env:
           COLLECT_DIR: ${{ runner.temp }}
         run: |
@@ -173,10 +201,20 @@ jobs:
       - name: Comment on the PR
         if: steps.merge_commit.outputs.found
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          # Empty when the PR changes no E2E test, so nothing was counted.
+          COUNTED: ${{ steps.e2e_changes.outputs.changed }}
+          # Only needed to find our comment when nothing was counted, since the
+          # summary that normally carries this was never produced. Must equal
+          # COMMENT_MARKER in scripts/compare_e2e_test_counts.py. Editing either
+          # one orphans the comments already posted on open PRs, so don't.
+          MARKER: "<!-- STREAMLIT-E2E-TEST-COUNT-CHECK -->"
         with:
           script: |
             const fs = require('fs');
-            const summary = JSON.parse(fs.readFileSync(process.env.SUMMARY_PATH, 'utf8'));
+            const summary = process.env.COUNTED
+              ? JSON.parse(fs.readFileSync(process.env.SUMMARY_PATH, 'utf8'))
+              : null;
 
             // Fork PRs get a read-only token, so commenting would fail. The
             // numbers are in the job logs of the previous step either way.
@@ -192,7 +230,24 @@ jobs:
               issue_number: context.issue.number,
               per_page: 100,
             });
-            const existingComment = comments.find(comment => comment.body.includes(summary.marker));
+            const marker = summary ? summary.marker : process.env.MARKER;
+            const existingComment = comments.find(comment => comment.body.includes(marker));
+
+            // An earlier commit of this PR changed E2E tests and this one does
+            // not, so whatever we said about it no longer applies.
+            if (!summary) {
+              if (existingComment) {
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existingComment.id,
+                });
+                console.log('Deleted obsolete E2E test count comment');
+              } else {
+                console.log('PR changes no E2E tests, nothing to report');
+              }
+              return;
+            }
 
             // Only speak up about a significant increase, or to correct a
             // comment we already left on an earlier commit of this PR.

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -84,14 +84,19 @@ jobs:
           path: e2e_playwright/test-results
 
   # Reports how many E2E test cases a PR adds, by collecting test IDs on the PR
-  # and on its merge base. This deliberately does not compare against the test
+  # and on its base branch. This deliberately does not compare against the test
   # counts of a develop CI run: those runs drift with every merge, so the diff
   # would include tests added by other PRs.
   check-e2e-test-count:
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    # A merge base only exists for pull_request events.
-    if: github.event_name == 'pull_request' && github.repository == 'streamlit/streamlit'
+    # A pull request merge commit only exists for pull_request events. Fork PRs
+    # get a read-only token, so the comment would fail; skip the whole job rather
+    # than collect twice for a log line nobody reads.
+    if: >-
+      github.event_name == 'pull_request'
+      && github.repository == 'streamlit/streamlit'
+      && github.event.pull_request.head.repo.fork == false
     continue-on-error: true
 
     permissions:
@@ -124,7 +129,7 @@ jobs:
           fetch-depth: 2
       # Everything below relies on HEAD being that merge commit. If it is not
       # (for example because the PR has conflicts), HEAD^1 would be the previous
-      # commit of the PR branch instead of the merge base, and the reported
+      # commit of the PR branch instead of the base branch, and the reported
       # numbers would be nonsense. Skip the check rather than guess.
       - name: Check for a PR merge commit
         id: merge_commit
@@ -160,7 +165,7 @@ jobs:
         uses: ./.github/actions/make_init
         with:
           python_version: ${{ env.PYTHON_MAX_VERSION }}
-      - name: Collect test IDs for the PR and its merge base
+      - name: Collect test IDs for the PR and its base branch
         if: steps.e2e_changes.outputs.changed
         run: |
           set -euo pipefail
@@ -176,7 +181,7 @@ jobs:
           #   verbose output, which would replace the test IDs with
           #   human-readable lines;
           # - `--no-stats` comes from e2e_playwright/shared/stats_reporter.py,
-          #   which the swap below replaces with the merge base's copy, so
+          #   which the swap below replaces with the base branch's copy, so
           #   renaming that option breaks the second collection.
           read -ra selection_flags <<< "$E2E_SELECTION_FLAGS"
           collect() {
@@ -191,13 +196,13 @@ jobs:
           # HEAD^1 of the merge commit is the develop commit this PR merges
           # into, i.e. exactly the baseline the PR is responsible for changing.
           git rev-parse --short HEAD^1 > "$RUNNER_TEMP/base-ref.txt"
-          # Swap in the merge base's tests: restoring tracked files is not
+          # Swap in the base branch's tests: restoring tracked files is not
           # enough, because files the PR added would linger and inflate the
           # baseline. `--no-renames` keeps a renamed file from being missed
           # here (it would otherwise be reported as a rename, not an addition).
-          # Deleting only those files, rather than the whole directory, keeps
-          # this off the untracked __pycache__ that the collection above is
-          # still writing: `rm -rf e2e_playwright` loses that race.
+          # Deleting only the added files, rather than the whole directory,
+          # preserves the __pycache__ that the first collection just wrote, so
+          # the second one does not recompile every test module.
           git diff --name-only -z --diff-filter=A --no-renames HEAD^1 HEAD \
             -- e2e_playwright | xargs -0 -r rm -f
           git checkout HEAD^1 -- e2e_playwright
@@ -231,13 +236,6 @@ jobs:
             const summary = process.env.COUNTED
               ? JSON.parse(fs.readFileSync(summaryPath, 'utf8'))
               : null;
-
-            // Fork PRs get a read-only token, so commenting would fail. The
-            // numbers are in the job logs of the previous step either way.
-            if (context.payload.pull_request?.head?.repo?.fork === true) {
-              console.log('PR is from a fork - skipping comment (insufficient permissions)');
-              return;
-            }
 
             // Paginate: on a busy PR our comment can be well past the first page.
             const comments = await github.paginate(github.rest.issues.listComments, {

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -21,9 +21,9 @@ concurrency:
 
 # Which tests the suite runs. Shared with the `check-e2e-test-count` job below so
 # that the counts it reports stay in sync with what actually runs; keep both jobs
-# reading these instead of spelling the arguments out again. The marker
-# expression is separate because it contains a space and has to stay quoted,
-# while the flags rely on word splitting.
+# reading these instead of spelling the arguments out again. Both jobs split
+# E2E_SELECTION_FLAGS with `read -ra`, so no value in it may contain whitespace,
+# which is why the marker expression is separate: it contains a space.
 env:
   E2E_SELECTION_FLAGS: --ignore ./custom_components --ignore ./load_testing --browser webkit --browser chromium --browser firefox
   E2E_MARKER_EXPR: not performance
@@ -66,9 +66,9 @@ jobs:
       - name: Run playwright tests
         # With psutil installed, pytest-xdist's `-n auto` uses physical cores (32 on 64-core runner)
         run: |
+          read -ra selection_flags <<< "$E2E_SELECTION_FLAGS"
           cd e2e_playwright && rm -rf ./test-results
-          # shellcheck disable=SC2086  # E2E_SELECTION_FLAGS must word split
-          uv run pytest $E2E_SELECTION_FLAGS -m "$E2E_MARKER_EXPR" -n auto --reruns 1
+          uv run pytest "${selection_flags[@]}" -m "$E2E_MARKER_EXPR" -n auto --reruns 1
       - name: Upload test statistics
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
@@ -104,14 +104,21 @@ jobs:
 
     env:
       NEW_TEST_THRESHOLD: 30
-      SUMMARY_PATH: ${{ runner.temp }}/e2e-test-count-summary.json
+      # Just the file name: steps join it with $RUNNER_TEMP themselves, because
+      # job-level env cannot use `runner.temp` (the `runner` context is only
+      # available to steps, and an invalid expression here makes the whole
+      # workflow file unparseable rather than just this job).
+      SUMMARY_FILE: e2e-test-count-summary.json
 
     steps:
+      # This job imports PR-authored code (collection executes conftest.py and
+      # every test module) while holding `pull-requests: write`. That is only
+      # safe under `pull_request`, where GitHub downgrades the token to
+      # read-only for forks; never move this job to `pull_request_target`.
       - name: Checkout Streamlit code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-          submodules: "recursive"
           # For pull_request events, the checked out HEAD is the merge commit
           # GitHub creates for the PR, so depth 2 also gets us its parents.
           fetch-depth: 2
@@ -128,16 +135,19 @@ jobs:
           else
             echo "::warning::HEAD is not a PR merge commit, skipping the E2E test count check."
           fi
-      # Most PRs touch no E2E test at all, and no E2E test imports `streamlit`,
-      # so nothing outside this directory can change what gets collected. Skip
-      # the environment setup and collection for those PRs; the comment step
-      # still runs, to clear a comment left on an earlier commit.
+      # Most PRs touch no E2E test at all, and nothing outside this directory
+      # feeds pytest's collection: every parametrized test takes its values from
+      # literals inside e2e_playwright/. So the count cannot have changed, and
+      # neither can snapshots change it. Skip the environment setup and the
+      # collection for those PRs; the comment step still runs, to correct a
+      # comment left by an earlier commit.
       - name: Check for E2E test changes
         id: e2e_changes
         if: steps.merge_commit.outputs.found
         run: |
           set -euo pipefail
-          if git diff --quiet HEAD^1 HEAD -- e2e_playwright; then
+          if git diff --quiet HEAD^1 HEAD -- e2e_playwright \
+            ':(exclude)e2e_playwright/__snapshots__'; then
             echo "No changes under e2e_playwright/, the test count cannot have changed."
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
@@ -152,52 +162,57 @@ jobs:
           python_version: ${{ env.PYTHON_MAX_VERSION }}
       - name: Collect test IDs for the PR and its merge base
         if: steps.e2e_changes.outputs.changed
-        env:
-          COLLECT_DIR: ${{ runner.temp }}
         run: |
           set -euo pipefail
-          # Counts the tests that CI actually runs: the selection comes from the
-          # same variables as the suite job above, and the plugin drops the tests
-          # Playwright would skip for their browser. The plugin lives in
-          # scripts/, which is never swapped out below, so both collections apply
-          # the PR's rules. Playwright browsers are not needed, since collection
-          # never launches one. `addopts` is cleared because
-          # e2e_playwright/pytest.ini turns on verbose output, which would
-          # replace the test IDs with human-readable lines.
+          # Counts the tests that CI actually runs:
+          # - the selection comes from the same variables as the suite job above,
+          #   and the plugin drops the tests Playwright would skip for their
+          #   browser;
+          # - the plugin lives in scripts/, which is never swapped out below, so
+          #   both collections apply the PR's rules;
+          # - Playwright browsers are not needed, since collection never launches
+          #   one;
+          # - `addopts` is cleared because e2e_playwright/pytest.ini turns on
+          #   verbose output, which would replace the test IDs with
+          #   human-readable lines;
+          # - `--no-stats` comes from e2e_playwright/shared/stats_reporter.py,
+          #   which the swap below replaces with the merge base's copy, so
+          #   renaming that option breaks the second collection.
+          read -ra selection_flags <<< "$E2E_SELECTION_FLAGS"
           collect() {
-            # shellcheck disable=SC2086  # E2E_SELECTION_FLAGS must word split
             (cd e2e_playwright && PYTHONPATH="$GITHUB_WORKSPACE/scripts" \
               uv run pytest -p e2e_executable_tests_plugin --collect-only -q \
-              -o addopts= --no-stats $E2E_SELECTION_FLAGS \
+              -o addopts= --no-stats "${selection_flags[@]}" \
               -m "$E2E_MARKER_EXPR") > "$1"
           }
 
-          collect "$COLLECT_DIR/head-test-ids.txt"
+          collect "$RUNNER_TEMP/head-test-ids.txt"
 
           # HEAD^1 of the merge commit is the develop commit this PR merges
           # into, i.e. exactly the baseline the PR is responsible for changing.
-          git rev-parse --short HEAD^1 > "$COLLECT_DIR/base-ref.txt"
+          git rev-parse --short HEAD^1 > "$RUNNER_TEMP/base-ref.txt"
           # Swap in the merge base's tests: restoring tracked files is not
           # enough, because files the PR added would linger and inflate the
           # baseline. `--no-renames` keeps a renamed file from being missed
           # here (it would otherwise be reported as a rename, not an addition).
+          # Deleting only those files, rather than the whole directory, keeps
+          # this off the untracked __pycache__ that the collection above is
+          # still writing: `rm -rf e2e_playwright` loses that race.
           git diff --name-only -z --diff-filter=A --no-renames HEAD^1 HEAD \
             -- e2e_playwright | xargs -0 -r rm -f
           git checkout HEAD^1 -- e2e_playwright
 
-          collect "$COLLECT_DIR/base-test-ids.txt"
+          collect "$RUNNER_TEMP/base-test-ids.txt"
       - name: Compare test counts
         if: steps.e2e_changes.outputs.changed
-        env:
-          COLLECT_DIR: ${{ runner.temp }}
         run: |
           set -euo pipefail
           uv run python scripts/compare_e2e_test_counts.py \
-            --base "$COLLECT_DIR/base-test-ids.txt" \
-            --head "$COLLECT_DIR/head-test-ids.txt" \
-            --base-ref "$(cat "$COLLECT_DIR/base-ref.txt")" \
+            --base "$RUNNER_TEMP/base-test-ids.txt" \
+            --head "$RUNNER_TEMP/head-test-ids.txt" \
+            --base-ref "$(cat "$RUNNER_TEMP/base-ref.txt")" \
             --threshold "$NEW_TEST_THRESHOLD" \
-            --output "$SUMMARY_PATH"
+            --output "$RUNNER_TEMP/$SUMMARY_FILE"
       - name: Comment on the PR
         if: steps.merge_commit.outputs.found
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -212,8 +227,9 @@ jobs:
         with:
           script: |
             const fs = require('fs');
+            const summaryPath = `${process.env.RUNNER_TEMP}/${process.env.SUMMARY_FILE}`;
             const summary = process.env.COUNTED
-              ? JSON.parse(fs.readFileSync(process.env.SUMMARY_PATH, 'utf8'))
+              ? JSON.parse(fs.readFileSync(summaryPath, 'utf8'))
               : null;
 
             // Fork PRs get a read-only token, so commenting would fail. The
@@ -234,15 +250,22 @@ jobs:
             const existingComment = comments.find(comment => comment.body.includes(marker));
 
             // An earlier commit of this PR changed E2E tests and this one does
-            // not, so whatever we said about it no longer applies.
+            // not, so correct what we said rather than delete it: a reviewer who
+            // saw the warning should see it withdrawn, not find it missing.
             if (!summary) {
               if (existingComment) {
-                await github.rest.issues.deleteComment({
+                await github.rest.issues.updateComment({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   comment_id: existingComment.id,
+                  body: [
+                    marker,
+                    '### ✅ No E2E test count change',
+                    '',
+                    'This PR no longer changes any E2E test cases.',
+                  ].join('\n'),
                 });
-                console.log('Deleted obsolete E2E test count comment');
+                console.log('Withdrew obsolete E2E test count comment');
               } else {
                 console.log('PR changes no E2E tests, nothing to report');
               }

--- a/scripts/compare_e2e_test_counts.py
+++ b/scripts/compare_e2e_test_counts.py
@@ -1,0 +1,262 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A script to compare collected E2E test IDs between two revisions.
+
+Usage:
+    python scripts/compare_e2e_test_counts.py --base BASE_IDS --head HEAD_IDS
+        [--threshold 30] [--output summary.json]
+
+Both inputs are files containing the test IDs printed by
+`pytest --collect-only -q`, one per line, e.g.:
+
+    st_dialog_test.py::test_dialog_displays_correctly[chromium]
+
+The script diffs the two sets of test IDs and prints a JSON summary to stdout
+(or to --output), including a ready-to-post Markdown comment body. Because it
+compares test IDs rather than plain totals, it reports what a PR actually
+changed even when tests were renamed or moved, and it can attribute the change
+to individual test files.
+
+Node IDs come from a `--collect-only` run, so the counts include every browser
+parametrization (a single new test function adds one test case per browser).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any, Final, NamedTuple
+
+# Comment marker used to find and update our own comment on a PR.
+COMMENT_MARKER: Final = "<!-- STREAMLIT-E2E-TEST-COUNT-CHECK -->"
+
+# Maximum number of test files listed in the per-file breakdown table.
+MAX_LISTED_FILES: Final = 10
+
+
+class TestIds(NamedTuple):
+    """A collected set of test IDs, indexed for comparison."""
+
+    # Full test IDs, one per browser parametrization.
+    cases: set[str]
+    # Test IDs without their parameters, i.e. one entry per test function.
+    functions: set[str]
+    # Number of test cases per test file.
+    per_file: Counter[str]
+
+
+def parse_test_ids(path: Path) -> TestIds:
+    """Read a `pytest --collect-only -q` output file into a `TestIds`."""
+    cases = {
+        line.strip()
+        for line in path.read_text(encoding="utf-8").splitlines()
+        # Anything without "::" is a summary line ("6084 tests collected") or
+        # a warning, not a test ID.
+        if "::" in line
+    }
+
+    return TestIds(
+        cases=cases,
+        # Parameters start at the first "[", e.g. "…::test_foo[chromium-wide]".
+        functions={case.split("[", 1)[0] for case in cases},
+        per_file=Counter(case.split("::", 1)[0] for case in cases),
+    )
+
+
+def _format_delta(delta: int) -> str:
+    """Format a change as a signed number, e.g. "+12" or "-3"."""
+    return f"{delta:+d}"
+
+
+def _build_file_table(base: TestIds, head: TestIds) -> list[str]:
+    """Build a Markdown table of the test files whose test count changed."""
+    # `Counter.__sub__` keeps only positive counts, so subtract in both
+    # directions to catch the files that gained and that lost test cases.
+    gained = head.per_file - base.per_file
+    lost = base.per_file - head.per_file
+    changed = {**gained, **{file: -count for file, count in lost.items()}}
+
+    if not changed:
+        return []
+
+    # Largest increases first; the files a reviewer most likely cares about.
+    ranked = sorted(changed.items(), key=lambda item: (-item[1], item[0]))
+    listed = ranked[:MAX_LISTED_FILES]
+
+    lines = ["", "| Test file | Test cases |", "| --- | --- |"]
+    lines += [f"| `{file}` | {_format_delta(delta)} |" for file, delta in listed]
+
+    if len(ranked) > len(listed):
+        lines.append("")
+        lines.append(f"…and {len(ranked) - len(listed)} more test files.")
+
+    return lines
+
+
+def _build_comment(
+    base: TestIds,
+    head: TestIds,
+    threshold: int,
+    base_ref: str | None,
+) -> tuple[str, bool]:
+    """Build the PR comment body. Returns the body and whether it's significant.
+
+    A change counts as significant when the PR adds more test cases than the
+    threshold allows; that is the only case that warrants a new comment.
+    """
+    net_change = len(head.cases) - len(base.cases)
+    new_functions = len(head.functions - base.functions)
+    is_significant = net_change > threshold
+
+    if is_significant:
+        header = "### 🧪 Significant E2E test count increase detected"
+        message = (
+            f"This PR adds **{net_change} E2E test cases** (threshold: {threshold})"
+        )
+    else:
+        header = "### ✅ E2E test count change is within normal range"
+        if net_change == 0:
+            message = "This PR does **not change** the number of E2E test cases"
+        elif net_change > 0:
+            message = f"This PR adds **{net_change} E2E test cases**"
+        else:
+            message = f"This PR removes **{abs(net_change)} E2E test cases**"
+
+    # Only when the count grew: "removes 5 test cases, from 2 new test
+    # functions" would read as a contradiction.
+    if new_functions and net_change > 0:
+        message += (
+            f", from {new_functions} new test "
+            f"{'function' if new_functions == 1 else 'functions'} "
+            "(each test runs once per browser)"
+        )
+
+    base_label = f" (`{base_ref}`)" if base_ref else ""
+    lines = [
+        COMMENT_MARKER,
+        header,
+        "",
+        f"{message}.",
+        "",
+        f"- Merge base{base_label}: {len(base.cases)} test cases",
+        f"- This PR: {len(head.cases)} test cases",
+        *_build_file_table(base, head),
+    ]
+
+    if is_significant:
+        lines += [
+            "",
+            (
+                "> ⚠️ **Note:** E2E tests are expensive to run. Please ensure "
+                "you're following best practices:"
+            ),
+            "> - Prefer aggregated scenario tests over many micro-tests",
+            "> - Add tests to existing files when they fit the scope",
+            "> - Test each aspect only once per browser run",
+        ]
+
+    return "\n".join(lines), is_significant
+
+
+def compare(
+    base_path: Path,
+    head_path: Path,
+    threshold: int,
+    base_ref: str | None = None,
+) -> dict[str, Any]:
+    """Compare two collected test ID files and summarize the difference."""
+    base = parse_test_ids(base_path)
+    head = parse_test_ids(head_path)
+
+    if not base.cases or not head.cases:
+        raise ValueError(
+            "Collected no test IDs for "
+            f"{'the merge base' if not base.cases else 'this PR'}. "
+            "The pytest collection step probably failed."
+        )
+
+    body, is_significant = _build_comment(base, head, threshold, base_ref)
+
+    return {
+        "marker": COMMENT_MARKER,
+        "body": body,
+        "is_significant": is_significant,
+        "threshold": threshold,
+        "base_total": len(base.cases),
+        "head_total": len(head.cases),
+        "net_change": len(head.cases) - len(base.cases),
+        # Renames and moves show up as an addition and a removal, so these do
+        # not have to add up to net_change.
+        "added_cases": len(head.cases - base.cases),
+        "removed_cases": len(base.cases - head.cases),
+        "new_functions": sorted(head.functions - base.functions),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base",
+        type=Path,
+        required=True,
+        help="File with the test IDs collected at the merge base.",
+    )
+    parser.add_argument(
+        "--head",
+        type=Path,
+        required=True,
+        help="File with the test IDs collected on the PR branch.",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=int,
+        default=30,
+        help="Number of added test cases that is still considered normal.",
+    )
+    parser.add_argument(
+        "--base-ref",
+        default=None,
+        help="Merge base revision, shown in the comment for traceability.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Write the JSON summary to this file instead of stdout.",
+    )
+    args = parser.parse_args()
+
+    try:
+        summary = compare(args.base, args.head, args.threshold, args.base_ref)
+    except (OSError, ValueError) as error:
+        # A traceback adds nothing here: the interesting failure is upstream, in
+        # the collection step whose output we were handed.
+        sys.exit(f"Cannot compare E2E test counts: {error}")
+
+    serialized = json.dumps(summary, indent=2)
+
+    if args.output:
+        args.output.write_text(serialized, encoding="utf-8")
+
+    # Always log the summary so the numbers are visible in the job logs, even
+    # when no comment gets posted.
+    print(serialized, file=sys.stdout)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/compare_e2e_test_counts.py
+++ b/scripts/compare_e2e_test_counts.py
@@ -42,7 +42,10 @@ from collections import Counter
 from pathlib import Path
 from typing import Any, Final, NamedTuple
 
-# Comment marker used to find and update our own comment on a PR.
+# Comment marker used to find and update our own comment on a PR. Mirrored as
+# MARKER in .github/workflows/playwright.yml, which needs it for the case where
+# no count was produced. Editing either one orphans the comments already posted
+# on open PRs, so don't.
 COMMENT_MARKER: Final = "<!-- STREAMLIT-E2E-TEST-COUNT-CHECK -->"
 
 # Maximum number of test files listed in the per-file breakdown table.

--- a/scripts/compare_e2e_test_counts.py
+++ b/scripts/compare_e2e_test_counts.py
@@ -68,9 +68,9 @@ def parse_test_ids(path: Path) -> TestIds:
     cases = {
         line.strip()
         for line in path.read_text(encoding="utf-8").splitlines()
-        # Anything without "::" is a summary line ("6084 tests collected") or
-        # a warning, not a test ID.
-        if "::" in line
+        # Anything else is a summary line ("6084 tests collected") or a
+        # warning, not a test ID.
+        if ".py::" in line
     }
 
     return TestIds(
@@ -157,7 +157,7 @@ def _build_comment(
         "",
         f"{message}.",
         "",
-        f"- Merge base{base_label}: {len(base.cases)} test cases",
+        f"- Base branch{base_label}: {len(base.cases)} test cases",
         f"- This PR: {len(head.cases)} test cases",
         *_build_file_table(base, head),
     ]
@@ -190,7 +190,7 @@ def compare(
     if not base.cases or not head.cases:
         raise ValueError(
             "Collected no test IDs for "
-            f"{'the merge base' if not base.cases else 'this PR'}. "
+            f"{'the base branch' if not base.cases else 'this PR'}. "
             "The pytest collection step probably failed."
         )
 
@@ -218,7 +218,7 @@ def main() -> None:
         "--base",
         type=Path,
         required=True,
-        help="File with the test IDs collected at the merge base.",
+        help="File with the test IDs collected on the base branch.",
     )
     parser.add_argument(
         "--head",
@@ -230,12 +230,12 @@ def main() -> None:
         "--threshold",
         type=int,
         default=30,
-        help="Number of added test cases that is still considered normal.",
+        help="Largest net increase in test cases that is still considered normal.",
     )
     parser.add_argument(
         "--base-ref",
         default=None,
-        help="Merge base revision, shown in the comment for traceability.",
+        help="Base branch revision, shown in the comment for traceability.",
     )
     parser.add_argument(
         "--output",

--- a/scripts/compare_e2e_test_counts.py
+++ b/scripts/compare_e2e_test_counts.py
@@ -29,7 +29,7 @@ compares test IDs rather than plain totals, it reports what a PR actually
 changed even when tests were renamed or moved, and it can attribute the change
 to individual test files.
 
-Node IDs come from a `--collect-only` run, so the counts include every browser
+Test IDs come from a `--collect-only` run, so the counts include every browser
 parametrization (a single new test function adds one test case per browser).
 """
 
@@ -140,8 +140,9 @@ def _build_comment(
         else:
             message = f"This PR removes **{abs(net_change)} E2E test cases**"
 
-    # Only when the count grew: "removes 5 test cases, from 2 new test
-    # functions" would read as a contradiction.
+    # A net removal can still introduce new test functions, but "removes 5 test
+    # cases, from 2 new test functions" reads as a contradiction, so only mention
+    # them when the count grew.
     if new_functions and net_change > 0:
         message += (
             f", from {new_functions} new test "

--- a/scripts/e2e_executable_tests_plugin.py
+++ b/scripts/e2e_executable_tests_plugin.py
@@ -49,12 +49,12 @@ _BROWSERS: Final = ("chromium", "firefox", "webkit")
 
 
 def _would_run(item: pytest.Item) -> bool:
-    """Return whether CI would execute this test, rather than skip it.
+    """Return whether this test survives the skips known at collection time.
 
-    Neither `skipif` conditions nor `pytest.skip()` calls in a test body are
-    evaluated: doing so needs pytest internals or running the test itself. Both
-    inflate the count equally on each side of the comparison, so the delta the
-    check reports stays correct.
+    That covers `skip` markers and Playwright's browser skiplist. `skipif`
+    conditions and `pytest.skip()` calls in a test body are not evaluated, since
+    doing so needs pytest internals or running the test itself, so a PR that
+    adds or changes those moves what CI runs without a matching delta here.
     """
     if item.get_closest_marker("skip") is not None:
         return False

--- a/scripts/e2e_executable_tests_plugin.py
+++ b/scripts/e2e_executable_tests_plugin.py
@@ -1,0 +1,81 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A pytest plugin that deselects E2E tests which would be skipped anyway.
+
+Usage:
+    PYTHONPATH=scripts pytest -p e2e_executable_tests_plugin --collect-only -q
+
+Tests marked with `only_browser` or `skip_browser` are collected for every
+browser and then skipped during setup, so a plain `--collect-only` over-reports
+what a CI run executes (~250 test cases at the time of writing). Deselecting
+them makes `--collect-only` output list exactly the tests that would run, which
+is what the E2E test count check in `.github/workflows/playwright.yml` reports.
+
+This plugin lives in `scripts/` rather than in `e2e_playwright/` on purpose: the
+test count check swaps `e2e_playwright/` to the PR's merge base, so a plugin in
+there would disappear with it, and older revisions would apply older rules.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Final
+
+# Reuse Playwright's own skip logic instead of reimplementing it, so that the
+# reported count cannot quietly drift away from what the plugin does at runtime.
+# If a Playwright upgrade renames this, the import fails loudly, which is much
+# better than silently counting tests that never run.
+from pytest_playwright.pytest_playwright import _get_skiplist
+
+if TYPE_CHECKING:
+    import pytest
+
+# The browsers Playwright can parametrize over, in the order it lists them.
+_BROWSERS: Final = ("chromium", "firefox", "webkit")
+
+
+def _would_run(item: pytest.Item) -> bool:
+    """Return whether this test runs, rather than being skipped.
+
+    Note that `skipif` conditions are not evaluated: doing so needs pytest
+    internals, and no E2E test uses one today. Should that change, the reported
+    count is too high by the number of tests that the condition skips.
+    """
+    if item.get_closest_marker("skip") is not None:
+        return False
+
+    callspec = getattr(item, "callspec", None)
+    if callspec is None:
+        return True
+
+    browser_name = callspec.params.get("browser_name")
+    if not browser_name:
+        return True
+
+    # `_get_skiplist` mutates the list of browsers it is handed, so pass a copy.
+    return browser_name not in _get_skiplist(item, list(_BROWSERS), "browser")
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config, items: list[pytest.Item]
+) -> None:
+    """Deselect every test Playwright would skip for its browser."""
+    executable: list[pytest.Item] = []
+    skipped: list[pytest.Item] = []
+    for item in items:
+        (executable if _would_run(item) else skipped).append(item)
+
+    if skipped:
+        config.hook.pytest_deselected(items=skipped)
+        items[:] = executable

--- a/scripts/e2e_executable_tests_plugin.py
+++ b/scripts/e2e_executable_tests_plugin.py
@@ -19,9 +19,10 @@ Usage:
 
 Tests marked with `only_browser` or `skip_browser` are collected for every
 browser and then skipped during setup, so a plain `--collect-only` over-reports
-what a CI run executes (~250 test cases at the time of writing). Deselecting
-them makes `--collect-only` output list exactly the tests that would run, which
-is what the E2E test count check in `.github/workflows/playwright.yml` reports.
+what a CI run executes (by ~250 test cases at the time of writing). Deselecting
+them makes `--collect-only` output list the tests that would run, up to the
+runtime skips noted in `_would_run`, which is what the E2E test count check in
+`.github/workflows/playwright.yml` reports.
 
 This plugin lives in `scripts/` rather than in `e2e_playwright/` on purpose: the
 test count check swaps `e2e_playwright/` to the PR's merge base, so a plugin in
@@ -41,16 +42,19 @@ from pytest_playwright.pytest_playwright import _get_skiplist
 if TYPE_CHECKING:
     import pytest
 
-# The browsers Playwright can parametrize over, in the order it lists them.
+# Mirrors the browser list Playwright hardcodes in `pytest_runtest_setup`. Only
+# membership matters, not order, and a superset is fine: a test's `browser_name`
+# is always one that `--browser` selected.
 _BROWSERS: Final = ("chromium", "firefox", "webkit")
 
 
 def _would_run(item: pytest.Item) -> bool:
-    """Return whether this test runs, rather than being skipped.
+    """Return whether CI would execute this test, rather than skip it.
 
-    Note that `skipif` conditions are not evaluated: doing so needs pytest
-    internals, and no E2E test uses one today. Should that change, the reported
-    count is too high by the number of tests that the condition skips.
+    Neither `skipif` conditions nor `pytest.skip()` calls in a test body are
+    evaluated: doing so needs pytest internals or running the test itself. Both
+    inflate the count equally on each side of the comparison, so the delta the
+    check reports stays correct.
     """
     if item.get_closest_marker("skip") is not None:
         return False
@@ -70,7 +74,9 @@ def _would_run(item: pytest.Item) -> bool:
 def pytest_collection_modifyitems(
     config: pytest.Config, items: list[pytest.Item]
 ) -> None:
-    """Deselect every test Playwright would skip for its browser."""
+    """Deselect every test CI would skip: `skip`-marked ones, and the ones
+    Playwright skips for their browser.
+    """
     executable: list[pytest.Item] = []
     skipped: list[pytest.Item] = []
     for item in items:


### PR DESCRIPTION
## Describe your changes
The E2E test count check no longer needs a baseline CI run at all. It collects test IDs twice in one job — once on the PR, once with `e2e_playwright/` swapped to `HEAD^1` of the pull request merge commit — so the reported delta is the PR's own by construction, whatever state `develop`'s CI is in.

- Counts only the tests that run. Roughly 250 test cases are collected for every browser and then skipped for theirs (`only_browser` / `skip_browser`), so the previous totals over-reported what CI executes; a collection-time plugin deselects them.
- Reports new test functions alongside test cases, plus a per-file breakdown. The bare count hid that every test is counted once per browser, which made a 10-test PR look like a 30-test one.
- Drops `needs: playwright-e2e-tests` and skips setup entirely for PRs that touch no E2E test: ~1 minute instead of ~30, and 8 seconds in the common case.
- Withdraws its own comment once a later commit stops changing E2E tests, and no longer posts duplicates — the lookup previously read only the first page of comments, so on a busy PR it failed to find what it had already posted.

#16592 fixed the stale baseline lookup that made these comments unreliable (for example #16583, reported as adding 80 test cases when it added 6), and remains the right approach for wheel size, bundle size, and coverage, which need a built artifact rather than a source tree. Test counts can be derived from source, so this removes the dependency instead of repairing it — worth doing because 16 of the last 40 `develop` commits have no successful `playwright.yml` run, mostly cancelled by the concurrency group when merges land in quick succession, and the newest successful run is then a merge or two behind the tip.

## GitHub Issue Link (if applicable)
N/A

## Testing Plan
- No unit tests: `scripts/AGENTS.md` does not require them for CI utilities.
- Manual: verified that adding E2E tests produces the expected merge-base count and that removing them updates the existing PR comment.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches GitHub Actions that collect PR-authored pytest code and post PR comments (`pull-requests: write`). The job stays on `pull_request` (not `pull_request_target`) and skips forks, but a workflow bug could still mis-comment or skip the check.
> 
> **Overview**
> Stops blaming PRs for E2E tests other merges already landed. `check-e2e-test-count` no longer diffs against the latest develop Playwright artifact; it collects pytest IDs on the GitHub merge commit and on `HEAD^1` (the current base tip).
> 
> The job no longer waits on the full suite. It skips env setup when `e2e_playwright/` is unchanged (except snapshots), skips non-merge HEADs and fork PRs, and paginates comment lookup so it can update or withdraw an earlier warning.
> 
> Counts now match what CI would execute: a new `e2e_executable_tests_plugin` drops `skip` / Playwright browser-skiplist cases, and `compare_e2e_test_counts.py` diffs IDs (not totals) so comments show new functions and per-file deltas. Suite selection flags are shared via workflow env so the two jobs stay in sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cacbfac2f816f2f7158114cb24196a8277558c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->