### PR TITLE
[feature] Configurable cache background-refresh TTL multiplier

### DIFF
--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/performance.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/performance.md
@@ -76,11 +76,12 @@ combined with `persist`. The function can't use session-specific features (e.g.
 with both `st.cache_data` and `st.cache_resource`.
 
 By default Streamlit hard-expires a background-refresh entry at `2 × ttl`, serving
-it stale for one extra `ttl`. Set `runner.cacheBackgroundRefreshTTLMultiplier` (a
-finite number greater than `1.0`) to move that bound to `M × ttl`, giving a stale
-window of `(M - 1) × ttl`. Invalid values warn and fall back to `2.0`. Raising it
-avoids blocking recomputes after idle periods or failed refreshes; lowering it
-serves fresher data and frees memory sooner.
+it stale for one extra `ttl`. Set `runner.cacheBackgroundRefreshTTLMultiplier` to a
+finite number greater than `1.0` to move that bound: a multiplier of `M`
+hard-expires at `M × ttl`, giving a stale window of `(M - 1) × ttl`. Invalid
+values warn and fall back to `2.0`. Raising it avoids blocking recomputes after
+idle periods or failed refreshes; lowering it serves fresher data and frees
+memory sooner.
 
 ```toml
 # .streamlit/config.toml

--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/performance.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/performance.md
@@ -75,6 +75,24 @@ combined with `persist`. The function can't use session-specific features (e.g.
 `st.session_state`) or render Streamlit elements—pass any needed values as arguments. Works
 with both `st.cache_data` and `st.cache_resource`.
 
+By default, Streamlit serves a stale entry for up to one additional `ttl` and hard-expires it
+at `2 × ttl`. To adjust the process-wide stale window, set
+`runner.cacheBackgroundRefreshTTLMultiplier` to a finite number greater than `1.0`. Invalid
+values fall back to `2.0` with a warning. A value of `M` hard-expires entries at `M × ttl`,
+so the stale window lasts up to `(M - 1) × ttl`.
+
+For example:
+
+```toml
+# .streamlit/config.toml
+[runner]
+cacheBackgroundRefreshTTLMultiplier = 4.0
+```
+
+Larger values reduce blocking refreshes after idle periods or refresh failures, but can
+increase memory usage and permit older values to be served; smaller valid values make the
+opposite tradeoff.
+
 Background refresh is access-driven: it starts only after a call observes an expired entry,
 so the caller may briefly receive stale data. For advanced cases that need the server to
 initiate background refreshes for specific global cache keys even without user traffic, use

--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/performance.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/performance.md
@@ -75,23 +75,18 @@ combined with `persist`. The function can't use session-specific features (e.g.
 `st.session_state`) or render Streamlit elements—pass any needed values as arguments. Works
 with both `st.cache_data` and `st.cache_resource`.
 
-By default, Streamlit serves a stale entry for up to one additional `ttl` and hard-expires it
-at `2 × ttl`. To adjust the process-wide stale window, set
-`runner.cacheBackgroundRefreshTTLMultiplier` to a finite number greater than `1.0`. Invalid
-values fall back to `2.0` with a warning. A value of `M` hard-expires entries at `M × ttl`,
-so the stale window lasts up to `(M - 1) × ttl`.
-
-For example:
+By default Streamlit hard-expires a background-refresh entry at `2 × ttl`, serving
+it stale for one extra `ttl`. Set `runner.cacheBackgroundRefreshTTLMultiplier` (a
+finite number greater than `1.0`) to move that bound to `M × ttl`, giving a stale
+window of `(M - 1) × ttl`. Invalid values warn and fall back to `2.0`. Raising it
+avoids blocking recomputes after idle periods or failed refreshes; lowering it
+serves fresher data and frees memory sooner.
 
 ```toml
 # .streamlit/config.toml
 [runner]
 cacheBackgroundRefreshTTLMultiplier = 4.0
 ```
-
-Larger values reduce blocking refreshes after idle periods or refresh failures, but can
-increase memory usage and permit older values to be served; smaller valid values make the
-opposite tradeoff.
 
 Background refresh is access-driven: it starts only after a call observes an expired entry,
 so the caller may briefly receive stale data. For advanced cases that need the server to

--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/server-asgi.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/server-asgi.md
@@ -298,14 +298,14 @@ Keep these caveats in mind:
 - **This does not refresh before the TTL.** Calls made while the entry is fresh return the
   current value without executing the cached function. Polling controls how soon the server
   notices expiration and triggers background refresh.
-- **Poll comfortably below `ttl`.** By default, background refresh serves the stale value for
-  one extra `ttl`; past `2 × ttl` the entry is hard-evicted and the next call (including a
-  scheduled touch) blocks on a foreground recompute. The
-  `runner.cacheBackgroundRefreshTTLMultiplier` configuration option changes that process-wide
-  hard-expiration bound to `M × ttl` for a multiplier `M` greater than `1.0`. Keep the polling
-  interval well under `ttl` so several touches land in the stale grace window, giving the
-  scheduler multiple chances to trigger a refresh before hard eviction if a touch is delayed
-  or a refresh runs long.
+- **Poll comfortably below the stale window.** By default, background refresh serves the
+  stale value for one extra `ttl`; past `2 × ttl` the entry is hard-evicted and the next
+  call (including a scheduled touch) blocks on a foreground recompute. The
+  `runner.cacheBackgroundRefreshTTLMultiplier` option changes that bound to `M × ttl`.
+  Keep the polling interval well under `(M - 1) × ttl` so several touches land in the
+  stale grace window. With the default `M = 2.0` that is well under `ttl`; with
+  `M = 1.5`, poll comfortably below `0.5 × ttl` — a `0.75 × ttl` cadence can jump from
+  fresh to hard expiry without triggering a background refresh.
 - **Stale values remain possible.** The scheduled touch preserves the last good value while
   refreshing, but users can receive it until the refresh completes. If uninterrupted,
   atomically replaced fresh reads are required, refresh a shared external store instead.

--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/server-asgi.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/server-asgi.md
@@ -298,12 +298,14 @@ Keep these caveats in mind:
 - **This does not refresh before the TTL.** Calls made while the entry is fresh return the
   current value without executing the cached function. Polling controls how soon the server
   notices expiration and triggers background refresh.
-- **Poll comfortably below `ttl`.** Background refresh serves the stale value for only one
-  extra `ttl`; past `2 × ttl` the entry is hard-evicted and the next call (including a
-  scheduled touch) blocks on a foreground recompute. Keep the interval well under `ttl` (not
-  just under `2 × ttl`) so several touches land in the `[ttl, 2 × ttl)` grace window, giving
-  the scheduler multiple chances to trigger a refresh before hard eviction if a touch is
-  delayed or a refresh runs long.
+- **Poll comfortably below `ttl`.** By default, background refresh serves the stale value for
+  one extra `ttl`; past `2 × ttl` the entry is hard-evicted and the next call (including a
+  scheduled touch) blocks on a foreground recompute. The
+  `runner.cacheBackgroundRefreshTTLMultiplier` configuration option changes that process-wide
+  hard-expiration bound to `M × ttl` for a multiplier `M` greater than `1.0`. Keep the polling
+  interval well under `ttl` so several touches land in the stale grace window, giving the
+  scheduler multiple chances to trigger a refresh before hard eviction if a touch is delayed
+  or a refresh runs long.
 - **Stale values remain possible.** The scheduled touch preserves the last good value while
   refreshing, but users can receive it until the refresh completes. If uninterrupted,
   atomically replaced fresh reads are required, refresh a shared external store instead.

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -816,11 +816,31 @@ _create_option(
         still served) rather than queued.
 
         Set to 0 to disable background refresh entirely: stale entries are then
-        recomputed by a blocking foreground call at hard expiry (2 x ttl).
+        recomputed by a blocking foreground call at the configured hard-expiry
+        bound.
     """,
     visibility="hidden",
     default_val=4,
     type_=int,
+)
+
+_create_option(
+    "runner.cacheBackgroundRefreshTTLMultiplier",
+    description="""
+        Multiplier applied to a cached function's ttl to set the hard-expiration
+        bound for refresh_mode="background". Hard expiry occurs at
+        multiplier * ttl. The default is 2.0, so stale values can be served
+        for one additional ttl while Streamlit attempts a background refresh.
+
+        Values must be finite and greater than 1.0. Invalid values, and values
+        that cannot produce a finite hard-expiration ttl, are ignored with a
+        warning and the default is used instead. Larger values keep entries
+        longer after idle periods or refresh failures, at the cost of higher
+        memory use and older served data. Applies to both @st.cache_data and
+        @st.cache_resource.
+    """,
+    default_val=2.0,
+    type_=float,
 )
 
 _create_option(

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -832,6 +832,11 @@ _create_option(
         multiplier * ttl. The default is 2.0, so stale values can be served
         for one additional ttl while Streamlit attempts a background refresh.
 
+        This is a process-wide bound for every refresh_mode="background"
+        function in the process, not a per-function default. Raising it to
+        keep one long-idle cache also keeps stale entries for every other
+        background cache for (multiplier - 1) * ttl.
+
         Values must be finite and greater than 1.0. Invalid values, and values
         that cannot produce a finite hard-expiration ttl, are ignored with a
         warning and the default is used instead. Larger values keep entries

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -837,9 +837,13 @@ _create_option(
         keep one long-idle cache also keeps stale entries for every other
         background cache for (multiplier - 1) * ttl.
 
-        Values must be finite and greater than 1.0. Invalid values, and values
-        that cannot produce a finite hard-expiration ttl, are ignored with a
-        warning and the default is used instead. Larger values keep entries
+        Values must be finite and greater than 1.0. Values of 1.0 or below
+        would remove the stale window and are rejected; use
+        refresh_mode="foreground" to never serve stale values, or
+        runner.cacheBackgroundRefreshMaxWorkers = 0 to skip background
+        refresh while still serving stale values until hard expiry. If the
+        multiplier or resulting hard-expiration TTL is not finite, Streamlit
+        warns and uses the default multiplier. Larger values keep entries
         longer after idle periods or refresh failures, at the cost of higher
         memory use and older served data. Applies to both @st.cache_data and
         @st.cache_resource.

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -837,16 +837,13 @@ _create_option(
         keep one long-idle cache also keeps stale entries for every other
         background cache for (multiplier - 1) * ttl.
 
-        Values must be finite and greater than 1.0. Values of 1.0 or below
-        would remove the stale window and are rejected; use
-        refresh_mode="foreground" to never serve stale values, or
-        runner.cacheBackgroundRefreshMaxWorkers = 0 to skip background
-        refresh while still serving stale values until hard expiry. If the
-        multiplier or resulting hard-expiration TTL is not finite, Streamlit
-        warns and uses the default multiplier. Larger values keep entries
-        longer after idle periods or refresh failures, at the cost of higher
-        memory use and older served data. Applies to both @st.cache_data and
-        @st.cache_resource.
+        Values must be finite and greater than 1.0. Invalid values are ignored
+        with a warning and the default 2.0 is used. Values of 1.0 would remove
+        the stale window; values below 1.0 would hard-expire before the
+        freshness ttl. Use refresh_mode="foreground" to never serve stale
+        values. Larger values keep entries longer after idle periods or
+        refresh failures, at the cost of higher memory use and older served
+        data. Applies to both @st.cache_data and @st.cache_resource.
     """,
     default_val=2.0,
     type_=float,

--- a/lib/streamlit/runtime/caching/cache_data_api.py
+++ b/lib/streamlit/runtime/caching/cache_data_api.py
@@ -195,15 +195,7 @@ class DataCaches(StatsProvider):
             context.
         """
 
-        # The user-facing freshness ttl. In background mode the underlying storage uses
-        # a hard-eviction ttl of 2*ttl and tracks freshness separately via stored_at.
         fresh_ttl_seconds = time_to_seconds(ttl, coerce_none_to_inf=False)
-        if refresh_mode == "background" and fresh_ttl_seconds is not None:
-            hard_ttl_seconds: float | None = (
-                fresh_ttl_seconds * cache_utils.BACKGROUND_REFRESH_TTL_MULTIPLIER
-            )
-        else:
-            hard_ttl_seconds = fresh_ttl_seconds
 
         # Fetch the session ID. Note that this will throw an exception if there is no
         # session associated with the current thread.
@@ -253,6 +245,10 @@ class DataCaches(StatsProvider):
                 persist,
                 max_entries,
                 ttl,
+            )
+
+            hard_ttl_seconds = cache_utils._hard_ttl_seconds(
+                refresh_mode, fresh_ttl_seconds
             )
 
             cache_context = self.create_cache_storage_context(
@@ -597,9 +593,11 @@ class CacheDataAPI:
               runs the cached function synchronously. The app rerun waits until the new
               value is ready.
             - ``"background"``: Return the expired value immediately and update it in
-              the background. Streamlit can keep returning the expired value for up to
-              one additional ``ttl``. After that, the next call waits for a new value.
-              This mode requires a ``ttl`` and can't be used with ``persist``.
+              the background. Streamlit can keep returning the expired value until
+              the hard-expiration bound, which is ``ttl`` multiplied by the
+              ``runner.cacheBackgroundRefreshTTLMultiplier`` configuration option
+              (default ``2.0``). After that bound, the next call waits for a new
+              value. This mode requires a ``ttl`` and can't be used with ``persist``.
 
             .. note::
                 A function that refreshes in the background can't use session-specific
@@ -782,8 +780,8 @@ class DataCache(Cache[R]):
         self.key = key
         self.display_name = display_name
         self.storage = storage
-        # In background mode this is the hard-eviction bound (2*ttl); freshness within
-        # the fresh window is tracked separately via CachedResult.stored_at.
+        # In background mode this is the configured hard-expiration bound; freshness
+        # within the fresh window is tracked separately via CachedResult.stored_at.
         self.ttl_seconds = ttl_seconds
         self.max_entries = max_entries
         self.persist = persist
@@ -831,7 +829,7 @@ class DataCache(Cache[R]):
             raise CacheError(f"Failed to unpickle {value_key}") from exc
 
     def _is_stale(self, result: CachedResult[R]) -> bool:
-        """Whether a present entry is in the stale grace window ``[ttl, 2*ttl)``."""
+        """Whether a present entry is past its freshness TTL but not yet hard-expired."""
         if (
             self.refresh_mode != "background"
             or result.stored_at is None

--- a/lib/streamlit/runtime/caching/cache_data_api.py
+++ b/lib/streamlit/runtime/caching/cache_data_api.py
@@ -247,7 +247,12 @@ class DataCaches(StatsProvider):
                 ttl,
             )
 
-            hard_ttl_seconds = cache_utils._hard_ttl_seconds(
+            # Capture the multiplier only when creating a cache, not on the reuse
+            # path above. A live config.toml edit therefore does not re-bound
+            # existing caches (same as runner.cacheBackgroundRefreshMaxWorkers).
+            # get_option takes _config_lock while _caches_lock is held; that is
+            # safe because this option is not scriptable.
+            hard_ttl_seconds = cache_utils.get_hard_ttl_seconds(
                 refresh_mode, fresh_ttl_seconds
             )
 

--- a/lib/streamlit/runtime/caching/cache_data_api.py
+++ b/lib/streamlit/runtime/caching/cache_data_api.py
@@ -247,7 +247,7 @@ class DataCaches(StatsProvider):
                 ttl,
             )
 
-            # Multiplier is captured at creation; existing caches are not re-bound.
+            # Resolved after the reuse check so the hot path never reads config.
             hard_ttl_seconds = cache_utils.get_hard_ttl_seconds(
                 refresh_mode, fresh_ttl_seconds
             )
@@ -595,11 +595,10 @@ class CacheDataAPI:
               value is ready.
             - ``"background"``: Return the expired value immediately and update it in
               the background. By default, Streamlit can keep returning the expired
-              value for one extra ``ttl``. Set
-              ``runner.cacheBackgroundRefreshTTLMultiplier`` to change that
-              hard-expiration bound. After hard expiry, the next call waits for a
-              new value. This mode requires a ``ttl`` and can't be used with
-              ``persist``.
+              value for one extra ``ttl``; after that, the next call waits for a new
+              value. To change how long expired values can be returned, use the
+              ``runner.cacheBackgroundRefreshTTLMultiplier`` configuration option.
+              This mode requires a ``ttl`` and can't be used with ``persist``.
 
             .. note::
                 A function that refreshes in the background can't use session-specific

--- a/lib/streamlit/runtime/caching/cache_data_api.py
+++ b/lib/streamlit/runtime/caching/cache_data_api.py
@@ -247,11 +247,7 @@ class DataCaches(StatsProvider):
                 ttl,
             )
 
-            # Capture the multiplier only when creating a cache, not on the reuse
-            # path above. A live config.toml edit therefore does not re-bound
-            # existing caches (same as runner.cacheBackgroundRefreshMaxWorkers).
-            # get_option takes _config_lock while _caches_lock is held; that is
-            # safe because this option is not scriptable.
+            # Multiplier is captured at creation; existing caches are not re-bound.
             hard_ttl_seconds = cache_utils.get_hard_ttl_seconds(
                 refresh_mode, fresh_ttl_seconds
             )
@@ -834,7 +830,11 @@ class DataCache(Cache[R]):
             raise CacheError(f"Failed to unpickle {value_key}") from exc
 
     def _is_stale(self, result: CachedResult[R]) -> bool:
-        """Whether a present entry is past its freshness TTL but not yet hard-expired."""
+        """Whether a present entry is past its freshness TTL.
+
+        Hard-expired keys never reach this method: the storage layer treats them as
+        missing.
+        """
         if (
             self.refresh_mode != "background"
             or result.stored_at is None

--- a/lib/streamlit/runtime/caching/cache_data_api.py
+++ b/lib/streamlit/runtime/caching/cache_data_api.py
@@ -594,11 +594,12 @@ class CacheDataAPI:
               runs the cached function synchronously. The app rerun waits until the new
               value is ready.
             - ``"background"``: Return the expired value immediately and update it in
-              the background. Streamlit can keep returning the expired value until
-              the hard-expiration bound, which is ``ttl`` multiplied by the
-              ``runner.cacheBackgroundRefreshTTLMultiplier`` configuration option
-              (default ``2.0``). After that bound, the next call waits for a new
-              value. This mode requires a ``ttl`` and can't be used with ``persist``.
+              the background. By default, Streamlit can keep returning the expired
+              value for one extra ``ttl``. Set
+              ``runner.cacheBackgroundRefreshTTLMultiplier`` to change that
+              hard-expiration bound. After hard expiry, the next call waits for a
+              new value. This mode requires a ``ttl`` and can't be used with
+              ``persist``.
 
             .. note::
                 A function that refreshes in the background can't use session-specific

--- a/lib/streamlit/runtime/caching/cache_resource_api.py
+++ b/lib/streamlit/runtime/caching/cache_resource_api.py
@@ -517,11 +517,11 @@ class CacheResourceAPI:
               runs the cached function synchronously. The app rerun waits until the new
               resource is ready.
             - ``"background"``: Return the expired resource immediately and update it
-              in the background. Streamlit can keep returning the expired resource
-              until the hard-expiration bound, which is ``ttl`` multiplied by the
-              ``runner.cacheBackgroundRefreshTTLMultiplier`` configuration option
-              (default ``2.0``). After that bound, the next call waits for a new
-              resource. This mode requires a ``ttl``. If you set ``on_release``,
+              in the background. By default, Streamlit can keep returning the expired
+              resource for one extra ``ttl``. Set
+              ``runner.cacheBackgroundRefreshTTLMultiplier`` to change that
+              hard-expiration bound. After hard expiry, the next call waits for a
+              new resource. This mode requires a ``ttl``. If you set ``on_release``,
               Streamlit calls it for the old resource after a successful update.
 
             .. note::

--- a/lib/streamlit/runtime/caching/cache_resource_api.py
+++ b/lib/streamlit/runtime/caching/cache_resource_api.py
@@ -158,7 +158,10 @@ class ResourceCaches(StatsProvider):
             if cache is not None:
                 cache.mark_detached()
 
-            hard_ttl_seconds = cache_utils._hard_ttl_seconds(
+            # Capture the multiplier only when creating a cache, not on the reuse
+            # path above. A live config.toml edit therefore does not re-bound
+            # existing caches (same as runner.cacheBackgroundRefreshMaxWorkers).
+            hard_ttl_seconds = cache_utils.get_hard_ttl_seconds(
                 refresh_mode, fresh_ttl_seconds
             )
 

--- a/lib/streamlit/runtime/caching/cache_resource_api.py
+++ b/lib/streamlit/runtime/caching/cache_resource_api.py
@@ -126,14 +126,7 @@ class ResourceCaches(StatsProvider):
         if max_entries is None:
             max_entries = math.inf
 
-        # The user-facing freshness ttl. In background mode the underlying cache uses a
-        # hard-eviction ttl of 2*ttl and tracks freshness separately via stored_at.
         fresh_ttl_seconds = time_to_seconds(ttl)
-        hard_ttl_seconds = (
-            fresh_ttl_seconds * cache_utils.BACKGROUND_REFRESH_TTL_MULTIPLIER
-            if refresh_mode == "background"
-            else fresh_ttl_seconds
-        )
 
         # Fetch the session ID. Note that this will throw an exception if there is no
         # session associated with the current thread.
@@ -164,6 +157,10 @@ class ResourceCaches(StatsProvider):
             # refresh is discarded rather than written back to a replaced cache.
             if cache is not None:
                 cache.mark_detached()
+
+            hard_ttl_seconds = cache_utils._hard_ttl_seconds(
+                refresh_mode, fresh_ttl_seconds
+            )
 
             # Create a new cache object and put it in our dict
             _LOGGER.debug("Creating new ResourceCache (key=%s)", key)
@@ -519,8 +516,10 @@ class CacheResourceAPI:
               runs the cached function synchronously. The app rerun waits until the new
               resource is ready.
             - ``"background"``: Return the expired resource immediately and update it
-              in the background. Streamlit can keep returning the expired resource for
-              up to one additional ``ttl``. After that, the next call waits for a new
+              in the background. Streamlit can keep returning the expired resource
+              until the hard-expiration bound, which is ``ttl`` multiplied by the
+              ``runner.cacheBackgroundRefreshTTLMultiplier`` configuration option
+              (default ``2.0``). After that bound, the next call waits for a new
               resource. This mode requires a ``ttl``. If you set ``on_release``,
               Streamlit calls it for the old resource after a successful update.
 
@@ -711,7 +710,7 @@ class ResourceCache(Cache[R]):
         self.display_name = display_name
         self._mem_cache: TTLCleanupCache[str, CachedResult[R]] = TTLCleanupCache(
             maxsize=max_entries,
-            # In background mode this is the hard-eviction bound (2*ttl); freshness
+            # In background mode this is the configured hard-expiration bound; freshness
             # within the fresh window is tracked separately via stored_at.
             ttl=ttl_seconds,
             timer=cache_utils.TTLCACHE_TIMER,
@@ -738,7 +737,7 @@ class ResourceCache(Cache[R]):
         return self._mem_cache.ttl
 
     def _is_stale(self, result: CachedResult[R]) -> bool:
-        """Whether a present entry is in the stale grace window ``[ttl, 2*ttl)``."""
+        """Whether a present entry is past its freshness TTL but not yet hard-expired."""
         # Unlike DataCache, no ``fresh_ttl_seconds is None`` guard is needed here:
         # resource caches always resolve it to a float (ttl uses coerce_none_to_inf).
         if self.refresh_mode != "background" or result.stored_at is None:

--- a/lib/streamlit/runtime/caching/cache_resource_api.py
+++ b/lib/streamlit/runtime/caching/cache_resource_api.py
@@ -158,7 +158,7 @@ class ResourceCaches(StatsProvider):
             if cache is not None:
                 cache.mark_detached()
 
-            # Multiplier is captured at creation; existing caches are not re-bound.
+            # Resolved after the reuse check so the hot path never reads config.
             hard_ttl_seconds = cache_utils.get_hard_ttl_seconds(
                 refresh_mode, fresh_ttl_seconds
             )
@@ -518,10 +518,10 @@ class CacheResourceAPI:
               resource is ready.
             - ``"background"``: Return the expired resource immediately and update it
               in the background. By default, Streamlit can keep returning the expired
-              resource for one extra ``ttl``. Set
-              ``runner.cacheBackgroundRefreshTTLMultiplier`` to change that
-              hard-expiration bound. After hard expiry, the next call waits for a
-              new resource. This mode requires a ``ttl``. If you set ``on_release``,
+              resource for one extra ``ttl``; after that, the next call waits for a
+              new resource. To change how long expired resources can be returned, use
+              the ``runner.cacheBackgroundRefreshTTLMultiplier`` configuration option.
+              This mode requires a ``ttl``. If you set ``on_release``,
               Streamlit calls it for the old resource after a successful update.
 
             .. note::

--- a/lib/streamlit/runtime/caching/cache_resource_api.py
+++ b/lib/streamlit/runtime/caching/cache_resource_api.py
@@ -158,9 +158,7 @@ class ResourceCaches(StatsProvider):
             if cache is not None:
                 cache.mark_detached()
 
-            # Capture the multiplier only when creating a cache, not on the reuse
-            # path above. A live config.toml edit therefore does not re-bound
-            # existing caches (same as runner.cacheBackgroundRefreshMaxWorkers).
+            # Multiplier is captured at creation; existing caches are not re-bound.
             hard_ttl_seconds = cache_utils.get_hard_ttl_seconds(
                 refresh_mode, fresh_ttl_seconds
             )
@@ -740,7 +738,11 @@ class ResourceCache(Cache[R]):
         return self._mem_cache.ttl
 
     def _is_stale(self, result: CachedResult[R]) -> bool:
-        """Whether a present entry is past its freshness TTL but not yet hard-expired."""
+        """Whether a present entry is past its freshness TTL.
+
+        Hard-expired keys never reach this method: the storage layer treats them as
+        missing.
+        """
         # Unlike DataCache, no ``fresh_ttl_seconds is None`` guard is needed here:
         # resource caches always resolve it to a float (ttl uses coerce_none_to_inf).
         if self.refresh_mode != "background" or result.stored_at is None:

--- a/lib/streamlit/runtime/caching/cache_utils.py
+++ b/lib/streamlit/runtime/caching/cache_utils.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import contextlib
 import functools
 import inspect
+import math
 import threading
 import time
 from abc import abstractmethod
@@ -92,9 +93,13 @@ CacheScope: TypeAlias = Literal["global", "session"]
 # How a cache entry is refreshed once its ttl expires.
 RefreshMode: TypeAlias = Literal["foreground", "background"]
 
-# The hard-expiration TTL for background refresh caches is this multiple of the
-# user-facing freshness TTL.
-BACKGROUND_REFRESH_TTL_MULTIPLIER: Final = 2
+# Default hard-expiration multiplier for background-refresh caches.
+# Hard TTL is ttl multiplied by this value.
+_DEFAULT_BACKGROUND_REFRESH_TTL_MULTIPLIER: Final = 2.0
+
+# Values already warned about. Many cached functions can be created under one
+# misconfiguration, so warning unconditionally would flood the log.
+_warned_background_refresh_ttl_multipliers: Final[set[str]] = set()
 
 # How long (in seconds) to wait before retrying a background refresh after a failure,
 # so a persistently failing upstream isn't retried on every rerun.
@@ -105,13 +110,87 @@ _FAILURE_COOLDOWN_SECONDS: Final = 60.0
 class CacheReadResult(Generic[R]):
     """The result of a cache read together with its freshness.
 
-    ``is_stale`` is only ever ``True`` for ``refresh_mode="background"`` caches when
-    the entry is within the stale grace window ``[ttl, 2*ttl)``. Fresh hits and any
-    foreground-mode read report ``is_stale=False``.
+    ``is_stale`` is ``True`` only when a ``refresh_mode="background"`` entry is past
+    its freshness TTL but still within the configured hard-expiration TTL. Fresh hits
+    and foreground-mode reads report ``is_stale=False``.
     """
 
     result: CachedResult[R]
     is_stale: bool
+
+
+def _warn_unusable_background_refresh_ttl_multiplier(configured: object) -> None:
+    """Warn that the TTL multiplier is being ignored, once per distinct value.
+
+    Keyed on the repr so a quoted and an unquoted TOML value are reported as the
+    user wrote them, and so an unhashable value cannot raise from here.
+    """
+    key = repr(configured)
+    if key in _warned_background_refresh_ttl_multipliers:
+        return
+    _warned_background_refresh_ttl_multipliers.add(key)
+    _LOGGER.warning(
+        "Ignoring runner.cacheBackgroundRefreshTTLMultiplier=%s: it must be a "
+        "finite number greater than 1.0 and produce a finite hard-expiration TTL. "
+        "Falling back to the default multiplier of %s.",
+        key,
+        _DEFAULT_BACKGROUND_REFRESH_TTL_MULTIPLIER,
+    )
+
+
+def _get_background_refresh_ttl_multiplier() -> float:
+    """Return a valid hard-expiration multiplier for background caches.
+
+    Invalid values fall back to the default so malformed configuration cannot break
+    cache creation or make the hard TTL shorter than the freshness TTL.
+    """
+    from streamlit import config
+
+    configured = config.get_option("runner.cacheBackgroundRefreshTTLMultiplier")
+    try:
+        multiplier = float(configured)
+    except (TypeError, ValueError, OverflowError):
+        multiplier = None
+
+    if multiplier is None or not math.isfinite(multiplier) or multiplier <= 1.0:
+        _warn_unusable_background_refresh_ttl_multiplier(configured)
+        return _DEFAULT_BACKGROUND_REFRESH_TTL_MULTIPLIER
+
+    return multiplier
+
+
+def _get_background_refresh_hard_ttl(fresh_ttl_seconds: float) -> float:
+    """Return the configured hard-expiration TTL for a background cache."""
+    multiplier = _get_background_refresh_ttl_multiplier()
+    hard_ttl_seconds = fresh_ttl_seconds * multiplier
+    # A huge-but-finite multiplier can overflow the product to inf.
+    if math.isfinite(fresh_ttl_seconds) and not math.isfinite(hard_ttl_seconds):
+        _warn_unusable_background_refresh_ttl_multiplier(multiplier)
+        return fresh_ttl_seconds * _DEFAULT_BACKGROUND_REFRESH_TTL_MULTIPLIER
+    return hard_ttl_seconds
+
+
+@overload
+def _hard_ttl_seconds(refresh_mode: RefreshMode, fresh_ttl_seconds: float) -> float: ...
+
+
+@overload
+def _hard_ttl_seconds(
+    refresh_mode: RefreshMode, fresh_ttl_seconds: float | None
+) -> float | None: ...
+
+
+def _hard_ttl_seconds(
+    refresh_mode: RefreshMode, fresh_ttl_seconds: float | None
+) -> float | None:
+    """Return the eviction TTL for a cache.
+
+    Background caches use a later hard-expiration TTL so stale values can still be
+    served while a refresh runs. Foreground caches use the freshness TTL as-is.
+    """
+    if refresh_mode != "background" or fresh_ttl_seconds is None:
+        return fresh_ttl_seconds
+    return _get_background_refresh_hard_ttl(fresh_ttl_seconds)
 
 
 def validate_refresh_mode(refresh_mode: str, ttl_seconds: float | None) -> None:
@@ -227,8 +306,8 @@ class Cache(Generic[R]):
         """Read a value together with its freshness.
 
         Delegates to ``read_result`` and to ``_is_stale``. Foreground caches are never
-        stale; background-mode caches override ``_is_stale`` to detect entries in the
-        stale grace window ``[ttl, 2*ttl)``.
+        stale; background-mode caches override ``_is_stale`` to detect entries that are
+        past their freshness TTL but not yet hard-expired.
 
         Raises
         ------
@@ -244,7 +323,7 @@ class Cache(Generic[R]):
         """Whether a present entry is past its fresh ttl.
 
         Always ``False`` for foreground caches. Background-mode caches override this to
-        report entries in the stale grace window ``[ttl, 2*ttl)``.
+        report entries that are past their freshness TTL but not yet hard-expired.
         """
         return False
 

--- a/lib/streamlit/runtime/caching/cache_utils.py
+++ b/lib/streamlit/runtime/caching/cache_utils.py
@@ -147,6 +147,8 @@ def _resolve_background_refresh_ttl_multiplier() -> tuple[float, object]:
     """
     from streamlit import config
 
+    # Callers hold `_caches_lock` while `config.get_option` takes `_config_lock`.
+    # Safe because no `_on_config_parsed` receiver acquires a cache-registry lock.
     configured = config.get_option("runner.cacheBackgroundRefreshTTLMultiplier")
     try:
         multiplier = float(configured)
@@ -161,12 +163,6 @@ def _resolve_background_refresh_ttl_multiplier() -> tuple[float, object]:
         return _DEFAULT_BACKGROUND_REFRESH_TTL_MULTIPLIER, configured
 
     return multiplier, configured
-
-
-def _get_background_refresh_ttl_multiplier() -> float:
-    """Return a valid hard-expiration multiplier for background caches."""
-    multiplier, _configured = _resolve_background_refresh_ttl_multiplier()
-    return multiplier
 
 
 def _get_background_refresh_hard_ttl(fresh_ttl_seconds: float) -> float:
@@ -202,12 +198,6 @@ def get_hard_ttl_seconds(
 
     Background caches use a later hard-expiration TTL so stale values can still be
     served while a refresh runs. Foreground caches use the freshness TTL as-is.
-
-    The multiplier is captured when the cache is created, not on later reuse, so a
-    live ``config.toml`` edit does not re-bound existing caches (same as
-    ``runner.cacheBackgroundRefreshMaxWorkers``). ``config.get_option`` takes
-    ``_config_lock`` while callers hold ``_caches_lock``; that is safe because this
-    option is not scriptable.
     """
     if refresh_mode != "background" or fresh_ttl_seconds is None:
         return fresh_ttl_seconds

--- a/lib/streamlit/runtime/caching/cache_utils.py
+++ b/lib/streamlit/runtime/caching/cache_utils.py
@@ -93,12 +93,13 @@ CacheScope: TypeAlias = Literal["global", "session"]
 # How a cache entry is refreshed once its ttl expires.
 RefreshMode: TypeAlias = Literal["foreground", "background"]
 
-# Default hard-expiration multiplier for background-refresh caches.
-# Hard TTL is ttl multiplied by this value.
+# Historical default and fallback so unset or invalid config still hard-expires
+# at 2 * ttl.
 _DEFAULT_BACKGROUND_REFRESH_TTL_MULTIPLIER: Final = 2.0
 
-# Values already warned about. Many cached functions can be created under one
-# misconfiguration, so warning unconditionally would flood the log.
+# Configured multipliers we have already warned about. Many cached functions can
+# be created under one misconfiguration, so warning on every read would flood
+# the log.
 _warned_background_refresh_ttl_multipliers: Final[set[str]] = set()
 
 # How long (in seconds) to wait before retrying a background refresh after a failure,
@@ -119,7 +120,7 @@ class CacheReadResult(Generic[R]):
     is_stale: bool
 
 
-def _warn_unusable_background_refresh_ttl_multiplier(configured: object) -> None:
+def _warn_background_refresh_ttl_multiplier(configured: object, reason: str) -> None:
     """Warn that the TTL multiplier is being ignored, once per distinct value.
 
     Keyed on the repr so a quoted and an unquoted TOML value are reported as the
@@ -130,10 +131,10 @@ def _warn_unusable_background_refresh_ttl_multiplier(configured: object) -> None
         return
     _warned_background_refresh_ttl_multipliers.add(key)
     _LOGGER.warning(
-        "Ignoring runner.cacheBackgroundRefreshTTLMultiplier=%s: it must be a "
-        "finite number greater than 1.0 and produce a finite hard-expiration TTL. "
-        "Falling back to the default multiplier of %s.",
+        "Ignoring runner.cacheBackgroundRefreshTTLMultiplier=%s: %s Falling "
+        "back to the default multiplier of %s.",
         key,
+        reason,
         _DEFAULT_BACKGROUND_REFRESH_TTL_MULTIPLIER,
     )
 
@@ -153,7 +154,11 @@ def _get_background_refresh_ttl_multiplier() -> float:
         multiplier = None
 
     if multiplier is None or not math.isfinite(multiplier) or multiplier <= 1.0:
-        _warn_unusable_background_refresh_ttl_multiplier(configured)
+        _warn_background_refresh_ttl_multiplier(
+            configured,
+            "it must be a finite number greater than 1.0 and produce a finite "
+            "hard-expiration TTL.",
+        )
         return _DEFAULT_BACKGROUND_REFRESH_TTL_MULTIPLIER
 
     return multiplier
@@ -165,22 +170,31 @@ def _get_background_refresh_hard_ttl(fresh_ttl_seconds: float) -> float:
     hard_ttl_seconds = fresh_ttl_seconds * multiplier
     # A huge-but-finite multiplier can overflow the product to inf.
     if math.isfinite(fresh_ttl_seconds) and not math.isfinite(hard_ttl_seconds):
-        _warn_unusable_background_refresh_ttl_multiplier(multiplier)
+        from streamlit import config
+
+        # Use the raw configured value so a quoted TOML number is logged as written.
+        configured = config.get_option("runner.cacheBackgroundRefreshTTLMultiplier")
+        _warn_background_refresh_ttl_multiplier(
+            configured,
+            "ttl * multiplier overflows to infinity.",
+        )
         return fresh_ttl_seconds * _DEFAULT_BACKGROUND_REFRESH_TTL_MULTIPLIER
     return hard_ttl_seconds
 
 
 @overload
-def _hard_ttl_seconds(refresh_mode: RefreshMode, fresh_ttl_seconds: float) -> float: ...
+def get_hard_ttl_seconds(
+    refresh_mode: RefreshMode, fresh_ttl_seconds: float
+) -> float: ...
 
 
 @overload
-def _hard_ttl_seconds(
+def get_hard_ttl_seconds(
     refresh_mode: RefreshMode, fresh_ttl_seconds: float | None
 ) -> float | None: ...
 
 
-def _hard_ttl_seconds(
+def get_hard_ttl_seconds(
     refresh_mode: RefreshMode, fresh_ttl_seconds: float | None
 ) -> float | None:
     """Return the eviction TTL for a cache.

--- a/lib/streamlit/runtime/caching/cache_utils.py
+++ b/lib/streamlit/runtime/caching/cache_utils.py
@@ -93,8 +93,7 @@ CacheScope: TypeAlias = Literal["global", "session"]
 # How a cache entry is refreshed once its ttl expires.
 RefreshMode: TypeAlias = Literal["foreground", "background"]
 
-# Historical default and fallback so unset or invalid config still hard-expires
-# at 2 * ttl.
+# Unset or invalid config still hard-expires background caches at 2 * ttl.
 _DEFAULT_BACKGROUND_REFRESH_TTL_MULTIPLIER: Final = 2.0
 
 # Configured multipliers we have already warned about. Many cached functions can
@@ -139,11 +138,12 @@ def _warn_background_refresh_ttl_multiplier(configured: object, reason: str) -> 
     )
 
 
-def _get_background_refresh_ttl_multiplier() -> float:
-    """Return a valid hard-expiration multiplier for background caches.
+def _resolve_background_refresh_ttl_multiplier() -> tuple[float, object]:
+    """Return ``(multiplier, configured)`` for the hard-expiration bound.
 
     Invalid values fall back to the default so malformed configuration cannot break
-    cache creation or make the hard TTL shorter than the freshness TTL.
+    cache creation or make the hard TTL shorter than the freshness TTL. The raw
+    configured value is returned so overflow warnings can log it as the user wrote it.
     """
     from streamlit import config
 
@@ -156,24 +156,25 @@ def _get_background_refresh_ttl_multiplier() -> float:
     if multiplier is None or not math.isfinite(multiplier) or multiplier <= 1.0:
         _warn_background_refresh_ttl_multiplier(
             configured,
-            "it must be a finite number greater than 1.0 and produce a finite "
-            "hard-expiration TTL.",
+            "it must be a finite number greater than 1.0.",
         )
-        return _DEFAULT_BACKGROUND_REFRESH_TTL_MULTIPLIER
+        return _DEFAULT_BACKGROUND_REFRESH_TTL_MULTIPLIER, configured
 
+    return multiplier, configured
+
+
+def _get_background_refresh_ttl_multiplier() -> float:
+    """Return a valid hard-expiration multiplier for background caches."""
+    multiplier, _configured = _resolve_background_refresh_ttl_multiplier()
     return multiplier
 
 
 def _get_background_refresh_hard_ttl(fresh_ttl_seconds: float) -> float:
     """Return the configured hard-expiration TTL for a background cache."""
-    multiplier = _get_background_refresh_ttl_multiplier()
+    multiplier, configured = _resolve_background_refresh_ttl_multiplier()
     hard_ttl_seconds = fresh_ttl_seconds * multiplier
     # A huge-but-finite multiplier can overflow the product to inf.
     if math.isfinite(fresh_ttl_seconds) and not math.isfinite(hard_ttl_seconds):
-        from streamlit import config
-
-        # Use the raw configured value so a quoted TOML number is logged as written.
-        configured = config.get_option("runner.cacheBackgroundRefreshTTLMultiplier")
         _warn_background_refresh_ttl_multiplier(
             configured,
             "ttl * multiplier overflows to infinity.",
@@ -201,6 +202,12 @@ def get_hard_ttl_seconds(
 
     Background caches use a later hard-expiration TTL so stale values can still be
     served while a refresh runs. Foreground caches use the freshness TTL as-is.
+
+    The multiplier is captured when the cache is created, not on later reuse, so a
+    live ``config.toml`` edit does not re-bound existing caches (same as
+    ``runner.cacheBackgroundRefreshMaxWorkers``). ``config.get_option`` takes
+    ``_config_lock`` while callers hold ``_caches_lock``; that is safe because this
+    option is not scriptable.
     """
     if refresh_mode != "background" or fresh_ttl_seconds is None:
         return fresh_ttl_seconds
@@ -321,7 +328,8 @@ class Cache(Generic[R]):
 
         Delegates to ``read_result`` and to ``_is_stale``. Foreground caches are never
         stale; background-mode caches override ``_is_stale`` to detect entries that are
-        past their freshness TTL but not yet hard-expired.
+        past their freshness TTL. Hard-expired keys never reach this method: the
+        storage layer treats them as missing.
 
         Raises
         ------
@@ -334,10 +342,11 @@ class Cache(Generic[R]):
 
     # Positional-only so subclasses can name the parameter freely (e.g. result).
     def _is_stale(self, _result: CachedResult[R], /) -> bool:
-        """Whether a present entry is past its fresh ttl.
+        """Whether a present entry is past its freshness TTL.
 
-        Always ``False`` for foreground caches. Background-mode caches override this to
-        report entries that are past their freshness TTL but not yet hard-expired.
+        Always ``False`` for foreground caches. Background-mode caches override this.
+        Hard-expired keys never reach this method: the storage layer treats them as
+        missing.
         """
         return False
 

--- a/lib/streamlit/runtime/caching/cached_message_replay.py
+++ b/lib/streamlit/runtime/caching/cached_message_replay.py
@@ -85,9 +85,9 @@ class CachedResult(Generic[R]):
     main_id: str
     sidebar_id: str
     # The monotonic time (via cache_utils.TTLCACHE_TIMER) at which this entry was
-    # written. Only used by refresh_mode="background" to distinguish a fresh entry
-    # ([0, ttl)) from a stale one ([ttl, 2*ttl)). ``None`` means "freshness not
-    # tracked" (foreground mode), in which case the entry is always treated as fresh.
+    # written. Background mode uses this to tell a still-fresh entry from a stale
+    # one that has not yet hit the hard-expiration TTL. ``None`` means freshness
+    # is not tracked (foreground mode); the entry is then treated as fresh.
     stored_at: float | None = None
 
 

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -785,6 +785,7 @@ class ConfigTest(unittest.TestCase):
                 "logger.level",
                 "logger.messageFormat",
                 "runner.cacheBackgroundRefreshMaxWorkers",
+                "runner.cacheBackgroundRefreshTTLMultiplier",
                 "runner.cacheHashSeed",
                 "runner.enforceSerializableSessionState",
                 "runner.magicEnabled",
@@ -1062,6 +1063,14 @@ class ConfigTest(unittest.TestCase):
         assert option.default_val == []
         assert option.visibility == "hidden"
         assert config.get_option("server.unsafeMetricsUserAttributes") == []
+
+    def test_cache_background_refresh_ttl_multiplier_option_attrs(self) -> None:
+        """The background-refresh TTL multiplier is visible and defaults to 2.0."""
+        option = config._config_options["runner.cacheBackgroundRefreshTTLMultiplier"]
+        assert option.default_val == 2.0
+        assert option.type is float
+        assert option.visibility == "visible"
+        assert config.get_option("runner.cacheBackgroundRefreshTTLMultiplier") == 2.0
 
     def test_unsafe_metrics_user_attributes_parses_from_toml(self):
         toml_content = """

--- a/lib/tests/streamlit/runtime/caching/cache_data_api_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_data_api_test.py
@@ -956,10 +956,11 @@ class CacheDataBackgroundRefreshTest(unittest.TestCase):
             ("overflow_fallback", 1e308, 200),
         ]
     )
-    def test_multiplier_sets_hard_ttl(
+    # Each case needs a distinct key so it builds a fresh cache rather than reusing one.
+    def test_configured_multiplier_sets_background_hard_ttl(
         self, case: str, multiplier: float, expected_hard_ttl: float
     ) -> None:
-        """The configured multiplier sets hard TTL; overflow falls back to the default."""
+        """The configured multiplier sets background hard TTL; overflow falls back."""
         with patch_config_options(
             {"runner.cacheBackgroundRefreshTTLMultiplier": multiplier}
         ):

--- a/lib/tests/streamlit/runtime/caching/cache_data_api_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_data_api_test.py
@@ -71,7 +71,7 @@ from tests.streamlit.element_mocks import (
 from tests.streamlit.runtime.caching.common_cache_test import (
     as_cached_result as _as_cached_result,
 )
-from tests.testutil import create_mock_script_run_ctx
+from tests.testutil import create_mock_script_run_ctx, patch_config_options
 
 
 def as_cached_result(value: Any) -> CachedResult:
@@ -938,7 +938,7 @@ class CacheDataBackgroundRefreshTest(unittest.TestCase):
         )
 
     def test_hard_ttl_is_double_fresh_ttl(self) -> None:
-        """In background mode the underlying storage ttl is 2x the user-facing ttl."""
+        """The default hard TTL is twice the user-facing freshness TTL."""
         cache = _data_caches.get_cache(
             key="bg_key",
             persist=None,
@@ -949,6 +949,31 @@ class CacheDataBackgroundRefreshTest(unittest.TestCase):
         )
         assert cache.fresh_ttl_seconds == 100
         assert cache.ttl_seconds == 200
+
+    @parameterized.expand(
+        [
+            ("custom", 3.5, 350),
+            ("overflow_fallback", 1e308, 200),
+        ]
+    )
+    def test_multiplier_sets_hard_ttl(
+        self, case: str, multiplier: float, expected_hard_ttl: float
+    ) -> None:
+        """The configured multiplier sets hard TTL; overflow falls back to the default."""
+        with patch_config_options(
+            {"runner.cacheBackgroundRefreshTTLMultiplier": multiplier}
+        ):
+            cache = _data_caches.get_cache(
+                key=f"multiplier_{case}",
+                persist=None,
+                max_entries=None,
+                ttl=100,
+                display_name=f"multiplier_{case}",
+                refresh_mode="background",
+            )
+
+        assert cache.fresh_ttl_seconds == 100
+        assert cache.ttl_seconds == expected_hard_ttl
 
     def test_stored_at_set_only_in_background_mode(self) -> None:
         """stored_at is set (and survives pickling) in background mode, and None otherwise."""

--- a/lib/tests/streamlit/runtime/caching/cache_resource_api_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_resource_api_test.py
@@ -638,10 +638,11 @@ class CacheResourceBackgroundRefreshTest(unittest.TestCase):
             ("overflow_fallback", 1e308, _BG_TTL * 2),
         ]
     )
-    def test_multiplier_sets_hard_ttl(
+    # Each case needs a distinct key so it builds a fresh cache rather than reusing one.
+    def test_configured_multiplier_sets_background_hard_ttl(
         self, case: str, multiplier: float, expected_hard_ttl: float
     ) -> None:
-        """The configured multiplier sets hard TTL; overflow falls back to the default."""
+        """The configured multiplier sets background hard TTL; overflow falls back."""
         with patch_config_options(
             {"runner.cacheBackgroundRefreshTTLMultiplier": multiplier}
         ):

--- a/lib/tests/streamlit/runtime/caching/cache_resource_api_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_resource_api_test.py
@@ -619,7 +619,7 @@ class CacheResourceBackgroundRefreshTest(unittest.TestCase):
         )
 
     def test_hard_ttl_is_double_fresh_ttl(self) -> None:
-        """In background mode the underlying cache ttl is 2x the user-facing ttl."""
+        """The default hard TTL is twice the user-facing freshness TTL."""
         cache = _resource_caches.get_cache(
             key="bg_key",
             display_name="bg",
@@ -631,6 +631,32 @@ class CacheResourceBackgroundRefreshTest(unittest.TestCase):
         )
         assert cache.fresh_ttl_seconds == _BG_TTL
         assert cache.ttl_seconds == _BG_TTL * 2
+
+    @parameterized.expand(
+        [
+            ("custom", 3.5, _BG_TTL * 3.5),
+            ("overflow_fallback", 1e308, _BG_TTL * 2),
+        ]
+    )
+    def test_multiplier_sets_hard_ttl(
+        self, case: str, multiplier: float, expected_hard_ttl: float
+    ) -> None:
+        """The configured multiplier sets hard TTL; overflow falls back to the default."""
+        with patch_config_options(
+            {"runner.cacheBackgroundRefreshTTLMultiplier": multiplier}
+        ):
+            cache = _resource_caches.get_cache(
+                key=f"multiplier_{case}",
+                display_name=f"multiplier_{case}",
+                max_entries=None,
+                ttl=_BG_TTL,
+                validate=None,
+                on_release=lambda _v: None,
+                refresh_mode="background",
+            )
+
+        assert cache.fresh_ttl_seconds == _BG_TTL
+        assert cache.ttl_seconds == expected_hard_ttl
 
     def test_cache_recreated_on_mode_change(self) -> None:
         """Changing refresh_mode across reruns rebuilds the cache."""

--- a/lib/tests/streamlit/runtime/caching/cache_utils_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_utils_test.py
@@ -111,8 +111,7 @@ def test_background_refresh_ttl_multiplier_warns_once_per_invalid_value() -> Non
         "Ignoring runner.cacheBackgroundRefreshTTLMultiplier=%s: %s Falling "
         "back to the default multiplier of %s.",
         "'bad-repeat'",
-        "it must be a finite number greater than 1.0 and produce a finite "
-        "hard-expiration TTL.",
+        "it must be a finite number greater than 1.0.",
         2.0,
     )
 

--- a/lib/tests/streamlit/runtime/caching/cache_utils_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_utils_test.py
@@ -47,7 +47,7 @@ def _reset_multiplier_warnings(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_background_refresh_ttl_multiplier_defaults_to_two() -> None:
     """The default background-refresh TTL multiplier is 2.0."""
-    assert cache_utils._get_background_refresh_ttl_multiplier() == 2.0
+    assert cache_utils._get_background_refresh_hard_ttl(10) == 20
 
 
 @pytest.mark.parametrize(
@@ -67,7 +67,7 @@ def test_background_refresh_ttl_multiplier_accepts_numeric_representations(
     the declared type.
     """
     with patch_config_options({"runner.cacheBackgroundRefreshTTLMultiplier": value}):
-        assert cache_utils._get_background_refresh_ttl_multiplier() == expected
+        assert cache_utils._get_background_refresh_hard_ttl(10) == expected * 10
 
 
 @pytest.mark.parametrize(
@@ -91,7 +91,7 @@ def test_background_refresh_ttl_multiplier_falls_back_for_invalid_values(
         patch.object(cache_utils._LOGGER, "warning") as mock_warning,
         patch_config_options({"runner.cacheBackgroundRefreshTTLMultiplier": value}),
     ):
-        assert cache_utils._get_background_refresh_ttl_multiplier() == 2.0
+        assert cache_utils._get_background_refresh_hard_ttl(10) == 20
 
     mock_warning.assert_called_once()
 
@@ -104,8 +104,8 @@ def test_background_refresh_ttl_multiplier_warns_once_per_invalid_value() -> Non
             {"runner.cacheBackgroundRefreshTTLMultiplier": "bad-repeat"}
         ),
     ):
-        assert cache_utils._get_background_refresh_ttl_multiplier() == 2.0
-        assert cache_utils._get_background_refresh_ttl_multiplier() == 2.0
+        assert cache_utils._get_background_refresh_hard_ttl(10) == 20
+        assert cache_utils._get_background_refresh_hard_ttl(10) == 20
 
     mock_warning.assert_called_once_with(
         "Ignoring runner.cacheBackgroundRefreshTTLMultiplier=%s: %s Falling "

--- a/lib/tests/streamlit/runtime/caching/cache_utils_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_utils_test.py
@@ -37,6 +37,14 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 
+@pytest.fixture(autouse=True)
+def _reset_multiplier_warnings(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Isolate the warn-once set so a failed test cannot leak into later ones."""
+    monkeypatch.setattr(
+        cache_utils, "_warned_background_refresh_ttl_multipliers", set()
+    )
+
+
 def test_background_refresh_ttl_multiplier_defaults_to_two() -> None:
     """The default background-refresh TTL multiplier is 2.0."""
     assert cache_utils._get_background_refresh_ttl_multiplier() == 2.0
@@ -79,8 +87,6 @@ def test_background_refresh_ttl_multiplier_falls_back_for_invalid_values(
     value: object,
 ) -> None:
     """Malformed values fall back to 2.0 and warn, rather than breaking cache creation."""
-    cache_utils._warned_background_refresh_ttl_multipliers.clear()
-
     with (
         patch.object(cache_utils._LOGGER, "warning") as mock_warning,
         patch_config_options({"runner.cacheBackgroundRefreshTTLMultiplier": value}),
@@ -92,8 +98,6 @@ def test_background_refresh_ttl_multiplier_falls_back_for_invalid_values(
 
 def test_background_refresh_ttl_multiplier_warns_once_per_invalid_value() -> None:
     """One bad value can be read for many cache creations, so it must not flood the log."""
-    cache_utils._warned_background_refresh_ttl_multipliers.clear()
-
     with (
         patch.object(cache_utils._LOGGER, "warning") as mock_warning,
         patch_config_options(
@@ -104,25 +108,36 @@ def test_background_refresh_ttl_multiplier_warns_once_per_invalid_value() -> Non
         assert cache_utils._get_background_refresh_ttl_multiplier() == 2.0
 
     mock_warning.assert_called_once_with(
-        "Ignoring runner.cacheBackgroundRefreshTTLMultiplier=%s: it must be a "
-        "finite number greater than 1.0 and produce a finite hard-expiration TTL. "
-        "Falling back to the default multiplier of %s.",
+        "Ignoring runner.cacheBackgroundRefreshTTLMultiplier=%s: %s Falling "
+        "back to the default multiplier of %s.",
         "'bad-repeat'",
+        "it must be a finite number greater than 1.0 and produce a finite "
+        "hard-expiration TTL.",
         2.0,
     )
 
 
 def test_background_refresh_ttl_multiplier_overflow_uses_default() -> None:
     """A finite multiplier that overflows ``ttl * multiplier`` falls back to the default."""
-    cache_utils._warned_background_refresh_ttl_multipliers.clear()
-
     with (
         patch.object(cache_utils._LOGGER, "warning") as mock_warning,
         patch_config_options({"runner.cacheBackgroundRefreshTTLMultiplier": 1e308}),
     ):
         assert cache_utils._get_background_refresh_hard_ttl(10) == 20
 
-    mock_warning.assert_called_once()
+    mock_warning.assert_called_once_with(
+        "Ignoring runner.cacheBackgroundRefreshTTLMultiplier=%s: %s Falling "
+        "back to the default multiplier of %s.",
+        "1e+308",
+        "ttl * multiplier overflows to infinity.",
+        2.0,
+    )
+
+
+def test_multiplier_does_not_affect_foreground_caches() -> None:
+    """The multiplier only applies to refresh_mode="background"."""
+    with patch_config_options({"runner.cacheBackgroundRefreshTTLMultiplier": 4.0}):
+        assert cache_utils.get_hard_ttl_seconds("foreground", 100) == 100
 
 
 def function_for_testing(

--- a/lib/tests/streamlit/runtime/caching/cache_utils_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_utils_test.py
@@ -21,6 +21,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from streamlit.errors import StreamlitAPIException
+from streamlit.runtime.caching import cache_utils
 from streamlit.runtime.caching.cache_utils import (
     BoundCachedFunc,
     Cache,
@@ -30,9 +31,98 @@ from streamlit.runtime.caching.cache_utils import (
     get_session_id_or_throw,
 )
 from streamlit.runtime.scriptrunner_utils import script_run_context
+from tests.testutil import patch_config_options
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+
+def test_background_refresh_ttl_multiplier_defaults_to_two() -> None:
+    """The default background-refresh TTL multiplier is 2.0."""
+    assert cache_utils._get_background_refresh_ttl_multiplier() == 2.0
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param(3, 3.0, id="integer"),
+        pytest.param(3.5, 3.5, id="float"),
+        pytest.param("4.5", 4.5, id="float_string"),
+    ],
+)
+def test_background_refresh_ttl_multiplier_accepts_numeric_representations(
+    value: object, expected: float
+) -> None:
+    """Quoted and unquoted TOML numbers must produce the same multiplier.
+
+    ``config.get_option`` returns the raw parsed value rather than coercing it to
+    the declared type.
+    """
+    with patch_config_options({"runner.cacheBackgroundRefreshTTLMultiplier": value}):
+        assert cache_utils._get_background_refresh_ttl_multiplier() == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(True, id="bool_true"),
+        pytest.param(None, id="none"),
+        pytest.param("not-a-number", id="text"),
+        pytest.param(float("nan"), id="nan"),
+        pytest.param(float("inf"), id="infinity"),
+        pytest.param(1, id="one"),
+        pytest.param(0, id="zero"),
+        pytest.param(-1, id="negative"),
+    ],
+)
+def test_background_refresh_ttl_multiplier_falls_back_for_invalid_values(
+    value: object,
+) -> None:
+    """Malformed values fall back to 2.0 and warn, rather than breaking cache creation."""
+    cache_utils._warned_background_refresh_ttl_multipliers.clear()
+
+    with (
+        patch.object(cache_utils._LOGGER, "warning") as mock_warning,
+        patch_config_options({"runner.cacheBackgroundRefreshTTLMultiplier": value}),
+    ):
+        assert cache_utils._get_background_refresh_ttl_multiplier() == 2.0
+
+    mock_warning.assert_called_once()
+
+
+def test_background_refresh_ttl_multiplier_warns_once_per_invalid_value() -> None:
+    """One bad value can be read for many cache creations, so it must not flood the log."""
+    cache_utils._warned_background_refresh_ttl_multipliers.clear()
+
+    with (
+        patch.object(cache_utils._LOGGER, "warning") as mock_warning,
+        patch_config_options(
+            {"runner.cacheBackgroundRefreshTTLMultiplier": "bad-repeat"}
+        ),
+    ):
+        assert cache_utils._get_background_refresh_ttl_multiplier() == 2.0
+        assert cache_utils._get_background_refresh_ttl_multiplier() == 2.0
+
+    mock_warning.assert_called_once_with(
+        "Ignoring runner.cacheBackgroundRefreshTTLMultiplier=%s: it must be a "
+        "finite number greater than 1.0 and produce a finite hard-expiration TTL. "
+        "Falling back to the default multiplier of %s.",
+        "'bad-repeat'",
+        2.0,
+    )
+
+
+def test_background_refresh_ttl_multiplier_overflow_uses_default() -> None:
+    """A finite multiplier that overflows ``ttl * multiplier`` falls back to the default."""
+    cache_utils._warned_background_refresh_ttl_multipliers.clear()
+
+    with (
+        patch.object(cache_utils._LOGGER, "warning") as mock_warning,
+        patch_config_options({"runner.cacheBackgroundRefreshTTLMultiplier": 1e308}),
+    ):
+        assert cache_utils._get_background_refresh_hard_ttl(10) == 20
+
+    mock_warning.assert_called_once()
 
 
 def function_for_testing(

--- a/lib/tests/streamlit/runtime/caching/common_cache_test.py
+++ b/lib/tests/streamlit/runtime/caching/common_cache_test.py
@@ -61,7 +61,7 @@ from streamlit.testing.v1.app_test import AppTest
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 from tests.exception_capturing_thread import call_on_threads
 from tests.streamlit.elements.image_test import create_image
-from tests.testutil import create_mock_script_run_ctx
+from tests.testutil import create_mock_script_run_ctx, patch_config_options
 
 
 def get_text_or_block(delta):
@@ -1211,7 +1211,7 @@ class CommonCacheBackgroundRefreshTest(DeltaGeneratorTestCase):
     )
     @patch("streamlit.runtime.caching.cache_utils.TTLCACHE_TIMER")
     def test_hard_expiry_blocks_foreground(self, _, cache_decorator, timer_patch: Mock):
-        """Past 2*ttl the entry is a hard miss: a blocking foreground recompute, no stale serve."""
+        """Past the default 2*ttl hard bound, the call blocks and recomputes."""
         call_count = [0]
 
         @cache_decorator(ttl=_BG_TTL, refresh_mode="background", show_spinner=False)
@@ -1228,6 +1228,82 @@ class CommonCacheBackgroundRefreshTest(DeltaGeneratorTestCase):
             assert foo() == 2
             # A hard miss is not a stale serve, so no background refresh is triggered.
             submit_mock.assert_not_called()
+
+        assert call_count[0] == 2
+
+    @parameterized.expand(
+        [("cache_data", cache_data), ("cache_resource", cache_resource)]
+    )
+    @patch("streamlit.runtime.caching.cache_utils.TTLCACHE_TIMER")
+    def test_configured_multiplier_extends_hard_expiry(
+        self, _name: str, cache_decorator: Any, timer_patch: Mock
+    ) -> None:
+        """A larger multiplier serves stale beyond 2*ttl until its new hard bound."""
+        call_count = [0]
+
+        with patch_config_options({"runner.cacheBackgroundRefreshTTLMultiplier": 4.0}):
+
+            @cache_decorator(ttl=_BG_TTL, refresh_mode="background", show_spinner=False)
+            def foo() -> int:
+                call_count[0] += 1
+                return call_count[0]
+
+            timer_patch.return_value = 0
+            assert foo() == 1
+
+            # Fail the refresh so the stale value stays cached past 2*ttl.
+            with patch.object(
+                cache_background_refresh.get_background_refresh_manager(),
+                "submit",
+                return_value=False,
+            ) as submit_mock:
+                timer_patch.return_value = _BG_TTL * 2.5
+                assert foo() == 1
+                submit_mock.assert_called_once()
+                assert call_count[0] == 1
+
+                submit_mock.reset_mock()
+                timer_patch.return_value = _BG_TTL * 4 + 1
+                assert foo() == 2
+                submit_mock.assert_not_called()
+
+        assert call_count[0] == 2
+
+    @parameterized.expand(
+        [("cache_data", cache_data), ("cache_resource", cache_resource)]
+    )
+    @patch("streamlit.runtime.caching.cache_utils.TTLCACHE_TIMER")
+    def test_configured_multiplier_can_shorten_hard_expiry(
+        self, _name: str, cache_decorator: Any, timer_patch: Mock
+    ) -> None:
+        """A multiplier below 2.0 hard-expires before the default 2*ttl bound."""
+        call_count = [0]
+
+        with patch_config_options({"runner.cacheBackgroundRefreshTTLMultiplier": 1.5}):
+
+            @cache_decorator(ttl=_BG_TTL, refresh_mode="background", show_spinner=False)
+            def foo() -> int:
+                call_count[0] += 1
+                return call_count[0]
+
+            timer_patch.return_value = 0
+            assert foo() == 1
+
+            # Fail the refresh so the stale value stays until hard expiry.
+            with patch.object(
+                cache_background_refresh.get_background_refresh_manager(),
+                "submit",
+                return_value=False,
+            ) as submit_mock:
+                timer_patch.return_value = _BG_TTL * 1.25
+                assert foo() == 1
+                submit_mock.assert_called_once()
+                assert call_count[0] == 1
+
+                submit_mock.reset_mock()
+                timer_patch.return_value = _BG_TTL * 1.75
+                assert foo() == 2
+                submit_mock.assert_not_called()
 
         assert call_count[0] == 2
 

--- a/lib/tests/streamlit/runtime/caching/common_cache_test.py
+++ b/lib/tests/streamlit/runtime/caching/common_cache_test.py
@@ -1115,8 +1115,8 @@ def test_arrow_replay():
     assert not at.exception
 
 
-# The fresh ttl (in seconds) used across the background-refresh tests. The hard
-# eviction bound is 2*_BG_TTL, and the stale grace window is [_BG_TTL, 2*_BG_TTL).
+# The fresh ttl (in seconds) used across the background-refresh tests. Default
+# hard eviction bound is 2*_BG_TTL; individual tests may override the multiplier.
 _BG_TTL = 100
 
 
@@ -1232,54 +1232,41 @@ class CommonCacheBackgroundRefreshTest(DeltaGeneratorTestCase):
         assert call_count[0] == 2
 
     @parameterized.expand(
-        [("cache_data", cache_data), ("cache_resource", cache_resource)]
+        [
+            ("cache_data_widen", cache_data, 4.0, _BG_TTL * 2.5, _BG_TTL * 4 + 1),
+            (
+                "cache_resource_widen",
+                cache_resource,
+                4.0,
+                _BG_TTL * 2.5,
+                _BG_TTL * 4 + 1,
+            ),
+            ("cache_data_shorten", cache_data, 1.5, _BG_TTL * 1.25, _BG_TTL * 1.75),
+            (
+                "cache_resource_shorten",
+                cache_resource,
+                1.5,
+                _BG_TTL * 1.25,
+                _BG_TTL * 1.75,
+            ),
+        ]
     )
     @patch("streamlit.runtime.caching.cache_utils.TTLCACHE_TIMER")
-    def test_configured_multiplier_extends_hard_expiry(
-        self, _name: str, cache_decorator: Any, timer_patch: Mock
+    def test_configured_multiplier_sets_hard_expiry(
+        self,
+        _name: str,
+        cache_decorator: Any,
+        multiplier: float,
+        stale_at: float,
+        expired_at: float,
+        timer_patch: Mock,
     ) -> None:
-        """A larger multiplier serves stale beyond 2*ttl until its new hard bound."""
+        """The configured multiplier sets when a stale value is served vs hard-expired."""
         call_count = [0]
 
-        with patch_config_options({"runner.cacheBackgroundRefreshTTLMultiplier": 4.0}):
-
-            @cache_decorator(ttl=_BG_TTL, refresh_mode="background", show_spinner=False)
-            def foo() -> int:
-                call_count[0] += 1
-                return call_count[0]
-
-            timer_patch.return_value = 0
-            assert foo() == 1
-
-            # Fail the refresh so the stale value stays cached past 2*ttl.
-            with patch.object(
-                cache_background_refresh.get_background_refresh_manager(),
-                "submit",
-                return_value=False,
-            ) as submit_mock:
-                timer_patch.return_value = _BG_TTL * 2.5
-                assert foo() == 1
-                submit_mock.assert_called_once()
-                assert call_count[0] == 1
-
-                submit_mock.reset_mock()
-                timer_patch.return_value = _BG_TTL * 4 + 1
-                assert foo() == 2
-                submit_mock.assert_not_called()
-
-        assert call_count[0] == 2
-
-    @parameterized.expand(
-        [("cache_data", cache_data), ("cache_resource", cache_resource)]
-    )
-    @patch("streamlit.runtime.caching.cache_utils.TTLCACHE_TIMER")
-    def test_configured_multiplier_can_shorten_hard_expiry(
-        self, _name: str, cache_decorator: Any, timer_patch: Mock
-    ) -> None:
-        """A multiplier below 2.0 hard-expires before the default 2*ttl bound."""
-        call_count = [0]
-
-        with patch_config_options({"runner.cacheBackgroundRefreshTTLMultiplier": 1.5}):
+        with patch_config_options(
+            {"runner.cacheBackgroundRefreshTTLMultiplier": multiplier}
+        ):
 
             @cache_decorator(ttl=_BG_TTL, refresh_mode="background", show_spinner=False)
             def foo() -> int:
@@ -1295,13 +1282,13 @@ class CommonCacheBackgroundRefreshTest(DeltaGeneratorTestCase):
                 "submit",
                 return_value=False,
             ) as submit_mock:
-                timer_patch.return_value = _BG_TTL * 1.25
+                timer_patch.return_value = stale_at
                 assert foo() == 1
                 submit_mock.assert_called_once()
                 assert call_count[0] == 1
 
                 submit_mock.reset_mock()
-                timer_patch.return_value = _BG_TTL * 1.75
+                timer_patch.return_value = expired_at
                 assert foo() == 2
                 submit_mock.assert_not_called()
 

--- a/specs/2026-04-08-cache-background-refresh/product-spec.md
+++ b/specs/2026-04-08-cache-background-refresh/product-spec.md
@@ -11,9 +11,10 @@ Add a `refresh_mode` parameter to `st.cache_data` and `st.cache_resource` that e
 cache entries to be refreshed in the background while immediately returning stale data. This
 eliminates blocking waits for users hitting expired cache entries, providing a significantly
 better experience for slow functions (expensive database queries, ML model predictions, API
-calls). Staleness and memory stay bounded: stale data is only served within a grace window of
-one extra `ttl` period (users never see data older than `2 × ttl`); after that, entries are
-evicted and calls block exactly as they do today.
+calls). Staleness and memory stay bounded: stale data is only served until a configurable
+hard-expiration bound. The default preserves a grace window of one extra `ttl` period (users
+never see data older than `2 × ttl`); after that, entries are evicted and calls block exactly
+as they do today.
 
 ## Problem
 
@@ -76,12 +77,16 @@ Background refresh separates *freshness* from *eviction* — a bounded variant o
 [stale-while-revalidate](https://datatracker.ietf.org/doc/html/rfc5861) pattern:
 
 ```
-0 ────────────── ttl ────────────── 2 × ttl
+0 ────────────── ttl ────────────── M × ttl
        fresh     │   stale grace    │   evicted
 ```
 
+Here, `M` is `runner.cacheBackgroundRefreshTTLMultiplier`, which defaults to `2.0` and
+must be a finite number greater than `1.0`. Invalid values fall back to `2.0` with a
+warning. The option applies process-wide to both cache decorators.
+
 1. Before `ttl`: cache hit -> return the fresh value (unchanged behavior)
-2. Between `ttl` and `2 × ttl` (stale grace window), a call:
+2. Between `ttl` and `M × ttl` (stale grace window), a call:
    - Returns the stale value immediately (no blocking)
    - Triggers a single background refresh in a separate thread — unless one is already
      running for this key, or a recent failure's per-key cooldown is still active (see
@@ -103,7 +108,7 @@ Background refresh separates *freshness* from *eviction* — a bounded variant o
    - **Failure:** Log warning, keep serving the stale value, and retry on a later
      access with a per-key cooldown (so a failing upstream isn't retried on every
      rerun)
-4. After `2 × ttl` (hard expiry): the entry is evicted -> next call is a normal
+4. After `M × ttl` (hard expiry): the entry is evicted -> next call is a normal
    blocking cache miss, identical to foreground behavior. If refreshes kept failing,
    the error surfaces to the user here.
 
@@ -118,13 +123,13 @@ Background completes:
   * Failure -> log warning, keep stale value, retry (with cooldown) on later access
                 |
 Time=1h+2s    : Call -> fresh value (success case) or stale value (failure case)
-Time=2h       : Hard expiry -> entry evicted (if no refresh succeeded)
+Time=2h       : Hard expiry -> entry evicted (if no refresh succeeded; default M=2.0)
 Time=2h+1s    : Call -> cache miss -> blocking foreground compute (errors surface here)
 ```
 
 **Key behaviors:**
 
-- **Bounded staleness & memory**: Users never see data older than `2 × ttl` — past hard
+- **Bounded staleness & memory**: Users never see data older than `M × ttl` — past hard
   expiry a stale entry is treated as absent (a miss) on the next access, exactly like an
   expired foreground entry. Memory stays bounded too, but reclamation is lazy: the
   internal cache reaps expired entries on the next write, `expire()`, or size query
@@ -132,9 +137,8 @@ Time=2h+1s    : Call -> cache miss -> blocking foreground compute (errors surfac
   freed the next time some cache operation touches it. A lightweight periodic sweep to
   bound that worst case is an implementation detail for the tech spec. Stale entries
   count against `max_entries` and follow the same LRU eviction as fresh entries. The
-  grace window equals `ttl` (mirroring the equal fresh/stale windows in the RFC 5861
-  example): it is easy to explain and scales automatically with the freshness
-  requirement the user already expressed via `ttl`.
+  grace window defaults to `ttl` (mirroring the equal fresh/stale windows in the RFC 5861
+  example) and is `(M - 1) × ttl` when the process-wide multiplier is customized.
 - **Deduplicated refreshes**: Only one background refresh runs per cache key at a time
   (reusing the existing per-key computation locks). Concurrent requests for the same
   stale key all receive stale data while a single background refresh runs. Deduplication
@@ -147,16 +151,16 @@ Time=2h+1s    : Call -> cache miss -> blocking foreground compute (errors surfac
   backlog of potentially never-needed work during mass expiry. Implementation details
   (pool size) will be determined in the tech spec.
 - **Cleanup guarantee**: A stale entry is removed by whichever comes first: a successful
-  refresh (replaced with the fresh value), hard expiry (`2 × ttl`), or `max_entries` LRU
-  eviction. Past `2 × ttl` an untouched entry is already treated as a miss on read; its
+  refresh (replaced with the fresh value), hard expiry (`M × ttl`), or `max_entries` LRU
+  eviction. Past `M × ttl` an untouched entry is already treated as a miss on read; its
   memory is reclaimed lazily on the next cache operation that reaps expired entries (or a
   periodic sweep), since the internal cache has no timer-driven reaper — so a
-  never-again-requested entry may briefly linger in memory past `2 × ttl` even though it
+  never-again-requested entry may briefly linger in memory past `M × ttl` even though it
   is never served again. Since stale entries participate in LRU eviction like any other
   entry, a stale key can also be evicted before hard expiry under memory pressure; the
   next access is then a normal blocking cache miss rather than a stale serve.
 - **Late / orphaned refreshes**: A refresh that finishes *after* its entry was already
-  hard-evicted (`2 × ttl`), cleared via `.clear()`, or otherwise invalidated (cache
+  hard-evicted (`M × ttl`), cleared via `.clear()`, or otherwise invalidated (cache
   generation changed, or the owning session ended for `scope="session"`) is discarded
   rather than written back — the next access is a normal blocking cache miss. This keeps a
   slow refresh from repopulating a cache the user deliberately cleared or that no longer
@@ -167,7 +171,7 @@ Time=2h+1s    : Call -> cache miss -> blocking foreground compute (errors surfac
   degrades gracefully to foreground semantics without breaking the stale-first contract:
   stale hits are still returned immediately (non-blocking), the background refresh is
   skipped, and recomputation happens via a blocking foreground call only at hard expiry
-  (`2 × ttl`) — never on the stale-hit path.
+  (`M × ttl`) — never on the stale-hit path.
 - **Error surfacing**: Background refresh errors log a warning but don't crash the app
   and don't evict the stale entry. Users keep seeing (bounded) stale data while
   refreshes fail; the error only surfaces to a user after hard expiry, when the next
@@ -196,8 +200,8 @@ Time=2h+1s    : Call -> cache miss -> blocking foreground compute (errors surfac
 
 **Implementation note**: The storage layer builds on Streamlit's internal `TTLCache`
 ([#16014](https://github.com/streamlit/streamlit/pull/16014)), which we fully control —
-tracking per-entry freshness (`ttl`) separately from hard eviction (`2 × ttl`) requires
-no third-party changes. Details belong in the tech spec.
+tracking per-entry freshness (`ttl`) separately from configurable hard eviction
+(`M × ttl`) requires no third-party changes. Details belong in the tech spec.
 
 ### Validation
 
@@ -301,16 +305,16 @@ import streamlit as st
 @st.cache_data(ttl="6h", refresh_mode="background")
 def fetch_daily_report():
     """
-    Data updates at 6am daily. As long as the app is accessed at least
-    once per 2 x ttl, background refresh keeps responses instant right
-    after the update. After a longer idle gap (> 2 x ttl) the entry
+    Data updates at 6am daily. As long as the app is accessed within the
+    configured hard-expiration window, background refresh keeps responses
+    instant right after the update. After a longer idle gap the entry
     hard-expires, so the next access blocks on a foreground recompute
-    (see the out-of-scope `max_stale` option for bridging long idle gaps).
+    (increase the process-wide TTL multiplier to bridge longer idle gaps).
     """
     return download_and_process_csv()  # Takes 60+ seconds
 
 
-# Instant responses while the app is used at least once per 2 x ttl
+# Instant responses while the app is used within the hard-expiration window
 report = fetch_daily_report()
 st.dataframe(report)
 ```
@@ -325,7 +329,7 @@ def slow_query_foreground():
     return fetch_data()
 
 
-# Users don't wait, as long as the app is used at least once per 2 x ttl
+# Users don't wait while the entry remains within its hard-expiration window
 @st.cache_data(ttl="1h", refresh_mode="background")
 def slow_query_background():
     time.sleep(5)  # Runs in background
@@ -455,17 +459,18 @@ them at once — every strategy sacrifices at least one:
 3. **Bounded resources**: memory and compute stay proportional to what users actually
    request
 
-| Strategy                              | Blocking                        | Staleness   | Extra compute         | Extra memory      |
-|---------------------------------------|---------------------------------|-------------|-----------------------|-------------------|
-| Foreground (today)                    | Every expiry                    | ≤ `ttl`     | None                  | None              |
-| **Bounded stale-while-revalidate (chosen)** | Only after idle gap > `2 × ttl` | ≤ `2 × ttl` | None                  | ≤ one extra `ttl` |
-| Unbounded stale retention             | Never                           | Unbounded   | None                  | Unbounded         |
-| Refresh-ahead (`ttl` hard limit)      | After idle gaps                 | ≤ `ttl`     | Up to 2× for hot keys | None              |
-| Eager/proactive refresh               | Never                           | ≤ `ttl`     | Unbounded (refreshes keys nobody requests) | High (tracks all keys) |
+| Strategy                              | Blocking                        | Staleness   | Extra compute         | Extra retention                            |
+|---------------------------------------|---------------------------------|-------------|-----------------------|--------------------------------------------|
+| Foreground (today)                    | Every expiry                    | ≤ `ttl`     | None                  | None                                       |
+| **Bounded stale-while-revalidate (chosen)** | Only after idle gap > `M × ttl` | ≤ `M × ttl` | None                  | Stale entries kept `(M - 1) × ttl` longer |
+| Unbounded stale retention             | Never                           | Unbounded   | None                  | Unbounded                                  |
+| Refresh-ahead (`ttl` hard limit)      | After idle gaps                 | ≤ `ttl`     | Up to 2× for hot keys | None                                       |
+| Eager/proactive refresh               | Never                           | ≤ `ttl`     | Unbounded (refreshes keys nobody requests) | High (tracks all keys)                    |
 
 The chosen design keeps everything bounded and relaxes "never block" only minimally:
-requests block solely after an idle gap longer than `2 × ttl` — exactly the case where
-blocking is also today's behavior. Notably, it adds **zero compute** over foreground
+requests block solely after an idle gap longer than the configured `M × ttl`
+hard-expiration bound — exactly the case where blocking is also today's behavior. Notably,
+it adds **zero compute** over foreground
 mode: background refreshes fire at precisely the moments a foreground miss would have
 executed the function; the work just moves off the user's thread. The sections below
 detail the rejected strategies.
@@ -521,8 +526,8 @@ how much later.
   `max_entries`, which defaults to unlimited — parameterized functions could accumulate
   stale entries forever
 - **Unbounded staleness**: A dashboard untouched for a week would instantly serve
-  week-old data to the next visitor; with the `2 × ttl` bound, that visitor waits for a
-  fresh foreground compute instead (today's predictable behavior)
+  week-old data to the next visitor; with the configured `M × ttl` bound, that visitor
+  waits for a fresh foreground compute instead (today's predictable behavior)
 
 ### Refresh-Ahead (`ttl` as a hard accuracy limit)
 
@@ -587,9 +592,9 @@ fetch_stock_prices.warm("AAPL", "GOOGL", "MSFT")
 - **Stale data indicator**: Visual indicator that displayed data is stale while refreshing
 - **Priority-based refresh**: Prioritize some cache keys over others
 - **Refresh timeout**: Limit how long background refresh can run
-- **`max_stale` parameter**: Explicitly configure the stale grace window (default: equal
-  to `ttl`), e.g. `ttl="1h", max_stale="12h"` to serve stale data across an overnight
-  idle gap without blocking the first morning user
+- **Per-function `max_stale` parameter**: Configure the stale grace window independently
+  for one cached function, e.g. `ttl="1h", max_stale="12h"`, instead of using the
+  process-wide `runner.cacheBackgroundRefreshTTLMultiplier` option
 - **Smarter eviction under memory pressure**: Prefer evicting stale entries that were
   never requested again (a SIEVE-style reuse hint) before recently served ones — plain
   LRU already approximates this, so it's deferred until there's evidence it's needed
@@ -603,4 +608,4 @@ fetch_stock_prices.warm("AAPL", "GOOGL", "MSFT")
 | No new dependencies        | ✅ Uses stdlib `concurrent.futures`; builds on the internal `TTLCache` introduced in [#16014](https://github.com/streamlit/streamlit/pull/16014) |
 | Metrics collected          | ✅ Cache API usage is already tracked via the existing `gather_metrics` decorator. Distinguishing `refresh_mode="background"` adoption specifically needs explicit instrumentation — `gather_metrics` records argument names/types but not string values (and `"background"`/`"foreground"` even share the same length) — added as part of the tech spec. |
 | Any security/legal impact? | ✅ No new security concerns                                          |
-| Any docs changes needed?   | ✅ Document `refresh_mode` param, note that `st.*` display output isn't replayed on cache hits in background mode (and that Streamlit warns when display commands are used), and that background-refreshed functions must be context-free (no `st.session_state` or other session-bound APIs during refresh) |
+| Any docs changes needed?   | ✅ Document `refresh_mode`, `runner.cacheBackgroundRefreshTTLMultiplier`, that `st.*` display output isn't replayed on cache hits in background mode (and that Streamlit warns when display commands are used), and that background-refreshed functions must be context-free (no `st.session_state` or other session-bound APIs during refresh) |


### PR DESCRIPTION
## Describe your changes

Adds `runner.cacheBackgroundRefreshTTLMultiplier` so operators can widen or narrow the stale-while-revalidate window for `refresh_mode="background"` caches.

- Default remains `2.0`, so existing apps still hard-expire at `2 × ttl`.
- Accepts any finite value greater than `1.0`, so operators can shorten the stale window (`1.5`) as well as widen it (`4.0`); invalid values warn once and fall back to the default.
- Uses a process-wide configuration option to avoid adding a permanent per-function parameter; per-function stale limits remain out of scope.
- The multiplier is captured when a cache is created. Editing `config.toml` at runtime does not re-bound caches that already exist (same as `runner.cacheBackgroundRefreshMaxWorkers`).
- Amends the merged background-refresh product spec to describe the new option; the per-function `max_stale` parameter stays out of scope.

## GitHub Issue Link (if applicable)

Follow-up to the background-refresh feature in #16057.

## Testing Plan

- [x] Unit Tests (JS and/or Python)
  Multiplier parsing, invalid fallbacks, overflow, foreground pass-through, and stale-serve vs hard-miss for multipliers above and below `2.0` on both cache decorators.
- [ ] E2E Tests
  Existing background-refresh e2e covers the default `2 × ttl` window. A dedicated e2e for this config would be timer-heavy; mocked unit tests cover the multiplier.
- [ ] Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

Made with [Cursor](https://cursor.com)