### PR TITLE
[chore] Add FloatingPortal guidance to agent docs

### DIFF
--- a/.cursor/rules/typescript.mdc
+++ b/.cursor/rules/typescript.mdc
@@ -72,7 +72,9 @@ alwaysApply: false
 
 ## Floating Portals
 
-- **Always pass an `id` to `<FloatingPortal>`**: Bare `<FloatingPortal>` creates a new sibling of `document.body`. React Aria’s `ModalOverlay` (used by `st.dialog` and other modal contexts) marks all body siblings as `inert`, which blocks interaction, prevents focus, and hides the content from assistive technology. Use `id={FLOATING_OVERLAY_PORTAL_ID}` (from `~lib/components/core/Portal/constants`) so the portal renders inside the shared host that carries `data-react-aria-top-layer`.
+- **Always pass an `id` to `<FloatingPortal>`**: A bare `<FloatingPortal>` appends a new `<div>` directly to `document.body`. React Aria’s `ModalOverlay` (used by `st.dialog` and other modal contexts) marks every other child of `document.body` as `inert`, which blocks interaction, prevents focus, and hides the content from assistive technology. Default to `id={FLOATING_OVERLAY_PORTAL_ID}` (from `~lib/components/core/Portal/constants`) so the portal renders inside the shared host that carries `data-react-aria-top-layer`.
+  - Exception: dataframe overlays use `DataFrameOverlayPortal` (`DATAFRAME_PORTAL_ID`), which glide-data-grid requires by name.
+  - Exception: app-chrome menus (`MainMenu`, `TopNavSection`) use a bare `<FloatingPortal>` because they are never opened from inside a dialog.
 
 ## Logging
 

--- a/.cursor/rules/typescript.mdc
+++ b/.cursor/rules/typescript.mdc
@@ -70,6 +70,10 @@ alwaysApply: false
   - Don't remove focus outlines without replacing them. Prefer `:focus-visible` styles and use `theme.shadows` values for consistent rings.
 - **Keyboard dismissal shouldn’t steal focus**: Popovers/tooltips/dialogs should support Escape to dismiss while keeping focus on the trigger unless there’s a strong reason to move it.
 
+## Floating Portals
+
+- **Always pass an `id` to `<FloatingPortal>`**: Bare `<FloatingPortal>` creates a new sibling of `document.body`. React Aria’s `ModalOverlay` (used by `st.dialog` and other modal contexts) marks all body siblings as `inert`, which blocks interaction, prevents focus, and hides the content from assistive technology. Use `id={FLOATING_OVERLAY_PORTAL_ID}` (from `~lib/components/core/Portal/constants`) so the portal renders inside the shared host that carries `data-react-aria-top-layer`.
+
 ## Logging
 
 - Use `loglevel`'s `getLogger` for logging (e.g. warnings / errors). Create a module-level `LOG` constant with a descriptive name:

--- a/.github/instructions/typescript.instructions.md
+++ b/.github/instructions/typescript.instructions.md
@@ -70,7 +70,9 @@ applyTo: "**/*.ts, **/*.tsx"
 
 ## Floating Portals
 
-- **Always pass an `id` to `<FloatingPortal>`**: Bare `<FloatingPortal>` creates a new sibling of `document.body`. React Aria’s `ModalOverlay` (used by `st.dialog` and other modal contexts) marks all body siblings as `inert`, which blocks interaction, prevents focus, and hides the content from assistive technology. Use `id={FLOATING_OVERLAY_PORTAL_ID}` (from `~lib/components/core/Portal/constants`) so the portal renders inside the shared host that carries `data-react-aria-top-layer`.
+- **Always pass an `id` to `<FloatingPortal>`**: A bare `<FloatingPortal>` appends a new `<div>` directly to `document.body`. React Aria’s `ModalOverlay` (used by `st.dialog` and other modal contexts) marks every other child of `document.body` as `inert`, which blocks interaction, prevents focus, and hides the content from assistive technology. Default to `id={FLOATING_OVERLAY_PORTAL_ID}` (from `~lib/components/core/Portal/constants`) so the portal renders inside the shared host that carries `data-react-aria-top-layer`.
+  - Exception: dataframe overlays use `DataFrameOverlayPortal` (`DATAFRAME_PORTAL_ID`), which glide-data-grid requires by name.
+  - Exception: app-chrome menus (`MainMenu`, `TopNavSection`) use a bare `<FloatingPortal>` because they are never opened from inside a dialog.
 
 ## Logging
 

--- a/.github/instructions/typescript.instructions.md
+++ b/.github/instructions/typescript.instructions.md
@@ -68,6 +68,10 @@ applyTo: "**/*.ts, **/*.tsx"
   - Don't remove focus outlines without replacing them. Prefer `:focus-visible` styles and use `theme.shadows` values for consistent rings.
 - **Keyboard dismissal shouldn’t steal focus**: Popovers/tooltips/dialogs should support Escape to dismiss while keeping focus on the trigger unless there’s a strong reason to move it.
 
+## Floating Portals
+
+- **Always pass an `id` to `<FloatingPortal>`**: Bare `<FloatingPortal>` creates a new sibling of `document.body`. React Aria’s `ModalOverlay` (used by `st.dialog` and other modal contexts) marks all body siblings as `inert`, which blocks interaction, prevents focus, and hides the content from assistive technology. Use `id={FLOATING_OVERLAY_PORTAL_ID}` (from `~lib/components/core/Portal/constants`) so the portal renders inside the shared host that carries `data-react-aria-top-layer`.
+
 ## Logging
 
 - Use `loglevel`'s `getLogger` for logging (e.g. warnings / errors). Create a module-level `LOG` constant with a descriptive name:

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -64,7 +64,9 @@
 
 ## Floating Portals
 
-- **Always pass an `id` to `<FloatingPortal>`**: Bare `<FloatingPortal>` creates a new sibling of `document.body`. React Aria’s `ModalOverlay` (used by `st.dialog` and other modal contexts) marks all body siblings as `inert`, which blocks interaction, prevents focus, and hides the content from assistive technology. Use `id={FLOATING_OVERLAY_PORTAL_ID}` (from `~lib/components/core/Portal/constants`) so the portal renders inside the shared host that carries `data-react-aria-top-layer`.
+- **Always pass an `id` to `<FloatingPortal>`**: A bare `<FloatingPortal>` appends a new `<div>` directly to `document.body`. React Aria’s `ModalOverlay` (used by `st.dialog` and other modal contexts) marks every other child of `document.body` as `inert`, which blocks interaction, prevents focus, and hides the content from assistive technology. Default to `id={FLOATING_OVERLAY_PORTAL_ID}` (from `~lib/components/core/Portal/constants`) so the portal renders inside the shared host that carries `data-react-aria-top-layer`.
+  - Exception: dataframe overlays use `DataFrameOverlayPortal` (`DATAFRAME_PORTAL_ID`), which glide-data-grid requires by name.
+  - Exception: app-chrome menus (`MainMenu`, `TopNavSection`) use a bare `<FloatingPortal>` because they are never opened from inside a dialog.
 
 ## Logging
 

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -62,6 +62,10 @@
   - Don't remove focus outlines without replacing them. Prefer `:focus-visible` styles and use `theme.shadows` values for consistent rings.
 - **Keyboard dismissal shouldn’t steal focus**: Popovers/tooltips/dialogs should support Escape to dismiss while keeping focus on the trigger unless there’s a strong reason to move it.
 
+## Floating Portals
+
+- **Always pass an `id` to `<FloatingPortal>`**: Bare `<FloatingPortal>` creates a new sibling of `document.body`. React Aria’s `ModalOverlay` (used by `st.dialog` and other modal contexts) marks all body siblings as `inert`, which blocks interaction, prevents focus, and hides the content from assistive technology. Use `id={FLOATING_OVERLAY_PORTAL_ID}` (from `~lib/components/core/Portal/constants`) so the portal renders inside the shared host that carries `data-react-aria-top-layer`.
+
 ## Logging
 
 - Use `loglevel`'s `getLogger` for logging (e.g. warnings / errors). Create a module-level `LOG` constant with a descriptive name:


### PR DESCRIPTION
## Summary
- Adds a Floating Portals section to frontend/AGENTS.md documenting that FloatingPortal must always receive an id prop to avoid being marked inert by React Aria ModalOverlay inside st.dialog and other modal contexts.
- Follow-up from #16583 review feedback.

## Test plan
- [x] Verify agent docs render correctly in the generated Cursor/Copilot rule files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to agent rules; no runtime or security impact.
> 
> **Overview**
> Documents that `<FloatingPortal>` must receive an `id` so overlays stay interactive inside React Aria modals (`st.dialog`).
> 
> The new **Floating Portals** section in `frontend/AGENTS.md` (and generated Cursor/Copilot TypeScript rules) tells agents to default to `FLOATING_OVERLAY_PORTAL_ID`, with exceptions for dataframe overlays and app-chrome menus.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06f6c61ecc8334cc8a9e63cf0267a7543558e14e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->