### PR TITLE
[fix] Origin-dependent is_fragment_scoped_rerun for keyed targets

### DIFF
--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -46,6 +46,25 @@ _KEYED_RERUN_ALLOWED_LOCATIONS: frozenset[RunLocation] = frozenset(
 )
 
 
+def _is_fragment_scoped(scope: str | Sequence[str]) -> bool:
+    """Whether the rerun should preempt the run in progress.
+
+    ``scope="app"`` → ``False`` (full-app rerun, not fragment-scoped).
+    ``scope="fragment"`` → ``True`` (always preempts).
+    Keyed target (anything else) → depends on where the callback's widget lives:
+    a main-script widget returns ``True`` (the keyed target replaces the default
+    full-app rerun), a fragment widget returns ``False`` (the keyed target composes
+    with the fragment's own rerun — both run).
+    """
+    if scope == "app":
+        return False
+    if scope == "fragment":
+        return True
+    # Keyed target: origin-dependent.
+    ts = ThreadState.get()
+    return ts.fragment_id is None
+
+
 @gather_metrics("stop")
 def stop() -> NoReturn:  # type: ignore[misc] # ty: ignore[invalid-return-type]
     """Stops execution immediately.
@@ -204,7 +223,7 @@ def rerun(  # type: ignore[misc]
                 query_string=query_string,
                 page_script_hash=page_script_hash,
                 fragment_id_queue=fragment_id_queue,
-                is_fragment_scoped_rerun=scope != "app",
+                is_fragment_scoped_rerun=_is_fragment_scoped(scope),
                 cached_message_hashes=cached_message_hashes,
                 context_info=ctx.context_info,
             )

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -716,12 +716,15 @@ class ScriptRunner:
                     # Run callbacks for widgets whose values have changed.
                     if rerun_data.widget_states is not None:
                         self._session_state.on_script_will_rerun(
-                            rerun_data.widget_states
+                            rerun_data.widget_states,
+                            suppress_callbacks=rerun_data.suppress_callbacks,
                         )
-                        # Callbacks above may have queued an st.rerun(). Honor it before
-                        # on_script_start() below: leaving has_script_started False is
-                        # what tells on_script_finished to keep this run's widget values.
-                        self._maybe_handle_execution_control_request()
+                        if not rerun_data.suppress_callbacks:
+                            # Callbacks above may have queued an st.rerun(). Honor
+                            # it before on_script_start() below: leaving
+                            # has_script_started False is what tells
+                            # on_script_finished to keep this run's widget values.
+                            self._maybe_handle_execution_control_request()
 
                     ctx.on_script_start()
 

--- a/lib/streamlit/runtime/scriptrunner_utils/script_requests.py
+++ b/lib/streamlit/runtime/scriptrunner_utils/script_requests.py
@@ -57,6 +57,11 @@ class RerunData:
     is_fragment_scoped_rerun: bool = False
     # set to true when a script is rerun by the fragment auto-rerun mechanism
     is_auto_rerun: bool = False
+    # When True, widget_states carry values but callbacks should not re-fire.
+    # Used by the forced full-app rerun that escalates a targeted rerun from a
+    # main-script interaction: the callbacks already ran, and the body just needs
+    # to see the submitted values (including form submit triggers).
+    suppress_callbacks: bool = False
     # Hashes of messages that are cached in the client browser:
     cached_message_hashes: frozenset[str] = field(default_factory=frozenset)
     # context_info is used to store information from the user browser (e.g. timezone)
@@ -263,6 +268,10 @@ class ScriptRequests:
                     cached_message_hashes=new_data.cached_message_hashes,
                     is_fragment_scoped_rerun=is_fragment_scoped_rerun,
                     is_auto_rerun=new_data.is_auto_rerun,
+                    suppress_callbacks=(
+                        self._rerun_data.suppress_callbacks
+                        or new_data.suppress_callbacks
+                    ),
                     context_info=new_data.context_info,
                 )
 

--- a/lib/streamlit/runtime/state/safe_session_state.py
+++ b/lib/streamlit/runtime/state/safe_session_state.py
@@ -58,14 +58,21 @@ class SafeSessionState:
         with self._lock:
             return self._state.register_widget(metadata, user_key)
 
-    def on_script_will_rerun(self, latest_widget_states: WidgetStatesProto) -> None:
+    def on_script_will_rerun(
+        self,
+        latest_widget_states: WidgetStatesProto,
+        *,
+        suppress_callbacks: bool = False,
+    ) -> None:
         self._yield_callback()
         with self._lock:
             # TODO: rewrite this to copy the callbacks list into a local
             #  variable so that we don't need to hold our lock for the
             #  duration. (This will also allow us to downgrade our RLock
             #  to a Lock.)
-            self._state.on_script_will_rerun(latest_widget_states)
+            self._state.on_script_will_rerun(
+                latest_widget_states, suppress_callbacks=suppress_callbacks
+            )
 
     def on_script_finished(
         self,

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -678,6 +678,12 @@ class SessionState:
         default_factory=PersistedWidgetTracker
     )
 
+    # The proto widget_states from the current interaction, stashed during
+    # on_script_will_rerun so _request_full_app_rerun can forward them.
+    _current_interaction_widget_states: WidgetStatesProto | None = field(
+        default=None, repr=False
+    )
+
     def __repr__(self) -> str:
         return util.repr_(self)
 
@@ -880,16 +886,32 @@ class SessionState:
         for state in widget_states.widgets:
             self._new_widget_state.set_widget_from_proto(state)
 
-    def on_script_will_rerun(self, latest_widget_states: WidgetStatesProto) -> None:
+    def on_script_will_rerun(
+        self,
+        latest_widget_states: WidgetStatesProto,
+        *,
+        suppress_callbacks: bool = False,
+    ) -> None:
         """Called by ScriptRunner before its script re-runs.
 
         Update widget data and call callbacks on widgets whose value changed
         between the previous and current script runs.
+
+        Parameters
+        ----------
+        suppress_callbacks
+            When True, apply the widget values but skip callback dispatch.
+            Used by the forced full-app rerun that escalates a targeted rerun:
+            the callbacks already ran, and the body just needs to see the
+            submitted values (including form submit triggers).
         """
-        # Clear any triggers that weren't reset because the script was disconnected
         self._reset_triggers()
         self._compact_state()
         self.set_widgets_from_proto(latest_widget_states)
+        if suppress_callbacks:
+            self._current_interaction_widget_states = None
+            return
+        self._current_interaction_widget_states = latest_widget_states
         self._call_callbacks()
 
     def _call_callbacks(self) -> None:
@@ -1024,7 +1046,7 @@ class SessionState:
         the last callback has run (see the comment there for why it waits), and the
         callback's rerun scope is recorded as:
 
-        - a fragment-scoped rerun → ``requested_targeted``
+        - a targeted rerun (non-empty ``fragment_id_queue``) → ``requested_targeted``
         - a plain ``st.rerun()``, or a normal return → ``wants_interaction_default``
         """
         from streamlit.runtime.scriptrunner import RerunException
@@ -1033,7 +1055,7 @@ class SessionState:
             run()
         except RerunException as e:
             rerun_data = e.rerun_data
-            if rerun_data.is_fragment_scoped_rerun:
+            if rerun_data.fragment_id_queue:
                 votes.requested_targeted = True
             else:
                 votes.wants_interaction_default = True
@@ -1042,7 +1064,11 @@ class SessionState:
             votes.wants_interaction_default = True
 
     def _request_full_app_rerun(self) -> None:
-        """Queue a full-app rerun with no ``widget_states``, so callbacks are not re-fired."""
+        """Queue a full-app rerun that preserves widget values (including triggers).
+
+        Carries the interaction's ``widget_states`` with ``suppress_callbacks=True``
+        so the follow-up run applies the values without re-dispatching callbacks.
+        """
         from streamlit.runtime.scriptrunner import RerunData
 
         ctx = get_script_run_ctx()
@@ -1051,6 +1077,8 @@ class SessionState:
                 RerunData(
                     query_string=ctx.query_string,
                     page_script_hash=ctx.page_script_hash,
+                    widget_states=self._current_interaction_widget_states,
+                    suppress_callbacks=True,
                     cached_message_hashes=ctx.cached_message_hashes,
                     context_info=ctx.context_info,
                 )

--- a/lib/tests/streamlit/commands/execution_control_test.py
+++ b/lib/tests/streamlit/commands/execution_control_test.py
@@ -175,6 +175,28 @@ def test_key_scope_delegates_to_resolve_target(patched_get_script_run_ctx) -> No
 
 
 @patch("streamlit.commands.execution_control.get_script_run_ctx")
+def test_key_scope_from_fragment_callback_composes(
+    patched_get_script_run_ctx,
+) -> None:
+    """st.rerun('charts') from a fragment widget sets is_fragment_scoped_rerun=False.
+
+    A fragment-origin keyed target composes with the enclosing fragment: the fragment
+    finishes, then the target runs.
+    """
+    ctx = MagicMock()
+    ctx.fragment_storage.resolve_target.return_value = ["frag_id_1"]
+    patched_get_script_run_ctx.return_value = ctx
+
+    ThreadState.initialize(run_location=RunLocation.CALLBACK, fragment_id="enclosing")
+
+    rerun("charts")
+
+    call = ctx.script_requests.request_rerun.call_args[0][0]
+    assert call.fragment_id_queue == ["frag_id_1"]
+    assert call.is_fragment_scoped_rerun is False
+
+
+@patch("streamlit.commands.execution_control.get_script_run_ctx")
 def test_list_scope_delegates_to_resolve_target(patched_get_script_run_ctx) -> None:
     """st.rerun(['charts', 'table']) passes the list to resolve_target."""
     ctx = MagicMock()

--- a/lib/tests/streamlit/runtime/scriptrunner_utils/script_requests_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner_utils/script_requests_test.py
@@ -268,6 +268,22 @@ class ScriptRequestsTest(unittest.TestCase):
         assert reqs._rerun_data.fragment_id_queue == []
         assert reqs._rerun_data.is_fragment_scoped_rerun is False
 
+    def test_suppress_callbacks_preserved_during_coalescing(self):
+        """suppress_callbacks=True survives coalescing with a regular request."""
+        reqs = ScriptRequests()
+        reqs.request_rerun(
+            RerunData(fragment_id_queue=["frag"], is_fragment_scoped_rerun=True)
+        )
+        reqs.request_rerun(RerunData(suppress_callbacks=True))
+        assert reqs._rerun_data.suppress_callbacks is True
+
+    def test_suppress_callbacks_false_when_neither_sets_it(self):
+        """Two non-suppressing requests coalesce to suppress_callbacks=False."""
+        reqs = ScriptRequests()
+        reqs.request_rerun(RerunData())
+        reqs.request_rerun(RerunData(query_string="new"))
+        assert reqs._rerun_data.suppress_callbacks is False
+
     def test_on_script_yield_with_no_request(self):
         """Return None; remain in the CONTINUE state."""
         reqs = ScriptRequests()
@@ -284,6 +300,23 @@ class ScriptRequestsTest(unittest.TestCase):
         assert None is result
         assert reqs._state == ScriptRequestType.RERUN
         assert reqs._rerun_data == RerunData(fragment_id_queue=["my_fragment_id"])
+
+    def test_compose_fragment_rerun_lets_body_finish_then_serves_target(self):
+        """A non-scoped fragment rerun composes: body finishes, then target runs.
+
+        on_scriptrunner_yield returns None (body not preempted), and
+        on_scriptrunner_ready returns the pending fragment rerun afterwards.
+        """
+        reqs = ScriptRequests()
+        rerun_data = RerunData(fragment_id_queue=["target-frag"])
+        reqs.request_rerun(rerun_data)
+
+        assert reqs.on_scriptrunner_yield() is None
+        assert reqs._state == ScriptRequestType.RERUN
+
+        result = reqs.on_scriptrunner_ready()
+        assert result == ScriptRequest(ScriptRequestType.RERUN, rerun_data)
+        assert reqs._state == ScriptRequestType.CONTINUE
 
     def test_on_script_yield_with_is_fragment_scoped_rerun(self):
         """Return RERUN; transition to the CONTINUE state."""

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -1029,16 +1029,32 @@ def _call_callbacks_in_main_script(ss: SessionState) -> list[RerunData]:
 
 
 def _raise_targeted_rerun() -> None:
-    """Raise what a targeted rerun at another fragment sends.
+    """Raise what a main-script-origin targeted rerun sends (preempts).
 
-    Stands in for ``st.rerun(scope="<key>")``, per
-    specs/2026-06-23-event-scoped-fragment-reruns/product-spec.md.
+    Stands in for ``st.rerun(scope="<key>")`` from a main-script widget callback.
+    ``is_fragment_scoped_rerun=True`` causes the target to preempt the run in progress.
     """
     raise RerunException(
         RerunData(
             page_script_hash=_CURRENT_PAGE_HASH,
             fragment_id_queue=["other-frag"],
             is_fragment_scoped_rerun=True,
+        )
+    )
+
+
+def _raise_composing_targeted_rerun() -> None:
+    """Raise what a fragment-origin targeted rerun sends (composes).
+
+    Stands in for ``st.rerun(scope="<key>")`` from a fragment widget callback.
+    ``is_fragment_scoped_rerun=False`` lets the enclosing fragment finish first, then
+    the target runs.
+    """
+    raise RerunException(
+        RerunData(
+            page_script_hash=_CURRENT_PAGE_HASH,
+            fragment_id_queue=["other-frag"],
+            is_fragment_scoped_rerun=False,
         )
     )
 
@@ -1065,6 +1081,30 @@ def test_changed_widget_without_callback_forces_app_wide_rerun() -> None:
     assert not forced.is_fragment_scoped_rerun
 
 
+def test_composing_target_with_callback_less_vote_does_not_escalate() -> None:
+    """A composing targeted rerun (flag False) is not escalated by the vote.
+
+    When the keyed target has is_fragment_scoped_rerun=False (fragment-origin
+    interaction), the target does not preempt the body. The vote fires because a
+    callback-less field changed, but the flag stays False — there is no preemption to
+    escape, so the vote has no effect.
+    """
+    ss = _state_with_changed_widgets(
+        [("field", None), ("submit", _raise_composing_targeted_rerun)]
+    )
+
+    requeue_calls = _call_callbacks_in_main_script(ss)
+
+    # The composing targeted re-queue plus the forced app-wide default.
+    assert len(requeue_calls) == 2
+    targeted = requeue_calls[0]
+    assert targeted.fragment_id_queue == ["other-frag"]
+    assert targeted.is_fragment_scoped_rerun is False
+    forced = requeue_calls[-1]
+    assert not forced.fragment_id_queue
+    assert forced.suppress_callbacks is True
+
+
 def test_changed_widgets_without_callbacks_queue_no_rerun() -> None:
     """The vote only breaks a tie; on its own it must not add a rerun.
 
@@ -1075,6 +1115,60 @@ def test_changed_widgets_without_callbacks_queue_no_rerun() -> None:
     ss = _state_with_changed_widgets([("field", None), ("other_field", None)])
 
     assert _call_callbacks_in_main_script(ss) == []
+
+
+def test_forced_full_app_rerun_carries_widget_states_with_suppress() -> None:
+    """_request_full_app_rerun forwards widget_states with suppress_callbacks=True.
+
+    The forced full-app rerun that escalates a targeted rerun carries the current
+    interaction's widget_states so the body sees submitted values (including triggers),
+    and suppress_callbacks=True so callbacks are not re-dispatched.
+    """
+    ss = _state_with_changed_widgets(
+        [("field", None), ("submit", _raise_targeted_rerun)]
+    )
+    # Simulate on_script_will_rerun stashing the proto.
+    proto_states = WidgetStatesProto()
+    for wid in ("field", "submit"):
+        ws = proto_states.widgets.add()
+        ws.id = wid
+        ws.int_value = 1
+    ss._current_interaction_widget_states = proto_states
+
+    requeue_calls = _call_callbacks_in_main_script(ss)
+
+    assert len(requeue_calls) == 2
+    forced = requeue_calls[-1]
+    assert not forced.fragment_id_queue
+    assert not forced.is_fragment_scoped_rerun
+    assert forced.suppress_callbacks is True
+    assert forced.widget_states is proto_states
+
+
+def test_suppress_callbacks_skips_dispatch_but_applies_values() -> None:
+    """on_script_will_rerun with suppress_callbacks applies values without callbacks.
+
+    The trigger value is set (so the body sees it) but no callback fires.
+    """
+    ss = SessionState()
+    trigger_wid = "submit_btn"
+    meta = WidgetMetadata(
+        id=trigger_wid,
+        deserializer=lambda v: v,
+        serializer=lambda v: v,
+        value_type="trigger_value",
+        callback=lambda: (_ for _ in ()).throw(AssertionError("should not fire")),
+    )
+    ss._set_widget_metadata(meta)
+
+    proto_states = WidgetStatesProto()
+    ws = proto_states.widgets.add()
+    ws.id = trigger_wid
+    ws.trigger_value = True
+
+    ss.on_script_will_rerun(proto_states, suppress_callbacks=True)
+
+    assert ss[trigger_wid] is True
 
 
 def test_disabled_widget_change_does_not_force_app_wide_rerun() -> None:

--- a/specs/2026-06-23-event-scoped-fragment-reruns/product-spec.md
+++ b/specs/2026-06-23-event-scoped-fragment-reruns/product-spec.md
@@ -164,11 +164,12 @@ any app that relied on that no-op.)
 This is a deliberate starting point we may relax later. For now the restriction buys four things:
 
 - **Execution stays easy to reason about.** Callbacks run as a distinct phase *before* the run body,
-  so a targeted rerun is applied at that clean boundary: the callback phase finishes and then — before
-  the pending run's body executes — Streamlit preempts the run and executes only the target(s), with
-  no partially-rendered output. Allowing the call mid-body would instead abandon a partially-executed
-  script or fragment and jump elsewhere — a "goto" style of control flow that is hard to follow and at
-  odds with the deterministic, top-to-bottom model.
+  so a targeted rerun is applied at that clean boundary. For a main-script interaction, the callback
+  phase finishes, the full-app body runs (rendering submitted values), and the targeted fragments
+  re-execute as part of the full pass. For a fragment interaction, the enclosing fragment finishes
+  and then the target runs — both fragments execute. Allowing the call mid-body would instead
+  abandon a partially-executed script or fragment and jump elsewhere — a "goto" style of control
+  flow that is hard to follow and at odds with the deterministic, top-to-bottom model.
 - **It covers the use cases people actually ask for.** The requests behind this feature — dashboard
   filters, cross-filtering, fragment-to-fragment updates — are all "when the user does X, update
   region Y," which is exactly what a widget callback expresses.
@@ -330,11 +331,18 @@ reasons:
 
 ### Rerun handling: skipping the default rerun, coalescing, and precedence
 
-**A targeted rerun replaces the interaction's default rerun.** A widget interaction normally schedules
-a full-app rerun once its callbacks have run (or a fragment-scoped rerun, if the triggering widget
-already lives inside a fragment). When a callback issues a targeted rerun, that default full-app rerun
-is **skipped** — Streamlit runs only the targeted fragment(s), not the whole app; running the full app
-in addition would just redo those fragments and erase the partial-update benefit.
+**How a targeted rerun interacts with the default depends on where the interaction originates:**
+
+- **Main-script interaction (widget outside any fragment).** The default rerun is a full-app rerun.
+  A targeted rerun from the callback does not cancel that default — a changed form field or another
+  callback that returns normally still expects the body to run. The targeted rerun is additive: the
+  full-app rerun runs the body (rendering the submitted values) and the targeted fragments re-execute
+  as part of the full pass. The coalescing rules below collapse this to a single full-app rerun.
+- **Fragment interaction (widget inside a fragment).** The default rerun covers only the enclosing
+  fragment. A targeted rerun from the callback **composes**: the enclosing fragment finishes its
+  current run, and then the target runs afterwards. Both fragments execute, because the target's
+  scope does not subsume the enclosing fragment — the justification for skipping ("would just redo
+  those fragments") does not apply when the default is fragment-scoped rather than app-wide.
 
 Beyond replacing that default rerun, targeted reruns make it normal for a **single interaction to
 produce several rerun requests at once** — a list of keys, multiple `st.rerun` calls, or reruns from


### PR DESCRIPTION
## Describe your changes

Makes `is_fragment_scoped_rerun` origin-dependent for keyed rerun targets (`st.rerun("<key>")`):
- **Main-script interaction → `True` (preempt):** the callback-less widget vote escalates to a full-app rerun, the body runs with submitted values, and targeted fragments re-execute as part of the full pass.
- **Fragment interaction → `False` (compose):** the enclosing fragment finishes, then the target runs — both fragments execute.

Also fixes the trigger-loss defect where `_request_full_app_rerun` built `RerunData` with no `widget_states`, causing `st.form_submit_button()` to return `False` in the body. The fix forwards widget_states with `suppress_callbacks=True` so the body sees triggers without re-dispatching callbacks.

Key implementation details:
- `_is_fragment_scoped` in `execution_control.py` reads `ThreadState.get().fragment_id` to detect origin
- `_run_callback_and_record_rerun` now classifies by `fragment_id_queue` presence (not the preemption flag), so composing targets are correctly identified as targeted
- New `suppress_callbacks` field on `RerunData` carries widget values through the forced full-app rerun without re-firing callbacks
- Coalescing ORs `suppress_callbacks` alongside `is_fragment_scoped_rerun`
- Product spec amended to document origin-dependent behavior

The edited-field asymmetry (`_widget_changed` fires the vote only for fields the user actually edited) is accepted: unchanged fields need no re-rendering, and the trigger-loss fix ensures the submit trigger survives escalation regardless.

## GitHub Issue Link (if applicable)

Stacked on [#16161](https://github.com/streamlit/streamlit/pull/16161) (keyed fragment targets).

## Testing Plan

- Unit Tests (Python):
  - `test_key_scope_from_fragment_callback_composes` — fragment-origin keyed target sets `is_fragment_scoped_rerun=False`
  - `test_compose_fragment_rerun_lets_body_finish_then_serves_target` — compose path: yield returns None, ready returns rerun
  - `test_suppress_callbacks_preserved_during_coalescing` — coalescing preserves `suppress_callbacks`
  - `test_composing_target_with_callback_less_vote_does_not_escalate` — flag-False shape of the vote
  - `test_forced_full_app_rerun_carries_widget_states_with_suppress` — forced rerun carries widget_states + suppress
  - `test_suppress_callbacks_skips_dispatch_but_applies_values` — values applied without callback dispatch

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

Made with [Cursor](https://cursor.com)