### PR TITLE
[chore] Replace blinker with an in-house signal

### DIFF
--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -60,7 +60,6 @@ dependencies = [
   # (alt.XOffset/alt.YOffset) and the alt.selection_point/selection_interval
   # API that our built-in charts rely on.
   "altair>=5.0.0,<7,!=5.4.0,!=5.4.1",
-  "blinker>=1.5.0,<2",
   "click>=7.0,<9",
   "numpy>=1.23,<3",
   # The "packaging" package isn't version-capped because they use calendar-based

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -27,11 +27,10 @@ from collections import OrderedDict
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Final, Literal
 
-from blinker import Signal
-
 from streamlit import config_util, development, env_util, file_util, util
 from streamlit.config_option import ConfigOption
 from streamlit.errors import StreamlitAPIException, StreamlitInvalidThemeSectionError
+from streamlit.signal_util import Signal
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -2941,7 +2940,7 @@ def _maybe_convert_to_number(v: Any) -> Any:
 
 # Allow outside modules to wait for the config file to be parsed before doing
 # something.
-_on_config_parsed = Signal(doc="Emitted when the config file is parsed.")
+_on_config_parsed = Signal()
 
 
 def get_config_files(file_name: str) -> list[str]:

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -23,8 +23,6 @@ from enum import Enum
 from timeit import default_timer as timer
 from typing import TYPE_CHECKING, Any, Final, Literal, cast
 
-from blinker import Signal
-
 from streamlit import config, runtime, util
 from streamlit.errors import FragmentStorageKeyError
 from streamlit.logger import get_logger
@@ -60,6 +58,7 @@ from streamlit.runtime.state import (
     SafeSessionState,
     SessionState,
 )
+from streamlit.signal_util import Signal
 from streamlit.source_util import page_sort_key
 
 if TYPE_CHECKING:
@@ -248,33 +247,14 @@ class ScriptRunner:
         self._requests = ScriptRequests()
         self._requests.request_rerun(initial_rerun_data)
 
-        self.on_event = Signal(
-            doc="""Emitted when a ScriptRunnerEvent occurs.
-
-            This signal is generally emitted on the ScriptRunner's script
-            thread (which is *not* the same thread that the ScriptRunner was
-            created on).
-
-            Parameters
-            ----------
-            sender: ScriptRunner
-                The sender of the event (this ScriptRunner).
-
-            event : ScriptRunnerEvent
-
-            forward_msg : ForwardMsg | None
-                The ForwardMsg to send to the frontend. Set only for the
-                ENQUEUE_FORWARD_MSG event.
-
-            exception : BaseException | None
-                Our compile error. Set only for the
-                SCRIPT_STOPPED_WITH_COMPILE_ERROR event.
-
-            widget_states : streamlit.proto.WidgetStates_pb2.WidgetStates | None
-                The ScriptRunner's final WidgetStates. Set only for the
-                SHUTDOWN event.
-            """
-        )
+        # Emitted synchronously on the script or fragment-worker thread (not
+        # the thread that created this ScriptRunner) when a ScriptRunnerEvent
+        # occurs. Receivers are called as receiver(sender, event=..., **payload):
+        # - ENQUEUE_FORWARD_MSG: forward_msg
+        # - SCRIPT_STOPPED_WITH_COMPILE_ERROR: exception
+        # - SHUTDOWN: client_state
+        # - SCRIPT_STARTED: page_script_hash, fragment_ids_this_run, pages
+        self.on_event = Signal()
 
         # Set to true while we're executing. Used by
         # _maybe_handle_execution_control_request.

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -247,9 +247,11 @@ class ScriptRunner:
         self._requests = ScriptRequests()
         self._requests.request_rerun(initial_rerun_data)
 
-        # Emitted synchronously on the script or fragment-worker thread (not
-        # the thread that created this ScriptRunner) when a ScriptRunnerEvent
-        # occurs. Receivers are called as receiver(sender, event=..., **payload):
+        # Emitted synchronously when a ScriptRunnerEvent occurs, usually on the
+        # script or fragment-worker thread rather than the thread that created
+        # this ScriptRunner. Receivers are called as
+        # receiver(sender, event=..., **payload); events not listed below carry
+        # no payload:
         # - ENQUEUE_FORWARD_MSG: forward_msg
         # - SCRIPT_STOPPED_WITH_COMPILE_ERROR: exception
         # - SHUTDOWN: client_state

--- a/lib/streamlit/runtime/secrets.py
+++ b/lib/streamlit/runtime/secrets.py
@@ -24,12 +24,11 @@ from typing import (
     NoReturn,
 )
 
-from blinker import Signal
-
 import streamlit.watcher.path_watcher
 from streamlit import config, runtime
 from streamlit.errors import StreamlitMaxRetriesError, StreamlitSecretNotFoundError
 from streamlit.logger import get_logger
+from streamlit.signal_util import Signal
 
 _LOGGER: Final = get_logger(__name__)
 
@@ -256,9 +255,8 @@ class Secrets(Mapping[str, Any]):
         # Store programmatic secrets separately so they survive file-change reloads
         self._programmatic_secrets: Mapping[str, SecretsValue] | None = None
 
-        self.file_change_listener = Signal(
-            doc="Emitted when a `secrets.toml` file has been changed."
-        )
+        # Fires when a `secrets.toml` file has changed.
+        self.file_change_listener = Signal()
 
     def load_if_toml_exists(self) -> bool:
         """Load secrets.toml files from disk if they exists. If none exist,

--- a/lib/streamlit/signal_util.py
+++ b/lib/streamlit/signal_util.py
@@ -1,0 +1,110 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Synchronous in-process signals for Streamlit internals."""
+
+from __future__ import annotations
+
+import inspect
+import threading
+import weakref
+from collections.abc import Callable
+from typing import Any, TypeAlias
+
+_Receiver: TypeAlias = Callable[..., Any]
+_ReceiverKey: TypeAlias = int | tuple[int, int]
+_StoredReceiver: TypeAlias = _Receiver | weakref.ReferenceType[_Receiver]
+
+
+class Signal:
+    """Broadcast synchronous events to connected receivers."""
+
+    def __init__(self) -> None:
+        self._receivers: dict[_ReceiverKey, _StoredReceiver] = {}
+        # RLock: a weakref callback may re-enter remove_receiver while the
+        # registry lock is held.
+        self._lock = threading.RLock()
+
+    def connect(self, receiver: _Receiver, *, weak: bool = True) -> None:
+        """Connect a receiver. Weak by default so the signal does not keep it alive."""
+        receiver_key = _get_receiver_key(receiver)
+        stored_receiver: _StoredReceiver
+
+        if weak:
+            # Bound methods are ephemeral, so WeakMethod watches the instance.
+            # A normal weakref would go dead as soon as connect() returns.
+            signal_ref = weakref.ref(self)
+
+            def remove_receiver(receiver_ref: weakref.ReferenceType[Any]) -> None:
+                signal = signal_ref()
+                if signal is None:
+                    return
+
+                with signal._lock:
+                    # Skip if connect() later stored a different receiver at this key.
+                    if signal._receivers.get(receiver_key) is receiver_ref:
+                        del signal._receivers[receiver_key]
+
+            if inspect.ismethod(receiver):
+                stored_receiver = weakref.WeakMethod(receiver, remove_receiver)
+            else:
+                stored_receiver = weakref.ref(receiver, remove_receiver)
+        else:
+            stored_receiver = receiver
+
+        with self._lock:
+            self._receivers[receiver_key] = stored_receiver
+
+    def disconnect(self, receiver: _Receiver) -> None:
+        """Disconnect a receiver if it is connected."""
+        with self._lock:
+            self._receivers.pop(_get_receiver_key(receiver), None)
+
+    def send(self, sender: Any = None, /, **kwargs: Any) -> None:
+        """Call each live receiver synchronously.
+
+        Uses a snapshot so receivers can connect or disconnect during dispatch.
+        """
+        for receiver in self._get_live_receivers():
+            receiver(sender, **kwargs)
+
+    def has_receivers(self) -> bool:
+        """Return whether the signal has any live receivers."""
+        return bool(self._get_live_receivers())
+
+    def _get_live_receivers(self) -> list[_Receiver]:
+        live_receivers: list[_Receiver] = []
+
+        with self._lock:
+            for receiver_key, stored_receiver in list(self._receivers.items()):
+                receiver = (
+                    stored_receiver()
+                    if isinstance(stored_receiver, weakref.ReferenceType)
+                    else stored_receiver
+                )
+                if receiver is None:
+                    del self._receivers[receiver_key]
+                else:
+                    live_receivers.append(receiver)
+
+        return live_receivers
+
+
+def _get_receiver_key(receiver: _Receiver) -> _ReceiverKey:
+    if inspect.ismethod(receiver):
+        # Bound methods are recreated on each access. Key by (function, instance)
+        # so a fresh `obj.method` still connects and disconnects the same receiver.
+        return (id(receiver.__func__), id(receiver.__self__))
+
+    return id(receiver)

--- a/lib/streamlit/signal_util.py
+++ b/lib/streamlit/signal_util.py
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Synchronous in-process signals for Streamlit internals."""
+"""Synchronous in-process signals for Streamlit internals.
+
+Intentionally minimal: receivers get every event (no per-sender filtering),
+return values are discarded, and async receivers are unsupported. Add
+capabilities only when a call site needs them.
+"""
 
 from __future__ import annotations
 
@@ -37,7 +42,13 @@ class Signal:
         self._lock = threading.RLock()
 
     def connect(self, receiver: _Receiver, *, weak: bool = True) -> _Receiver:
-        """Connect and return a receiver. Weak by default so the signal does not keep it alive."""
+        """Connect a receiver and return it, so this also works as a decorator.
+
+        Connections are weak by default: the signal does not keep the receiver
+        alive, so a receiver with no other strong reference (a lambda or nested
+        function) is dropped right away. Pass ``weak=False`` to let the signal
+        own the receiver until it is disconnected.
+        """
         receiver_key = _get_receiver_key(receiver)
         stored_receiver: _StoredReceiver
 
@@ -77,7 +88,7 @@ class Signal:
             self._receivers.pop(_get_receiver_key(receiver), None)
 
     def send(self, sender: Any = None, /, **kwargs: Any) -> None:
-        """Call each live receiver synchronously.
+        """Call each live receiver synchronously, in the order they connected.
 
         Receivers run against a snapshot, so a receiver may connect or
         disconnect during dispatch. Changes take effect on the next send: a
@@ -93,6 +104,7 @@ class Signal:
         return bool(self._get_live_receivers())
 
     def _get_live_receivers(self) -> list[_Receiver]:
+        """Return the live receivers, dropping entries whose weak reference died."""
         live_receivers: list[_Receiver] = []
 
         with self._lock:
@@ -102,7 +114,7 @@ class Signal:
                     if isinstance(stored_receiver, weakref.ReferenceType)
                     else stored_receiver
                 )
-                if receiver is None:
+                if receiver is None:  # pragma: no cover - defensive
                     self._receivers.pop(receiver_key, None)
                 else:
                     live_receivers.append(receiver)

--- a/lib/streamlit/signal_util.py
+++ b/lib/streamlit/signal_util.py
@@ -36,27 +36,30 @@ class Signal:
         # registry lock is held.
         self._lock = threading.RLock()
 
-    def connect(self, receiver: _Receiver, *, weak: bool = True) -> None:
-        """Connect a receiver. Weak by default so the signal does not keep it alive."""
+    def connect(self, receiver: _Receiver, *, weak: bool = True) -> _Receiver:
+        """Connect and return a receiver. Weak by default so the signal does not keep it alive."""
         receiver_key = _get_receiver_key(receiver)
         stored_receiver: _StoredReceiver
 
         if weak:
-            # Bound methods are ephemeral, so WeakMethod watches the instance.
-            # A normal weakref would go dead as soon as connect() returns.
+            # Weak so the cleanup callback does not keep this signal alive.
             signal_ref = weakref.ref(self)
 
             def remove_receiver(receiver_ref: weakref.ReferenceType[Any]) -> None:
                 signal = signal_ref()
                 if signal is None:
-                    return
+                    return  # pragma: no cover - defensive
 
                 with signal._lock:
                     # Skip if connect() later stored a different receiver at this key.
-                    if signal._receivers.get(receiver_key) is receiver_ref:
-                        del signal._receivers[receiver_key]
+                    if signal._receivers.get(receiver_key) is not receiver_ref:
+                        return  # pragma: no cover - defensive
+                    del signal._receivers[receiver_key]
 
             if inspect.ismethod(receiver):
+                # A bound method is created fresh on each attribute access, so a
+                # plain weakref would die as soon as connect() returns. WeakMethod
+                # tracks the underlying instance instead.
                 stored_receiver = weakref.WeakMethod(receiver, remove_receiver)
             else:
                 stored_receiver = weakref.ref(receiver, remove_receiver)
@@ -66,6 +69,8 @@ class Signal:
         with self._lock:
             self._receivers[receiver_key] = stored_receiver
 
+        return receiver
+
     def disconnect(self, receiver: _Receiver) -> None:
         """Disconnect a receiver if it is connected."""
         with self._lock:
@@ -74,7 +79,11 @@ class Signal:
     def send(self, sender: Any = None, /, **kwargs: Any) -> None:
         """Call each live receiver synchronously.
 
-        Uses a snapshot so receivers can connect or disconnect during dispatch.
+        Receivers run against a snapshot, so a receiver may connect or
+        disconnect during dispatch. Changes take effect on the next send: a
+        receiver disconnected mid-dispatch still runs for the current one. A
+        receiver exception propagates to the caller and skips remaining
+        receivers.
         """
         for receiver in self._get_live_receivers():
             receiver(sender, **kwargs)
@@ -94,7 +103,7 @@ class Signal:
                     else stored_receiver
                 )
                 if receiver is None:
-                    del self._receivers[receiver_key]
+                    self._receivers.pop(receiver_key, None)
                 else:
                     live_receivers.append(receiver)
 

--- a/lib/streamlit/watcher/event_based_path_watcher.py
+++ b/lib/streamlit/watcher/event_based_path_watcher.py
@@ -58,7 +58,6 @@ import os
 import threading
 from typing import TYPE_CHECKING, Final, cast
 
-from blinker import ANY, Signal
 from typing_extensions import Self
 from watchdog import events
 from watchdog.observers import Observer
@@ -66,6 +65,7 @@ from watchdog.observers import Observer
 from streamlit import env_util
 from streamlit.errors import StreamlitMaxRetriesError
 from streamlit.logger import get_logger
+from streamlit.signal_util import Signal
 from streamlit.util import repr_
 from streamlit.watcher import util
 
@@ -391,7 +391,7 @@ class _FolderEventHandler(events.FileSystemEventHandler):
                 return
 
             watched_path.on_changed.disconnect(callback)
-            if not watched_path.on_changed.has_receivers_for(ANY):
+            if not watched_path.on_changed.has_receivers():
                 del self._watched_paths[path]
 
     def is_watching_paths(self) -> bool:

--- a/lib/tests/streamlit/runtime/secrets_test.py
+++ b/lib/tests/streamlit/runtime/secrets_test.py
@@ -30,7 +30,6 @@ from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
-from blinker import Signal
 from parameterized import parameterized
 from typing_extensions import Self
 
@@ -43,6 +42,7 @@ from streamlit.runtime.secrets import (
     Secrets,
     _convert_to_dict,
 )
+from streamlit.signal_util import Signal
 from tests import testutil
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 from tests.exception_capturing_thread import call_on_threads

--- a/lib/tests/streamlit/signal_util_test.py
+++ b/lib/tests/streamlit/signal_util_test.py
@@ -1,0 +1,230 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import gc
+import threading
+import weakref
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+
+from streamlit.signal_util import Signal
+
+
+class _BoundReceiver:
+    def receive(self, sender: object) -> None:
+        pass
+
+
+def test_send_without_receivers_is_noop() -> None:
+    """Sending without receivers is a no-op."""
+    signal = Signal()
+
+    signal.send()
+
+
+def test_send_forwards_sender_and_kwargs() -> None:
+    """Signal payloads are forwarded to each receiver."""
+    signal = Signal()
+    receiver = Mock()
+    signal.connect(receiver, weak=False)
+
+    signal.send()
+    signal.send("sender", value=42)
+
+    assert receiver.call_args_list == [
+        ((None,), {}),
+        (("sender",), {"value": 42}),
+    ]
+
+
+def test_send_calls_each_receiver_once() -> None:
+    """Each connected receiver is called once per send."""
+    signal = Signal()
+    first_receiver = Mock()
+    second_receiver = Mock()
+    signal.connect(first_receiver, weak=False)
+    signal.connect(second_receiver, weak=False)
+
+    signal.send("sender")
+
+    first_receiver.assert_called_once_with("sender")
+    second_receiver.assert_called_once_with("sender")
+
+
+def test_duplicate_connect_and_disconnect_are_idempotent() -> None:
+    """Duplicate connection and disconnection do not change delivery counts."""
+    signal = Signal()
+    receiver = Mock()
+
+    signal.connect(receiver, weak=False)
+    signal.connect(receiver, weak=False)
+    signal.send()
+
+    receiver.assert_called_once_with(None)
+
+    signal.disconnect(receiver)
+    signal.disconnect(receiver)
+    signal.send()
+
+    receiver.assert_called_once_with(None)
+
+
+def test_disconnect_matches_freshly_accessed_bound_method() -> None:
+    """A bound method can be disconnected through a fresh attribute access."""
+    signal = Signal()
+    receiver = _BoundReceiver()
+    signal.connect(receiver.receive)
+
+    signal.disconnect(receiver.receive)
+
+    assert not signal.has_receivers()
+
+
+def test_weak_bound_receiver_is_dropped_after_gc() -> None:
+    """A weakly connected bound method is dropped when its instance is gone."""
+    signal = Signal()
+    receiver = _BoundReceiver()
+    receiver_ref = weakref.ref(receiver)
+    signal.connect(receiver.receive)
+    assert signal.has_receivers()
+
+    del receiver
+    gc.collect()
+
+    assert receiver_ref() is None
+    assert not signal.has_receivers()
+
+
+def test_weak_nested_function_is_dropped_after_gc() -> None:
+    """A weakly connected nested function is dropped when no other refs remain."""
+    signal = Signal()
+
+    def receiver(sender: object) -> None:
+        pass
+
+    receiver_ref = weakref.ref(receiver)
+    signal.connect(receiver)
+    assert signal.has_receivers()
+
+    del receiver
+    gc.collect()
+
+    assert receiver_ref() is None
+    assert not signal.has_receivers()
+
+
+def test_strong_connection_retains_nested_function() -> None:
+    """A strong connection retains a nested receiver function."""
+    signal = Signal()
+    received: list[object] = []
+
+    def connect_receiver() -> weakref.ReferenceType[Any]:
+        def receiver(sender: object) -> None:
+            received.append(sender)
+
+        receiver_ref = weakref.ref(receiver)
+        signal.connect(receiver, weak=False)
+        return receiver_ref
+
+    receiver_ref = connect_receiver()
+    gc.collect()
+
+    assert receiver_ref() is not None
+
+    signal.send("sender")
+    assert received == ["sender"]
+
+
+def test_receiver_exception_propagates() -> None:
+    """Exceptions raised by receivers propagate to the sender."""
+    signal = Signal()
+
+    def receiver(sender: object) -> None:
+        raise RuntimeError("receiver failed")
+
+    signal.connect(receiver, weak=False)
+
+    with pytest.raises(RuntimeError, match="receiver failed"):
+        signal.send()
+
+
+def test_receiver_can_mutate_connections_during_send() -> None:
+    """A receiver can mutate connections during synchronous dispatch."""
+    signal = Signal()
+    received: list[str] = []
+
+    def second_receiver(sender: object) -> None:
+        received.append("second")
+
+    def first_receiver(sender: object) -> None:
+        received.append("first")
+        signal.disconnect(first_receiver)
+        signal.connect(second_receiver, weak=False)
+
+    signal.connect(first_receiver, weak=False)
+
+    signal.send()
+    assert received == ["first"]
+
+    signal.send()
+    assert received == ["first", "second"]
+
+
+def test_receiver_runs_outside_registry_lock() -> None:
+    """Dispatch uses a snapshot and does not hold the registry lock."""
+    signal = Signal()
+    receiver_started = threading.Event()
+    release_receiver = threading.Event()
+    connections_updated = threading.Event()
+    snapshotted_receiver = Mock()
+    new_receiver = Mock()
+
+    def blocking_receiver(sender: object) -> None:
+        receiver_started.set()
+        assert release_receiver.wait(timeout=5)
+
+    signal.connect(blocking_receiver, weak=False)
+    signal.connect(snapshotted_receiver, weak=False)
+
+    send_thread = threading.Thread(target=signal.send)
+    send_thread.start()
+    assert receiver_started.wait(timeout=5)
+
+    def update_connections() -> None:
+        signal.connect(new_receiver, weak=False)
+        signal.disconnect(blocking_receiver)
+        signal.disconnect(snapshotted_receiver)
+        connections_updated.set()
+
+    update_thread = threading.Thread(target=update_connections)
+    update_thread.start()
+
+    try:
+        assert connections_updated.wait(timeout=5)
+    finally:
+        release_receiver.set()
+        send_thread.join(timeout=5)
+        update_thread.join(timeout=5)
+
+    assert not send_thread.is_alive()
+    assert not update_thread.is_alive()
+    snapshotted_receiver.assert_called_once_with(None)
+
+    signal.send("next")
+    snapshotted_receiver.assert_called_once_with(None)
+    new_receiver.assert_called_once_with("next")

--- a/lib/tests/streamlit/signal_util_test.py
+++ b/lib/tests/streamlit/signal_util_test.py
@@ -30,6 +30,14 @@ class _BoundReceiver:
         pass
 
 
+class _RecordingReceiver:
+    def __init__(self) -> None:
+        self.received: list[object] = []
+
+    def receive(self, sender: object) -> None:
+        self.received.append(sender)
+
+
 def test_send_without_receivers_is_noop() -> None:
     """Sending without receivers is a no-op."""
     signal = Signal()
@@ -95,6 +103,34 @@ def test_disconnect_matches_freshly_accessed_bound_method() -> None:
     assert not signal.has_receivers()
 
 
+def test_distinct_instances_of_same_method_are_separate_receivers() -> None:
+    """Bound methods of different instances are tracked independently."""
+    signal = Signal()
+    first = _RecordingReceiver()
+    second = _RecordingReceiver()
+    signal.connect(first.receive, weak=False)
+    signal.connect(second.receive, weak=False)
+
+    signal.disconnect(first.receive)
+    signal.send("sender")
+
+    assert first.received == []
+    assert second.received == ["sender"]
+
+
+def test_connect_returns_receiver_for_decorator_form() -> None:
+    """connect returns the receiver so @signal.connect keeps the function bound."""
+    signal = Signal()
+    received: list[object] = []
+
+    @signal.connect
+    def receiver(sender: object) -> None:
+        received.append(sender)
+
+    signal.send("sender")
+    assert received == ["sender"]
+
+
 def test_weak_bound_receiver_is_dropped_after_gc() -> None:
     """A weakly connected bound method is dropped when its instance is gone."""
     signal = Signal()
@@ -153,14 +189,18 @@ def test_strong_connection_retains_nested_function() -> None:
 def test_receiver_exception_propagates() -> None:
     """Exceptions raised by receivers propagate to the sender."""
     signal = Signal()
+    later_receiver = Mock()
 
     def receiver(sender: object) -> None:
         raise RuntimeError("receiver failed")
 
     signal.connect(receiver, weak=False)
+    signal.connect(later_receiver, weak=False)
 
     with pytest.raises(RuntimeError, match="receiver failed"):
         signal.send()
+
+    later_receiver.assert_not_called()
 
 
 def test_receiver_can_mutate_connections_during_send() -> None:

--- a/lib/tests/streamlit/signal_util_test.py
+++ b/lib/tests/streamlit/signal_util_test.py
@@ -23,6 +23,7 @@ from unittest.mock import Mock
 import pytest
 
 from streamlit.signal_util import Signal
+from tests.exception_capturing_thread import ExceptionCapturingThread
 
 
 class _BoundReceiver:
@@ -134,9 +135,11 @@ def test_connect_returns_receiver_for_decorator_form() -> None:
 def test_weak_bound_receiver_is_dropped_after_gc() -> None:
     """A weakly connected bound method is dropped when its instance is gone."""
     signal = Signal()
-    receiver = _BoundReceiver()
+    receiver = _RecordingReceiver()
     receiver_ref = weakref.ref(receiver)
     signal.connect(receiver.receive)
+    signal.send("sender")
+    assert receiver.received == ["sender"]
     assert signal.has_receivers()
 
     del receiver
@@ -162,6 +165,25 @@ def test_weak_nested_function_is_dropped_after_gc() -> None:
 
     assert receiver_ref() is None
     assert not signal.has_receivers()
+
+
+def test_reconnecting_weakly_connected_receiver_strongly_retains_it() -> None:
+    """Reconnecting a weak receiver with weak=False makes the signal retain it."""
+    signal = Signal()
+    received: list[object] = []
+
+    def connect_receiver() -> None:
+        def receiver(sender: object) -> None:
+            received.append(sender)
+
+        signal.connect(receiver)
+        signal.connect(receiver, weak=False)
+
+    connect_receiver()
+    gc.collect()
+
+    signal.send("sender")
+    assert received == ["sender"]
 
 
 def test_strong_connection_retains_nested_function() -> None:
@@ -241,7 +263,7 @@ def test_receiver_runs_outside_registry_lock() -> None:
     signal.connect(blocking_receiver, weak=False)
     signal.connect(snapshotted_receiver, weak=False)
 
-    send_thread = threading.Thread(target=signal.send)
+    send_thread = ExceptionCapturingThread(target=signal.send)
     send_thread.start()
     assert receiver_started.wait(timeout=5)
 
@@ -251,7 +273,7 @@ def test_receiver_runs_outside_registry_lock() -> None:
         signal.disconnect(snapshotted_receiver)
         connections_updated.set()
 
-    update_thread = threading.Thread(target=update_connections)
+    update_thread = ExceptionCapturingThread(target=update_connections)
     update_thread.start()
 
     try:
@@ -261,6 +283,8 @@ def test_receiver_runs_outside_registry_lock() -> None:
         send_thread.join(timeout=5)
         update_thread.join(timeout=5)
 
+    send_thread.assert_no_unhandled_exception()
+    update_thread.assert_no_unhandled_exception()
     assert not send_thread.is_alive()
     assert not update_thread.is_alive()
     snapshotted_receiver.assert_called_once_with(None)

--- a/scripts/assets/min-constraints-gen.txt
+++ b/scripts/assets/min-constraints-gen.txt
@@ -1,6 +1,5 @@
 altair==5.0.0
 anyio==4.0.0
-blinker==1.5.0
 click==7.0
 httptools==0.6.3
 itsdangerous==2.1.2

--- a/specs/2026-03-05-parallel-fragments/tech-spec.md
+++ b/specs/2026-03-05-parallel-fragments/tech-spec.md
@@ -568,7 +568,7 @@ fragment worker threads:
 st.text("hello")                               (on script thread or worker thread)
   → ctx.enqueue(msg)                           script_run_context.py
     → ScriptRunner._enqueue_forward_msg(msg)   script_runner.py — yield point check
-      → on_event.send(ENQUEUE_FORWARD_MSG)     blinker signal, fires synchronously
+      → on_event.send(ENQUEUE_FORWARD_MSG)     `streamlit.signal_util.Signal`, fires synchronously
         → AppSession._on_scriptrunner_event    still on the calling thread
           → call_soon_threadsafe(callback)     schedules onto event loop, returns immediately
                                                 ──→ event loop thread picks up callback

--- a/uv.lock
+++ b/uv.lock
@@ -178,15 +178,6 @@ wheels = [
 ]
 
 [[package]]
-name = "blinker"
-version = "1.9.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/21/28/9b3f50ce0e048515135495f198351908d99540d69bfdc8c1d15b73dc55ce/blinker-1.9.0.tar.gz", hash = "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf", size = 22460, upload-time = "2024-11-08T17:25:47.436Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc", size = 8458, upload-time = "2024-11-08T17:25:46.184Z" },
-]
-
-[[package]]
 name = "boto3"
 version = "1.43.72"
 source = { registry = "https://pypi.org/simple" }
@@ -4495,7 +4486,6 @@ source = { editable = "lib" }
 dependencies = [
     { name = "altair" },
     { name = "anyio" },
-    { name = "blinker" },
     { name = "click" },
     { name = "httptools" },
     { name = "itsdangerous" },
@@ -4547,7 +4537,6 @@ requires-dist = [
     { name = "altair", specifier = ">=5.0.0,!=5.4.0,!=5.4.1,<7" },
     { name = "anyio", specifier = ">=4.0.0,<5" },
     { name = "authlib", marker = "extra == 'auth'", specifier = ">=1.3.2" },
-    { name = "blinker", specifier = ">=1.5.0,<2" },
     { name = "click", specifier = ">=7.0,<9" },
     { name = "graphviz", marker = "extra == 'charts'", specifier = ">=0.19.0" },
     { name = "httptools", specifier = ">=0.6.3,<1" },


### PR DESCRIPTION
## Describe your changes

Replace the Blinker runtime dependency with a small in-house `Signal` that implements only the synchronous multicast Streamlit uses.

- Drops `blinker` from the published package. Apps that imported it without declaring it need to add it themselves.
- `st.secrets.file_change_listener` keeps `connect` / `disconnect` / `send` for undocumented listeners. Sender filtering and Blinker's `send()` return value are not reimplemented; no Streamlit call site uses them. `connect()` returns the receiver so decorator-style `@signal.connect` still works.

## Testing Plan

- [x] Unit Tests (Python): `lib/tests/streamlit/signal_util_test.py` covers connect/disconnect, weak vs strong retention, GC, snapshot dispatch, and exceptions.
- Existing ScriptRunner, secrets, and path-watcher tests cover the production call sites.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.