### PR TITLE
[fix] Stop Cmd/Ctrl+C from opening clear-cache dialog

### DIFF
--- a/e2e_playwright/app_hotkeys_test.py
+++ b/e2e_playwright/app_hotkeys_test.py
@@ -35,6 +35,15 @@ def test_does_not_show_clear_cache_when_modifier_c_is_pressed(app: Page):
     expect(app.get_by_test_id("stClearCacheDialog")).not_to_be_visible()
 
 
+def test_does_not_show_clear_cache_when_copy_modifier_is_released_first(app: Page):
+    for key in modifier_keys:
+        app.keyboard.down(key)
+        app.keyboard.down("c")
+        app.keyboard.up(key)
+        app.keyboard.up("c")
+    expect(app.get_by_test_id("stClearCacheDialog")).not_to_be_visible()
+
+
 def test_does_not_clear_cache_dialog_when_c_is_pressed_inside_text_input(app: Page):
     app.get_by_test_id("stTextInput").type("c")
     expect(app.get_by_test_id("stClearCacheDialog")).not_to_be_visible()

--- a/e2e_playwright/app_hotkeys_test.py
+++ b/e2e_playwright/app_hotkeys_test.py
@@ -32,11 +32,8 @@ modifier_keys = ["Control", "Meta"]
 def test_does_not_show_clear_cache_when_modifier_c_is_pressed(app: Page):
     for key in modifier_keys:
         app.keyboard.press(f"{key}+c")
-    expect(app.get_by_test_id("stClearCacheDialog")).not_to_be_visible()
-
-
-def test_does_not_show_clear_cache_when_copy_modifier_is_released_first(app: Page):
-    for key in modifier_keys:
+        # Releasing the modifier before "c" must not turn the "c" keyup into a
+        # bare-key shortcut.
         app.keyboard.down(key)
         app.keyboard.down("c")
         app.keyboard.up(key)

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -4203,6 +4203,29 @@ describe("App", () => {
         vi.useRealTimers()
       }
     })
+
+    it("does not clear caches when the copy modifier is released first", async () => {
+      const user = userEvent.setup({
+        advanceTimers: advanceUserEventTimers,
+      })
+      renderApp(getProps())
+
+      sendForwardMessage("newSession", {
+        ...NEW_SESSION_JSON,
+        config: {
+          ...NEW_SESSION_JSON.config,
+          toolbarMode: Config.ToolbarMode.DEVELOPER,
+        },
+      })
+
+      getMockConnectionManager(true)
+
+      await user.keyboard("[MetaLeft>][KeyC>][/MetaLeft][/KeyC]")
+
+      expect(
+        screen.queryByTestId("stClearCacheDialog")
+      ).not.toBeInTheDocument()
+    })
   })
 
   describe("showDevelopmentMenu", () => {

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -17,6 +17,7 @@
 import { act } from "react"
 
 import {
+  fireEvent,
   render,
   RenderResult,
   screen,
@@ -4226,6 +4227,33 @@ describe("App", () => {
       expect(
         screen.queryByTestId("stClearCacheDialog")
       ).not.toBeInTheDocument()
+    })
+
+    it("stops screencast recording when Escape is released", async () => {
+      const props = getProps()
+      renderApp(props)
+
+      // hotkeys-js matches Escape via keyCode 27; userEvent does not set it.
+      /* eslint-disable testing-library/prefer-user-event */
+      fireEvent.keyDown(document, {
+        key: "Escape",
+        code: "Escape",
+        keyCode: 27,
+        which: 27,
+      })
+      fireEvent.keyUp(document, {
+        key: "Escape",
+        code: "Escape",
+        keyCode: 27,
+        which: 27,
+      })
+      /* eslint-enable testing-library/prefer-user-event */
+
+      // react-hot-keys delivers onKeyUp from a document keyup listener on a
+      // 0ms timeout so hotkeys-js can drop the key from its pressed set.
+      await waitFor(() => {
+        expect(props.screenCast.stopRecording).toHaveBeenCalled()
+      })
     })
   })
 

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -4220,6 +4220,7 @@ describe("App", () => {
 
       getMockConnectionManager(true)
 
+      // Hold Cmd+C, then release Cmd before C.
       await user.keyboard("[MetaLeft>][KeyC>][/MetaLeft][/KeyC]")
 
       expect(

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -2688,6 +2688,13 @@ export class App extends PureComponent<Props, State> {
   }
 
   handleKeyDown = (keyName: string, keyboardEvent?: KeyboardEvent): void => {
+    // react-hot-keys also invokes onKeyDown for matching keyup events. Ignoring
+    // them prevents a modified shortcut from becoming a bare-key shortcut when
+    // the user releases the modifier first (for example, Cmd+C).
+    if (keyboardEvent?.type === "keyup") {
+      return
+    }
+
     // See `isKeyboardEventFromEditableTarget` for editable/shadow DOM behavior.
     // We never fire global single-letter shortcuts while the user is typing.
     if (

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -2688,9 +2688,9 @@ export class App extends PureComponent<Props, State> {
   }
 
   handleKeyDown = (keyName: string, keyboardEvent?: KeyboardEvent): void => {
-    // react-hot-keys also invokes onKeyDown for matching keyup events. Ignoring
-    // them prevents a modified shortcut from becoming a bare-key shortcut when
-    // the user releases the modifier first (for example, Cmd+C).
+    // Ignore keyup events so a modified shortcut cannot become a bare-key
+    // shortcut when the user releases the modifier first (for example, Cmd+C).
+    // react-hot-keys binds keydown and keyup to the same onKeyDown handler.
     if (keyboardEvent?.type === "keyup") {
       return
     }


### PR DESCRIPTION
## Describe your changes

Prevents Cmd/Ctrl+C from opening the clear-cache dialog when users release the modifier key before C.

- Ignores keyup events forwarded through the app-level keydown handler so modified shortcuts cannot be reinterpreted as bare-key shortcuts.

## GitHub Issue Link (if applicable)

- Not applicable

## Testing Plan

- [x] Unit Tests (JS and/or Python)
- [x] E2E Tests
- [ ] Any manual testing needed?

`frontend/app/src/App.test.tsx` and `e2e_playwright/app_hotkeys_test.py` cover the modifier-release ordering that caused the regression.
