### PR TITLE
[docs] Add docs-update stage to release runbook

### DIFF
--- a/wiki/release-process.md
+++ b/wiki/release-process.md
@@ -156,7 +156,39 @@ should verify:
 - package versions match the tag;
 - all required automated and focused manual tests passed.
 
-### 7. Verify and close out
+### 7. Update the documentation
+
+1. In the `streamlit/streamlit` repository, generate the release notes from the
+   previous release tag to the new release tag:
+
+   ```text
+   /generating-changelog <previous-version-tag> <new-version-tag>
+   ```
+
+   For example:
+
+   ```text
+   /generating-changelog 1.61.0 1.62.0
+   ```
+
+   Review the generated changelog before continuing.
+
+2. In the `streamlit/docs` repository, run the
+   [`update-docs-for-release`](https://github.com/streamlit/docs/blob/main/.cursor/skills/update-docs-for-release/SKILL.md)
+   skill with the new release tag:
+
+   ```text
+   /update-docs-for-release <new-version-tag>
+   ```
+
+   The skill runs the relevant documentation updates and creates a PR in the
+   docs repository. Provide the generated changelog when prompted.
+3. Wait for Netlify to create a preview deployment and post its link in a
+   comment on the docs PR.
+4. Verify the documentation changes using the Netlify preview.
+5. Merge the docs PR. Merging updates the main documentation site.
+
+### 8. Verify and close out
 
 1. Confirm the new version appears in the
    [Streamlit PyPI history](https://pypi.org/project/streamlit/#history).
@@ -173,8 +205,7 @@ should verify:
    starts successfully.
 4. Confirm the GitHub release exists and skim its generated notes.
 5. Merge the release PR back into `develop`.
-6. Complete the documentation release, public release notes, and any relevant
-   issue or forum follow-ups.
+6. Complete any relevant issue or forum follow-ups.
 7. Wait for the automated release PR to appear in the
    [conda-forge Streamlit feedstock](https://github.com/conda-forge/streamlit-feedstock/pulls).
    This can take a couple of hours after the PyPI release.
@@ -244,7 +275,8 @@ Use the same steps as a regular release:
 1. [Create the tag and merge-back PR](#4-create-the-tag-and-merge-back-pr).
 2. [Deploy static assets for SiS](#5-deploy-static-assets-for-sis-streamlit-in-snowflake).
 3. [Build and publish](#6-build-and-publish) from the patch tag.
-4. [Verify and close out](#7-verify-and-close-out).
+4. [Update the documentation](#7-update-the-documentation).
+5. [Verify and close out](#8-verify-and-close-out).
 
 Also respond to the people who reported the issue. For a significant incident
 or a failed emergency release, create a postmortem and schedule a review

--- a/wiki/release-process.md
+++ b/wiki/release-process.md
@@ -158,37 +158,12 @@ should verify:
 
 ### 7. Update the documentation
 
-1. In the `streamlit/streamlit` repository, generate the release notes from the
-   previous release tag to the new release tag:
+Slash commands in this section are coding-agent skills. Invoke them from an
+agent session that supports repository skills, such as Cursor or Claude Code,
+rather than from a shell.
 
-   ```text
-   /generating-changelog <previous-version-tag> <new-version-tag>
-   ```
-
-   For example:
-
-   ```text
-   /generating-changelog 1.61.0 1.62.0
-   ```
-
-   Review the generated changelog before continuing.
-
-2. In the `streamlit/docs` repository, run the
-   [`update-docs-for-release`](https://github.com/streamlit/docs/blob/main/.cursor/skills/update-docs-for-release/SKILL.md)
-   skill with the new release tag:
-
-   ```text
-   /update-docs-for-release <new-version-tag>
-   ```
-
-   The skill runs the relevant documentation updates and creates a PR in the
-   docs repository. Provide the generated changelog when prompted.
-3. Wait for Netlify to create a preview deployment and post its link in a
-   comment on the docs PR.
-4. Verify the documentation changes using the Netlify preview.
-5. Merge the docs PR. Merging updates the main documentation site.
-
-### 8. Verify and close out
+Before generating and publishing the documentation, verify that the new package
+is available:
 
 1. Confirm the new version appears in the
    [Streamlit PyPI history](https://pypi.org/project/streamlit/#history).
@@ -203,15 +178,58 @@ should verify:
 
 3. Confirm the command prints the expected version and smoke-test that the app
    starts successfully.
-4. Confirm the GitHub release exists and skim its generated notes.
-5. Merge the release PR back into `develop`.
-6. Complete any relevant issue or forum follow-ups.
-7. Wait for the automated release PR to appear in the
+4. In the `streamlit/streamlit` repository, use the
+   [`generating-changelog`](../.claude/skills/generating-changelog/SKILL.md)
+   skill to generate the release notes from the previous release tag to the new
+   release tag:
+
+   ```text
+   /generating-changelog <previous-version-tag> <new-version-tag>
+   ```
+
+   For example:
+
+   ```text
+   /generating-changelog 1.61.0 1.62.0
+   ```
+
+   Review the generated changelog before continuing.
+
+5. In the `streamlit/docs` repository, update the release documentation:
+
+   - For a regular `x.y.0` release, run the
+     [`update-docs-for-release`](https://github.com/streamlit/docs/blob/main/.cursor/skills/update-docs-for-release/SKILL.md)
+     skill with the new release tag:
+
+     ```text
+     /update-docs-for-release <new-version-tag>
+     ```
+
+     The skill runs the relevant documentation updates and creates a PR in the
+     docs repository. Provide the generated changelog when prompted.
+
+   - For a patch release, add the generated changelog to
+     `content/develop/quick-references/release-notes/_index.md` and the current
+     year's `content/develop/quick-references/release-notes/<year>.md` file,
+     then open a docs PR. Do not run the full skill or regenerate docstrings,
+     API tiles, or API pages; those updates target `x.y.0` releases.
+
+6. Wait for Netlify to create a preview deployment and post its link in a
+   comment on the docs PR.
+7. Verify the documentation changes using the Netlify preview.
+8. Merge the docs PR. Merging updates the main documentation site.
+
+### 8. Verify and close out
+
+1. Confirm the GitHub release exists and skim its generated notes.
+2. Merge the release PR back into `develop`.
+3. Complete any relevant issue or forum follow-ups.
+4. Wait for the automated release PR to appear in the
    [conda-forge Streamlit feedstock](https://github.com/conda-forge/streamlit-feedstock/pulls).
    This can take a couple of hours after the PyPI release.
-8. Confirm the feedstock PR checks pass, fix any failures if needed, and merge
+5. Confirm the feedstock PR checks pass, fix any failures if needed, and merge
    the PR.
-9. Request publication to the default Conda channel in the Snowflake-internal
+6. Request publication to the default Conda channel in the Snowflake-internal
    [#anaconda-snowflake-technical](https://snowflake.enterprise.slack.com/archives/C02D68R4D0D)
    Slack channel. This keeps Streamlit current in the main `anaconda` channel
    (separate from conda-forge). You may need to request access to the channel
@@ -275,7 +293,9 @@ Use the same steps as a regular release:
 1. [Create the tag and merge-back PR](#4-create-the-tag-and-merge-back-pr).
 2. [Deploy static assets for SiS](#5-deploy-static-assets-for-sis-streamlit-in-snowflake).
 3. [Build and publish](#6-build-and-publish) from the patch tag.
-4. [Update the documentation](#7-update-the-documentation).
+4. [Update the documentation](#7-update-the-documentation), using the
+   patch-release path in that section (release notes only; skip docstring
+   generation and API tiles/pages).
 5. [Verify and close out](#8-verify-and-close-out).
 
 Also respond to the people who reported the issue. For a significant incident

--- a/wiki/release-process.md
+++ b/wiki/release-process.md
@@ -199,11 +199,11 @@ is available:
 
    - For a regular `x.y.0` release, paste the generated changelog into the
      agent session and run the
-     [`update-docs-for-release`](https://github.com/streamlit/docs/blob/main/.cursor/skills/update-docs-for-release/SKILL.md)
+     [`updating-docs-for-release`](https://github.com/streamlit/docs/blob/main/.cursor/skills/updating-docs-for-release/SKILL.md)
      skill with the new release tag:
 
      ```text
-     /update-docs-for-release <new-version-tag>
+     /updating-docs-for-release <new-version-tag>
      ```
 
      The skill runs the relevant documentation updates and creates a PR in the

--- a/wiki/release-process.md
+++ b/wiki/release-process.md
@@ -197,7 +197,8 @@ is available:
 
 5. In the `streamlit/docs` repository, update the release documentation:
 
-   - For a regular `x.y.0` release, run the
+   - For a regular `x.y.0` release, paste the generated changelog into the
+     agent session and run the
      [`update-docs-for-release`](https://github.com/streamlit/docs/blob/main/.cursor/skills/update-docs-for-release/SKILL.md)
      skill with the new release tag:
 
@@ -206,7 +207,7 @@ is available:
      ```
 
      The skill runs the relevant documentation updates and creates a PR in the
-     docs repository. Provide the generated changelog when prompted.
+     docs repository.
 
    - For a patch release, add the generated changelog to
      `content/develop/quick-references/release-notes/_index.md` and the current

--- a/wiki/release-process.md
+++ b/wiki/release-process.md
@@ -163,8 +163,8 @@ agent session that supports repository skills, such as Cursor or Claude Code,
 rather than from a shell.
 
 Before generating and publishing the documentation, confirm the new package is
-installable from PyPI (steps 1–3). Then generate the website changelog and
-open the docs PR (steps 4–8).
+installable from PyPI (steps 1–3). Then generate the website changelog, open
+the docs PR, and merge the follow-up sitemap PR (steps 4–9).
 
 1. Confirm the new version appears in the
    [Streamlit PyPI history](https://pypi.org/project/streamlit/#history) and
@@ -197,34 +197,30 @@ open the docs PR (steps 4–8).
 
    Review the generated changelog before continuing.
 
-5. In the `streamlit/docs` repository, update the release documentation:
+5. In the `streamlit/docs` repository, run the
+   [`updating-docs-for-release`](https://github.com/streamlit/docs/blob/main/.claude/skills/updating-docs-for-release/SKILL.md)
+   skill with the new release tag and paste the generated website changelog
+   into the same message:
 
-   - For a regular `x.y.0` release, paste the generated website changelog into
-     the agent session and run the
-     [`updating-docs-for-release`](https://github.com/streamlit/docs/blob/main/.claude/skills/updating-docs-for-release/SKILL.md)
-     skill with the new release tag:
+   ```text
+   /updating-docs-for-release <new-version-tag>
 
-     ```text
-     /updating-docs-for-release <new-version-tag>
-     ```
+   <paste the generated website changelog>
+   ```
 
-     The skill runs the relevant documentation updates and creates a PR in the
-     docs repository. Plan for two manual inputs it will pause on: API
-     illustration images for brand-new commands
-     (`public/images/api/<name>.jpg`, often needing a designer) and Community
-     Cloud deployment of any new `<Cloud name="...">` example apps.
-
-   - For a patch release, do not run the full skill. Follow only its
-     [Release notes](https://github.com/streamlit/docs/blob/main/.claude/skills/updating-docs-for-release/SKILL.md#2-release-notes)
-     step: replace the current `(latest)` section (keep `(latest)` on the new
-     version) and prepend the same section to the current year's file, then
-     open a docs PR. Do not regenerate docstrings, API tiles, or API pages;
-     those updates target `x.y.0` releases.
+   The skill runs the relevant documentation updates and creates a PR in the
+   docs repository. Plan for two manual inputs it will pause on: API
+   illustration images for brand-new commands
+   (`public/images/api/<name>.jpg`, often needing a designer) and Community
+   Cloud deployment of any new `<Cloud name="...">` example apps.
 
 6. Wait for Netlify to create a preview deployment and post its link in a
    comment on the docs PR.
 7. Verify the documentation changes using the Netlify preview.
 8. Merge the docs PR. Merging updates the main documentation site.
+9. Wait for the [Automated sitemap update](https://github.com/streamlit/docs/pulls?q=is%3Apr+%22Automated+sitemap+update%22)
+   PR in `streamlit/docs` (opened after the docs PR merges to `main`) and merge
+   it as well.
 
 ### 8. Verify and close out
 
@@ -299,9 +295,7 @@ Use the same steps as a regular release:
 1. [Create the tag and merge-back PR](#4-create-the-tag-and-merge-back-pr).
 2. [Deploy static assets for SiS](#5-deploy-static-assets-for-sis-streamlit-in-snowflake).
 3. [Build and publish](#6-build-and-publish) from the patch tag.
-4. [Update the documentation](#7-update-the-documentation), using the
-   patch-release path in that section (release notes only; skip docstring
-   generation and API tiles/pages).
+4. [Update the documentation](#7-update-the-documentation).
 5. [Verify and close out](#8-verify-and-close-out).
 
 Also respond to the people who reported the issue. For a significant incident

--- a/wiki/release-process.md
+++ b/wiki/release-process.md
@@ -164,7 +164,8 @@ rather than from a shell.
 
 Before generating and publishing the documentation, confirm the new package is
 installable from PyPI (steps 1–3). Then generate the website changelog, open
-the docs PR, and merge the follow-up sitemap PR (steps 4–9).
+the docs PR, deploy any new Community Cloud examples, and merge the follow-up
+sitemap PR (steps 4–10).
 
 1. Confirm the new version appears in the
    [Streamlit PyPI history](https://pypi.org/project/streamlit/#history) and
@@ -205,20 +206,23 @@ the docs PR, and merge the follow-up sitemap PR (steps 4–9).
    ```text
    /updating-docs-for-release <new-version-tag>
 
+   Generated changelog:
    <paste the generated website changelog>
    ```
 
    The skill runs the relevant documentation updates and creates a PR in the
-   docs repository. Plan for two manual inputs it will pause on: API
-   illustration images for brand-new commands
-   (`public/images/api/<name>.jpg`, often needing a designer) and Community
-   Cloud deployment of any new `<Cloud name="...">` example apps.
+   docs repository. Plan for manual input if brand-new commands need API
+   illustration images (`public/images/api/<name>.jpg`, often needing a
+   designer). If any new example apps need to be deployed to Community Cloud,
+   the skill adds their deployment details to the docs PR description.
 
 6. Wait for Netlify to create a preview deployment and post its link in a
    comment on the docs PR.
 7. Verify the documentation changes using the Netlify preview.
 8. Merge the docs PR. Merging updates the main documentation site.
-9. Wait for the [Automated sitemap update](https://github.com/streamlit/docs/pulls?q=is%3Apr+%22Automated+sitemap+update%22)
+9. If the docs PR description lists new example apps, deploy them to Community
+   Cloud after the docs PR has merged.
+10. Wait for the [Automated sitemap update](https://github.com/streamlit/docs/pulls?q=is%3Apr+%22Automated+sitemap+update%22)
    PR in `streamlit/docs` (opened after the docs PR merges to `main`) and merge
    it as well.
 

--- a/wiki/release-process.md
+++ b/wiki/release-process.md
@@ -162,11 +162,13 @@ Slash commands in this section are coding-agent skills. Invoke them from an
 agent session that supports repository skills, such as Cursor or Claude Code,
 rather than from a shell.
 
-Before generating and publishing the documentation, verify that the new package
-is available:
+Before generating and publishing the documentation, confirm the new package is
+installable from PyPI (steps 1–3). Then generate the website changelog and
+open the docs PR (steps 4–8).
 
 1. Confirm the new version appears in the
-   [Streamlit PyPI history](https://pypi.org/project/streamlit/#history).
+   [Streamlit PyPI history](https://pypi.org/project/streamlit/#history) and
+   that the matching GitHub release exists. Skim the generated notes.
 2. Install from PyPI in a clean environment:
 
    ```bash
@@ -180,8 +182,8 @@ is available:
    starts successfully.
 4. In the `streamlit/streamlit` repository, use the
    [`generating-changelog`](../.claude/skills/generating-changelog/SKILL.md)
-   skill to generate the release notes from the previous release tag to the new
-   release tag:
+   skill to generate the website changelog from the previous release tag to the
+   new release tag. Run `git fetch --tags` first so both tags exist locally:
 
    ```text
    /generating-changelog <previous-version-tag> <new-version-tag>
@@ -197,9 +199,9 @@ is available:
 
 5. In the `streamlit/docs` repository, update the release documentation:
 
-   - For a regular `x.y.0` release, paste the generated changelog into the
-     agent session and run the
-     [`updating-docs-for-release`](https://github.com/streamlit/docs/blob/main/.cursor/skills/updating-docs-for-release/SKILL.md)
+   - For a regular `x.y.0` release, paste the generated website changelog into
+     the agent session and run the
+     [`updating-docs-for-release`](https://github.com/streamlit/docs/blob/main/.claude/skills/updating-docs-for-release/SKILL.md)
      skill with the new release tag:
 
      ```text
@@ -207,13 +209,17 @@ is available:
      ```
 
      The skill runs the relevant documentation updates and creates a PR in the
-     docs repository.
+     docs repository. Plan for two manual inputs it will pause on: API
+     illustration images for brand-new commands
+     (`public/images/api/<name>.jpg`, often needing a designer) and Community
+     Cloud deployment of any new `<Cloud name="...">` example apps.
 
-   - For a patch release, add the generated changelog to
-     `content/develop/quick-references/release-notes/_index.md` and the current
-     year's `content/develop/quick-references/release-notes/<year>.md` file,
-     then open a docs PR. Do not run the full skill or regenerate docstrings,
-     API tiles, or API pages; those updates target `x.y.0` releases.
+   - For a patch release, do not run the full skill. Follow only its
+     [Release notes](https://github.com/streamlit/docs/blob/main/.claude/skills/updating-docs-for-release/SKILL.md#2-release-notes)
+     step: replace the current `(latest)` section (keep `(latest)` on the new
+     version) and prepend the same section to the current year's file, then
+     open a docs PR. Do not regenerate docstrings, API tiles, or API pages;
+     those updates target `x.y.0` releases.
 
 6. Wait for Netlify to create a preview deployment and post its link in a
    comment on the docs PR.
@@ -222,15 +228,14 @@ is available:
 
 ### 8. Verify and close out
 
-1. Confirm the GitHub release exists and skim its generated notes.
-2. Merge the release PR back into `develop`.
-3. Complete any relevant issue or forum follow-ups.
-4. Wait for the automated release PR to appear in the
+1. Merge the release PR back into `develop`.
+2. Complete any relevant issue or forum follow-ups.
+3. Wait for the automated release PR to appear in the
    [conda-forge Streamlit feedstock](https://github.com/conda-forge/streamlit-feedstock/pulls).
    This can take a couple of hours after the PyPI release.
-5. Confirm the feedstock PR checks pass, fix any failures if needed, and merge
+4. Confirm the feedstock PR checks pass, fix any failures if needed, and merge
    the PR.
-6. Request publication to the default Conda channel in the Snowflake-internal
+5. Request publication to the default Conda channel in the Snowflake-internal
    [#anaconda-snowflake-technical](https://snowflake.enterprise.slack.com/archives/C02D68R4D0D)
    Slack channel. This keeps Streamlit current in the main `anaconda` channel
    (separate from conda-forge). You may need to request access to the channel

--- a/wiki/release-process.md
+++ b/wiki/release-process.md
@@ -158,6 +158,9 @@ should verify:
 
 ### 7. Update the documentation
 
+This step applies only to regular `x.y.0` releases. Patch releases do not
+require documentation updates.
+
 Slash commands in this section are coding-agent skills. Invoke them from an
 agent session that supports repository skills, such as Cursor or Claude Code,
 rather than from a shell.
@@ -299,8 +302,7 @@ Use the same steps as a regular release:
 1. [Create the tag and merge-back PR](#4-create-the-tag-and-merge-back-pr).
 2. [Deploy static assets for SiS](#5-deploy-static-assets-for-sis-streamlit-in-snowflake).
 3. [Build and publish](#6-build-and-publish) from the patch tag.
-4. [Update the documentation](#7-update-the-documentation).
-5. [Verify and close out](#8-verify-and-close-out).
+4. [Verify and close out](#8-verify-and-close-out).
 
 Also respond to the people who reported the issue. For a significant incident
 or a failed emergency release, create a postmortem and schedule a review


### PR DESCRIPTION
## Describe your changes

Adds an explicit documentation stage to the release runbook so release engineers publish the correct version-specific documentation after the package release.

- For regular (`x.y.0`) releases, generates the website changelog, passes it to the docs-repository skill, verifies the Netlify preview, and merges the docs PR.
- For patch releases, updates release notes without regenerating minor-release docstrings or API pages.
- Links the canonical `update-docs-for-release` skill and applies the documentation stage to the patch-release checklist.

## GitHub Issue Link (if applicable)

- Not applicable.

## Testing Plan

- Documentation-only change; `make check` passed.
