### PR TITLE
[fix] Select current develop CI baselines

### DIFF
--- a/.cursor/rules/workflows.mdc
+++ b/.cursor/rules/workflows.mdc
@@ -67,6 +67,7 @@ Reusable composite actions in `.github/actions/` encapsulate common setup steps.
 | `playwright_install` | Installs Playwright browsers with caching (by OS/arch/version). Call after `make_init` for E2E tests. |
 | `apt_mirror_fix` | Fixes slow Azure apt mirrors on Ubuntu runners. Called automatically by `playwright_install`. |
 | `preview_branch` | Sets `PREVIEW_BRANCH` and `BRANCH` env vars for PR preview deployments. Uses action inputs to mitigate script injection. |
+| `find_latest_workflow_artifact` | Finds the newest unexpired artifact from a successful branch push without relying on GitHub's stale workflow-run filters. |
 
 ### Typical Usage Pattern
 

--- a/.cursor/rules/workflows.mdc
+++ b/.cursor/rules/workflows.mdc
@@ -67,7 +67,7 @@ Reusable composite actions in `.github/actions/` encapsulate common setup steps.
 | `playwright_install` | Installs Playwright browsers with caching (by OS/arch/version). Call after `make_init` for E2E tests. |
 | `apt_mirror_fix` | Fixes slow Azure apt mirrors on Ubuntu runners. Called automatically by `playwright_install`. |
 | `preview_branch` | Sets `PREVIEW_BRANCH` and `BRANCH` env vars for PR preview deployments. Uses action inputs to mitigate script injection. |
-| `find_latest_workflow_artifact` | Finds the newest unexpired artifact from a successful branch push without relying on GitHub's stale workflow-run filters. |
+| `find_latest_workflow_artifact` | Selects the newest unexpired artifact from a successful branch push. Avoids GitHub REST run filters, which can return stale results. |
 
 ### Typical Usage Pattern
 

--- a/.github/actions/find_latest_workflow_artifact/action.yml
+++ b/.github/actions/find_latest_workflow_artifact/action.yml
@@ -1,0 +1,139 @@
+name: Find latest workflow artifact
+description: Find the newest unexpired artifact from a successful branch push
+
+inputs:
+  github_token:
+    description: GitHub token with Actions read access
+    required: true
+  workflow:
+    description: Workflow file name to inspect
+    required: true
+  artifact_name:
+    description: Artifact name that the selected workflow run must contain
+    required: true
+  branch:
+    description: Branch whose successful push runs should be inspected
+    required: false
+    default: develop
+
+outputs:
+  run_id:
+    description: Workflow run containing the selected artifact
+    value: ${{ steps.find-artifact.outputs.run_id }}
+  artifact_id:
+    description: ID of the selected artifact
+    value: ${{ steps.find-artifact.outputs.artifact_id }}
+  artifact_size_in_bytes:
+    description: Size of the selected artifact in bytes
+    value: ${{ steps.find-artifact.outputs.artifact_size_in_bytes }}
+
+runs:
+  using: composite
+  steps:
+    - name: Find latest successful branch artifact
+      id: find-artifact
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      env:
+        TARGET_ARTIFACT_NAME: ${{ inputs.artifact_name }}
+        TARGET_BRANCH: ${{ inputs.branch }}
+        TARGET_WORKFLOW: ${{ inputs.workflow }}
+      with:
+        github-token: ${{ inputs.github_token }}
+        script: |
+          const MAX_PAGES = 10;
+          const PAGE_SIZE = 100;
+          let runsChecked = 0;
+          let cursor = null;
+
+          // GitHub's REST branch and status filters can return stale results.
+          // GraphQL explicitly orders runs, so apply those filters locally.
+          const { data: workflow } = await github.rest.actions.getWorkflow({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            workflow_id: process.env.TARGET_WORKFLOW,
+          });
+
+          for (let page = 0; page < MAX_PAGES; page += 1) {
+            const response = await github.graphql(
+              `query($workflowId: ID!, $cursor: String, $pageSize: Int!) {
+                node(id: $workflowId) {
+                  ... on Workflow {
+                    runs(
+                      first: $pageSize
+                      after: $cursor
+                      orderBy: {field: CREATED_AT, direction: DESC}
+                    ) {
+                      nodes {
+                        databaseId
+                        createdAt
+                        event
+                        checkSuite {
+                          branch { name }
+                          conclusion
+                        }
+                      }
+                      pageInfo {
+                        endCursor
+                        hasNextPage
+                      }
+                    }
+                  }
+                }
+              }`,
+              {
+                workflowId: workflow.node_id,
+                cursor,
+                pageSize: PAGE_SIZE,
+              }
+            );
+
+            const { nodes: workflowRuns, pageInfo } = response.node.runs;
+            runsChecked += workflowRuns.length;
+
+            const matchingRuns = workflowRuns.filter(run =>
+              run.event === 'push' &&
+              run.checkSuite?.branch?.name === process.env.TARGET_BRANCH &&
+              run.checkSuite?.conclusion === 'SUCCESS'
+            );
+
+            for (const run of matchingRuns) {
+              const { data: artifacts } = await github.rest.actions.listWorkflowRunArtifacts({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: run.databaseId,
+                name: process.env.TARGET_ARTIFACT_NAME,
+                per_page: PAGE_SIZE,
+              });
+              const artifact = artifacts.artifacts.find(candidate =>
+                candidate.name === process.env.TARGET_ARTIFACT_NAME && !candidate.expired
+              );
+
+              if (!artifact) {
+                console.log(
+                  `Run ${run.databaseId} has no unexpired ` +
+                  `${process.env.TARGET_ARTIFACT_NAME} artifact; ` +
+                  'checking the next run.'
+                );
+                continue;
+              }
+
+              console.log(
+                `Selected run ${run.databaseId} from ${run.createdAt} with artifact ${artifact.id}.`
+              );
+              core.setOutput('run_id', String(run.databaseId));
+              core.setOutput('artifact_id', String(artifact.id));
+              core.setOutput('artifact_size_in_bytes', String(artifact.size_in_bytes));
+              return;
+            }
+
+            if (!pageInfo.hasNextPage) {
+              break;
+            }
+            cursor = pageInfo.endCursor;
+          }
+
+          core.warning(
+            `No unexpired ${process.env.TARGET_ARTIFACT_NAME} artifact was found in a successful ` +
+            `${process.env.TARGET_BRANCH} push among the latest ${runsChecked} ` +
+            `${process.env.TARGET_WORKFLOW} runs. Skipping the comparison.`
+          );

--- a/.github/actions/find_latest_workflow_artifact/action.yml
+++ b/.github/actions/find_latest_workflow_artifact/action.yml
@@ -18,11 +18,8 @@ inputs:
 
 outputs:
   run_id:
-    description: Workflow run containing the selected artifact
+    description: ID of the workflow run containing the selected artifact
     value: ${{ steps.find-artifact.outputs.run_id }}
-  artifact_id:
-    description: ID of the selected artifact
-    value: ${{ steps.find-artifact.outputs.artifact_id }}
   artifact_size_in_bytes:
     description: Size of the selected artifact in bytes
     value: ${{ steps.find-artifact.outputs.artifact_size_in_bytes }}
@@ -40,13 +37,18 @@ runs:
       with:
         github-token: ${{ inputs.github_token }}
         script: |
+          // Bound both pagination and artifact lookups when no baseline exists.
           const MAX_PAGES = 10;
+          const MAX_CANDIDATE_RUNS = 20;
           const PAGE_SIZE = 100;
           let runsChecked = 0;
+          let candidateRunsChecked = 0;
           let cursor = null;
 
-          // GitHub's REST branch and status filters can return stale results.
-          // GraphQL explicitly orders runs, so apply those filters locally.
+          // GitHub's REST run filters (branch, status) can return stale results, so page
+          // through GraphQL's explicitly ordered runs and apply branch, event, and success
+          // checks locally. GraphQL can only look up a workflow by node ID, so resolve that
+          // via REST first.
           const { data: workflow } = await github.rest.actions.getWorkflow({
             owner: context.repo.owner,
             repo: context.repo.repo,
@@ -90,6 +92,8 @@ runs:
             const { nodes: workflowRuns, pageInfo } = response.node.runs;
             runsChecked += workflowRuns.length;
 
+            // WorkflowRun does not expose branch or conclusion directly, so use its
+            // check suite and exclude PR or workflow_call runs from the baseline.
             const matchingRuns = workflowRuns.filter(run =>
               run.event === 'push' &&
               run.checkSuite?.branch?.name === process.env.TARGET_BRANCH &&
@@ -97,12 +101,16 @@ runs:
             );
 
             for (const run of matchingRuns) {
+              if (candidateRunsChecked >= MAX_CANDIDATE_RUNS) {
+                break;
+              }
+              candidateRunsChecked += 1;
+
               const { data: artifacts } = await github.rest.actions.listWorkflowRunArtifacts({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 run_id: run.databaseId,
                 name: process.env.TARGET_ARTIFACT_NAME,
-                per_page: PAGE_SIZE,
               });
               const artifact = artifacts.artifacts.find(candidate =>
                 candidate.name === process.env.TARGET_ARTIFACT_NAME && !candidate.expired
@@ -121,12 +129,11 @@ runs:
                 `Selected run ${run.databaseId} from ${run.createdAt} with artifact ${artifact.id}.`
               );
               core.setOutput('run_id', String(run.databaseId));
-              core.setOutput('artifact_id', String(artifact.id));
               core.setOutput('artifact_size_in_bytes', String(artifact.size_in_bytes));
               return;
             }
 
-            if (!pageInfo.hasNextPage) {
+            if (candidateRunsChecked >= MAX_CANDIDATE_RUNS || !pageInfo.hasNextPage) {
               break;
             }
             cursor = pageInfo.endCursor;
@@ -135,5 +142,6 @@ runs:
           core.warning(
             `No unexpired ${process.env.TARGET_ARTIFACT_NAME} artifact was found in a successful ` +
             `${process.env.TARGET_BRANCH} push among the latest ${runsChecked} ` +
-            `${process.env.TARGET_WORKFLOW} runs. Skipping the comparison.`
+            `${process.env.TARGET_WORKFLOW} runs (${candidateRunsChecked} matching candidates ` +
+            `checked). Skipping the comparison.`
           );

--- a/.github/actions/find_latest_workflow_artifact/action.yml
+++ b/.github/actions/find_latest_workflow_artifact/action.yml
@@ -2,9 +2,6 @@ name: Find latest workflow artifact
 description: Find the newest unexpired artifact from a successful branch push
 
 inputs:
-  github_token:
-    description: GitHub token with Actions read access
-    required: true
   workflow:
     description: Workflow file name to inspect
     required: true
@@ -18,7 +15,7 @@ inputs:
 
 outputs:
   run_id:
-    description: ID of the workflow run containing the selected artifact
+    description: ID of the workflow run containing the selected artifact, or empty if none was found
     value: ${{ steps.find-artifact.outputs.run_id }}
   artifact_size_in_bytes:
     description: Size of the selected artifact in bytes
@@ -35,7 +32,7 @@ runs:
         TARGET_BRANCH: ${{ inputs.branch }}
         TARGET_WORKFLOW: ${{ inputs.workflow }}
       with:
-        github-token: ${{ inputs.github_token }}
+        github-token: ${{ github.token }}
         script: |
           // Bound both pagination and artifact lookups when no baseline exists.
           const MAX_PAGES = 10;
@@ -89,7 +86,14 @@ runs:
               }
             );
 
-            const { nodes: workflowRuns, pageInfo } = response.node.runs;
+            const runsConnection = response.node?.runs;
+            if (!runsConnection) {
+              throw new Error(
+                `GraphQL did not return runs for workflow ` +
+                `${process.env.TARGET_WORKFLOW} (node ${workflow.node_id}).`
+              );
+            }
+            const { nodes: workflowRuns, pageInfo } = runsConnection;
             runsChecked += workflowRuns.length;
 
             // WorkflowRun does not expose branch or conclusion directly, so use its
@@ -112,9 +116,9 @@ runs:
                 run_id: run.databaseId,
                 name: process.env.TARGET_ARTIFACT_NAME,
               });
-              const artifact = artifacts.artifacts.find(candidate =>
-                candidate.name === process.env.TARGET_ARTIFACT_NAME && !candidate.expired
-              );
+              // Expired artifacts remain listed but cannot be downloaded, so fall back
+              // to an older run when the named artifact is expired.
+              const artifact = artifacts.artifacts.find(candidate => !candidate.expired);
 
               if (!artifact) {
                 console.log(

--- a/.github/actions/find_latest_workflow_artifact/action.yml
+++ b/.github/actions/find_latest_workflow_artifact/action.yml
@@ -1,5 +1,7 @@
 name: Find latest workflow artifact
-description: Find the newest unexpired artifact from a successful branch push
+description: >-
+  Find the newest unexpired artifact from a successful branch push.
+  Requires the calling job to grant actions read and check out the repository first.
 
 inputs:
   workflow:
@@ -34,12 +36,13 @@ runs:
       with:
         github-token: ${{ github.token }}
         script: |
-          // Bound both pagination and artifact lookups when no baseline exists.
+          // Cap GraphQL pages and REST artifact lookups so a missing baseline cannot
+          // scan unbounded history.
           const MAX_PAGES = 10;
           const MAX_CANDIDATE_RUNS = 20;
           const PAGE_SIZE = 100;
-          let runsChecked = 0;
-          let candidateRunsChecked = 0;
+          let runsScanned = 0;
+          let artifactLookups = 0;
           let cursor = null;
 
           // GitHub's REST run filters (branch, status) can return stale results, so page
@@ -94,10 +97,11 @@ runs:
               );
             }
             const { nodes: workflowRuns, pageInfo } = runsConnection;
-            runsChecked += workflowRuns.length;
+            runsScanned += workflowRuns.length;
 
-            // WorkflowRun does not expose branch or conclusion directly, so use its
-            // check suite and exclude PR or workflow_call runs from the baseline.
+            // Only successful branch pushes are valid baselines. PR runs build merge
+            // commits rather than the branch tip. Branch and conclusion live on the
+            // check suite because WorkflowRun does not expose them directly.
             const matchingRuns = workflowRuns.filter(run =>
               run.event === 'push' &&
               run.checkSuite?.branch?.name === process.env.TARGET_BRANCH &&
@@ -105,10 +109,10 @@ runs:
             );
 
             for (const run of matchingRuns) {
-              if (candidateRunsChecked >= MAX_CANDIDATE_RUNS) {
+              if (artifactLookups >= MAX_CANDIDATE_RUNS) {
                 break;
               }
-              candidateRunsChecked += 1;
+              artifactLookups += 1;
 
               const { data: artifacts } = await github.rest.actions.listWorkflowRunArtifacts({
                 owner: context.repo.owner,
@@ -117,8 +121,11 @@ runs:
                 name: process.env.TARGET_ARTIFACT_NAME,
               });
               // Expired artifacts remain listed but cannot be downloaded, so fall back
-              // to an older run when the named artifact is expired.
-              const artifact = artifacts.artifacts.find(candidate => !candidate.expired);
+              // to an older run. Assert the name client-side in case the REST filter is
+              // not honored.
+              const artifact = artifacts.artifacts.find(candidate =>
+                candidate.name === process.env.TARGET_ARTIFACT_NAME && !candidate.expired
+              );
 
               if (!artifact) {
                 console.log(
@@ -137,7 +144,7 @@ runs:
               return;
             }
 
-            if (candidateRunsChecked >= MAX_CANDIDATE_RUNS || !pageInfo.hasNextPage) {
+            if (artifactLookups >= MAX_CANDIDATE_RUNS || !pageInfo.hasNextPage) {
               break;
             }
             cursor = pageInfo.endCursor;
@@ -145,7 +152,7 @@ runs:
 
           core.warning(
             `No unexpired ${process.env.TARGET_ARTIFACT_NAME} artifact was found in a successful ` +
-            `${process.env.TARGET_BRANCH} push among the latest ${runsChecked} ` +
-            `${process.env.TARGET_WORKFLOW} runs (${candidateRunsChecked} matching candidates ` +
+            `${process.env.TARGET_BRANCH} push among the latest ${runsScanned} ` +
+            `${process.env.TARGET_WORKFLOW} runs (${artifactLookups} matching candidates ` +
             `checked). Skipping the comparison.`
           );

--- a/.github/instructions/workflows.instructions.md
+++ b/.github/instructions/workflows.instructions.md
@@ -65,6 +65,7 @@ Reusable composite actions in `.github/actions/` encapsulate common setup steps.
 | `playwright_install` | Installs Playwright browsers with caching (by OS/arch/version). Call after `make_init` for E2E tests. |
 | `apt_mirror_fix` | Fixes slow Azure apt mirrors on Ubuntu runners. Called automatically by `playwright_install`. |
 | `preview_branch` | Sets `PREVIEW_BRANCH` and `BRANCH` env vars for PR preview deployments. Uses action inputs to mitigate script injection. |
+| `find_latest_workflow_artifact` | Finds the newest unexpired artifact from a successful branch push without relying on GitHub's stale workflow-run filters. |
 
 ### Typical Usage Pattern
 

--- a/.github/instructions/workflows.instructions.md
+++ b/.github/instructions/workflows.instructions.md
@@ -65,7 +65,7 @@ Reusable composite actions in `.github/actions/` encapsulate common setup steps.
 | `playwright_install` | Installs Playwright browsers with caching (by OS/arch/version). Call after `make_init` for E2E tests. |
 | `apt_mirror_fix` | Fixes slow Azure apt mirrors on Ubuntu runners. Called automatically by `playwright_install`. |
 | `preview_branch` | Sets `PREVIEW_BRANCH` and `BRANCH` env vars for PR preview deployments. Uses action inputs to mitigate script injection. |
-| `find_latest_workflow_artifact` | Finds the newest unexpired artifact from a successful branch push without relying on GitHub's stale workflow-run filters. |
+| `find_latest_workflow_artifact` | Selects the newest unexpired artifact from a successful branch push. Avoids GitHub REST run filters, which can return stale results. |
 
 ### Typical Usage Pattern
 

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -59,7 +59,7 @@ Reusable composite actions in `.github/actions/` encapsulate common setup steps.
 | `playwright_install` | Installs Playwright browsers with caching (by OS/arch/version). Call after `make_init` for E2E tests. |
 | `apt_mirror_fix` | Fixes slow Azure apt mirrors on Ubuntu runners. Called automatically by `playwright_install`. |
 | `preview_branch` | Sets `PREVIEW_BRANCH` and `BRANCH` env vars for PR preview deployments. Uses action inputs to mitigate script injection. |
-| `find_latest_workflow_artifact` | Finds the newest unexpired artifact from a successful branch push without relying on GitHub's stale workflow-run filters. |
+| `find_latest_workflow_artifact` | Selects the newest unexpired artifact from a successful branch push. Avoids GitHub REST run filters, which can return stale results. |
 
 ### Typical Usage Pattern
 

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -59,6 +59,7 @@ Reusable composite actions in `.github/actions/` encapsulate common setup steps.
 | `playwright_install` | Installs Playwright browsers with caching (by OS/arch/version). Call after `make_init` for E2E tests. |
 | `apt_mirror_fix` | Fixes slow Azure apt mirrors on Ubuntu runners. Called automatically by `playwright_install`. |
 | `preview_branch` | Sets `PREVIEW_BRANCH` and `BRANCH` env vars for PR preview deployments. Uses action inputs to mitigate script injection. |
+| `find_latest_workflow_artifact` | Finds the newest unexpired artifact from a successful branch push without relying on GitHub's stale workflow-run filters. |
 
 ### Typical Usage Pattern
 

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -136,27 +136,16 @@ jobs:
           name: vitest_coverage_json
           path: /tmp/current_coverage
 
-      - name: Get latest develop run ID
+      - name: Find latest develop coverage
         id: get-latest-run
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        uses: ./.github/actions/find_latest_workflow_artifact
         with:
-          script: |
-            const { data: runs } = await github.rest.actions.listWorkflowRuns({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'js-tests.yml',
-              branch: 'develop',
-              status: 'success',
-              per_page: 1
-            });
-
-            if (runs.workflow_runs.length === 0) {
-              throw new Error('No successful workflow runs found on develop branch');
-            }
-
-            core.setOutput('run_id', runs.workflow_runs[0].id);
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: js-tests.yml
+          artifact_name: vitest_coverage_json
 
       - name: Download develop coverage
+        if: steps.get-latest-run.outputs.run_id != ''
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           repository: streamlit/streamlit
@@ -168,6 +157,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check coverage changes and comment
+        if: steps.get-latest-run.outputs.run_id != ''
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -140,7 +140,6 @@ jobs:
         id: get-latest-run
         uses: ./.github/actions/find_latest_workflow_artifact
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: js-tests.yml
           artifact_name: vitest_coverage_json
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -88,6 +88,11 @@ jobs:
       NEW_TEST_THRESHOLD: 30
 
     steps:
+      - name: Checkout Streamlit code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
       - name: Download current test stats
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         continue-on-error: true
@@ -95,29 +100,16 @@ jobs:
           name: playwright_test_stats
           path: current_stats
 
-      - name: Get latest develop run ID
+      - name: Find latest develop test stats
         id: get-latest-run
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        uses: ./.github/actions/find_latest_workflow_artifact
         with:
-          script: |
-            const { data: runs } = await github.rest.actions.listWorkflowRuns({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'playwright.yml',
-              branch: 'develop',
-              status: 'success',
-              per_page: 1
-            });
-
-            if (runs.workflow_runs.length === 0) {
-              core.warning('No successful workflow runs found on develop branch');
-              return;
-            }
-
-            core.setOutput('run_id', runs.workflow_runs[0].id);
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: playwright.yml
+          artifact_name: playwright_test_stats
 
       - name: Download develop test stats
-        if: steps.get-latest-run.outputs.run_id
+        if: steps.get-latest-run.outputs.run_id != ''
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         continue-on-error: true
         with:
@@ -128,7 +120,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Compare test counts and comment
-        if: steps.get-latest-run.outputs.run_id
+        if: steps.get-latest-run.outputs.run_id != ''
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -91,6 +91,7 @@ jobs:
       - name: Checkout Streamlit code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ inputs.ref }}
           persist-credentials: false
 
       - name: Download current test stats

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -105,7 +105,6 @@ jobs:
         id: get-latest-run
         uses: ./.github/actions/find_latest_workflow_artifact
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: playwright.yml
           artifact_name: playwright_test_stats
 

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -262,9 +262,8 @@ jobs:
         id: get-latest-run
         uses: ./.github/actions/find_latest_workflow_artifact
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: pr-preview.yml
-          artifact_name: whl_file
+          artifact_name: ${{ env.WHEEL_ARTIFACT_NAME }}
 
       - name: Compare wheel sizes
         if: steps.get-latest-run.outputs.run_id != ''
@@ -431,7 +430,6 @@ jobs:
         id: get-latest-run
         uses: ./.github/actions/find_latest_workflow_artifact
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: pr-preview.yml
           artifact_name: bundle_analysis_json
 

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -253,7 +253,21 @@ jobs:
       WHEEL_ARTIFACT_NAME: whl_file # Name of the wheel artifact
 
     steps:
+      - name: Checkout Streamlit code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Find latest develop wheel
+        id: get-latest-run
+        uses: ./.github/actions/find_latest_workflow_artifact
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: pr-preview.yml
+          artifact_name: whl_file
+
       - name: Compare wheel sizes
+        if: steps.get-latest-run.outputs.run_id != ''
         id: compare-sizes
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
@@ -282,36 +296,12 @@ jobs:
               const currentSize = currentWhlArtifact.size_in_bytes;
               console.log(`Current wheel size: ${currentSize} bytes (${(currentSize / 1024).toFixed(2)} KB)`);
 
-              // Get the latest successful workflow run on develop branch
-              const { data: runs } = await github.rest.actions.listWorkflowRuns({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                workflow_id: 'pr-preview.yml',
-                branch: 'develop',
-                status: 'success',
-                per_page: 1
-              });
-
-              if (runs.workflow_runs.length === 0) {
-                throw new Error('No successful workflow runs found on develop branch');
+              const developRunId = process.env.DEVELOP_RUN_ID;
+              const developSize = Number.parseInt(process.env.DEVELOP_ARTIFACT_SIZE, 10);
+              if (!Number.isFinite(developSize)) {
+                throw new Error(`Invalid develop wheel size: ${process.env.DEVELOP_ARTIFACT_SIZE}`);
               }
-
-              const latestRun = runs.workflow_runs[0];
-              console.log(`Latest successful run on develop: ${latestRun.id}`);
-
-              // Get artifacts for the develop run
-              const { data: developArtifacts } = await github.rest.actions.listWorkflowRunArtifacts({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                run_id: latestRun.id
-              });
-
-              const developWhlArtifact = developArtifacts.artifacts.find(artifact => artifact.name === wheelArtifactName);
-              if (!developWhlArtifact) {
-                throw new Error(`No ${wheelArtifactName} artifact found in the develop workflow run`);
-              }
-
-              const developSize = developWhlArtifact.size_in_bytes;
+              console.log(`Latest successful run on develop: ${developRunId}`);
               console.log(`Develop wheel size: ${developSize} bytes (${(developSize / 1024).toFixed(2)} KB)`);
 
               // Calculate percentage difference
@@ -341,11 +331,13 @@ jobs:
               throw error;
             }
         env:
+          DEVELOP_ARTIFACT_SIZE: ${{ steps.get-latest-run.outputs.artifact_size_in_bytes }}
+          DEVELOP_RUN_ID: ${{ steps.get-latest-run.outputs.run_id }}
           SIZE_CHANGE_THRESHOLD: ${{ env.SIZE_CHANGE_THRESHOLD }}
           WHEEL_ARTIFACT_NAME: ${{ env.WHEEL_ARTIFACT_NAME }}
 
       - name: Add PR comment for significant size change
-        if: success() && fromJSON(steps.compare-sizes.outputs.result).is_significant
+        if: steps.compare-sizes.outputs.result != '' && fromJSON(steps.compare-sizes.outputs.result).is_significant
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
@@ -424,34 +416,27 @@ jobs:
       BUNDLE_SIZE_CHANGE_PERCENTAGE_THRESHOLD: 0.5
 
     steps:
+      - name: Checkout Streamlit code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
       - name: Download current bundle analysis
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: bundle_analysis_json
           path: current_bundle
 
-      - name: Get latest develop run ID
+      - name: Find latest develop bundle analysis
         id: get-latest-run
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        uses: ./.github/actions/find_latest_workflow_artifact
         with:
-          script: |
-            const { data: runs } = await github.rest.actions.listWorkflowRuns({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'pr-preview.yml',
-              branch: 'develop',
-              status: 'success',
-              per_page: 1
-            });
-
-            if (runs.workflow_runs.length === 0) {
-              core.warning('No successful workflow runs found on develop branch');
-              return;
-            }
-
-            core.setOutput('run_id', runs.workflow_runs[0].id);
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: pr-preview.yml
+          artifact_name: bundle_analysis_json
 
       - name: Download develop bundle analysis
+        if: steps.get-latest-run.outputs.run_id != ''
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         continue-on-error: true
         with:
@@ -462,6 +447,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Compare bundle sizes and comment
+        if: steps.get-latest-run.outputs.run_id != ''
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -326,29 +326,17 @@ jobs:
           path: lib/htmlcov
           retention-days: 14
 
-      - name: Get latest develop run ID
+      - name: Find latest develop coverage
         if: github.event_name == 'pull_request'
         id: get-latest-run
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        uses: ./.github/actions/find_latest_workflow_artifact
         with:
-          script: |
-            const { data: runs } = await github.rest.actions.listWorkflowRuns({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'python-tests.yml',
-              branch: 'develop',
-              status: 'success',
-              per_page: 1
-            });
-
-            if (runs.workflow_runs.length === 0) {
-              throw new Error('No successful workflow runs found on develop branch');
-            }
-
-            core.setOutput('run_id', runs.workflow_runs[0].id);
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: python-tests.yml
+          artifact_name: combined_coverage_json
 
       - name: Download develop coverage
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && steps.get-latest-run.outputs.run_id != ''
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           repository: streamlit/streamlit
@@ -360,7 +348,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check coverage changes and comment
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && steps.get-latest-run.outputs.run_id != ''
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -331,7 +331,6 @@ jobs:
         id: get-latest-run
         uses: ./.github/actions/find_latest_workflow_artifact
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: python-tests.yml
           artifact_name: combined_coverage_json
 


### PR DESCRIPTION
## Describe your changes

- Selects baseline workflow runs through explicitly newest-first GraphQL results instead of REST branch and status filters that can return stale runs.
- Centralizes artifact selection for JavaScript and Python coverage, E2E test counts, wheel size, and bundle size; missing or expired artifacts fall back to an older successful run, and comparisons skip safely when no valid baseline exists.

## GitHub Issue Link (if applicable)

- Not applicable

## Testing Plan

- `make all`
- `make autofix`
- `make check`
- `E2E_CHECK=true make check`
- Live GraphQL/REST smoke test against all five current `develop` artifacts
- No additional unit or E2E tests: these changes only affect GitHub Actions workflow orchestration.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
