### PR TITLE
[docs] Clarify UploadedFile public API

### DIFF
--- a/lib/streamlit/runtime/uploaded_file_manager.py
+++ b/lib/streamlit/runtime/uploaded_file_manager.py
@@ -82,11 +82,14 @@ class UploadedFile(io.BytesIO):
         The name of the uploaded file. For directory uploads, this is the path
         of the file relative to the selected directory. The name is provided by
         the user's browser and isn't sanitized. Don't use it directly as a path
-        when writing the file to disk.
+        when writing the file to disk; choose an app-controlled destination
+        instead.
     type : str
         The MIME type of the uploaded file. For user-selected files, this is the
         type reported by the user's browser, or ``"application/octet-stream"``
-        if the browser doesn't report one.
+        if the browser doesn't report one. For ``st.camera_input``, this is
+        ``"image/jpeg"``. For ``st.audio_input`` and ``ChatInputValue.audio``,
+        this is ``"audio/wav"``.
     size : int
         The size of the uploaded file in bytes.
     """

--- a/lib/streamlit/runtime/uploaded_file_manager.py
+++ b/lib/streamlit/runtime/uploaded_file_manager.py
@@ -59,19 +59,29 @@ class DeletedFile(NamedTuple):
 
 
 class UploadedFile(io.BytesIO):
-    """A file uploaded through a Streamlit input widget.
+    """A file uploaded through ``st.file_uploader``, ``st.camera_input``,
+    ``st.audio_input``, or ``st.chat_input``.
+
+    To use this type in an annotation, import it from ``streamlit.typing``.
 
     ``UploadedFile`` is a subclass of ``io.BytesIO`` and therefore supports
     Python's file-like interface. You can pass it anywhere a file-like object is
-    accepted. To use this type in an annotation, import it from
-    ``streamlit.typing``.
+    accepted.
+
+    .. note::
+        Calling ``read()`` advances the file position. After reading all data,
+        another call returns no data. Use ``getvalue()`` to read the full
+        contents without changing the position, or ``seek(0)`` to rewind.
 
     Attributes
     ----------
     name : str
-        The name of the uploaded file.
+        The name of the uploaded file. For directory uploads, this is the path
+        of the file relative to the selected directory.
     type : str
-        The MIME type of the uploaded file.
+        The MIME type of the uploaded file, as reported by the user's browser.
+        This is ``"application/octet-stream"`` if the browser doesn't report a
+        type.
     size : int
         The size of the uploaded file in bytes.
     """

--- a/lib/streamlit/runtime/uploaded_file_manager.py
+++ b/lib/streamlit/runtime/uploaded_file_manager.py
@@ -59,12 +59,21 @@ class DeletedFile(NamedTuple):
 
 
 class UploadedFile(io.BytesIO):
-    """A mutable uploaded file.
+    """A file uploaded through a Streamlit input widget.
 
-    To use this type in an annotation, import it from ``streamlit.typing``.
+    ``UploadedFile`` is a subclass of ``io.BytesIO`` and therefore supports
+    Python's file-like interface. You can pass it anywhere a file-like object is
+    accepted. To use this type in an annotation, import it from
+    ``streamlit.typing``.
 
-    This class extends BytesIO, which has copy-on-write semantics when
-    initialized with `bytes`.
+    Attributes
+    ----------
+    name : str
+        The name of the uploaded file.
+    type : str
+        The MIME type of the uploaded file.
+    size : int
+        The size of the uploaded file in bytes.
     """
 
     def __init__(self, record: UploadedFileRec, file_urls: FileURLsProto) -> None:

--- a/lib/streamlit/runtime/uploaded_file_manager.py
+++ b/lib/streamlit/runtime/uploaded_file_manager.py
@@ -59,10 +59,13 @@ class DeletedFile(NamedTuple):
 
 
 class UploadedFile(io.BytesIO):
-    """A file uploaded through ``st.file_uploader``, ``st.camera_input``,
-    ``st.audio_input``, or ``st.chat_input``.
+    """A file uploaded by a user.
 
     To use this type in an annotation, import it from ``streamlit.typing``.
+
+    ``st.file_uploader``, ``st.camera_input``, and ``st.audio_input`` return
+    ``UploadedFile`` objects. ``st.chat_input`` returns them in the ``files``
+    and ``audio`` attributes of its ``ChatInputValue``.
 
     ``UploadedFile`` is a subclass of ``io.BytesIO`` and therefore supports
     Python's file-like interface. You can pass it anywhere a file-like object is
@@ -77,11 +80,13 @@ class UploadedFile(io.BytesIO):
     ----------
     name : str
         The name of the uploaded file. For directory uploads, this is the path
-        of the file relative to the selected directory.
+        of the file relative to the selected directory. The name is provided by
+        the user's browser and isn't sanitized. Don't use it directly as a path
+        when writing the file to disk.
     type : str
-        The MIME type of the uploaded file, as reported by the user's browser.
-        This is ``"application/octet-stream"`` if the browser doesn't report a
-        type.
+        The MIME type of the uploaded file. For user-selected files, this is the
+        type reported by the user's browser, or ``"application/octet-stream"``
+        if the browser doesn't report one.
     size : int
         The size of the uploaded file in bytes.
     """

--- a/lib/streamlit/runtime/uploaded_file_manager.py
+++ b/lib/streamlit/runtime/uploaded_file_manager.py
@@ -68,28 +68,31 @@ class UploadedFile(io.BytesIO):
     and ``audio`` attributes of its ``ChatInputValue``.
 
     ``UploadedFile`` is a subclass of ``io.BytesIO`` and therefore supports
-    Python's file-like interface. You can pass it anywhere a file-like object is
-    accepted.
+    Python's file-like interface. You can pass it anywhere a binary file-like
+    object is accepted.
 
     .. note::
-        Calling ``read()`` advances the file position. After reading all data,
-        another call returns no data. Use ``getvalue()`` to read the full
-        contents without changing the position, or ``seek(0)`` to rewind.
+        After you read the file to the end, another ``read()`` returns no data.
+        Use ``getvalue()`` to read the full contents without changing the
+        position, or ``seek(0)`` to rewind.
 
     Attributes
     ----------
     name : str
-        The name of the uploaded file. For directory uploads, this is the path
-        of the file relative to the selected directory. The name is provided by
-        the user's browser and isn't sanitized. Don't use it directly as a path
-        when writing the file to disk; choose an app-controlled destination
-        instead.
+        The name of the uploaded file. For directory uploads, this is the file's
+        path within the selected directory, including the directory name (for
+        example, ``"photos/2024/a.jpg"``). The name is provided by the user's
+        browser and isn't sanitized. Don't use it directly as a path when
+        writing the file to disk; choose an app-controlled destination instead.
     type : str
-        The MIME type of the uploaded file. For user-selected files, this is the
-        type reported by the user's browser, or ``"application/octet-stream"``
-        if the browser doesn't report one. For ``st.camera_input``, this is
-        ``"image/jpeg"``. For ``st.audio_input`` and ``ChatInputValue.audio``,
-        this is ``"audio/wav"``.
+        The MIME type of the uploaded file.
+
+        - For user-selected files, this is the type reported by the user's
+          browser, or ``"application/octet-stream"`` if the browser doesn't
+          report one.
+        - For ``st.camera_input``, this is ``"image/jpeg"``.
+        - For ``st.audio_input`` and ``ChatInputValue.audio``, this is
+          ``"audio/wav"``.
     size : int
         The size of the uploaded file in bytes.
     """

--- a/lib/streamlit/runtime/uploaded_file_manager.py
+++ b/lib/streamlit/runtime/uploaded_file_manager.py
@@ -81,9 +81,9 @@ class UploadedFile(io.BytesIO):
     name : str
         The name of the uploaded file. For directory uploads, this is the file's
         path within the selected directory, including the directory name (for
-        example, ``"photos/2024/a.jpg"``). The name is provided by the user's
-        browser and isn't sanitized. Don't use it directly as a path when
-        writing the file to disk; choose an app-controlled destination instead.
+        example, ``"photos/2024/a.jpg"``). Streamlit does not sanitize this
+        value. Don't use it directly as a path when writing the file to disk;
+        choose an app-controlled destination instead.
     type : str
         The MIME type of the uploaded file.
 


### PR DESCRIPTION
## Describe your changes

Documents `UploadedFile` as a file-like `io.BytesIO` subclass with stable
`name`, `type`, and `size` metadata, and how to import it from
`streamlit.typing`.

- Identifies the Streamlit commands that produce uploaded files.
- Clarifies directory-relative names, browser-reported MIME types, and file-position behavior.
- Drops the CPython copy-on-write note from the user-facing docstring; the maintainer-facing comment for it already sits in `__init__`.

## GitHub Issue Link (if applicable)

Not applicable.

## Testing Plan

- [x] No additional tests needed — docstring-only change
- [x] `make check` (11 tests passed)

Manual testing: Not applicable — no runtime behavior changes.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
