### PR TITLE
[refactor] Add typed API exceptions for telemetry

### DIFF
--- a/.cursor/rules/python_lib.mdc
+++ b/.cursor/rules/python_lib.mdc
@@ -137,10 +137,11 @@ generic `StreamlitAPIException` with a one-off message.
 - `StreamlitValueError(parameter, valid_values)`: use when a parameter receives
   an invalid value from a known finite set (Literal / enum-like options). Example:
   `raise StreamlitValueError("type", ["'primary'", "'secondary'", "'tertiary'"])`.
-- `StreamlitInvalidParameterTypeError(parameter, message)`: use when a parameter
-  has an unsupported type. `parameter` is appended in uncaught-exception
-  telemetry (`StreamlitInvalidParameterTypeError:<parameter>`). Pass `message`
-  as literal user-facing text; braces are not treated as format fields.
+- `StreamlitInvalidParameterTypeError(parameter, provided_type, expected_types)`:
+  use when a parameter has an unsupported type. `parameter` is appended in
+  uncaught-exception telemetry (`StreamlitInvalidParameterTypeError:<parameter>`).
+  Pass concise type names as strings; for example,
+  `raise StreamlitInvalidParameterTypeError("step", "str", ["int", "timedelta"])`.
 - Prefer other shared validators/errors when they already exist for the
   parameter, including:
   - `StreamlitInvalidWidthError` / `StreamlitInvalidHeightError` /
@@ -153,8 +154,8 @@ generic `StreamlitAPIException` with a one-off message.
   - `StreamlitValueBelowMinError` / `StreamlitValueAboveMaxError` (numeric /
     date/time bounds)
   - `StreamlitInvalidFormCallbackError` (form callback policy)
-  - `StreamlitInvalidContextError` (command used in a disallowed form/layout
-    context)
+  - `StreamlitInvalidLayoutContextError` (command used in a disallowed layout
+    or form context)
   - `StreamlitDuplicateElementKey` (duplicate user `key`, including `st.form`)
   - `StreamlitWidgetAlreadyInstantiatedError` (session state assigned after the
     widget with that key is instantiated this run)

--- a/.cursor/rules/python_lib.mdc
+++ b/.cursor/rules/python_lib.mdc
@@ -137,6 +137,10 @@ generic `StreamlitAPIException` with a one-off message.
 - `StreamlitValueError(parameter, valid_values)`: use when a parameter receives
   an invalid value from a known finite set (Literal / enum-like options). Example:
   `raise StreamlitValueError("type", ["'primary'", "'secondary'", "'tertiary'"])`.
+- `StreamlitInvalidParameterTypeError(parameter, message)`: use when a parameter
+  has an unsupported type. `parameter` is appended in uncaught-exception
+  telemetry (`StreamlitInvalidParameterTypeError:<parameter>`). Pass `message`
+  as literal user-facing text; braces are not treated as format fields.
 - Prefer other shared validators/errors when they already exist for the
   parameter, including:
   - `StreamlitInvalidWidthError` / `StreamlitInvalidHeightError` /
@@ -149,10 +153,20 @@ generic `StreamlitAPIException` with a one-off message.
   - `StreamlitValueBelowMinError` / `StreamlitValueAboveMaxError` (numeric /
     date/time bounds)
   - `StreamlitInvalidFormCallbackError` (form callback policy)
+  - `StreamlitInvalidContextError` (command used in a disallowed form/layout
+    context)
+  - `StreamlitDuplicateElementKey` (duplicate user `key`, including `st.form`)
+  - `StreamlitWidgetAlreadyInstantiatedError` (session state assigned after the
+    widget with that key is instantiated this run)
+  - `StreamlitDefaultNotInOptionsError` (default/index not in `options`)
+  - `StreamlitPageNotFoundError` (missing page path, `st.Page` file, `switch_page`,
+    `page_link`)
+  - `StreamlitDataframeConversionError` (value cannot be converted to a
+    DataFrame or Arrow table)
 
 Reserve bare `StreamlitAPIException` for cases that are not covered by a shared
-type (missing required args, incompatible option combinations, nesting rules,
-serialization failures, and similar).
+type (missing required args, incompatible option combinations, serialization
+failures, and similar).
 
 ## Theming and Layout
 

--- a/.cursor/rules/python_lib.mdc
+++ b/.cursor/rules/python_lib.mdc
@@ -162,8 +162,6 @@ generic `StreamlitAPIException` with a one-off message.
   - `StreamlitDefaultNotInOptionsError` (default/index not in `options`)
   - `StreamlitPageNotFoundError` (missing page path, `st.Page` file, `switch_page`,
     `page_link`)
-  - `StreamlitDataframeConversionError` (value cannot be converted to a
-    DataFrame or Arrow table)
 
 Reserve bare `StreamlitAPIException` for cases that are not covered by a shared
 type (missing required args, incompatible option combinations, serialization

--- a/.github/instructions/python_lib.instructions.md
+++ b/.github/instructions/python_lib.instructions.md
@@ -135,10 +135,11 @@ generic `StreamlitAPIException` with a one-off message.
 - `StreamlitValueError(parameter, valid_values)`: use when a parameter receives
   an invalid value from a known finite set (Literal / enum-like options). Example:
   `raise StreamlitValueError("type", ["'primary'", "'secondary'", "'tertiary'"])`.
-- `StreamlitInvalidParameterTypeError(parameter, message)`: use when a parameter
-  has an unsupported type. `parameter` is appended in uncaught-exception
-  telemetry (`StreamlitInvalidParameterTypeError:<parameter>`). Pass `message`
-  as literal user-facing text; braces are not treated as format fields.
+- `StreamlitInvalidParameterTypeError(parameter, provided_type, expected_types)`:
+  use when a parameter has an unsupported type. `parameter` is appended in
+  uncaught-exception telemetry (`StreamlitInvalidParameterTypeError:<parameter>`).
+  Pass concise type names as strings; for example,
+  `raise StreamlitInvalidParameterTypeError("step", "str", ["int", "timedelta"])`.
 - Prefer other shared validators/errors when they already exist for the
   parameter, including:
   - `StreamlitInvalidWidthError` / `StreamlitInvalidHeightError` /
@@ -151,8 +152,8 @@ generic `StreamlitAPIException` with a one-off message.
   - `StreamlitValueBelowMinError` / `StreamlitValueAboveMaxError` (numeric /
     date/time bounds)
   - `StreamlitInvalidFormCallbackError` (form callback policy)
-  - `StreamlitInvalidContextError` (command used in a disallowed form/layout
-    context)
+  - `StreamlitInvalidLayoutContextError` (command used in a disallowed layout
+    or form context)
   - `StreamlitDuplicateElementKey` (duplicate user `key`, including `st.form`)
   - `StreamlitWidgetAlreadyInstantiatedError` (session state assigned after the
     widget with that key is instantiated this run)

--- a/.github/instructions/python_lib.instructions.md
+++ b/.github/instructions/python_lib.instructions.md
@@ -135,6 +135,10 @@ generic `StreamlitAPIException` with a one-off message.
 - `StreamlitValueError(parameter, valid_values)`: use when a parameter receives
   an invalid value from a known finite set (Literal / enum-like options). Example:
   `raise StreamlitValueError("type", ["'primary'", "'secondary'", "'tertiary'"])`.
+- `StreamlitInvalidParameterTypeError(parameter, message)`: use when a parameter
+  has an unsupported type. `parameter` is appended in uncaught-exception
+  telemetry (`StreamlitInvalidParameterTypeError:<parameter>`). Pass `message`
+  as literal user-facing text; braces are not treated as format fields.
 - Prefer other shared validators/errors when they already exist for the
   parameter, including:
   - `StreamlitInvalidWidthError` / `StreamlitInvalidHeightError` /
@@ -147,10 +151,20 @@ generic `StreamlitAPIException` with a one-off message.
   - `StreamlitValueBelowMinError` / `StreamlitValueAboveMaxError` (numeric /
     date/time bounds)
   - `StreamlitInvalidFormCallbackError` (form callback policy)
+  - `StreamlitInvalidContextError` (command used in a disallowed form/layout
+    context)
+  - `StreamlitDuplicateElementKey` (duplicate user `key`, including `st.form`)
+  - `StreamlitWidgetAlreadyInstantiatedError` (session state assigned after the
+    widget with that key is instantiated this run)
+  - `StreamlitDefaultNotInOptionsError` (default/index not in `options`)
+  - `StreamlitPageNotFoundError` (missing page path, `st.Page` file, `switch_page`,
+    `page_link`)
+  - `StreamlitDataframeConversionError` (value cannot be converted to a
+    DataFrame or Arrow table)
 
 Reserve bare `StreamlitAPIException` for cases that are not covered by a shared
-type (missing required args, incompatible option combinations, nesting rules,
-serialization failures, and similar).
+type (missing required args, incompatible option combinations, serialization
+failures, and similar).
 
 ## Theming and Layout
 

--- a/.github/instructions/python_lib.instructions.md
+++ b/.github/instructions/python_lib.instructions.md
@@ -160,8 +160,6 @@ generic `StreamlitAPIException` with a one-off message.
   - `StreamlitDefaultNotInOptionsError` (default/index not in `options`)
   - `StreamlitPageNotFoundError` (missing page path, `st.Page` file, `switch_page`,
     `page_link`)
-  - `StreamlitDataframeConversionError` (value cannot be converted to a
-    DataFrame or Arrow table)
 
 Reserve bare `StreamlitAPIException` for cases that are not covered by a shared
 type (missing required args, incompatible option combinations, serialization

--- a/lib/streamlit/AGENTS.md
+++ b/lib/streamlit/AGENTS.md
@@ -129,10 +129,11 @@ generic `StreamlitAPIException` with a one-off message.
 - `StreamlitValueError(parameter, valid_values)`: use when a parameter receives
   an invalid value from a known finite set (Literal / enum-like options). Example:
   `raise StreamlitValueError("type", ["'primary'", "'secondary'", "'tertiary'"])`.
-- `StreamlitInvalidParameterTypeError(parameter, message)`: use when a parameter
-  has an unsupported type. `parameter` is appended in uncaught-exception
-  telemetry (`StreamlitInvalidParameterTypeError:<parameter>`). Pass `message`
-  as literal user-facing text; braces are not treated as format fields.
+- `StreamlitInvalidParameterTypeError(parameter, provided_type, expected_types)`:
+  use when a parameter has an unsupported type. `parameter` is appended in
+  uncaught-exception telemetry (`StreamlitInvalidParameterTypeError:<parameter>`).
+  Pass concise type names as strings; for example,
+  `raise StreamlitInvalidParameterTypeError("step", "str", ["int", "timedelta"])`.
 - Prefer other shared validators/errors when they already exist for the
   parameter, including:
   - `StreamlitInvalidWidthError` / `StreamlitInvalidHeightError` /
@@ -145,8 +146,8 @@ generic `StreamlitAPIException` with a one-off message.
   - `StreamlitValueBelowMinError` / `StreamlitValueAboveMaxError` (numeric /
     date/time bounds)
   - `StreamlitInvalidFormCallbackError` (form callback policy)
-  - `StreamlitInvalidContextError` (command used in a disallowed form/layout
-    context)
+  - `StreamlitInvalidLayoutContextError` (command used in a disallowed layout
+    or form context)
   - `StreamlitDuplicateElementKey` (duplicate user `key`, including `st.form`)
   - `StreamlitWidgetAlreadyInstantiatedError` (session state assigned after the
     widget with that key is instantiated this run)

--- a/lib/streamlit/AGENTS.md
+++ b/lib/streamlit/AGENTS.md
@@ -154,8 +154,6 @@ generic `StreamlitAPIException` with a one-off message.
   - `StreamlitDefaultNotInOptionsError` (default/index not in `options`)
   - `StreamlitPageNotFoundError` (missing page path, `st.Page` file, `switch_page`,
     `page_link`)
-  - `StreamlitDataframeConversionError` (value cannot be converted to a
-    DataFrame or Arrow table)
 
 Reserve bare `StreamlitAPIException` for cases that are not covered by a shared
 type (missing required args, incompatible option combinations, serialization

--- a/lib/streamlit/AGENTS.md
+++ b/lib/streamlit/AGENTS.md
@@ -129,6 +129,10 @@ generic `StreamlitAPIException` with a one-off message.
 - `StreamlitValueError(parameter, valid_values)`: use when a parameter receives
   an invalid value from a known finite set (Literal / enum-like options). Example:
   `raise StreamlitValueError("type", ["'primary'", "'secondary'", "'tertiary'"])`.
+- `StreamlitInvalidParameterTypeError(parameter, message)`: use when a parameter
+  has an unsupported type. `parameter` is appended in uncaught-exception
+  telemetry (`StreamlitInvalidParameterTypeError:<parameter>`). Pass `message`
+  as literal user-facing text; braces are not treated as format fields.
 - Prefer other shared validators/errors when they already exist for the
   parameter, including:
   - `StreamlitInvalidWidthError` / `StreamlitInvalidHeightError` /
@@ -141,10 +145,20 @@ generic `StreamlitAPIException` with a one-off message.
   - `StreamlitValueBelowMinError` / `StreamlitValueAboveMaxError` (numeric /
     date/time bounds)
   - `StreamlitInvalidFormCallbackError` (form callback policy)
+  - `StreamlitInvalidContextError` (command used in a disallowed form/layout
+    context)
+  - `StreamlitDuplicateElementKey` (duplicate user `key`, including `st.form`)
+  - `StreamlitWidgetAlreadyInstantiatedError` (session state assigned after the
+    widget with that key is instantiated this run)
+  - `StreamlitDefaultNotInOptionsError` (default/index not in `options`)
+  - `StreamlitPageNotFoundError` (missing page path, `st.Page` file, `switch_page`,
+    `page_link`)
+  - `StreamlitDataframeConversionError` (value cannot be converted to a
+    DataFrame or Arrow table)
 
 Reserve bare `StreamlitAPIException` for cases that are not covered by a shared
-type (missing required args, incompatible option combinations, nesting rules,
-serialization failures, and similar).
+type (missing required args, incompatible option combinations, serialization
+failures, and similar).
 
 ## Theming and Layout
 

--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -25,12 +25,14 @@ import streamlit as st
 from streamlit.errors import (
     NoSessionContext,
     StreamlitAPIException,
+    StreamlitPageNotFoundError,
     StreamlitValueError,
 )
 from streamlit.file_util import get_main_script_directory, normalize_path_join
 from streamlit.navigation.page import Page, _validate_registered_page
 from streamlit.runtime.fragment import _check_not_parallel_worker
 from streamlit.runtime.metrics_util import gather_metrics
+from streamlit.runtime.pages_manager import PagesManager
 from streamlit.runtime.runtime_util import MESSAGE_FLUSH_INTERVAL_SECS
 from streamlit.runtime.scriptrunner import (
     RerunData,
@@ -320,10 +322,10 @@ def switch_page(  # type: ignore[misc]
         matched_pages = [p for p in all_app_pages if p["script_path"] == requested_page]
 
         if len(matched_pages) == 0:
-            raise StreamlitAPIException(
-                f"Could not find page: `{page}`. Must be the file path relative to the main script, "
-                f"from the directory: `{os.path.basename(main_script_directory)}`. Only the main app file "
-                "and files in the `pages/` directory are supported."
+            raise StreamlitPageNotFoundError(
+                page=page,
+                main_script_directory=main_script_directory,
+                uses_pages_directory=bool(PagesManager.uses_pages_directory),
             )
 
         page_script_hash = matched_pages[0]["page_script_hash"]

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -800,12 +800,12 @@ def convert_anything_to_pandas_df(
     # compatible with the pandas.DataFrame constructor.
     try:
         return _fix_column_naming(pd.DataFrame(data))
-    except ValueError as ex:
+    except (ValueError, TypeError) as ex:
         if isinstance(data, dict):
-            with contextlib.suppress(ValueError):
+            with contextlib.suppress(ValueError, TypeError):
                 # Try to use index orient as back-up to support key-value dicts
                 return _dict_to_pandas_df(data)
-        raise errors.StreamlitAPIException(
+        raise errors.StreamlitDataframeConversionError(
             f"""
 Unable to convert object of type `{type(data)}` to `pandas.DataFrame`.
 Offending object:
@@ -938,9 +938,14 @@ def convert_pandas_df_to_arrow_table(
     """
     import pyarrow as pa
 
+    arrow_conversion_errors = (
+        pa.ArrowTypeError,
+        pa.ArrowInvalid,
+        pa.ArrowNotImplementedError,
+    )
     try:
         return pa.Table.from_pandas(df, preserve_index=preserve_index)
-    except (pa.ArrowTypeError, pa.ArrowInvalid, pa.ArrowNotImplementedError) as ex:
+    except arrow_conversion_errors as ex:
         _LOGGER.info(
             "Serialization of dataframe to Arrow table was unsuccessful. "
             "Applying automatic fixes for column types to make the dataframe "
@@ -948,7 +953,12 @@ def convert_pandas_df_to_arrow_table(
             exc_info=ex,
         )
         fixed_df = fix_arrow_incompatible_column_types(df)
-        return pa.Table.from_pandas(fixed_df, preserve_index=preserve_index)
+        try:
+            return pa.Table.from_pandas(fixed_df, preserve_index=preserve_index)
+        except arrow_conversion_errors as retry_ex:
+            raise errors.StreamlitDataframeConversionError(
+                f"Unable to convert dataframe to Arrow table.\n{retry_ex}"
+            ) from retry_ex
 
 
 def convert_pandas_df_to_arrow_bytes(

--- a/lib/streamlit/elements/form.py
+++ b/lib/streamlit/elements/form.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 from __future__ import annotations
 
-import textwrap
 from typing import TYPE_CHECKING, Literal, cast
 
 from streamlit.elements.lib.form_utils import FormData, current_form_id, is_in_form
@@ -34,7 +33,11 @@ from streamlit.elements.widgets.button import (
     IconPosition,
     _normalize_icon_position,
 )
-from streamlit.errors import StreamlitAPIException, StreamlitValueError
+from streamlit.errors import (
+    StreamlitDuplicateElementKey,
+    StreamlitInvalidContextError,
+    StreamlitValueError,
+)
 from streamlit.proto import Block_pb2
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
@@ -42,33 +45,6 @@ from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
     from streamlit.runtime.state import WidgetArgs, WidgetCallback, WidgetKwargs
-
-
-def _build_duplicate_form_message(user_key: str | None = None) -> str:
-    if user_key is not None:
-        message = textwrap.dedent(
-            f"""
-            There are multiple identical forms with `key='{user_key}'`.
-
-            To fix this, please make sure that the `key` argument is unique for
-            each `st.form` you create.
-            """
-        )
-    else:
-        message = textwrap.dedent(
-            """
-            There are multiple identical forms with the same generated key.
-
-            When a form is created, it's assigned an internal key based on
-            its structure. Multiple forms with an identical structure will
-            result in the same internal key, which causes this error.
-
-            To fix this error, please pass a unique `key` argument to
-            `st.form`.
-            """
-        )
-
-    return message.strip("\n")
 
 
 class FormMixin:
@@ -214,7 +190,7 @@ class FormMixin:
 
         """
         if is_in_form(self.dg):
-            raise StreamlitAPIException("Forms cannot be nested in other forms.")
+            raise StreamlitInvalidContextError("Forms cannot be nested in other forms.")
 
         check_cache_replay_rules()
         check_session_state_rules(default_value=None, key=key, writes_allowed=False)
@@ -224,7 +200,7 @@ class FormMixin:
 
         ctx = get_script_run_ctx()
         if ctx is not None and not ctx.shared.form_ids_this_run.check_and_add(form_id):
-            raise StreamlitAPIException(_build_duplicate_form_message(key))
+            raise StreamlitDuplicateElementKey(key)
 
         block_proto = Block_pb2.Block()
         block_proto.form.form_id = form_id

--- a/lib/streamlit/elements/form.py
+++ b/lib/streamlit/elements/form.py
@@ -35,7 +35,7 @@ from streamlit.elements.widgets.button import (
 )
 from streamlit.errors import (
     StreamlitDuplicateElementKey,
-    StreamlitInvalidContextError,
+    StreamlitInvalidLayoutContextError,
     StreamlitValueError,
 )
 from streamlit.proto import Block_pb2
@@ -190,7 +190,9 @@ class FormMixin:
 
         """
         if is_in_form(self.dg):
-            raise StreamlitInvalidContextError("Forms cannot be nested in other forms.")
+            raise StreamlitInvalidLayoutContextError(
+                "Forms cannot be nested in other forms."
+            )
 
         check_cache_replay_rules()
         check_session_state_rules(default_value=None, key=key, writes_allowed=False)

--- a/lib/streamlit/elements/heading.py
+++ b/lib/streamlit/elements/heading.py
@@ -21,7 +21,7 @@ from streamlit.elements.lib.layout_utils import create_layout_config
 from streamlit.errors import StreamlitAPIException, StreamlitValueError
 from streamlit.proto.Heading_pb2 import Heading as HeadingProto
 from streamlit.runtime.metrics_util import gather_metrics
-from streamlit.string_util import clean_text
+from streamlit.string_util import clean_text, to_str
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
@@ -412,6 +412,6 @@ class HeadingMixin:
                 )
 
         if help:
-            proto.help = help
+            proto.help = to_str(help)
 
         return proto

--- a/lib/streamlit/elements/heading.py
+++ b/lib/streamlit/elements/heading.py
@@ -21,7 +21,7 @@ from streamlit.elements.lib.layout_utils import create_layout_config
 from streamlit.errors import StreamlitAPIException, StreamlitValueError
 from streamlit.proto.Heading_pb2 import Heading as HeadingProto
 from streamlit.runtime.metrics_util import gather_metrics
-from streamlit.string_util import clean_text, to_str
+from streamlit.string_util import clean_text, to_help_str
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
@@ -412,6 +412,6 @@ class HeadingMixin:
                 )
 
         if help:
-            proto.help = to_str(help)
+            proto.help = to_help_str(help)
 
         return proto

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -671,9 +671,8 @@ class LayoutsMixin:
         except TypeError as ex:
             raise StreamlitInvalidParameterTypeError(
                 "spec",
-                "The `spec` argument to `st.columns` must be either a "
-                "positive integer (number of columns) or a list of positive numbers "
-                "(width ratios of the columns).",
+                type(spec).__name__,
+                ["int", "sequence of numbers"],
             ) from ex
 
         if invalid_spec:

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass
+from numbers import Integral
 from typing import TYPE_CHECKING, Literal, TypeAlias, cast
 
 from streamlit.delta_generator_singletons import get_dg_singleton_instance
@@ -43,6 +44,7 @@ from streamlit.elements.lib.utils import Key, compute_and_register_element_id, t
 from streamlit.errors import (
     StreamlitAPIException,
     StreamlitInvalidColumnSpecError,
+    StreamlitInvalidParameterTypeError,
     StreamlitInvalidVerticalAlignmentError,
     StreamlitValueError,
 )
@@ -651,14 +653,30 @@ class LayoutsMixin:
             height: 250px
 
         """
-        weights = spec
-        if isinstance(weights, int):
+        # Check `int` before `Integral` so ty can narrow `SpecType` (`int` is not
+        # treated as `numbers.Integral`). numpy integers (e.g. np.int64) are
+        # Integral but not int.
+        if isinstance(spec, int):
             # If the user provided a single number, expand into equal weights.
             # E.g. (1,) * 3 => (1, 1, 1)
             # NOTE: A negative/zero spec will expand into an empty tuple.
-            weights = (1,) * weights
+            weights: Sequence[int | float] = (1,) * spec
+        elif isinstance(spec, Integral):
+            weights = (1,) * int(spec)
+        else:
+            weights = spec
 
-        if len(weights) == 0 or any(weight <= 0 for weight in weights):
+        try:
+            invalid_spec = len(weights) == 0 or any(weight <= 0 for weight in weights)
+        except TypeError as ex:
+            raise StreamlitInvalidParameterTypeError(
+                "spec",
+                "The `spec` argument to `st.columns` must be either a "
+                "positive integer (number of columns) or a list of positive numbers "
+                "(width ratios of the columns).",
+            ) from ex
+
+        if invalid_spec:
             raise StreamlitInvalidColumnSpecError()
 
         if not isinstance(wrap, bool):

--- a/lib/streamlit/elements/lib/options_selector_utils.py
+++ b/lib/streamlit/elements/lib/options_selector_utils.py
@@ -20,7 +20,11 @@ from typing import TYPE_CHECKING, Any, Final, Literal, TypeVar, cast, overload
 
 from streamlit import config, logger
 from streamlit.dataframe_util import OptionSequence, convert_anything_to_list
-from streamlit.errors import StreamlitAPIException, StreamlitValueError
+from streamlit.errors import (
+    StreamlitAPIException,
+    StreamlitDefaultNotInOptionsError,
+    StreamlitValueError,
+)
 from streamlit.proto.SelectWidgetFilterMode_pb2 import (
     SelectWidgetFilterMode as ProtoSelectWidgetFilterMode,
 )
@@ -119,10 +123,7 @@ def check_and_convert_to_indices(
 
     for value in default_values:
         if value not in opt:
-            raise StreamlitAPIException(
-                f"The default value '{value}' is not part of the options. "
-                "Please make sure that every default values also exists in the options."
-            )
+            raise StreamlitDefaultNotInOptionsError(value)
 
     return [opt.index(value) for value in default_values]
 

--- a/lib/streamlit/elements/lib/policies.py
+++ b/lib/streamlit/elements/lib/policies.py
@@ -28,6 +28,7 @@ from streamlit.runtime.scriptrunner_utils.script_run_context import (
 )
 from streamlit.runtime.state import WidgetCallback, get_session_state
 from streamlit.runtime.state.common import require_valid_user_key
+from streamlit.string_util import to_str
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -145,8 +146,16 @@ def check_widget_policies(
     )
 
 
-def maybe_raise_label_warnings(label: str | None, label_visibility: str | None) -> None:
-    if not label:
+def maybe_raise_label_warnings(
+    label: object | None, label_visibility: str | None
+) -> str:
+    """Coerce ``label`` to ``str``, warn if empty, and validate ``label_visibility``.
+
+    Returns the coerced label so callers can assign it to protobuf string
+    fields without raising a protobuf ``TypeError``.
+    """
+    coerced = "" if label is None else to_str(label)
+    if not coerced:
         _LOGGER.warning(
             "`label` got an empty value. This is discouraged for accessibility "
             "reasons and may be disallowed in the future by raising an exception. "
@@ -158,3 +167,4 @@ def maybe_raise_label_warnings(label: str | None, label_visibility: str | None) 
         raise errors.StreamlitValueError(
             "label_visibility", ["'visible'", "'hidden'", "'collapsed'"]
         )
+    return coerced

--- a/lib/streamlit/elements/lib/policies.py
+++ b/lib/streamlit/elements/lib/policies.py
@@ -146,6 +146,14 @@ def check_widget_policies(
     )
 
 
+def validate_label_visibility(label_visibility: str | None) -> None:
+    """Raise if ``label_visibility`` is not a supported value."""
+    if label_visibility not in {"visible", "hidden", "collapsed"}:
+        raise errors.StreamlitValueError(
+            "label_visibility", ["'visible'", "'hidden'", "'collapsed'"]
+        )
+
+
 def maybe_raise_label_warnings(
     label: object | None, label_visibility: str | None
 ) -> str:
@@ -163,8 +171,5 @@ def maybe_raise_label_warnings(
             "if needed.",
             stack_info=True,
         )
-    if label_visibility not in {"visible", "hidden", "collapsed"}:
-        raise errors.StreamlitValueError(
-            "label_visibility", ["'visible'", "'hidden'", "'collapsed'"]
-        )
+    validate_label_visibility(label_visibility)
     return coerced

--- a/lib/streamlit/elements/markdown.py
+++ b/lib/streamlit/elements/markdown.py
@@ -24,7 +24,7 @@ from streamlit.elements.lib.layout_utils import (
 )
 from streamlit.proto.Markdown_pb2 import Markdown as MarkdownProto
 from streamlit.runtime.metrics_util import gather_metrics
-from streamlit.string_util import clean_text, to_str, validate_icon_or_emoji
+from streamlit.string_util import clean_text, to_help_str, validate_icon_or_emoji
 from streamlit.type_util import SupportsStr, is_sympy_expression
 
 if TYPE_CHECKING:
@@ -56,7 +56,7 @@ class MarkdownMixin:
         markdown_proto.unterminated_parsing = unterminated_parsing
         markdown_proto.hide_anchors = not anchors
         if help:
-            markdown_proto.help = to_str(help)
+            markdown_proto.help = to_help_str(help)
 
         if width != "auto":
             layout_config = create_layout_config(
@@ -338,7 +338,7 @@ class MarkdownMixin:
         caption_proto.allow_html = unsafe_allow_html
         caption_proto.element_type = MarkdownProto.Type.CAPTION
         if help:
-            caption_proto.help = to_str(help)
+            caption_proto.help = to_help_str(help)
 
         layout_config = create_layout_config(
             width=width, text_alignment=text_alignment, allow_content_width=True
@@ -409,7 +409,7 @@ class MarkdownMixin:
         latex_proto.body = f"$$\n{clean_text(body)}\n$$"
         latex_proto.element_type = MarkdownProto.Type.LATEX
         if help:
-            latex_proto.help = to_str(help)
+            latex_proto.help = to_help_str(help)
 
         layout_config = create_layout_config(width=width, allow_content_width=True)
 
@@ -575,7 +575,7 @@ class MarkdownMixin:
         badge_proto.element_type = MarkdownProto.Type.NATIVE
 
         if help is not None:
-            badge_proto.help = to_str(help)
+            badge_proto.help = to_help_str(help)
 
         layout_config = create_layout_config(width=width, allow_content_width=True)
 

--- a/lib/streamlit/elements/markdown.py
+++ b/lib/streamlit/elements/markdown.py
@@ -24,7 +24,7 @@ from streamlit.elements.lib.layout_utils import (
 )
 from streamlit.proto.Markdown_pb2 import Markdown as MarkdownProto
 from streamlit.runtime.metrics_util import gather_metrics
-from streamlit.string_util import clean_text, validate_icon_or_emoji
+from streamlit.string_util import clean_text, to_str, validate_icon_or_emoji
 from streamlit.type_util import SupportsStr, is_sympy_expression
 
 if TYPE_CHECKING:
@@ -56,7 +56,7 @@ class MarkdownMixin:
         markdown_proto.unterminated_parsing = unterminated_parsing
         markdown_proto.hide_anchors = not anchors
         if help:
-            markdown_proto.help = help
+            markdown_proto.help = to_str(help)
 
         if width != "auto":
             layout_config = create_layout_config(
@@ -338,7 +338,7 @@ class MarkdownMixin:
         caption_proto.allow_html = unsafe_allow_html
         caption_proto.element_type = MarkdownProto.Type.CAPTION
         if help:
-            caption_proto.help = help
+            caption_proto.help = to_str(help)
 
         layout_config = create_layout_config(
             width=width, text_alignment=text_alignment, allow_content_width=True
@@ -409,7 +409,7 @@ class MarkdownMixin:
         latex_proto.body = f"$$\n{clean_text(body)}\n$$"
         latex_proto.element_type = MarkdownProto.Type.LATEX
         if help:
-            latex_proto.help = help
+            latex_proto.help = to_str(help)
 
         layout_config = create_layout_config(width=width, allow_content_width=True)
 
@@ -575,7 +575,7 @@ class MarkdownMixin:
         badge_proto.element_type = MarkdownProto.Type.NATIVE
 
         if help is not None:
-            badge_proto.help = help
+            badge_proto.help = to_str(help)
 
         layout_config = create_layout_config(width=width, allow_content_width=True)
 

--- a/lib/streamlit/elements/metric.py
+++ b/lib/streamlit/elements/metric.py
@@ -32,6 +32,7 @@ from streamlit.string_util import (
     AnyNumber,
     clean_text,
     from_number,
+    to_help_str,
     validate_icon_or_emoji,
 )
 
@@ -406,15 +407,15 @@ class MetricMixin:
                     height: 210px
 
         """
-        maybe_raise_label_warnings(label, label_visibility)
+        label = maybe_raise_label_warnings(label, label_visibility)
 
         metric_proto = MetricProto()
         metric_proto.body = _parse_value(value)
-        metric_proto.label = _parse_label(label)
+        metric_proto.label = label
         metric_proto.delta = _parse_delta(delta)
         metric_proto.show_border = border
         if help is not None:
-            metric_proto.help = dedent(help)
+            metric_proto.help = to_help_str(help)
         metric_proto.icon = validate_icon_or_emoji(icon)
 
         color_and_direction = _determine_delta_color_and_direction(
@@ -483,15 +484,6 @@ def _parse_delta_arrow(delta_arrow: DeltaArrow) -> DeltaArrow:
     if delta_arrow not in {"auto", "up", "down", "off"}:
         raise StreamlitValueError("delta_arrow", ["'auto'", "'up'", "'down'", "'off'"])
     return delta_arrow
-
-
-def _parse_label(label: str) -> str:
-    if not isinstance(label, str):
-        raise TypeError(
-            f"'{label}' is of type {type(label)}, which is not an accepted type."
-            " label only accepts: str. Please convert the label to an accepted type."
-        )
-    return label
 
 
 def _parse_value(value: Value) -> str:

--- a/lib/streamlit/elements/text.py
+++ b/lib/streamlit/elements/text.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING, cast
 from streamlit.elements.lib.layout_utils import create_layout_config
 from streamlit.proto.Text_pb2 import Text as TextProto
 from streamlit.runtime.metrics_util import gather_metrics
-from streamlit.string_util import clean_text, to_str
+from streamlit.string_util import clean_text, to_help_str
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
@@ -100,7 +100,7 @@ class TextMixin:
         text_proto = TextProto()
         text_proto.body = clean_text(body)
         if help:
-            text_proto.help = to_str(help)
+            text_proto.help = to_help_str(help)
 
         layout_config = create_layout_config(
             width=width,

--- a/lib/streamlit/elements/text.py
+++ b/lib/streamlit/elements/text.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING, cast
 from streamlit.elements.lib.layout_utils import create_layout_config
 from streamlit.proto.Text_pb2 import Text as TextProto
 from streamlit.runtime.metrics_util import gather_metrics
-from streamlit.string_util import clean_text
+from streamlit.string_util import clean_text, to_str
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
@@ -100,7 +100,7 @@ class TextMixin:
         text_proto = TextProto()
         text_proto.body = clean_text(body)
         if help:
-            text_proto.help = help
+            text_proto.help = to_str(help)
 
         layout_config = create_layout_config(
             width=width,

--- a/lib/streamlit/elements/widgets/audio_input.py
+++ b/lib/streamlit/elements/widgets/audio_input.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from textwrap import dedent
 from typing import TYPE_CHECKING, TypeAlias, cast
 
 from streamlit.elements.lib.file_uploader_utils import enforce_filename_restriction
@@ -46,6 +45,7 @@ from streamlit.runtime.state import (
     register_widget,
 )
 from streamlit.runtime.uploaded_file_manager import DeletedFile, UploadedFile
+from streamlit.string_util import to_help_str
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
@@ -288,7 +288,7 @@ class AudioInputMixin:
             default_value=None,
             writes_allowed=False,
         )
-        maybe_raise_label_warnings(label, label_visibility)
+        label = maybe_raise_label_warnings(label, label_visibility)
 
         element_id = compute_and_register_element_id(
             "audio_input",
@@ -316,7 +316,7 @@ class AudioInputMixin:
             audio_input_proto.sample_rate = sample_rate
 
         if label and help is not None:
-            audio_input_proto.help = dedent(help)
+            audio_input_proto.help = to_help_str(help)
 
         layout_config = create_layout_config(width=width)
 

--- a/lib/streamlit/elements/widgets/button.py
+++ b/lib/streamlit/elements/widgets/button.py
@@ -20,7 +20,6 @@ import os
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from textwrap import dedent
 from typing import (
     TYPE_CHECKING,
     BinaryIO,
@@ -45,6 +44,7 @@ from streamlit.elements.lib.utils import (
 )
 from streamlit.errors import (
     StreamlitAPIException,
+    StreamlitInvalidContextError,
     StreamlitMissingPageLabelError,
     StreamlitPageNotFoundError,
     StreamlitValueError,
@@ -69,7 +69,7 @@ from streamlit.runtime.state import (
     register_widget,
 )
 from streamlit.runtime.state.query_params import process_query_params
-from streamlit.string_util import validate_icon_or_emoji
+from streamlit.string_util import to_help_str, to_str, validate_icon_or_emoji
 from streamlit.url_util import is_url
 from streamlit.util import in_sidebar
 
@@ -1384,6 +1384,7 @@ class ButtonMixin:
         wrap: bool | None = None,
     ) -> bool:
         key = to_key(key)
+        label = "" if label is None else to_str(label)
 
         on_click_callback: WidgetCallback | None = (
             None
@@ -1420,7 +1421,7 @@ class ButtonMixin:
         )
 
         if is_in_form(self.dg):
-            raise StreamlitAPIException(
+            raise StreamlitInvalidContextError(
                 f"`st.download_button()` can't be used in an `st.form()`.{FORM_DOCS_INFO}"
             )
 
@@ -1437,7 +1438,7 @@ class ButtonMixin:
         download_button_proto.disabled = disabled
 
         if help is not None:
-            download_button_proto.help = dedent(help)
+            download_button_proto.help = to_help_str(help)
 
         if icon is not None:
             download_button_proto.icon = validate_icon_or_emoji(icon)
@@ -1536,7 +1537,7 @@ class ButtonMixin:
                 shortcut=normalized_shortcut,
             )
 
-        link_button_proto.label = label
+        link_button_proto.label = "" if label is None else to_str(label)
         link_button_proto.url = url
         link_button_proto.type = type
         link_button_proto.disabled = disabled
@@ -1545,7 +1546,7 @@ class ButtonMixin:
             link_button_proto.wrap = wrap
 
         if help is not None:
-            link_button_proto.help = dedent(help)
+            link_button_proto.help = to_help_str(help)
 
         if icon is not None:
             link_button_proto.icon = validate_icon_or_emoji(icon)
@@ -1608,13 +1609,13 @@ class ButtonMixin:
         page_link_proto.disabled = disabled
 
         if label is not None:
-            page_link_proto.label = label
+            page_link_proto.label = to_str(label)
 
         if icon is not None:
             page_link_proto.icon = validate_icon_or_emoji(icon)
 
         if help is not None:
-            page_link_proto.help = dedent(help)
+            page_link_proto.help = to_help_str(help)
 
         if isinstance(page, Page):
             if label is None:
@@ -1663,12 +1664,16 @@ class ButtonMixin:
             for page_data in all_app_pages.values():
                 full_path = page_data["script_path"]
                 page_name = page_data["page_name"]
-                url_pathname = page_data["url_pathname"]
+                # Default pages payload omits url_pathname until st.navigation
+                # registers pages.
+                url_pathname = page_data.get("url_pathname")
                 if requested_page == full_path:
                     if label is None:
                         page_link_proto.label = page_name
                     page_link_proto.page_script_hash = page_data["page_script_hash"]
-                    page_link_proto.page = url_pathname
+                    # Click navigation uses page_script_hash. Do not fall back
+                    # to page_name (a display title) as the href.
+                    page_link_proto.page = url_pathname or ""
                     break
 
             if page_link_proto.page_script_hash == "":
@@ -1702,6 +1707,7 @@ class ButtonMixin:
         wrap: bool | None = None,
     ) -> bool:
         key = to_key(key)
+        label = "" if label is None else to_str(label)
 
         normalized_shortcut: str | None = None
         if shortcut is not None:
@@ -1740,13 +1746,13 @@ class ButtonMixin:
         # they will have no script_run_ctx.
         if runtime.exists():
             if is_in_form(self.dg) and not is_form_submitter:
-                raise StreamlitAPIException(
+                raise StreamlitInvalidContextError(
                     "`st.button()` can't be used in an `st.form()`. Use "
                     "`st.form_submit_button()` instead to submit the form."
                     f"{FORM_DOCS_INFO}"
                 )
             if not is_in_form(self.dg) and is_form_submitter:
-                raise StreamlitAPIException(
+                raise StreamlitInvalidContextError(
                     f"`st.form_submit_button()` must be used inside an `st.form()`.{FORM_DOCS_INFO}"
                 )
 
@@ -1762,7 +1768,7 @@ class ButtonMixin:
             button_proto.wrap = wrap
 
         if help is not None:
-            button_proto.help = dedent(help)
+            button_proto.help = to_help_str(help)
 
         if icon is not None:
             button_proto.icon = validate_icon_or_emoji(icon)

--- a/lib/streamlit/elements/widgets/button.py
+++ b/lib/streamlit/elements/widgets/button.py
@@ -44,7 +44,7 @@ from streamlit.elements.lib.utils import (
 )
 from streamlit.errors import (
     StreamlitAPIException,
-    StreamlitInvalidContextError,
+    StreamlitInvalidLayoutContextError,
     StreamlitMissingPageLabelError,
     StreamlitPageNotFoundError,
     StreamlitValueError,
@@ -1421,7 +1421,7 @@ class ButtonMixin:
         )
 
         if is_in_form(self.dg):
-            raise StreamlitInvalidContextError(
+            raise StreamlitInvalidLayoutContextError(
                 f"`st.download_button()` can't be used in an `st.form()`.{FORM_DOCS_INFO}"
             )
 
@@ -1747,13 +1747,13 @@ class ButtonMixin:
         # they will have no script_run_ctx.
         if runtime.exists():
             if is_in_form(self.dg) and not is_form_submitter:
-                raise StreamlitInvalidContextError(
+                raise StreamlitInvalidLayoutContextError(
                     "`st.button()` can't be used in an `st.form()`. Use "
                     "`st.form_submit_button()` instead to submit the form."
                     f"{FORM_DOCS_INFO}"
                 )
             if not is_in_form(self.dg) and is_form_submitter:
-                raise StreamlitInvalidContextError(
+                raise StreamlitInvalidLayoutContextError(
                     f"`st.form_submit_button()` must be used inside an `st.form()`.{FORM_DOCS_INFO}"
                 )
 

--- a/lib/streamlit/elements/widgets/button.py
+++ b/lib/streamlit/elements/widgets/button.py
@@ -1495,6 +1495,7 @@ class ButtonMixin:
         ctx: ScriptRunContext | None = None,
     ) -> bool | DeltaGenerator:
         key = to_key(key)
+        label = "" if label is None else to_str(label)
         ignore_rerun = on_click == "ignore"
         is_rerun_mode = not ignore_rerun
         on_click_callback: WidgetCallback | None = (
@@ -1537,7 +1538,7 @@ class ButtonMixin:
                 shortcut=normalized_shortcut,
             )
 
-        link_button_proto.label = "" if label is None else to_str(label)
+        link_button_proto.label = label
         link_button_proto.url = url
         link_button_proto.type = type
         link_button_proto.disabled = disabled

--- a/lib/streamlit/elements/widgets/button_group.py
+++ b/lib/streamlit/elements/widgets/button_group.py
@@ -43,6 +43,7 @@ from streamlit.elements.lib.options_selector_utils import (
 from streamlit.elements.lib.policies import (
     check_widget_policies,
     maybe_raise_label_warnings,
+    validate_label_visibility,
 )
 from streamlit.elements.lib.utils import (
     Key,
@@ -1088,10 +1089,8 @@ class ButtonGroupMixin:
         # would write an empty visible label and change the element id.
         if label is not None:
             label = maybe_raise_label_warnings(label, label_visibility)
-        elif label_visibility not in {"visible", "hidden", "collapsed"}:
-            raise StreamlitValueError(
-                "label_visibility", ["'visible'", "'hidden'", "'collapsed'"]
-            )
+        else:
+            validate_label_visibility(label_visibility)
 
         # Validate required with multi-select
         if required and selection_mode == "multi":

--- a/lib/streamlit/elements/widgets/button_group.py
+++ b/lib/streamlit/elements/widgets/button_group.py
@@ -62,7 +62,7 @@ from streamlit.runtime.state import (
     get_session_state,
     register_widget,
 )
-from streamlit.string_util import extract_leading_icon
+from streamlit.string_util import extract_leading_icon, to_str
 
 if TYPE_CHECKING:
     from streamlit.dataframe_util import OptionSequence
@@ -304,7 +304,7 @@ def _build_proto(
             label_visibility
         )
         if help is not None:
-            proto.help = help
+            proto.help = to_str(help)
 
     # wrap is layout-only and intentionally excluded from the element id
     # (it is not passed to compute_and_register_element_id), so toggling it
@@ -1083,7 +1083,7 @@ class ButtonGroupMixin:
         bind: BindOption = None,
         persist_state: PersistStateOption = None,
     ) -> list[V] | V | None:
-        maybe_raise_label_warnings(label, label_visibility)
+        label = maybe_raise_label_warnings(label, label_visibility)
 
         # Validate required with multi-select
         if required and selection_mode == "multi":

--- a/lib/streamlit/elements/widgets/button_group.py
+++ b/lib/streamlit/elements/widgets/button_group.py
@@ -1083,7 +1083,15 @@ class ButtonGroupMixin:
         bind: BindOption = None,
         persist_state: PersistStateOption = None,
     ) -> list[V] | V | None:
-        label = maybe_raise_label_warnings(label, label_visibility)
+        # Keep omitted labels as None so _build_proto can leave proto.label
+        # unset; the frontend treats that as collapsed. Coercing None to ""
+        # would write an empty visible label and change the element id.
+        if label is not None:
+            label = maybe_raise_label_warnings(label, label_visibility)
+        elif label_visibility not in {"visible", "hidden", "collapsed"}:
+            raise StreamlitValueError(
+                "label_visibility", ["'visible'", "'hidden'", "'collapsed'"]
+            )
 
         # Validate required with multi-select
         if required and selection_mode == "multi":

--- a/lib/streamlit/elements/widgets/button_group.py
+++ b/lib/streamlit/elements/widgets/button_group.py
@@ -63,7 +63,7 @@ from streamlit.runtime.state import (
     get_session_state,
     register_widget,
 )
-from streamlit.string_util import extract_leading_icon, to_str
+from streamlit.string_util import extract_leading_icon, to_help_str
 
 if TYPE_CHECKING:
     from streamlit.dataframe_util import OptionSequence
@@ -305,7 +305,7 @@ def _build_proto(
             label_visibility
         )
         if help is not None:
-            proto.help = to_str(help)
+            proto.help = to_help_str(help)
 
     # wrap is layout-only and intentionally excluded from the element id
     # (it is not passed to compute_and_register_element_id), so toggling it

--- a/lib/streamlit/elements/widgets/camera_input.py
+++ b/lib/streamlit/elements/widgets/camera_input.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from textwrap import dedent
 from typing import TYPE_CHECKING, Final, Literal, TypeAlias, cast
 
 from streamlit.elements.lib.file_uploader_utils import enforce_filename_restriction
@@ -46,6 +45,7 @@ from streamlit.runtime.state import (
     register_widget,
 )
 from streamlit.runtime.uploaded_file_manager import DeletedFile, UploadedFile
+from streamlit.string_util import to_help_str
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
@@ -284,7 +284,7 @@ class CameraInputMixin:
             default_value=None,
             writes_allowed=False,
         )
-        maybe_raise_label_warnings(label, label_visibility)
+        label = maybe_raise_label_warnings(label, label_visibility)
 
         element_id = compute_and_register_element_id(
             "camera_input",
@@ -310,7 +310,7 @@ class CameraInputMixin:
             camera_input_proto.resolution_height = _RESOLUTION_TO_HEIGHT[resolution]
 
         if help is not None:
-            camera_input_proto.help = dedent(help)
+            camera_input_proto.help = to_help_str(help)
 
         layout_config = create_layout_config(width=width)
 

--- a/lib/streamlit/elements/widgets/checkbox.py
+++ b/lib/streamlit/elements/widgets/checkbox.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from textwrap import dedent
 from typing import TYPE_CHECKING, cast
 
 from streamlit.elements.lib.form_utils import current_form_id
@@ -45,6 +44,7 @@ from streamlit.runtime.state import (
     WidgetKwargs,
     register_widget,
 )
+from streamlit.string_util import to_help_str
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
@@ -469,7 +469,7 @@ class CheckboxMixin:
             on_change,
             default_value=None if value is False else value,
         )
-        maybe_raise_label_warnings(label, label_visibility)
+        label = maybe_raise_label_warnings(label, label_visibility)
 
         element_id = compute_and_register_element_id(
             "toggle" if type == CheckboxProto.StyleType.TOGGLE else "checkbox",
@@ -494,7 +494,7 @@ class CheckboxMixin:
         )
 
         if help is not None:
-            checkbox_proto.help = dedent(help)
+            checkbox_proto.help = to_help_str(help)
 
         # wrap is layout-only, so it is intentionally excluded from the element
         # id above. Leaving it unset lets the frontend resolve the auto default

--- a/lib/streamlit/elements/widgets/color_picker.py
+++ b/lib/streamlit/elements/widgets/color_picker.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from textwrap import dedent
 from typing import TYPE_CHECKING, cast
 
 from streamlit.elements.lib.form_utils import current_form_id
@@ -47,10 +46,10 @@ from streamlit.runtime.state import (
     WidgetKwargs,
     register_widget,
 )
+from streamlit.string_util import to_help_str
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
-
 
 # Compiled regex for validating hex colors (#RGB or #RRGGBB format)
 _HEX_COLOR_RE = re.compile(r"^#(?:[0-9a-fA-F]{3}){1,2}$")
@@ -276,7 +275,7 @@ class ColorPickerMixin:
             on_change,
             default_value=value,
         )
-        maybe_raise_label_warnings(label, label_visibility)
+        label = maybe_raise_label_warnings(label, label_visibility)
 
         # Enforce minimum width of 40px to match the color block's intrinsic size.
         # The color block is always 40x40px, so the widget should never be smaller.
@@ -326,7 +325,7 @@ like '#00FFAA' or '#000'.
         )
 
         if help is not None:
-            color_picker_proto.help = dedent(help)
+            color_picker_proto.help = to_help_str(help)
 
         # Set query param key if bound
         if bind == "query-params" and key is not None:

--- a/lib/streamlit/elements/widgets/file_uploader.py
+++ b/lib/streamlit/elements/widgets/file_uploader.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from textwrap import dedent
 from typing import TYPE_CHECKING, Literal, TypeAlias, cast, overload
 
 from streamlit import config
@@ -52,6 +51,7 @@ from streamlit.runtime.state import (
     register_widget,
 )
 from streamlit.runtime.uploaded_file_manager import DeletedFile, UploadedFile
+from streamlit.string_util import to_help_str
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -533,7 +533,7 @@ class FileUploaderMixin:
             default_value=None,
             writes_allowed=False,
         )
-        maybe_raise_label_warnings(label, label_visibility)
+        label = maybe_raise_label_warnings(label, label_visibility)
 
         element_id = compute_and_register_element_id(
             "file_uploader",
@@ -580,7 +580,7 @@ class FileUploaderMixin:
         )
 
         if help is not None:
-            file_uploader_proto.help = dedent(help)
+            file_uploader_proto.help = to_help_str(help)
 
         serde = FileUploaderSerde(accept_multiple_files, allowed_types=normalized_type)
 

--- a/lib/streamlit/elements/widgets/menu_button.py
+++ b/lib/streamlit/elements/widgets/menu_button.py
@@ -30,7 +30,7 @@ from streamlit.elements.lib.utils import (
 )
 from streamlit.errors import (
     StreamlitAPIException,
-    StreamlitInvalidContextError,
+    StreamlitInvalidLayoutContextError,
     StreamlitValueError,
 )
 from streamlit.proto.Common_pb2 import StringTriggerValue
@@ -346,7 +346,7 @@ class MenuButtonMixin:
         )
 
         if runtime.exists() and is_in_form(self.dg):
-            raise StreamlitInvalidContextError(
+            raise StreamlitInvalidLayoutContextError(
                 f"`st.menu_button()` can't be used in an `st.form()`.{_FORM_DOCS_INFO}"
             )
 

--- a/lib/streamlit/elements/widgets/menu_button.py
+++ b/lib/streamlit/elements/widgets/menu_button.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-from textwrap import dedent
 from typing import TYPE_CHECKING, Any, Final, Generic, Literal, TypeVar, cast
 
 from streamlit import runtime
@@ -29,7 +28,11 @@ from streamlit.elements.lib.utils import (
     save_for_app_testing,
     to_key,
 )
-from streamlit.errors import StreamlitAPIException, StreamlitValueError
+from streamlit.errors import (
+    StreamlitAPIException,
+    StreamlitInvalidContextError,
+    StreamlitValueError,
+)
 from streamlit.proto.Common_pb2 import StringTriggerValue
 from streamlit.proto.MenuButton_pb2 import MenuButton as MenuButtonProto
 from streamlit.runtime.metrics_util import gather_metrics
@@ -40,7 +43,7 @@ from streamlit.runtime.state import (
     WidgetKwargs,
     register_widget,
 )
-from streamlit.string_util import validate_icon_or_emoji
+from streamlit.string_util import to_help_str, validate_icon_or_emoji
 from streamlit.type_util import check_python_comparable
 
 if TYPE_CHECKING:
@@ -342,7 +345,7 @@ class MenuButtonMixin:
         )
 
         if runtime.exists() and is_in_form(self.dg):
-            raise StreamlitAPIException(
+            raise StreamlitInvalidContextError(
                 f"`st.menu_button()` can't be used in an `st.form()`.{_FORM_DOCS_INFO}"
             )
 
@@ -397,7 +400,7 @@ class MenuButtonMixin:
             menu_button_proto.wrap = wrap
 
         if help is not None:
-            menu_button_proto.help = dedent(help)
+            menu_button_proto.help = to_help_str(help)
 
         if icon is not None:
             menu_button_proto.icon = validate_icon_or_emoji(icon)

--- a/lib/streamlit/elements/widgets/menu_button.py
+++ b/lib/streamlit/elements/widgets/menu_button.py
@@ -43,7 +43,7 @@ from streamlit.runtime.state import (
     WidgetKwargs,
     register_widget,
 )
-from streamlit.string_util import to_help_str, validate_icon_or_emoji
+from streamlit.string_util import to_help_str, to_str, validate_icon_or_emoji
 from streamlit.type_util import check_python_comparable
 
 if TYPE_CHECKING:
@@ -335,6 +335,7 @@ class MenuButtonMixin:
         ctx: ScriptRunContext | None = None,
     ) -> T | None:
         key = to_key(key)
+        label = "" if label is None else to_str(label)
 
         check_widget_policies(
             self.dg,

--- a/lib/streamlit/elements/widgets/multiselect.py
+++ b/lib/streamlit/elements/widgets/multiselect.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-from textwrap import dedent
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -60,9 +59,8 @@ from streamlit.proto.MultiSelect_pb2 import MultiSelect as MultiSelectProto
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
 from streamlit.runtime.state import BindOption, PersistStateOption, register_widget
-from streamlit.type_util import (
-    is_iterable,
-)
+from streamlit.string_util import to_help_str
+from streamlit.type_util import is_iterable
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
@@ -98,7 +96,6 @@ class MultiSelectSerde(Generic[T]):
         We do not store an option_to_formatted_option mapping because the generic
         options might not be hashable, which would raise a RuntimeError. So we do
         two lookups: option -> index -> formatted_option[index].
-
 
         Parameters
         ----------
@@ -603,7 +600,7 @@ class MultiSelectMixin:
             on_change,
             default_value=default,
         )
-        maybe_raise_label_warnings(label, label_visibility)
+        label = maybe_raise_label_warnings(label, label_visibility)
 
         if max_selections is not None and max_selections < 1:
             raise StreamlitInvalidMaxError(
@@ -668,7 +665,7 @@ class MultiSelectMixin:
         )
         proto.options[:] = formatted_options
         if help is not None:
-            proto.help = dedent(help)
+            proto.help = to_help_str(help)
         proto.accept_new_options = accept_new_options
         proto.filter_mode = proto_filter_mode
         # wrap is layout-only and intentionally excluded from the element id

--- a/lib/streamlit/elements/widgets/number_input.py
+++ b/lib/streamlit/elements/widgets/number_input.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 import math
 import numbers
 from dataclasses import dataclass
-from textwrap import dedent
 from typing import TYPE_CHECKING, Literal, TypeAlias, TypeVar, cast, overload
 
 from streamlit.elements.lib.form_utils import current_form_id
@@ -56,11 +55,10 @@ from streamlit.runtime.state import (
     get_session_state,
     register_widget,
 )
-from streamlit.string_util import validate_icon_or_emoji
+from streamlit.string_util import to_help_str, validate_icon_or_emoji
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
-
 
 Number: TypeAlias = int | float
 IntOrNone = TypeVar("IntOrNone", int, None)
@@ -523,7 +521,7 @@ class NumberInputMixin:
             on_change,
             default_value=value if value != "min" else None,
         )
-        maybe_raise_label_warnings(label, label_visibility)
+        label = maybe_raise_label_warnings(label, label_visibility)
 
         element_id = compute_and_register_element_id(
             "number_input",
@@ -680,7 +678,7 @@ class NumberInputMixin:
         )
 
         if help is not None:
-            number_input_proto.help = dedent(help)
+            number_input_proto.help = to_help_str(help)
 
         # min_value/max_value are guaranteed to be non-None here (unset bounds
         # were backfilled with JS sentinels above). We always send them as the

--- a/lib/streamlit/elements/widgets/radio.py
+++ b/lib/streamlit/elements/widgets/radio.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-from textwrap import dedent
 from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast, overload
 
 from typing_extensions import Never
@@ -55,9 +54,8 @@ from streamlit.runtime.state import (
     get_session_state,
     register_widget,
 )
-from streamlit.type_util import (
-    check_python_comparable,
-)
+from streamlit.string_util import to_help_str
+from streamlit.type_util import check_python_comparable
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
@@ -466,7 +464,7 @@ class RadioMixin:
             on_change,
             default_value=None if index == 0 else index,
         )
-        maybe_raise_label_warnings(label, label_visibility)
+        label = maybe_raise_label_warnings(label, label_visibility)
 
         layout_config = create_layout_config(width=width, allow_content_width=True)
 
@@ -531,7 +529,7 @@ class RadioMixin:
             radio_proto.captions[:] = map(handle_captions, captions)
 
         if help is not None:
-            radio_proto.help = dedent(help)
+            radio_proto.help = to_help_str(help)
 
         # Set query param key if bound
         if bind == "query-params" and key is not None:

--- a/lib/streamlit/elements/widgets/select_slider.py
+++ b/lib/streamlit/elements/widgets/select_slider.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-from textwrap import dedent
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -60,6 +59,7 @@ from streamlit.runtime.state import (
     WidgetKwargs,
     register_widget,
 )
+from streamlit.string_util import to_help_str
 from streamlit.type_util import check_python_comparable
 
 if TYPE_CHECKING:
@@ -457,7 +457,7 @@ class SelectSliderMixin:
             on_change,
             default_value=value,
         )
-        maybe_raise_label_warnings(label, label_visibility)
+        label = maybe_raise_label_warnings(label, label_visibility)
 
         opt = convert_anything_to_list(options)
         check_python_comparable(opt)
@@ -518,7 +518,7 @@ class SelectSliderMixin:
             label_visibility
         )
         if help is not None:
-            slider_proto.help = dedent(help)
+            slider_proto.help = to_help_str(help)
 
         if bind and key:
             slider_proto.query_param_key = str(key)

--- a/lib/streamlit/elements/widgets/selectbox.py
+++ b/lib/streamlit/elements/widgets/selectbox.py
@@ -629,7 +629,8 @@ class SelectboxMixin:
         if not isinstance(index, int) and index is not None:
             raise StreamlitInvalidParameterTypeError(
                 "index",
-                f"Selectbox Value has invalid type: {type(index).__name__}",
+                type(index).__name__,
+                ["int", "None"],
             )
 
         if index is not None and len(opt) > 0 and not 0 <= index < len(opt):

--- a/lib/streamlit/elements/widgets/selectbox.py
+++ b/lib/streamlit/elements/widgets/selectbox.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 from __future__ import annotations
 
-from textwrap import dedent
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -51,7 +50,7 @@ from streamlit.elements.lib.utils import (
     save_for_app_testing,
     to_key,
 )
-from streamlit.errors import StreamlitAPIException
+from streamlit.errors import StreamlitAPIException, StreamlitInvalidParameterTypeError
 from streamlit.proto.Selectbox_pb2 import Selectbox as SelectboxProto
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
@@ -64,9 +63,8 @@ from streamlit.runtime.state import (
     get_session_state,
     register_widget,
 )
-from streamlit.type_util import (
-    check_python_comparable,
-)
+from streamlit.string_util import to_help_str
+from streamlit.type_util import check_python_comparable
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
@@ -97,7 +95,6 @@ class SelectboxSerde(Generic[T]):
         We do not store an option_to_formatted_option mapping because the generic
         options might not be hashable, which would raise a RuntimeError. So we do
         two lookups: option -> index -> formatted_option[index].
-
 
         Parameters
         ----------
@@ -624,14 +621,15 @@ class SelectboxMixin:
             on_change,
             default_value=None if index == 0 else index,
         )
-        maybe_raise_label_warnings(label, label_visibility)
+        label = maybe_raise_label_warnings(label, label_visibility)
 
         opt = convert_anything_to_list(options)
         check_python_comparable(opt)
 
         if not isinstance(index, int) and index is not None:
-            raise StreamlitAPIException(
-                f"Selectbox Value has invalid type: {type(index).__name__}"
+            raise StreamlitInvalidParameterTypeError(
+                "index",
+                f"Selectbox Value has invalid type: {type(index).__name__}",
             )
 
         if index is not None and len(opt) > 0 and not 0 <= index < len(opt):
@@ -695,7 +693,7 @@ class SelectboxMixin:
         selectbox_proto.filter_mode = proto_filter_mode
 
         if help is not None:
-            selectbox_proto.help = dedent(help)
+            selectbox_proto.help = to_help_str(help)
 
         # Set query param key if bound
         if bind == "query-params" and key is not None:

--- a/lib/streamlit/elements/widgets/slider.py
+++ b/lib/streamlit/elements/widgets/slider.py
@@ -935,6 +935,14 @@ class SliderMixin:
         single_value = isinstance(value, tuple(SUPPORTED_TYPES.keys()))
         range_value = isinstance(value, (list, tuple)) and len(value) in {0, 1, 2}
         if not single_value and not range_value:
+            # A list/tuple of the wrong length is a value constraint, not a
+            # type mismatch — listing list/tuple as expected types would
+            # contradict the provided type.
+            if isinstance(value, (list, tuple)):
+                raise StreamlitAPIException(
+                    "Slider value should either be an int/float/datetime or a "
+                    "list/tuple of 0 to 2 ints/floats/datetimes"
+                )
             raise StreamlitInvalidParameterTypeError(
                 "value",
                 type(value).__name__,

--- a/lib/streamlit/elements/widgets/slider.py
+++ b/lib/streamlit/elements/widgets/slider.py
@@ -19,7 +19,6 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import date, datetime, time, timedelta, timezone, tzinfo
 from numbers import Integral, Real
-from textwrap import dedent
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -47,6 +46,8 @@ from streamlit.elements.lib.utils import (
 )
 from streamlit.errors import (
     StreamlitAPIException,
+    StreamlitInvalidParameterTypeError,
+    StreamlitJSNumberBoundsError,
     StreamlitValueAboveMaxError,
     StreamlitValueBelowMinError,
 )
@@ -64,6 +65,7 @@ from streamlit.runtime.state import (
     register_widget,
     validate_on_change_mode,
 )
+from streamlit.string_util import to_help_str
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
@@ -888,7 +890,7 @@ class SliderMixin:
             on_change_callback,
             default_value=value,
         )
-        maybe_raise_label_warnings(label, label_visibility)
+        label = maybe_raise_label_warnings(label, label_visibility)
 
         element_id = compute_and_register_element_id(
             "slider",
@@ -933,9 +935,10 @@ class SliderMixin:
         single_value = isinstance(value, tuple(SUPPORTED_TYPES.keys()))
         range_value = isinstance(value, (list, tuple)) and len(value) in {0, 1, 2}
         if not single_value and not range_value:
-            raise StreamlitAPIException(
+            raise StreamlitInvalidParameterTypeError(
+                "value",
                 "Slider value should either be an int/float/datetime or a list/tuple of "
-                "0 to 2 ints/floats/datetimes"
+                "0 to 2 ints/floats/datetimes",
             )
 
         # Simplify future logic by always making value a list
@@ -952,9 +955,10 @@ class SliderMixin:
             return len(set(map(value_to_generic_type, items))) < 2
 
         if not all_same_type(prepared_value):
-            raise StreamlitAPIException(
+            raise StreamlitInvalidParameterTypeError(
+                "value",
                 "Slider tuple/list components must be of the same type.\n"
-                f"But were: {list(map(type, prepared_value))}"
+                f"But were: {list(map(type, prepared_value))}",
             )
 
         data_type = (
@@ -1051,7 +1055,7 @@ class SliderMixin:
                 f"\n`max_value` has {type(max_value).__name__} type."
                 f"\n`step` has {type(step).__name__} type."
             )
-            raise StreamlitAPIException(msg)
+            raise StreamlitInvalidParameterTypeError("value", msg)
 
         # Ensure that the value matches arguments' types.
         all_ints = data_type == SliderProto.INT and int_args
@@ -1065,7 +1069,7 @@ class SliderMixin:
                 f"\n`min_value` has {type(min_value).__name__} type."
                 f"\n`max_value` has {type(max_value).__name__} type."
             )
-            raise StreamlitAPIException(msg)
+            raise StreamlitInvalidParameterTypeError("value", msg)
 
         # Ensure that min <= value(s) <= max, adjusting the bounds as necessary.
         min_value = min(min_value, max_value)
@@ -1099,7 +1103,7 @@ class SliderMixin:
                 JSNumber.validate_float_bounds(cast("float", min_value), "`min_value`")
                 JSNumber.validate_float_bounds(cast("float", max_value), "`max_value`")
         except JSNumberBoundsException as e:
-            raise StreamlitAPIException(str(e))
+            raise StreamlitJSNumberBoundsError(str(e))
 
         orig_tz = None
         # Convert dates or times into datetimes
@@ -1189,7 +1193,7 @@ class SliderMixin:
         )
 
         if help is not None:
-            slider_proto.help = dedent(help)
+            slider_proto.help = to_help_str(help)
 
         if bind and key:
             slider_proto.query_param_key = str(key)
@@ -1232,7 +1236,9 @@ class SliderMixin:
             if not isinstance(slider_min, (int, float)) or not isinstance(
                 slider_max, (int, float)
             ):
-                raise StreamlitAPIException("Slider bounds must be numeric.")
+                raise StreamlitInvalidParameterTypeError(
+                    "min_value", "Slider bounds must be numeric."
+                )
             for serialized_value in serialized_values:
                 # Use the deserialized values for more readable error messages for dates/times
                 deserialized_value = serde.deserialize_single_value(serialized_value)

--- a/lib/streamlit/elements/widgets/slider.py
+++ b/lib/streamlit/elements/widgets/slider.py
@@ -937,8 +937,8 @@ class SliderMixin:
         if not single_value and not range_value:
             raise StreamlitInvalidParameterTypeError(
                 "value",
-                "Slider value should either be an int/float/datetime or a list/tuple of "
-                "0 to 2 ints/floats/datetimes",
+                type(value).__name__,
+                ["int", "float", "date", "time", "datetime", "list", "tuple"],
             )
 
         # Simplify future logic by always making value a list
@@ -957,8 +957,8 @@ class SliderMixin:
         if not all_same_type(prepared_value):
             raise StreamlitInvalidParameterTypeError(
                 "value",
-                "Slider tuple/list components must be of the same type.\n"
-                f"But were: {list(map(type, prepared_value))}",
+                ", ".join(type(item).__name__ for item in prepared_value),
+                ["list or tuple containing values of the same type"],
             )
 
         data_type = (
@@ -1049,13 +1049,12 @@ class SliderMixin:
         )
 
         if not int_args and not float_args and not timelike_args:
-            msg = (
-                "Slider value arguments must be of matching types."
-                f"\n`min_value` has {type(min_value).__name__} type."
-                f"\n`max_value` has {type(max_value).__name__} type."
-                f"\n`step` has {type(step).__name__} type."
+            raise StreamlitInvalidParameterTypeError(
+                "value",
+                f"min_value={type(min_value).__name__}, "
+                f"max_value={type(max_value).__name__}, step={type(step).__name__}",
+                ["matching numeric types", "matching date/time types"],
             )
-            raise StreamlitInvalidParameterTypeError("value", msg)
 
         # Ensure that the value matches arguments' types.
         all_ints = data_type == SliderProto.INT and int_args
@@ -1063,13 +1062,13 @@ class SliderMixin:
         all_timelikes = data_type in TIMELIKE_TYPES and timelike_args
 
         if not all_ints and not all_floats and not all_timelikes:
-            msg = (
-                "Both value and arguments must be of the same type."
-                f"\n`value` has {type(value).__name__} type."
-                f"\n`min_value` has {type(min_value).__name__} type."
-                f"\n`max_value` has {type(max_value).__name__} type."
+            raise StreamlitInvalidParameterTypeError(
+                "value",
+                f"value={type(value).__name__}, "
+                f"min_value={type(min_value).__name__}, "
+                f"max_value={type(max_value).__name__}",
+                ["value and arguments with matching types"],
             )
-            raise StreamlitInvalidParameterTypeError("value", msg)
 
         # Ensure that min <= value(s) <= max, adjusting the bounds as necessary.
         min_value = min(min_value, max_value)
@@ -1237,7 +1236,10 @@ class SliderMixin:
                 slider_max, (int, float)
             ):
                 raise StreamlitInvalidParameterTypeError(
-                    "min_value", "Slider bounds must be numeric."
+                    "min_value",
+                    f"min_value={type(slider_min).__name__}, "
+                    f"max_value={type(slider_max).__name__}",
+                    ["int", "float"],
                 )
             for serialized_value in serialized_values:
                 # Use the deserialized values for more readable error messages for dates/times

--- a/lib/streamlit/elements/widgets/text_widgets.py
+++ b/lib/streamlit/elements/widgets/text_widgets.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from textwrap import dedent
 from typing import TYPE_CHECKING, Final, Literal, NamedTuple, cast, overload
 
 from streamlit.elements.lib.form_utils import current_form_id
@@ -49,7 +48,7 @@ from streamlit.runtime.state import (
     get_session_state,
     register_widget,
 )
-from streamlit.string_util import validate_icon_or_emoji
+from streamlit.string_util import to_help_str, validate_icon_or_emoji
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
@@ -597,7 +596,7 @@ class TextWidgetsMixin:
             on_change,
             default_value=None if value == "" else value,
         )
-        maybe_raise_label_warnings(label, label_visibility)
+        label = maybe_raise_label_warnings(label, label_visibility)
 
         # Make sure value is always string or None:
         value = str(value) if value is not None else None
@@ -687,7 +686,7 @@ class TextWidgetsMixin:
         )
 
         if help is not None:
-            text_input_proto.help = dedent(help)
+            text_input_proto.help = to_help_str(help)
 
         if max_chars is not None:
             text_input_proto.max_chars = max_chars
@@ -1038,7 +1037,7 @@ class TextWidgetsMixin:
             on_change,
             default_value=None if value == "" else value,
         )
-        maybe_raise_label_warnings(label, label_visibility)
+        label = maybe_raise_label_warnings(label, label_visibility)
 
         value = str(value) if value is not None else None
 
@@ -1074,7 +1073,7 @@ class TextWidgetsMixin:
         )
 
         if help is not None:
-            text_area_proto.help = dedent(help)
+            text_area_proto.help = to_help_str(help)
 
         if max_chars is not None:
             text_area_proto.max_chars = max_chars

--- a/lib/streamlit/elements/widgets/time_widgets.py
+++ b/lib/streamlit/elements/widgets/time_widgets.py
@@ -131,7 +131,8 @@ def _convert_timelike_to_time(value: TimeValue) -> time:
 
     raise StreamlitInvalidParameterTypeError(
         "value",
-        "The type of value should be one of datetime, time, ISO string or None",
+        type(value).__name__,
+        ["datetime", "time", "ISO string"],
     )
 
 
@@ -159,7 +160,8 @@ def _convert_datelike_to_date(
 
     raise StreamlitInvalidParameterTypeError(
         "value",
-        'Date value should either be an date/datetime or an ISO string or "today"',
+        type(value).__name__,
+        ["date", "datetime", "ISO string", '"today"'],
     )
 
 
@@ -179,8 +181,8 @@ def _parse_date_value(value: DateValue) -> tuple[list[date] | None, bool]:
     if len(value_tuple) not in {0, 1, 2}:
         raise StreamlitInvalidParameterTypeError(
             "value",
-            "DateInput value should either be an date/datetime or a list/tuple of "
-            "0 - 2 date/datetime values",
+            type(value).__name__,
+            ["date", "datetime", "sequence of 0 to 2 date or datetime values"],
         )
 
     parsed_dates = [_convert_datelike_to_date(v) for v in value_tuple]
@@ -203,7 +205,8 @@ def _parse_min_date(
     else:
         raise StreamlitInvalidParameterTypeError(
             "min_value",
-            "DateInput min should either be a date/datetime or None",
+            type(min_value).__name__,
+            ["date", "datetime", "ISO string", "None"],
         )
     return parsed_min_date
 
@@ -223,7 +226,8 @@ def _parse_max_date(
     else:
         raise StreamlitInvalidParameterTypeError(
             "max_value",
-            "DateInput max should either be a date/datetime or None",
+            type(max_value).__name__,
+            ["date", "datetime", "ISO string", "None"],
         )
     return parsed_max_date
 
@@ -307,7 +311,8 @@ def _convert_datetimelike_to_datetime(
 
     raise StreamlitInvalidParameterTypeError(
         "value",
-        "The type of value should be one of datetime, date, time, ISO string, or 'now'.",
+        type(value).__name__,
+        ["datetime", "date", "time", "ISO string", '"now"'],
     )
 
 
@@ -1048,7 +1053,8 @@ class TimeWidgetsMixin:
         if isinstance(step, bool) or not isinstance(step, (int, timedelta)):
             raise StreamlitInvalidParameterTypeError(
                 "step",
-                f"`step` can only be `int` or `timedelta` but {type(step)} is provided.",
+                type(step).__name__,
+                ["int", "timedelta"],
             )
         if isinstance(step, timedelta):
             step = int(step.total_seconds())
@@ -1472,7 +1478,8 @@ class TimeWidgetsMixin:
         if isinstance(step, bool) or not isinstance(step, (int, timedelta)):
             raise StreamlitInvalidParameterTypeError(
                 "step",
-                f"`step` can only be `int` or `timedelta` but {type(step)} is provided.",
+                type(step).__name__,
+                ["int", "timedelta"],
             )
         step_seconds = (
             int(step.total_seconds()) if isinstance(step, timedelta) else step

--- a/lib/streamlit/elements/widgets/time_widgets.py
+++ b/lib/streamlit/elements/widgets/time_widgets.py
@@ -17,7 +17,6 @@ import re
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import date, datetime, time, timedelta
-from textwrap import dedent
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -44,7 +43,11 @@ from streamlit.elements.lib.utils import (
     get_label_visibility_proto_value,
     to_key,
 )
-from streamlit.errors import StreamlitAPIException, StreamlitValueError
+from streamlit.errors import (
+    StreamlitAPIException,
+    StreamlitInvalidParameterTypeError,
+    StreamlitValueError,
+)
 from streamlit.proto.DateInput_pb2 import DateInput as DateInputProto
 from streamlit.proto.DateTimeInput_pb2 import DateTimeInput as DateTimeInputProto
 from streamlit.proto.TimeInput_pb2 import TimeInput as TimeInputProto
@@ -59,6 +62,7 @@ from streamlit.runtime.state import (
     get_session_state,
     register_widget,
 )
+from streamlit.string_util import to_help_str
 from streamlit.time_util import adjust_years
 
 if TYPE_CHECKING:
@@ -78,7 +82,6 @@ DateValue: TypeAlias = NullableScalarDateValue | Sequence[NullableScalarDateValu
 # The return value of st.date_input.
 DateWidgetRangeReturn: TypeAlias = tuple[()] | tuple[date] | tuple[date, date]
 DateWidgetReturn: TypeAlias = date | DateWidgetRangeReturn | None
-
 
 DEFAULT_STEP_MINUTES: Final = 15
 ALLOWED_DATE_FORMATS: Final = re.compile(
@@ -126,8 +129,9 @@ def _convert_timelike_to_time(value: TimeValue) -> time:
     if isinstance(value, time):
         return value
 
-    raise StreamlitAPIException(
-        "The type of value should be one of datetime, time, ISO string or None"
+    raise StreamlitInvalidParameterTypeError(
+        "value",
+        "The type of value should be one of datetime, time, ISO string or None",
     )
 
 
@@ -153,8 +157,9 @@ def _convert_datelike_to_date(
                 # We throw an error below.
                 pass
 
-    raise StreamlitAPIException(
-        'Date value should either be an date/datetime or an ISO string or "today"'
+    raise StreamlitInvalidParameterTypeError(
+        "value",
+        'Date value should either be an date/datetime or an ISO string or "today"',
     )
 
 
@@ -172,9 +177,10 @@ def _parse_date_value(value: DateValue) -> tuple[list[date] | None, bool]:
         value_tuple = [cast("NullableScalarDateValue", value)]
 
     if len(value_tuple) not in {0, 1, 2}:
-        raise StreamlitAPIException(
+        raise StreamlitInvalidParameterTypeError(
+            "value",
             "DateInput value should either be an date/datetime or a list/tuple of "
-            "0 - 2 date/datetime values"
+            "0 - 2 date/datetime values",
         )
 
     parsed_dates = [_convert_datelike_to_date(v) for v in value_tuple]
@@ -195,8 +201,9 @@ def _parse_min_date(
         else:
             parsed_min_date = adjust_years(date.today(), years=-10)
     else:
-        raise StreamlitAPIException(
-            "DateInput min should either be a date/datetime or None"
+        raise StreamlitInvalidParameterTypeError(
+            "min_value",
+            "DateInput min should either be a date/datetime or None",
         )
     return parsed_min_date
 
@@ -214,8 +221,9 @@ def _parse_max_date(
         else:
             parsed_max_date = adjust_years(date.today(), years=10)
     else:
-        raise StreamlitAPIException(
-            "DateInput max should either be a date/datetime or None"
+        raise StreamlitInvalidParameterTypeError(
+            "max_value",
+            "DateInput max should either be a date/datetime or None",
         )
     return parsed_max_date
 
@@ -297,8 +305,9 @@ def _convert_datetimelike_to_datetime(
         except ValueError:
             pass
 
-    raise StreamlitAPIException(
-        "The type of value should be one of datetime, date, time, ISO string, or 'now'."
+    raise StreamlitInvalidParameterTypeError(
+        "value",
+        "The type of value should be one of datetime, date, time, ISO string, or 'now'.",
     )
 
 
@@ -995,7 +1004,7 @@ class TimeWidgetsMixin:
             on_change,
             default_value=value if value != "now" else None,
         )
-        maybe_raise_label_warnings(label, label_visibility)
+        label = maybe_raise_label_warnings(label, label_visibility)
 
         parsed_time: time | None
         parsed_time = None if value is None else _convert_timelike_to_time(value)
@@ -1037,8 +1046,9 @@ class TimeWidgetsMixin:
         time_input_proto.id = element_id
         time_input_proto.label = label
         if isinstance(step, bool) or not isinstance(step, (int, timedelta)):
-            raise StreamlitAPIException(
-                f"`step` can only be `int` or `timedelta` but {type(step)} is provided."
+            raise StreamlitInvalidParameterTypeError(
+                "step",
+                f"`step` can only be `int` or `timedelta` but {type(step)} is provided.",
             )
         if isinstance(step, timedelta):
             step = int(step.total_seconds())
@@ -1058,7 +1068,7 @@ class TimeWidgetsMixin:
         )
 
         if help is not None:
-            time_input_proto.help = dedent(help)
+            time_input_proto.help = to_help_str(help)
 
         if bind == "query-params" and key is not None:
             time_input_proto.query_param_key = str(key)
@@ -1410,7 +1420,7 @@ class TimeWidgetsMixin:
             on_change,
             default_value=value if value != "now" else None,
         )
-        maybe_raise_label_warnings(label, label_visibility)
+        label = maybe_raise_label_warnings(label, label_visibility)
 
         datetime_values = _DateTimeInputValues.from_raw_values(
             value=value,
@@ -1459,9 +1469,10 @@ class TimeWidgetsMixin:
                 "and can also use a period (.) or hyphen (-) as separators."
             )
 
-        if not isinstance(step, (int, timedelta)):
-            raise StreamlitAPIException(
-                f"`step` can only be `int` or `timedelta` but {type(step)} is provided."
+        if isinstance(step, bool) or not isinstance(step, (int, timedelta)):
+            raise StreamlitInvalidParameterTypeError(
+                "step",
+                f"`step` can only be `int` or `timedelta` but {type(step)} is provided.",
             )
         step_seconds = (
             int(step.total_seconds()) if isinstance(step, timedelta) else step
@@ -1495,7 +1506,7 @@ class TimeWidgetsMixin:
         date_time_input_proto.is_range = False
 
         if help is not None:
-            date_time_input_proto.help = dedent(help)
+            date_time_input_proto.help = to_help_str(help)
 
         if bind == "query-params" and key is not None:
             date_time_input_proto.query_param_key = str(key)
@@ -1909,7 +1920,7 @@ class TimeWidgetsMixin:
             on_change,
             default_value=value if value != "today" else None,
         )
-        maybe_raise_label_warnings(label, label_visibility)
+        label = maybe_raise_label_warnings(label, label_visibility)
 
         def parse_date_deterministic_for_id(v: NullableScalarDateValue) -> str | None:
             if v == "today":
@@ -2011,7 +2022,7 @@ class TimeWidgetsMixin:
         date_input_proto.form_id = current_form_id(self.dg)
 
         if help is not None:
-            date_input_proto.help = dedent(help)
+            date_input_proto.help = to_help_str(help)
 
         if bind == "query-params" and key is not None:
             date_input_proto.query_param_key = str(key)

--- a/lib/streamlit/errors.py
+++ b/lib/streamlit/errors.py
@@ -102,6 +102,10 @@ class StreamlitAPIException(MarkdownFormattedException):
         return util.repr_(self)
 
 
+class StreamlitDataframeConversionError(StreamlitAPIException):
+    """Raised when a value cannot be converted to a DataFrame or Arrow table."""
+
+
 class DuplicateWidgetID(StreamlitAPIException):  # pragma: no cover - trivial subclass
     pass
 
@@ -448,8 +452,20 @@ class StreamlitPageNotFoundError(LocalizableStreamlitException):
     """Exception raised the linked page can not be found."""
 
     def __init__(
-        self, page: str, main_script_directory: str, uses_pages_directory: bool
+        self,
+        page: str,
+        main_script_directory: str = "",
+        uses_pages_directory: bool = False,
+        *,
+        during_construction: bool = False,
     ) -> None:
+        if during_construction:
+            super().__init__(
+                "Unable to create Page. The file `{page}` could not be found.",
+                page=page,
+            )
+            return
+
         directory = os.path.basename(main_script_directory)
 
         message = (
@@ -535,12 +551,27 @@ class StreamlitInvalidFormCallbackError(LocalizableStreamlitException):
         )
 
 
+class StreamlitInvalidContextError(StreamlitAPIException):
+    """Raised when a command is used in a disallowed layout or form context."""
+
+
 class StreamlitValueAssignmentNotAllowedError(LocalizableStreamlitException):
     """Exception raised when trying to set values where writes are not allowed."""
 
     def __init__(self, key: str) -> None:
         super().__init__(
             "Values for the widget with `key` '{key}' cannot be set using `st.session_state`.",
+            key=key,
+        )
+
+
+class StreamlitWidgetAlreadyInstantiatedError(LocalizableStreamlitException):
+    """Raised when session state is assigned after the widget is created."""
+
+    def __init__(self, key: str) -> None:
+        super().__init__(
+            "`st.session_state.{key}` cannot be modified after the widget"
+            " with key `{key}` is instantiated.",
             key=key,
         )
 
@@ -625,6 +656,29 @@ class StreamlitValueError(LocalizableStreamlitException):
             "Invalid `{parameter}` value. Supported values: {valid_values}.",
             parameter=parameter,
             valid_values=", ".join(valid_values),
+        )
+
+
+class StreamlitInvalidParameterTypeError(LocalizableStreamlitException):
+    """Raised when a parameter has an unsupported type.
+
+    ``parameter`` is appended in uncaught-exception telemetry. Pass ``message``
+    as the user-facing text; it is substituted rather than used as a format
+    string, so braces in the text stay literal.
+    """
+
+    def __init__(self, parameter: str, message: str) -> None:
+        super().__init__("{user_message}", user_message=message, parameter=parameter)
+
+
+class StreamlitDefaultNotInOptionsError(LocalizableStreamlitException):
+    """Raised when a default value is not among the provided options."""
+
+    def __init__(self, value: Any) -> None:
+        super().__init__(
+            "The default value '{value}' is not part of the options. "
+            "Please make sure that every default values also exists in the options.",
+            value=value,
         )
 
 

--- a/lib/streamlit/errors.py
+++ b/lib/streamlit/errors.py
@@ -449,7 +449,7 @@ class StreamlitQueryParamDictValueError(LocalizableStreamlitException):
 
 
 class StreamlitPageNotFoundError(LocalizableStreamlitException):
-    """Exception raised the linked page can not be found."""
+    """Raised when the linked page cannot be found."""
 
     def __init__(
         self,

--- a/lib/streamlit/errors.py
+++ b/lib/streamlit/errors.py
@@ -454,12 +454,10 @@ class StreamlitPageNotFoundError(LocalizableStreamlitException):
     def __init__(
         self,
         page: str,
-        main_script_directory: str = "",
+        main_script_directory: str | None = None,
         uses_pages_directory: bool = False,
-        *,
-        during_construction: bool = False,
     ) -> None:
-        if during_construction:
+        if main_script_directory is None:
             super().__init__(
                 "Unable to create Page. The file `{page}` could not be found.",
                 page=page,

--- a/lib/streamlit/errors.py
+++ b/lib/streamlit/errors.py
@@ -551,8 +551,8 @@ class StreamlitInvalidFormCallbackError(LocalizableStreamlitException):
         )
 
 
-class StreamlitInvalidContextError(StreamlitAPIException):
-    """Raised when a command is used in a disallowed layout or form context."""
+class StreamlitInvalidLayoutContextError(StreamlitAPIException):
+    """Raised when a command is used in a disallowed layout context."""
 
 
 class StreamlitValueAssignmentNotAllowedError(LocalizableStreamlitException):
@@ -660,15 +660,18 @@ class StreamlitValueError(LocalizableStreamlitException):
 
 
 class StreamlitInvalidParameterTypeError(LocalizableStreamlitException):
-    """Raised when a parameter has an unsupported type.
+    """Raised when a parameter has an unsupported type."""
 
-    ``parameter`` is appended in uncaught-exception telemetry. Pass ``message``
-    as the user-facing text; it is substituted rather than used as a format
-    string, so braces in the text stay literal.
-    """
-
-    def __init__(self, parameter: str, message: str) -> None:
-        super().__init__("{user_message}", user_message=message, parameter=parameter)
+    def __init__(
+        self, parameter: str, provided_type: str, expected_types: list[str]
+    ) -> None:
+        super().__init__(
+            "Invalid `{parameter}` type. Expected one of: {expected_types}. "
+            "Provided type: {provided_type}.",
+            parameter=parameter,
+            expected_types=", ".join(expected_types),
+            provided_type=provided_type,
+        )
 
 
 class StreamlitDefaultNotInOptionsError(LocalizableStreamlitException):

--- a/lib/streamlit/errors.py
+++ b/lib/streamlit/errors.py
@@ -677,7 +677,7 @@ class StreamlitDefaultNotInOptionsError(LocalizableStreamlitException):
     def __init__(self, value: Any) -> None:
         super().__init__(
             "The default value '{value}' is not part of the options. "
-            "Please make sure that every default values also exists in the options.",
+            "Please make sure that every default value also exists in the options.",
             value=value,
         )
 

--- a/lib/streamlit/navigation/page.py
+++ b/lib/streamlit/navigation/page.py
@@ -20,7 +20,11 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
 from streamlit import env_util
-from streamlit.errors import StreamlitAPIException, StreamlitValueError
+from streamlit.errors import (
+    StreamlitAPIException,
+    StreamlitPageNotFoundError,
+    StreamlitValueError,
+)
 from streamlit.path_security import is_windows_unc_path
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner_utils.script_run_context import get_script_run_ctx
@@ -323,9 +327,7 @@ class Page:
             page = (main_path / page).resolve()
 
             if not page.is_file():
-                raise StreamlitAPIException(
-                    f"Unable to create Page. The file `{page.name}` could not be found."
-                )
+                raise StreamlitPageNotFoundError(page.name, during_construction=True)
 
         inferred_name = ""
         inferred_icon = ""

--- a/lib/streamlit/navigation/page.py
+++ b/lib/streamlit/navigation/page.py
@@ -327,7 +327,7 @@ class Page:
             page = (main_path / page).resolve()
 
             if not page.is_file():
-                raise StreamlitPageNotFoundError(page.name, during_construction=True)
+                raise StreamlitPageNotFoundError(page.name)
 
         inferred_name = ""
         inferred_icon = ""

--- a/lib/streamlit/runtime/metrics_util.py
+++ b/lib/streamlit/runtime/metrics_util.py
@@ -567,13 +567,18 @@ def format_uncaught_exception(exc: BaseException) -> str:
                 module = match.group(1).split(".", 1)[0]
                 if module in _IMPORT_ERROR_MODULE_ALLOWLIST:
                     return f"{name}:{module}"
-        elif name == "MediaFileStorageError" and str(exc).startswith("Error opening"):
-            # Type name avoids importing MediaFileStorageError into this module.
-            return f"{name}:open"
         elif isinstance(exc, LocalizableStreamlitException):
             parameter = exc.exec_kwargs.get("parameter")
             if isinstance(parameter, str) and parameter:
                 return f"{name}:{parameter}"
+        else:
+            # Function-local import avoids a module-level cycle with media storage.
+            from streamlit.runtime.media_file_storage import MediaFileStorageError
+
+            if isinstance(exc, MediaFileStorageError) and str(exc).startswith(
+                "Error opening"
+            ):
+                return f"{name}:open"
     return name
 
 

--- a/lib/streamlit/runtime/metrics_util.py
+++ b/lib/streamlit/runtime/metrics_util.py
@@ -251,37 +251,10 @@ _UNEXPECTED_KWARG_RE: Final = re.compile(
 _MISSING_ARG_RE: Final = re.compile(
     r"missing \d+ required (?:positional |keyword-only )?arguments?: '(\w+)'"
 )
-# ``foo() takes 2 positional arguments but 3 were given``
-# ``foo() takes 0 positional arguments but 1 was given``
-_TOO_MANY_POS_RE: Final = re.compile(
-    r"takes(?: from \d+ to)? \d+ positional arguments? but \d+ (?:was|were) given"
-)
-_BYTESLIKE_RE: Final = re.compile(r"a bytes-like object is required, not '")
-_PROTO_TYPE_RE: Final = re.compile(
-    r"bad argument type for built-in operation"
-    r"|expected str(?:, but got|, got)"
-    r"|: expected a string"
-    r"|has type \w+, but expected one of:"
-)
 _NO_MODULE_RE: Final = re.compile(r"No module named ['\"]([^'\"]+)['\"]")
 _CANNOT_IMPORT_FROM_RE: Final = re.compile(r"cannot import name '[^']+' from '([^']+)'")
-# First path component of ImportError module names we record. Keep this tight
-# so telemetry cardinality stays bounded.
-_IMPORT_ERROR_MODULE_ALLOWLIST: Final = frozenset(
-    {
-        "altair",
-        "graphviz",
-        "matplotlib",
-        "numpy",
-        "orjson",
-        "pandas",
-        "PIL",
-        "plotly",
-        "polars",
-        "pyarrow",
-        "pydeck",
-        "watchdog",
-    }
+_STREAMLIT_ATTRIBUTE_RE: Final = re.compile(
+    r"module 'streamlit' has no attribute '([^']+)'"
 )
 
 
@@ -532,15 +505,12 @@ def format_uncaught_exception(exc: BaseException) -> str:
 
     - unexpected-keyword ``TypeError`` → ``"TypeError:<param>"``
     - missing required argument ``TypeError`` → ``"TypeError:missing:<param>"``
-    - too many positional arguments → ``"TypeError:positional"``
-    - protobuf string-field type errors → ``"TypeError:proto"``
-    - bytes-like-object ``TypeError`` → ``"TypeError:byteslike"``
-    - allowlisted ``ImportError`` / ``ModuleNotFoundError`` → ``"<Type>:<module>"``
-    - ``MediaFileStorageError`` opening a file → ``"MediaFileStorageError:open"``
+    - ``ImportError`` / ``ModuleNotFoundError`` → ``"<Type>:<module>"``
+    - missing top-level ``streamlit`` attributes → ``"AttributeError:<attribute>"``
     - ``LocalizableStreamlitException`` with a ``parameter`` kwarg
       → ``"<Type>:<parameter>"``
 
-    Does not append user values (widget keys, file paths) or command names.
+    Does not append user values such as widget keys or file paths.
     Enrichment failures are swallowed so telemetry cannot interrupt script
     execution or drop the page-profile payload.
     """
@@ -554,31 +524,31 @@ def format_uncaught_exception(exc: BaseException) -> str:
             match = _MISSING_ARG_RE.search(msg)
             if match:
                 return f"{name}:missing:{match.group(1)}"
-            if _TOO_MANY_POS_RE.search(msg):
-                return f"{name}:positional"
-            if _BYTESLIKE_RE.search(msg):
-                return f"{name}:byteslike"
-            if _PROTO_TYPE_RE.search(msg):
-                return f"{name}:proto"
         elif isinstance(exc, ImportError):
-            msg = str(exc)
-            match = _NO_MODULE_RE.search(msg) or _CANNOT_IMPORT_FROM_RE.search(msg)
-            if match:
-                module = match.group(1).split(".", 1)[0]
-                if module in _IMPORT_ERROR_MODULE_ALLOWLIST:
-                    return f"{name}:{module}"
+            module = getattr(exc, "name", None)
+            if not isinstance(module, str) or not module:
+                msg = str(exc)
+                match = _NO_MODULE_RE.search(msg) or _CANNOT_IMPORT_FROM_RE.search(msg)
+                module = match.group(1) if match else None
+            if isinstance(module, str) and module:
+                return f"{name}:{module}"
+        elif isinstance(exc, AttributeError):
+            attribute = getattr(exc, "name", None)
+            obj = getattr(exc, "obj", None)
+            if (
+                obj is sys.modules.get("streamlit")
+                and isinstance(attribute, str)
+                and attribute
+            ):
+                return f"{name}:{attribute}"
+            if obj is None and attribute is None:
+                match = _STREAMLIT_ATTRIBUTE_RE.fullmatch(str(exc))
+                if match:
+                    return f"{name}:{match.group(1)}"
         elif isinstance(exc, LocalizableStreamlitException):
             parameter = exc.exec_kwargs.get("parameter")
             if isinstance(parameter, str) and parameter:
                 return f"{name}:{parameter}"
-        else:
-            # Function-local import avoids a module-level cycle with media storage.
-            from streamlit.runtime.media_file_storage import MediaFileStorageError
-
-            if isinstance(exc, MediaFileStorageError) and str(exc).startswith(
-                "Error opening"
-            ):
-                return f"{name}:open"
     return name
 
 

--- a/lib/streamlit/runtime/metrics_util.py
+++ b/lib/streamlit/runtime/metrics_util.py
@@ -27,7 +27,7 @@ from functools import lru_cache, wraps
 from typing import Any, Final, TypeVar, cast, overload
 
 from streamlit import config, file_util, type_util, util
-from streamlit.errors import StreamlitValueError
+from streamlit.errors import LocalizableStreamlitException
 from streamlit.logger import get_logger
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.proto.PageProfile_pb2 import Argument, Command
@@ -246,6 +246,42 @@ _DBUS_MACHINE_ID_PATH = "/var/lib/dbus/machine-id"
 # Matches CPython's ``got an unexpected keyword argument 'name'`` TypeError.
 _UNEXPECTED_KWARG_RE: Final = re.compile(
     r"got an unexpected keyword argument '([^']+)'"
+)
+# ``foo() missing 1 required positional argument: 'bar'`` (also keyword-only).
+_MISSING_ARG_RE: Final = re.compile(
+    r"missing \d+ required (?:positional |keyword-only )?arguments?: '(\w+)'"
+)
+# ``foo() takes 2 positional arguments but 3 were given``
+# ``foo() takes 0 positional arguments but 1 was given``
+_TOO_MANY_POS_RE: Final = re.compile(
+    r"takes(?: from \d+ to)? \d+ positional arguments? but \d+ (?:was|were) given"
+)
+_BYTESLIKE_RE: Final = re.compile(r"a bytes-like object is required, not '")
+_PROTO_TYPE_RE: Final = re.compile(
+    r"bad argument type for built-in operation"
+    r"|expected str(?:, but got|, got)"
+    r"|: expected a string"
+    r"|has type \w+, but expected one of:"
+)
+_NO_MODULE_RE: Final = re.compile(r"No module named ['\"]([^'\"]+)['\"]")
+_CANNOT_IMPORT_FROM_RE: Final = re.compile(r"cannot import name '[^']+' from '([^']+)'")
+# First path component of ImportError module names we record. Keep this tight
+# so telemetry cardinality stays bounded.
+_IMPORT_ERROR_MODULE_ALLOWLIST: Final = frozenset(
+    {
+        "altair",
+        "graphviz",
+        "matplotlib",
+        "numpy",
+        "orjson",
+        "pandas",
+        "PIL",
+        "plotly",
+        "polars",
+        "pyarrow",
+        "pydeck",
+        "watchdog",
+    }
 )
 
 
@@ -491,22 +527,50 @@ def to_microseconds(seconds: float) -> int:
 def format_uncaught_exception(exc: BaseException) -> str:
     """Return a page-profile label for an uncaught exception.
 
-    Uses the exception type name, appending ``:<param>`` when the failing
-    parameter is known:
+    Uses the exception type name, appending a short suffix when a stable
+    category is known:
 
     - unexpected-keyword ``TypeError`` → ``"TypeError:<param>"``
-    - ``StreamlitValueError`` → ``"StreamlitValueError:<param>"``
+    - missing required argument ``TypeError`` → ``"TypeError:missing:<param>"``
+    - too many positional arguments → ``"TypeError:positional"``
+    - protobuf string-field type errors → ``"TypeError:proto"``
+    - bytes-like-object ``TypeError`` → ``"TypeError:byteslike"``
+    - allowlisted ``ImportError`` / ``ModuleNotFoundError`` → ``"<Type>:<module>"``
+    - ``MediaFileStorageError`` opening a file → ``"MediaFileStorageError:open"``
+    - ``LocalizableStreamlitException`` with a ``parameter`` kwarg
+      → ``"<Type>:<parameter>"``
 
+    Does not append user values (widget keys, file paths) or command names.
     Enrichment failures are swallowed so telemetry cannot interrupt script
     execution or drop the page-profile payload.
     """
     name = type(exc).__name__
     with contextlib.suppress(Exception):
         if isinstance(exc, TypeError):
-            match = _UNEXPECTED_KWARG_RE.search(str(exc))
+            msg = str(exc)
+            match = _UNEXPECTED_KWARG_RE.search(msg)
             if match:
                 return f"{name}:{match.group(1)}"
-        elif isinstance(exc, StreamlitValueError):
+            match = _MISSING_ARG_RE.search(msg)
+            if match:
+                return f"{name}:missing:{match.group(1)}"
+            if _TOO_MANY_POS_RE.search(msg):
+                return f"{name}:positional"
+            if _BYTESLIKE_RE.search(msg):
+                return f"{name}:byteslike"
+            if _PROTO_TYPE_RE.search(msg):
+                return f"{name}:proto"
+        elif isinstance(exc, ImportError):
+            msg = str(exc)
+            match = _NO_MODULE_RE.search(msg) or _CANNOT_IMPORT_FROM_RE.search(msg)
+            if match:
+                module = match.group(1).split(".", 1)[0]
+                if module in _IMPORT_ERROR_MODULE_ALLOWLIST:
+                    return f"{name}:{module}"
+        elif name == "MediaFileStorageError" and str(exc).startswith("Error opening"):
+            # Type name avoids importing MediaFileStorageError into this module.
+            return f"{name}:open"
+        elif isinstance(exc, LocalizableStreamlitException):
             parameter = exc.exec_kwargs.get("parameter")
             if isinstance(parameter, str) and parameter:
                 return f"{name}:{parameter}"

--- a/lib/streamlit/runtime/metrics_util.py
+++ b/lib/streamlit/runtime/metrics_util.py
@@ -256,6 +256,45 @@ _CANNOT_IMPORT_FROM_RE: Final = re.compile(r"cannot import name '[^']+' from '([
 _STREAMLIT_ATTRIBUTE_RE: Final = re.compile(
     r"module 'streamlit' has no attribute '([^']+)'"
 )
+# Import namespaces used by Streamlit itself or by its optional features. Only
+# these names are appended to telemetry to avoid recording private app modules.
+_STREAMLIT_IMPORT_MODULE_PREFIXES: Final = frozenset(
+    {
+        "altair",
+        "anyio",
+        "authlib",
+        "click",
+        "google.protobuf",
+        "graphviz",
+        "httptools",
+        "httpx",
+        "itsdangerous",
+        "matplotlib",
+        "multipart",
+        "numpy",
+        "orjson",
+        "packaging",
+        "pandas",
+        "PIL",
+        "plotly",
+        "pyarrow",
+        "pydeck",
+        "python_multipart",
+        "requests",
+        "rich",
+        "snowflake",
+        "sqlalchemy",
+        "starlette",
+        "streamlit",
+        "streamlit_pdf",
+        "toml",
+        "typing_extensions",
+        "uvicorn",
+        "uvloop",
+        "watchdog",
+        "websockets",
+    }
+)
 
 
 def _get_machine_id_v3() -> str:
@@ -497,6 +536,14 @@ def to_microseconds(seconds: float) -> int:
     return int(seconds * 1_000_000)
 
 
+def _is_streamlit_import_module(module: str) -> bool:
+    """Return whether an import namespace is relevant to Streamlit internals."""
+    return any(
+        module == prefix or module.startswith(f"{prefix}.")
+        for prefix in _STREAMLIT_IMPORT_MODULE_PREFIXES
+    )
+
+
 def format_uncaught_exception(exc: BaseException) -> str:
     """Return a page-profile label for an uncaught exception.
 
@@ -505,7 +552,8 @@ def format_uncaught_exception(exc: BaseException) -> str:
 
     - unexpected-keyword ``TypeError`` → ``"TypeError:<param>"``
     - missing required argument ``TypeError`` → ``"TypeError:missing:<param>"``
-    - ``ImportError`` / ``ModuleNotFoundError`` → ``"<Type>:<module>"``
+    - allowlisted ``ImportError`` / ``ModuleNotFoundError``
+      → ``"<Type>:<module>"``
     - missing top-level ``streamlit`` attributes → ``"AttributeError:<attribute>"``
     - ``LocalizableStreamlitException`` with a ``parameter`` kwarg
       → ``"<Type>:<parameter>"``
@@ -530,7 +578,11 @@ def format_uncaught_exception(exc: BaseException) -> str:
                 msg = str(exc)
                 match = _NO_MODULE_RE.search(msg) or _CANNOT_IMPORT_FROM_RE.search(msg)
                 module = match.group(1) if match else None
-            if isinstance(module, str) and module:
+            if (
+                isinstance(module, str)
+                and module
+                and _is_streamlit_import_module(module)
+            ):
                 return f"{name}:{module}"
         elif isinstance(exc, AttributeError):
             attribute = getattr(exc, "name", None)

--- a/lib/streamlit/runtime/state/session_state.py
+++ b/lib/streamlit/runtime/state/session_state.py
@@ -37,7 +37,10 @@ from typing import (
 )
 
 from streamlit import config, util
-from streamlit.errors import StreamlitAPIException, UnserializableSessionStateError
+from streamlit.errors import (
+    StreamlitWidgetAlreadyInstantiatedError,
+    UnserializableSessionStateError,
+)
 from streamlit.logger import get_logger
 from streamlit.proto.WidgetStates_pb2 import WidgetState as WidgetStateProto
 from streamlit.proto.WidgetStates_pb2 import WidgetStates as WidgetStatesProto
@@ -831,7 +834,8 @@ class SessionState:
         """Set the value of the session_state entry with the given user_key.
 
         If the key corresponds to a widget or form that's been instantiated
-        during the current script run, raise a StreamlitAPIException instead.
+        during the current script run, raise a StreamlitWidgetAlreadyInstantiatedError
+        instead.
         """
         ctx = get_script_run_ctx()
 
@@ -841,10 +845,7 @@ class SessionState:
             form_ids = ctx.shared.form_ids_this_run
 
             if widget_id in widget_ids or user_key in form_ids:
-                raise StreamlitAPIException(
-                    f"`st.session_state.{user_key}` cannot be modified after the widget"
-                    f" with key `{user_key}` is instantiated."
-                )
+                raise StreamlitWidgetAlreadyInstantiatedError(user_key)
 
         self._new_session_state[user_key] = value
 

--- a/lib/streamlit/string_util.py
+++ b/lib/streamlit/string_util.py
@@ -38,6 +38,19 @@ def clean_text(text: SupportsStr) -> str:
     return textwrap.dedent(str(text)).strip()
 
 
+def to_str(value: object) -> str:
+    """Coerce ``value`` to ``str`` for protobuf string fields.
+
+    Existing strings are returned unchanged so we do not allocate a copy.
+    """
+    return value if isinstance(value, str) else str(value)
+
+
+def to_help_str(help: object) -> str:
+    """Coerce ``help`` to ``str`` and dedent it for protobuf assignment."""
+    return textwrap.dedent(to_str(help))
+
+
 def _contains_special_chars(text: str) -> bool:
     """Check if a string contains any special chars.
 

--- a/lib/tests/streamlit/commands/execution_control_test.py
+++ b/lib/tests/streamlit/commands/execution_control_test.py
@@ -26,6 +26,7 @@ from streamlit.commands.execution_control import (
 from streamlit.errors import (
     NoSessionContext,
     StreamlitAPIException,
+    StreamlitPageNotFoundError,
     StreamlitValueError,
 )
 from streamlit.navigation.page import Page
@@ -404,12 +405,12 @@ def test_st_switch_page_string_path_unknown_page_raises(
     _patched_get_main_script_directory,
     patched_normalize_path_join,
 ):
-    """``switch_page`` raises ``StreamlitAPIException`` if the resolved path is unknown."""
+    """``switch_page`` raises ``StreamlitPageNotFoundError`` if the resolved path is unknown."""
     patched_normalize_path_join.return_value = "/some/path/missing.py"
     ctx = _make_pages_lookup_ctx("/some/path/pages/page_1.py")
     patched_get_script_run_ctx.return_value = ctx
 
-    with pytest.raises(StreamlitAPIException, match=r"Could not find page"):
+    with pytest.raises(StreamlitPageNotFoundError, match=r"Could not find page"):
         switch_page("missing.py")
 
     ctx.script_requests.request_rerun.assert_not_called()

--- a/lib/tests/streamlit/dataframe_util_test.py
+++ b/lib/tests/streamlit/dataframe_util_test.py
@@ -32,7 +32,7 @@ from pandas.api.types import infer_dtype
 from parameterized import parameterized
 
 from streamlit import dataframe_util
-from streamlit.errors import StreamlitAPIException
+from streamlit.errors import StreamlitDataframeConversionError
 from streamlit.type_util import get_fqn_type
 from tests.streamlit.data_mocks.snowpandas_mocks import DataFrame as SnowpandasDataFrame
 from tests.streamlit.data_mocks.snowpandas_mocks import Index as SnowpandasIndex
@@ -368,7 +368,6 @@ class DataframeUtilTest(unittest.TestCase):
         """Test that ArrowInvalid from __arrow_c_stream__ causes fallback to
         later conversion methods (interchange protocol or pandas constructor).
         """
-        from streamlit.errors import StreamlitAPIException
 
         class PyCapsuleOnlyObject:
             """Object with only __arrow_c_stream__ (no to_pandas or __dataframe__).
@@ -389,7 +388,9 @@ class DataframeUtilTest(unittest.TestCase):
         obj = PyCapsuleOnlyObject()
 
         # Should raise because there's no fallback after PyCapsule fails
-        with pytest.raises(StreamlitAPIException, match="Unable to convert"):
+        with pytest.raises(
+            StreamlitDataframeConversionError, match="Unable to convert"
+        ):
             dataframe_util.convert_anything_to_pandas_df(obj)
 
         # Verify the PyCapsule path was attempted
@@ -1160,11 +1161,13 @@ def test_fix_arrow_incompatible_column_types_stringifies_mixed_index_only() -> N
     assert infer_dtype(fixed.index) == "string"
 
 
-def test_convert_dict_fallback_failure_raises_streamlit_api_exception() -> None:
+def test_convert_dict_fallback_failure_raises_dataframe_conversion_error() -> None:
     """If both the default and key-value dict conversions fail, raise a clear error."""
     bad: dict[int, list[int]] = {0: [1], 1: [2, 3]}
     with (
-        pytest.raises(StreamlitAPIException, match="Unable to convert object"),
+        pytest.raises(
+            StreamlitDataframeConversionError, match="Unable to convert object"
+        ),
         patch.object(
             dataframe_util,
             "_dict_to_pandas_df",

--- a/lib/tests/streamlit/dataframe_util_test.py
+++ b/lib/tests/streamlit/dataframe_util_test.py
@@ -22,7 +22,7 @@ from collections.abc import Iterator, Mapping
 from datetime import date
 from decimal import Decimal
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pandas as pd
@@ -111,6 +111,29 @@ class DataframeUtilTest(unittest.TestCase):
 
         table = dataframe_util.convert_pandas_df_to_arrow_table(df)
         assert isinstance(table, pa.Table)
+
+    def test_convert_pandas_df_to_arrow_table_retry_failure_raises(self):
+        """A second from_pandas failure raises StreamlitDataframeConversionError."""
+        df = pd.DataFrame({"col": [1, 2, 3]})
+        arrow_error = pa.ArrowInvalid("still incompatible")
+        fake_pa = MagicMock()
+        fake_pa.ArrowTypeError = pa.ArrowTypeError
+        fake_pa.ArrowInvalid = pa.ArrowInvalid
+        fake_pa.ArrowNotImplementedError = pa.ArrowNotImplementedError
+        fake_pa.Table.from_pandas.side_effect = arrow_error
+
+        with (
+            # pa.Table is a C-extension type, so from_pandas cannot be patched
+            # on the class. Replace the local ``import pyarrow`` instead.
+            patch.dict("sys.modules", {"pyarrow": fake_pa}),
+            pytest.raises(
+                StreamlitDataframeConversionError,
+                match="Unable to convert dataframe to Arrow table",
+            ) as exc_info,
+        ):
+            dataframe_util.convert_pandas_df_to_arrow_table(df)
+
+        assert exc_info.value.__cause__ is arrow_error
 
     def test_convert_arrow_table_to_arrow_bytes_downcasts_large_list(self):
         """Test that convert_arrow_table_to_arrow_bytes downcasts large_list to list."""

--- a/lib/tests/streamlit/delta_generator_test.py
+++ b/lib/tests/streamlit/delta_generator_test.py
@@ -384,7 +384,7 @@ class DeltaGeneratorColumnsTest(DeltaGeneratorTestCase):
             st.columns(-1337)
 
     def test_bad_columns_single_float(self):
-        with pytest.raises(TypeError):
+        with pytest.raises(StreamlitAPIException):
             st.columns(6.28)
 
     def test_bad_columns_list_negative_value(self):

--- a/lib/tests/streamlit/elements/button_group_test.py
+++ b/lib/tests/streamlit/elements/button_group_test.py
@@ -705,6 +705,17 @@ class ButtonGroupCommandTests(DeltaGeneratorTestCase):
         assert delta.label == ""
         assert not delta.HasField("label_visibility")
 
+    def test_omitted_label_invalid_visibility_raises(self) -> None:
+        """Omitted labels still validate ``label_visibility``."""
+        with pytest.raises(
+            StreamlitValueError, match=r"Invalid `label_visibility` value"
+        ):
+            ButtonGroupMixin._internal_button_group(
+                st._main,
+                ["a", "b"],
+                label_visibility="wrong_value",  # type: ignore[arg-type]
+            )
+
     def test_non_string_label_is_coerced(self) -> None:
         """Non-string labels are coerced without collapsing the proto label."""
         st.pills(123, ["a", "b", "c"])  # type: ignore[arg-type]

--- a/lib/tests/streamlit/elements/button_group_test.py
+++ b/lib/tests/streamlit/elements/button_group_test.py
@@ -572,7 +572,7 @@ class ButtonGroupCommandTests(DeltaGeneratorTestCase):
             (
                 st.pills,
                 ("label", ["a", "b", "c"]),
-                {"help": "Test help param"},
+                {"help": "    Test help param"},
                 ["a", "b", "c"],
                 "content",
                 ButtonGroupProto.Style.PILLS,
@@ -617,6 +617,7 @@ class ButtonGroupCommandTests(DeltaGeneratorTestCase):
 
         if test_label:
             assert delta.label == command_args[0]
+            assert delta.help == "Test help param"
         assert (
             delta.label_visibility.value
             is LabelVisibility.LabelVisibilityOptions.VISIBLE

--- a/lib/tests/streamlit/elements/button_group_test.py
+++ b/lib/tests/streamlit/elements/button_group_test.py
@@ -698,6 +698,20 @@ class ButtonGroupCommandTests(DeltaGeneratorTestCase):
 
         assert button_group_1.id != button_group_2.id
 
+    def test_omitted_label_leaves_proto_label_unset(self) -> None:
+        """Omitted labels stay unset so the frontend collapses them."""
+        ButtonGroupMixin._internal_button_group(st._main, ["a", "b", "c"])
+        delta = self.get_delta_from_queue().new_element.button_group
+        assert delta.label == ""
+        assert not delta.HasField("label_visibility")
+
+    def test_non_string_label_is_coerced(self) -> None:
+        """Non-string labels are coerced without collapsing the proto label."""
+        st.pills(123, ["a", "b", "c"])  # type: ignore[arg-type]
+        delta = self.get_delta_from_queue().new_element.button_group
+        assert delta.label == "123"
+        assert delta.HasField("label_visibility")
+
     @parameterized.expand(
         get_command_matrix(
             [

--- a/lib/tests/streamlit/elements/button_test.py
+++ b/lib/tests/streamlit/elements/button_test.py
@@ -665,6 +665,31 @@ class ButtonTest(DeltaGeneratorTestCase):
                     assert c.page_script_hash == "hash123"
                     assert c.label == "Page 1"
 
+    def test_page_link_missing_url_pathname_does_not_raise_keyerror(self):
+        """Pages without ``url_pathname`` (default registry payload) still resolve."""
+        ctx = MagicMock()
+        ctx.main_script_path = "/app/main.py"
+        ctx.pages_manager.get_pages.return_value = {
+            "page1": {
+                "script_path": "/app/pages/page1.py",
+                "page_name": "Page 1",
+                "page_script_hash": "hash123",
+            }
+        }
+
+        with patch(
+            "streamlit.elements.widgets.button.get_script_run_ctx", return_value=ctx
+        ):
+            with patch(
+                "streamlit.file_util.get_main_script_directory", return_value="/app"
+            ):
+                with patch("os.path.realpath", return_value="/app/pages/page1.py"):
+                    st.page_link("pages/page1.py")
+                    c = self.get_delta_from_queue().new_element.page_link
+                    assert c.page == ""
+                    assert c.page_script_hash == "hash123"
+                    assert c.label == "Page 1"
+
     def test_page_link_page_not_found(self):
         """Test page_link with non-existent page."""
         ctx = MagicMock()

--- a/lib/tests/streamlit/elements/button_test.py
+++ b/lib/tests/streamlit/elements/button_test.py
@@ -119,6 +119,15 @@ class ButtonTest(DeltaGeneratorTestCase):
         assert not c.is_form_submitter
         assert not c.disabled
 
+    @parameterized.expand(get_button_command_matrix([123]))
+    def test_non_string_label_is_coerced(
+        self, name: str, command: Callable[..., Any], label: int
+    ) -> None:
+        """Non-string labels are coerced to strings for protobuf assignment."""
+        command(label=label)
+        c = getattr(self.get_delta_from_queue().new_element, name)
+        assert c.label == "123"
+
     @parameterized.expand(
         [
             (name, command, type_)

--- a/lib/tests/streamlit/elements/checkbox_test.py
+++ b/lib/tests/streamlit/elements/checkbox_test.py
@@ -53,6 +53,20 @@ class CheckboxTest(DeltaGeneratorTestCase):
         )
         assert c.type == CheckboxProto.StyleType.DEFAULT
 
+    def test_non_str_label_is_coerced(self):
+        """Non-string labels are coerced so protobuf assignment does not TypeError."""
+        st.checkbox(123)
+
+        c = self.get_delta_from_queue().new_element.checkbox
+        assert c.label == "123"
+
+    def test_non_str_help_is_coerced(self):
+        """Non-string help is coerced so protobuf assignment does not TypeError."""
+        st.checkbox("the label", help=123)
+
+        c = self.get_delta_from_queue().new_element.checkbox
+        assert c.help == "123"
+
     def test_just_disabled(self):
         """Test that it can be called with disabled param."""
         st.checkbox("the label", disabled=True)

--- a/lib/tests/streamlit/elements/datetime_input_test.py
+++ b/lib/tests/streamlit/elements/datetime_input_test.py
@@ -26,6 +26,7 @@ import streamlit as st
 from streamlit.elements.widgets.time_widgets import DateTimeInputSerde
 from streamlit.errors import (
     StreamlitAPIException,
+    StreamlitInvalidParameterTypeError,
     StreamlitInvalidWidthError,
     StreamlitValueError,
 )
@@ -142,9 +143,9 @@ class DateTimeInputTest(DeltaGeneratorTestCase):
 
     def test_step_validation(self):
         """Test invalid step values."""
-        with pytest.raises(StreamlitAPIException):
+        with pytest.raises(StreamlitInvalidParameterTypeError):
             st.datetime_input("The label", step=True)
-        with pytest.raises(StreamlitAPIException):
+        with pytest.raises(StreamlitInvalidParameterTypeError):
             st.datetime_input("The label", step=(1, 0))
         with pytest.raises(StreamlitAPIException):
             st.datetime_input("The label", step=30)

--- a/lib/tests/streamlit/elements/heading_test.py
+++ b/lib/tests/streamlit/elements/heading_test.py
@@ -63,7 +63,7 @@ class StHeaderTest(DeltaGeneratorTestCase):
 
     def test_st_header_with_help(self):
         """Test st.header with help."""
-        st.header("some header", help="help text")
+        st.header("some header", help="    help text")
         el = self.get_delta_from_queue().new_element
         assert el.heading.body == "some header"
         assert el.heading.tag == "h2"

--- a/lib/tests/streamlit/elements/layouts_test.py
+++ b/lib/tests/streamlit/elements/layouts_test.py
@@ -15,6 +15,7 @@
 from typing import Literal
 from unittest.mock import MagicMock, patch
 
+import numpy as np
 import pytest
 from parameterized import parameterized
 
@@ -27,6 +28,7 @@ from streamlit.errors import (
     StreamlitInvalidColumnGapError,
     StreamlitInvalidFormCallbackError,
     StreamlitInvalidHorizontalAlignmentError,
+    StreamlitInvalidParameterTypeError,
     StreamlitInvalidVerticalAlignmentError,
     StreamlitValueError,
 )
@@ -69,6 +71,17 @@ class ColumnsTest(DeltaGeneratorTestCase):
         assert columns_blocks[0].add_block.column.weight == 1.0 / 3
         assert columns_blocks[1].add_block.column.weight == 1.0 / 3
         assert columns_blocks[2].add_block.column.weight == 1.0 / 3
+
+    def test_numpy_integer_spec(self):
+        """numpy integer specs are treated as a column count, like Python ints."""
+        columns = st.columns(np.int64(3))
+        assert len(columns) == 3
+
+    def test_float_spec_raises_invalid_parameter_type(self):
+        """A non-integer scalar spec is a type error, not a crash on ``len()``."""
+        with pytest.raises(StreamlitInvalidParameterTypeError) as exc:
+            st.columns(6.28)
+        assert exc.value.exec_kwargs["parameter"] == "spec"
 
     @parameterized.expand(
         [

--- a/lib/tests/streamlit/elements/layouts_test.py
+++ b/lib/tests/streamlit/elements/layouts_test.py
@@ -82,6 +82,8 @@ class ColumnsTest(DeltaGeneratorTestCase):
         with pytest.raises(StreamlitInvalidParameterTypeError) as exc:
             st.columns(6.28)
         assert exc.value.exec_kwargs["parameter"] == "spec"
+        assert "Expected one of: int, sequence of numbers" in str(exc.value)
+        assert "Provided type: float" in str(exc.value)
 
     @parameterized.expand(
         [

--- a/lib/tests/streamlit/elements/lib/options_selector_utils_test.py
+++ b/lib/tests/streamlit/elements/lib/options_selector_utils_test.py
@@ -36,7 +36,10 @@ from streamlit.elements.lib.options_selector_utils import (
     validate_and_sync_value_with_options,
     validate_select_widget_filter_mode,
 )
-from streamlit.errors import StreamlitAPIException, StreamlitValueError
+from streamlit.errors import (
+    StreamlitDefaultNotInOptionsError,
+    StreamlitValueError,
+)
 from streamlit.proto.SelectWidgetFilterMode_pb2 import (
     SelectWidgetFilterMode as ProtoSelectWidgetFilterMode,
 )
@@ -71,7 +74,7 @@ class TestCheckAndConvertToIndices:
         assert res == [1]
 
     def test_check_and_convert_to_indices_default_not_in_opts(self):
-        with pytest.raises(StreamlitAPIException):
+        with pytest.raises(StreamlitDefaultNotInOptionsError):
             check_and_convert_to_indices(["a", "b"], "c")
 
 

--- a/lib/tests/streamlit/elements/markdown_test.py
+++ b/lib/tests/streamlit/elements/markdown_test.py
@@ -91,7 +91,7 @@ class StMarkdownAPITest(DeltaGeneratorTestCase):
         assert el.markdown.allow_html
 
         # test the help keyword
-        st.markdown("    some markdown  ", help="help text")
+        st.markdown("    some markdown  ", help="    help text")
         el = self.get_delta_from_queue().new_element
         assert el.markdown.body == "some markdown"
         assert el.markdown.help == "help text"

--- a/lib/tests/streamlit/elements/menu_button_test.py
+++ b/lib/tests/streamlit/elements/menu_button_test.py
@@ -49,6 +49,18 @@ class MenuButtonTest(DeltaGeneratorTestCase):
         assert c.help == ""
         assert c.icon == ""
 
+    def test_non_string_label_is_coerced(self) -> None:
+        """Non-string labels are coerced to strings for protobuf assignment."""
+        st.menu_button(123, ["Option A"])  # type: ignore[arg-type]
+        c = self.get_delta_from_queue().new_element.menu_button
+        assert c.label == "123"
+
+    def test_none_label_is_coerced_to_empty(self) -> None:
+        """None labels become an empty string instead of raising TypeError."""
+        st.menu_button(None, ["Option A"])  # type: ignore[arg-type]
+        c = self.get_delta_from_queue().new_element.menu_button
+        assert c.label == ""
+
     def test_disabled(self):
         """Test that disabled param is set correctly."""
         st.menu_button("the label", ["Option A", "Option B"], disabled=True)

--- a/lib/tests/streamlit/elements/metric_test.py
+++ b/lib/tests/streamlit/elements/metric_test.py
@@ -346,14 +346,12 @@ class MetricTest(DeltaGeneratorTestCase):
 
         assert metric_proto.label == "Column 5"
 
-    def test_invalid_label(self):
-        with pytest.raises(TypeError) as exc:
-            st.metric(123, "-321")
+    def test_non_str_label_is_coerced(self):
+        """Non-string labels are coerced so protobuf assignment does not TypeError."""
+        st.metric(123, "-321")
 
-        assert str(exc.value) == (
-            "'123' is of type <class 'int'>, which is not an accepted type. "
-            "label only accepts: str. Please convert the label to an accepted type."
-        )
+        metric_proto = self.get_delta_from_queue().new_element.metric
+        assert metric_proto.label == "123"
 
     def test_invalid_label_visibility(self):
         with pytest.raises(StreamlitValueError) as e:

--- a/lib/tests/streamlit/elements/selectbox_test.py
+++ b/lib/tests/streamlit/elements/selectbox_test.py
@@ -27,6 +27,7 @@ from streamlit.elements.lib.options_selector_utils import create_mappings
 from streamlit.elements.widgets.selectbox import SelectboxSerde
 from streamlit.errors import (
     StreamlitAPIException,
+    StreamlitInvalidParameterTypeError,
     StreamlitInvalidWidthError,
     StreamlitValueError,
 )
@@ -185,7 +186,7 @@ class SelectboxTest(DeltaGeneratorTestCase):
 
     def test_invalid_value(self):
         """Test that value must be an int."""
-        with pytest.raises(StreamlitAPIException):
+        with pytest.raises(StreamlitInvalidParameterTypeError):
             st.selectbox("the label", ("m", "f"), "1")
 
     def test_invalid_value_range(self):

--- a/lib/tests/streamlit/elements/selectbox_test.py
+++ b/lib/tests/streamlit/elements/selectbox_test.py
@@ -186,7 +186,10 @@ class SelectboxTest(DeltaGeneratorTestCase):
 
     def test_invalid_value(self):
         """Test that value must be an int."""
-        with pytest.raises(StreamlitInvalidParameterTypeError):
+        with pytest.raises(
+            StreamlitInvalidParameterTypeError,
+            match=r"Expected one of: int, None\. Provided type: str\.",
+        ):
             st.selectbox("the label", ("m", "f"), "1")
 
     def test_invalid_value_range(self):

--- a/lib/tests/streamlit/elements/slider_test.py
+++ b/lib/tests/streamlit/elements/slider_test.py
@@ -34,7 +34,9 @@ from streamlit.elements.widgets.slider import (
 )
 from streamlit.errors import (
     StreamlitAPIException,
+    StreamlitInvalidParameterTypeError,
     StreamlitInvalidWidthError,
+    StreamlitJSNumberBoundsError,
     StreamlitValueAboveMaxError,
     StreamlitValueBelowMinError,
     StreamlitValueError,
@@ -135,7 +137,7 @@ class SliderTest(DeltaGeneratorTestCase):
     )
     def test_invalid_types(self, value):
         """Test that it rejects invalid types, specifically things that are *almost* numbers"""
-        with pytest.raises(StreamlitAPIException):
+        with pytest.raises(StreamlitInvalidParameterTypeError):
             st.slider("the label", value=value)
 
     @parameterized.expand(
@@ -227,13 +229,13 @@ class SliderTest(DeltaGeneratorTestCase):
 
     def test_value_out_of_bounds(self):
         # Max int
-        with pytest.raises(StreamlitAPIException) as exc:
+        with pytest.raises(StreamlitJSNumberBoundsError) as exc:
             max_value = JSNumber.MAX_SAFE_INTEGER + 1
             st.slider("Label", max_value=max_value)
         assert f"`max_value` ({max_value}) must be <= (1 << 53) - 1" == str(exc.value)
 
         # Min int
-        with pytest.raises(StreamlitAPIException) as exc:
+        with pytest.raises(StreamlitJSNumberBoundsError) as exc:
             min_value = JSNumber.MIN_SAFE_INTEGER - 1
             st.slider("Label", min_value=min_value)
         assert f"`min_value` ({min_value}) must be >= -((1 << 53) - 1)" == str(
@@ -241,13 +243,13 @@ class SliderTest(DeltaGeneratorTestCase):
         )
 
         # Max float
-        with pytest.raises(StreamlitAPIException) as exc:
+        with pytest.raises(StreamlitJSNumberBoundsError) as exc:
             max_value = 2e308
             st.slider("Label", value=0.5, max_value=max_value)
         assert f"`max_value` ({max_value}) must be <= 1.797e+308" == str(exc.value)
 
         # Min float
-        with pytest.raises(StreamlitAPIException) as exc:
+        with pytest.raises(StreamlitJSNumberBoundsError) as exc:
             min_value = -2e308
             st.slider("Label", value=0.5, min_value=min_value)
         assert f"`min_value` ({min_value}) must be >= -1.797e+308" == str(exc.value)
@@ -1002,22 +1004,25 @@ class SliderEdgeCasesTest(DeltaGeneratorTestCase):
     """Tests for slider parameter validation edge cases."""
 
     def test_mixed_types_in_value_raises(self):
-        """A list with mixed numeric types raises StreamlitAPIException."""
-        with pytest.raises(StreamlitAPIException, match="must be of the same type"):
+        """A list with mixed numeric types raises StreamlitInvalidParameterTypeError."""
+        with pytest.raises(
+            StreamlitInvalidParameterTypeError, match="must be of the same type"
+        ):
             st.slider("the label", value=[1, 2.5])
 
     def test_mismatched_arg_types_raises(self):
-        """Mismatched min/max/step types raise StreamlitAPIException."""
+        """Mismatched min/max/step types raise StreamlitInvalidParameterTypeError."""
         with pytest.raises(
-            StreamlitAPIException, match="arguments must be of matching types"
+            StreamlitInvalidParameterTypeError,
+            match="arguments must be of matching types",
         ):
             # min/max are float but step is int, so the args-type-mismatch error fires.
             st.slider("label", min_value=0.0, max_value=10.0, value=5.0, step=1)
 
     def test_value_type_mismatch_with_args(self):
-        """Value type that doesn't match arg types raises StreamlitAPIException."""
+        """Value type that doesn't match arg types raises StreamlitInvalidParameterTypeError."""
         with pytest.raises(
-            StreamlitAPIException,
+            StreamlitInvalidParameterTypeError,
             match="value and arguments must be of the same type",
         ):
             # min/max/step are float but value is int, so data_type is INT and

--- a/lib/tests/streamlit/elements/slider_test.py
+++ b/lib/tests/streamlit/elements/slider_test.py
@@ -1006,7 +1006,8 @@ class SliderEdgeCasesTest(DeltaGeneratorTestCase):
     def test_mixed_types_in_value_raises(self):
         """A list with mixed numeric types raises StreamlitInvalidParameterTypeError."""
         with pytest.raises(
-            StreamlitInvalidParameterTypeError, match="must be of the same type"
+            StreamlitInvalidParameterTypeError,
+            match="list or tuple containing values of the same type",
         ):
             st.slider("the label", value=[1, 2.5])
 
@@ -1014,7 +1015,7 @@ class SliderEdgeCasesTest(DeltaGeneratorTestCase):
         """Mismatched min/max/step types raise StreamlitInvalidParameterTypeError."""
         with pytest.raises(
             StreamlitInvalidParameterTypeError,
-            match="arguments must be of matching types",
+            match="matching numeric types",
         ):
             # min/max are float but step is int, so the args-type-mismatch error fires.
             st.slider("label", min_value=0.0, max_value=10.0, value=5.0, step=1)
@@ -1023,7 +1024,7 @@ class SliderEdgeCasesTest(DeltaGeneratorTestCase):
         """Value type that doesn't match arg types raises StreamlitInvalidParameterTypeError."""
         with pytest.raises(
             StreamlitInvalidParameterTypeError,
-            match="value and arguments must be of the same type",
+            match="value and arguments with matching types",
         ):
             # min/max/step are float but value is int, so data_type is INT and
             # the value-vs-args matching-type check fails.

--- a/lib/tests/streamlit/elements/slider_test.py
+++ b/lib/tests/streamlit/elements/slider_test.py
@@ -1003,6 +1003,14 @@ def test_slider_serde_deserialize_passes_through_in_range_value() -> None:
 class SliderEdgeCasesTest(DeltaGeneratorTestCase):
     """Tests for slider parameter validation edge cases."""
 
+    def test_overlong_value_sequence_raises(self):
+        """A list or tuple longer than 2 items raises StreamlitAPIException."""
+        with pytest.raises(
+            StreamlitAPIException,
+            match="list/tuple of 0 to 2",
+        ):
+            st.slider("the label", value=[1, 2, 3])
+
     def test_mixed_types_in_value_raises(self):
         """A list with mixed numeric types raises StreamlitInvalidParameterTypeError."""
         with pytest.raises(

--- a/lib/tests/streamlit/elements/text_test.py
+++ b/lib/tests/streamlit/elements/text_test.py
@@ -33,7 +33,7 @@ class StTextAPITest(DeltaGeneratorTestCase):
 
     def test_st_text_with_help(self):
         """Test st.text with help."""
-        st.text("some text", help="help text")
+        st.text("some text", help="    help text")
         el = self.get_delta_from_queue().new_element
         assert el.text.body == "some text"
         assert el.text.help == "help text"

--- a/lib/tests/streamlit/elements/time_input_test.py
+++ b/lib/tests/streamlit/elements/time_input_test.py
@@ -29,6 +29,7 @@ from streamlit.elements.widgets.time_widgets import (
 )
 from streamlit.errors import (
     StreamlitAPIException,
+    StreamlitInvalidParameterTypeError,
     StreamlitInvalidWidthError,
     StreamlitValueError,
 )
@@ -147,9 +148,9 @@ class TimeInputTest(DeltaGeneratorTestCase):
     def test_st_time_input_exceptions(self):
         """Test st.time_input exceptions."""
         value = time(9, 00)
-        with pytest.raises(StreamlitAPIException):
+        with pytest.raises(StreamlitInvalidParameterTypeError):
             st.time_input("Set an alarm for", value, step=True)
-        with pytest.raises(StreamlitAPIException):
+        with pytest.raises(StreamlitInvalidParameterTypeError):
             st.time_input("Set an alarm for", value, step=(90, 0))
         with pytest.raises(StreamlitAPIException):
             st.time_input("Set an alarm for", value, step=0)
@@ -455,15 +456,18 @@ def test_convert_timelike_to_time_returns_same_instance_for_time() -> None:
 
 
 @pytest.mark.parametrize(
-    ("invalid_input", "match"),
-    [("not-a-time", "datetime, time"), (42, None)],
+    ("invalid_input", "exc", "match"),
+    [
+        ("not-a-time", StreamlitAPIException, "datetime, time"),
+        (42, StreamlitInvalidParameterTypeError, None),
+    ],
     ids=["invalid_string", "invalid_type"],
 )
 def test_convert_timelike_to_time_invalid_raises(
-    invalid_input: object, match: str | None
+    invalid_input: object, exc: type[Exception], match: str | None
 ) -> None:
-    """Unparseable strings or wrong types raise StreamlitAPIException."""
-    with pytest.raises(StreamlitAPIException, match=match):
+    """Unparseable strings or wrong types raise a Streamlit API exception."""
+    with pytest.raises(exc, match=match):
         _convert_timelike_to_time(invalid_input)  # type: ignore[arg-type]
 
 
@@ -514,15 +518,18 @@ def test_convert_datelike_to_date_parses_iso_strings(
 
 
 @pytest.mark.parametrize(
-    ("invalid_input", "match"),
-    [("not-a-date", "ISO string"), (42, None)],
+    ("invalid_input", "exc", "match"),
+    [
+        ("not-a-date", StreamlitAPIException, "ISO string"),
+        (42, StreamlitInvalidParameterTypeError, None),
+    ],
     ids=["invalid_string", "invalid_type"],
 )
 def test_convert_datelike_to_date_invalid_raises(
-    invalid_input: object, match: str | None
+    invalid_input: object, exc: type[Exception], match: str | None
 ) -> None:
-    """Unparseable strings or wrong types raise StreamlitAPIException."""
-    with pytest.raises(StreamlitAPIException, match=match):
+    """Unparseable strings or wrong types raise a Streamlit API exception."""
+    with pytest.raises(exc, match=match):
         _convert_datelike_to_date(invalid_input)  # type: ignore[arg-type]
 
 

--- a/lib/tests/streamlit/elements/time_input_test.py
+++ b/lib/tests/streamlit/elements/time_input_test.py
@@ -540,7 +540,7 @@ def test_parse_date_value_none_is_not_range() -> None:
 
 def test_parse_date_value_too_many_dates_raises() -> None:
     """A range of more than 2 dates raises StreamlitAPIException."""
-    with pytest.raises(StreamlitAPIException, match="0 - 2 date"):
+    with pytest.raises(StreamlitAPIException, match="0 to 2 date"):
         _parse_date_value([date(2020, 1, 1), date(2020, 1, 2), date(2020, 1, 3)])
 
 

--- a/lib/tests/streamlit/elements/time_widgets_test.py
+++ b/lib/tests/streamlit/elements/time_widgets_test.py
@@ -29,7 +29,7 @@ from streamlit.elements.widgets.time_widgets import (
     _parse_max_date,
     _parse_min_date,
 )
-from streamlit.errors import StreamlitAPIException
+from streamlit.errors import StreamlitAPIException, StreamlitInvalidParameterTypeError
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -37,8 +37,8 @@ if TYPE_CHECKING:
 
 @pytest.mark.parametrize("parse_fn", [_parse_min_date, _parse_max_date])
 def test_parse_date_bound_rejects_invalid_type(parse_fn: Callable[..., date]) -> None:
-    """Test that a non-date/datetime/None bound raises a StreamlitAPIException."""
-    with pytest.raises(StreamlitAPIException):
+    """Test that a non-date/datetime/None bound raises StreamlitInvalidParameterTypeError."""
+    with pytest.raises(StreamlitInvalidParameterTypeError):
         parse_fn(123, None)
 
 

--- a/lib/tests/streamlit/errors_test.py
+++ b/lib/tests/streamlit/errors_test.py
@@ -144,6 +144,36 @@ def test_page_not_found_without_pages_directory() -> None:
     assert "st.navigation" in msg
 
 
+def test_page_not_found_during_construction() -> None:
+    """st.Page file-not-found uses a construction-specific message."""
+    exc = errors.StreamlitPageNotFoundError("nonexistent.py", during_construction=True)
+    assert (
+        str(exc)
+        == "Unable to create Page. The file `nonexistent.py` could not be found."
+    )
+
+
+def test_invalid_parameter_type_error_preserves_message() -> None:
+    """Message text is used literally, including braces; parameter is for telemetry."""
+    message = "Expected one of {int, float}, not str"
+    exc = errors.StreamlitInvalidParameterTypeError("index", message)
+    assert str(exc) == message
+    assert exc.exec_kwargs["parameter"] == "index"
+
+
+def test_widget_already_instantiated_error_message() -> None:
+    """Session-state assignment after widget creation names the key."""
+    exc = errors.StreamlitWidgetAlreadyInstantiatedError("my_key")
+    assert "`st.session_state.my_key`" in str(exc)
+    assert "instantiated" in str(exc)
+
+
+def test_default_not_in_options_error_message() -> None:
+    """Default-not-in-options names the missing value."""
+    exc = errors.StreamlitDefaultNotInOptionsError("c")
+    assert "The default value 'c' is not part of the options." in str(exc)
+
+
 # StreamlitSelectionCountExceedsMaxError tests
 
 

--- a/lib/tests/streamlit/errors_test.py
+++ b/lib/tests/streamlit/errors_test.py
@@ -146,7 +146,7 @@ def test_page_not_found_without_pages_directory() -> None:
 
 def test_page_not_found_during_construction() -> None:
     """st.Page file-not-found uses a construction-specific message."""
-    exc = errors.StreamlitPageNotFoundError("nonexistent.py", during_construction=True)
+    exc = errors.StreamlitPageNotFoundError("nonexistent.py")
     assert (
         str(exc)
         == "Unable to create Page. The file `nonexistent.py` could not be found."

--- a/lib/tests/streamlit/errors_test.py
+++ b/lib/tests/streamlit/errors_test.py
@@ -172,6 +172,7 @@ def test_default_not_in_options_error_message() -> None:
     """Default-not-in-options names the missing value."""
     exc = errors.StreamlitDefaultNotInOptionsError("c")
     assert "The default value 'c' is not part of the options." in str(exc)
+    assert "every default value also exists in the options." in str(exc)
 
 
 # StreamlitSelectionCountExceedsMaxError tests

--- a/lib/tests/streamlit/errors_test.py
+++ b/lib/tests/streamlit/errors_test.py
@@ -153,12 +153,18 @@ def test_page_not_found_during_construction() -> None:
     )
 
 
-def test_invalid_parameter_type_error_preserves_message() -> None:
-    """Message text is used literally, including braces; parameter is for telemetry."""
-    message = "Expected one of {int, float}, not str"
-    exc = errors.StreamlitInvalidParameterTypeError("index", message)
-    assert str(exc) == message
-    assert exc.exec_kwargs["parameter"] == "index"
+def test_invalid_parameter_type_error_message() -> None:
+    """The parameter, expected types, and provided type form one stable message."""
+    exc = errors.StreamlitInvalidParameterTypeError("index", "str", ["int", "None"])
+    assert (
+        str(exc)
+        == "Invalid `index` type. Expected one of: int, None. Provided type: str."
+    )
+    assert exc.exec_kwargs == {
+        "parameter": "index",
+        "expected_types": "int, None",
+        "provided_type": "str",
+    }
 
 
 def test_widget_already_instantiated_error_message() -> None:

--- a/lib/tests/streamlit/form_test.py
+++ b/lib/tests/streamlit/form_test.py
@@ -22,7 +22,12 @@ import pytest
 from parameterized import parameterized
 
 import streamlit as st
-from streamlit.errors import StreamlitAPIException, StreamlitValueError
+from streamlit.errors import (
+    StreamlitAPIException,
+    StreamlitDuplicateElementKey,
+    StreamlitInvalidContextError,
+    StreamlitValueError,
+)
 from streamlit.proto.ButtonLikeIconPosition_pb2 import (
     ButtonLikeIconPosition as ProtoButtonLikeIconPosition,
 )
@@ -246,11 +251,15 @@ class FormMarshallingTest(DeltaGeneratorTestCase):
     def test_multiple_forms_same_key(self):
         """Multiple forms with the same key are not allowed."""
 
-        with pytest.raises(StreamlitAPIException) as ctx:
+        with pytest.raises(StreamlitDuplicateElementKey) as ctx:
             st.form(key="foo")
             st.form(key="foo")
 
-        assert "There are multiple identical forms with `key='foo'`" in str(ctx.value)
+        assert str(ctx.value) == (
+            "There are multiple elements with the same `key='foo'`. "
+            "To fix this, please make sure that the `key` argument is unique for "
+            "each element you create."
+        )
 
     def test_multiple_forms_same_labels_different_keys(self):
         """Multiple forms with different keys are allowed."""
@@ -265,7 +274,7 @@ class FormMarshallingTest(DeltaGeneratorTestCase):
     def test_form_in_form(self):
         """Test that forms cannot be nested in other forms."""
 
-        with pytest.raises(StreamlitAPIException) as ctx:
+        with pytest.raises(StreamlitInvalidContextError) as ctx:
             with st.form("foo"):
                 with st.form("bar"):
                     pass
@@ -275,7 +284,7 @@ class FormMarshallingTest(DeltaGeneratorTestCase):
     def test_button_in_form(self):
         """Test that buttons are not allowed in forms."""
 
-        with pytest.raises(StreamlitAPIException) as ctx:
+        with pytest.raises(StreamlitInvalidContextError) as ctx:
             with st.form("foo"):
                 st.button("foo")
 
@@ -306,7 +315,7 @@ class FormSubmitButtonTest(DeltaGeneratorTestCase):
     def test_submit_button_outside_form(self):
         """Test that a submit button is not allowed outside a form."""
 
-        with pytest.raises(StreamlitAPIException) as ctx:
+        with pytest.raises(StreamlitInvalidContextError) as ctx:
             st.form_submit_button()
 
         assert "`st.form_submit_button()` must be used inside an `st.form()`" in str(

--- a/lib/tests/streamlit/form_test.py
+++ b/lib/tests/streamlit/form_test.py
@@ -25,7 +25,7 @@ import streamlit as st
 from streamlit.errors import (
     StreamlitAPIException,
     StreamlitDuplicateElementKey,
-    StreamlitInvalidContextError,
+    StreamlitInvalidLayoutContextError,
     StreamlitValueError,
 )
 from streamlit.proto.ButtonLikeIconPosition_pb2 import (
@@ -274,7 +274,7 @@ class FormMarshallingTest(DeltaGeneratorTestCase):
     def test_form_in_form(self):
         """Test that forms cannot be nested in other forms."""
 
-        with pytest.raises(StreamlitInvalidContextError) as ctx:
+        with pytest.raises(StreamlitInvalidLayoutContextError) as ctx:
             with st.form("foo"):
                 with st.form("bar"):
                     pass
@@ -284,7 +284,7 @@ class FormMarshallingTest(DeltaGeneratorTestCase):
     def test_button_in_form(self):
         """Test that buttons are not allowed in forms."""
 
-        with pytest.raises(StreamlitInvalidContextError) as ctx:
+        with pytest.raises(StreamlitInvalidLayoutContextError) as ctx:
             with st.form("foo"):
                 st.button("foo")
 
@@ -315,7 +315,7 @@ class FormSubmitButtonTest(DeltaGeneratorTestCase):
     def test_submit_button_outside_form(self):
         """Test that a submit button is not allowed outside a form."""
 
-        with pytest.raises(StreamlitInvalidContextError) as ctx:
+        with pytest.raises(StreamlitInvalidLayoutContextError) as ctx:
             st.form_submit_button()
 
         assert "`st.form_submit_button()` must be used inside an `st.form()`" in str(

--- a/lib/tests/streamlit/navigation/page_test.py
+++ b/lib/tests/streamlit/navigation/page_test.py
@@ -22,7 +22,11 @@ import pytest
 from parameterized import parameterized
 
 import streamlit as st
-from streamlit.errors import StreamlitAPIException, StreamlitValueError
+from streamlit.errors import (
+    StreamlitAPIException,
+    StreamlitPageNotFoundError,
+    StreamlitValueError,
+)
 from streamlit.navigation.page import Page, StreamlitPage, _create_page
 from tests.conftest import enable_mpa_v2_mode
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
@@ -305,19 +309,17 @@ class StPagesTest(DeltaGeneratorTestCase):
 # @patch mocking the return value of `is_file` takes precedence over the method level
 # patch.
 @patch("pathlib.Path.is_file", MagicMock(return_value=False))
-def test_st_Page_throws_error_if_path_is_invalid():
-    with pytest.raises(StreamlitAPIException) as e:
-        st.Page("nonexistent.py")
-    assert (
-        str(e.value)
-        == "Unable to create Page. The file `nonexistent.py` could not be found."
-    )
-
-    with pytest.raises(StreamlitAPIException) as e:
-        st.Page(Path("nonexistent2.py"))
-    assert (
-        str(e.value)
-        == "Unable to create Page. The file `nonexistent2.py` could not be found."
+@pytest.mark.parametrize(
+    "page",
+    ["nonexistent.py", Path("nonexistent2.py")],
+    ids=["str-path", "path-object"],
+)
+def test_st_Page_throws_error_if_path_is_invalid(page: str | Path) -> None:
+    """Missing page files raise StreamlitPageNotFoundError."""
+    with pytest.raises(StreamlitPageNotFoundError) as e:
+        st.Page(page)
+    assert str(e.value) == (
+        f"Unable to create Page. The file `{Path(page).name}` could not be found."
     )
 
 

--- a/lib/tests/streamlit/runtime/metrics_util_test.py
+++ b/lib/tests/streamlit/runtime/metrics_util_test.py
@@ -33,10 +33,15 @@ import streamlit.components.v1 as components
 from streamlit import config
 from streamlit.components.v1.custom_component import CustomComponent
 from streamlit.connections import SQLConnection
-from streamlit.errors import StreamlitValueError
+from streamlit.errors import (
+    StreamlitInvalidContextError,
+    StreamlitInvalidParameterTypeError,
+    StreamlitValueError,
+)
 from streamlit.navigation.page import _create_page
 from streamlit.runtime import metrics_util
 from streamlit.runtime.caching import cache_data_api, cache_resource_api
+from streamlit.runtime.media_file_storage import MediaFileStorageError
 from streamlit.runtime.scriptrunner import get_script_run_ctx, magic_funcs
 from streamlit.runtime.scriptrunner_utils.exceptions import RerunException
 from streamlit.runtime.scriptrunner_utils.shared_run_state import SharedRunState
@@ -843,15 +848,75 @@ def test_gather_metrics_records_time_when_rerun_exception_raised() -> None:
             "TypeError:use_container_width",
         ),
         (
+            TypeError("button() missing 1 required positional argument: 'label'"),
+            "TypeError:missing:label",
+        ),
+        (
+            TypeError("button() takes 2 positional arguments but 3 were given"),
+            "TypeError:positional",
+        ),
+        (
+            TypeError("button() takes 0 positional arguments but 1 was given"),
+            "TypeError:positional",
+        ),
+        (
+            TypeError("bad argument type for built-in operation"),
+            "TypeError:proto",
+        ),
+        (
+            TypeError("has type int, but expected one of: bytes, unicode"),
+            "TypeError:proto",
+        ),
+        (
+            TypeError("a bytes-like object is required, not 'Figure'"),
+            "TypeError:byteslike",
+        ),
+        (
             StreamlitValueError("width", ["stretch", "content"]),
             "StreamlitValueError:width",
+        ),
+        (
+            StreamlitInvalidParameterTypeError("spec", "bad spec type"),
+            "StreamlitInvalidParameterTypeError:spec",
+        ),
+        (
+            StreamlitInvalidContextError("Forms cannot be nested in other forms."),
+            "StreamlitInvalidContextError",
+        ),
+        (
+            ModuleNotFoundError("No module named 'pyarrow'"),
+            "ModuleNotFoundError:pyarrow",
+        ),
+        (
+            ImportError("cannot import name 'Table' from 'pyarrow'"),
+            "ImportError:pyarrow",
+        ),
+        (
+            ModuleNotFoundError("No module named 'not_allowlisted_pkg'"),
+            "ModuleNotFoundError",
+        ),
+        (
+            MediaFileStorageError("Error opening 'foo.png'"),
+            "MediaFileStorageError:open",
         ),
         (ValueError("boom"), "ValueError"),
         (TypeError("other"), "TypeError"),
     ],
     ids=[
         "unexpected-kwarg",
+        "missing-positional",
+        "too-many-positional",
+        "too-many-positional-was-given",
+        "proto-type",
+        "proto-type-has-type",
+        "byteslike",
         "streamlit-value-error",
+        "invalid-parameter-type",
+        "invalid-context-no-command-suffix",
+        "modulenotfound-allowlisted",
+        "import-error-allowlisted",
+        "modulenotfound-other",
+        "media-file-open",
         "plain-value-error",
         "other-type-error",
     ],

--- a/lib/tests/streamlit/runtime/metrics_util_test.py
+++ b/lib/tests/streamlit/runtime/metrics_util_test.py
@@ -853,23 +853,15 @@ def test_gather_metrics_records_time_when_rerun_exception_raised() -> None:
         ),
         (
             TypeError("button() takes 2 positional arguments but 3 were given"),
-            "TypeError:positional",
-        ),
-        (
-            TypeError("button() takes 0 positional arguments but 1 was given"),
-            "TypeError:positional",
+            "TypeError",
         ),
         (
             TypeError("bad argument type for built-in operation"),
-            "TypeError:proto",
-        ),
-        (
-            TypeError("has type int, but expected one of: bytes, unicode"),
-            "TypeError:proto",
+            "TypeError",
         ),
         (
             TypeError("a bytes-like object is required, not 'Figure'"),
-            "TypeError:byteslike",
+            "TypeError",
         ),
         (
             StreamlitValueError("width", ["stretch", "content"]),
@@ -894,12 +886,38 @@ def test_gather_metrics_records_time_when_rerun_exception_raised() -> None:
             "ImportError:pyarrow",
         ),
         (
-            ModuleNotFoundError("No module named 'not_allowlisted_pkg'"),
-            "ModuleNotFoundError",
+            ModuleNotFoundError("No module named 'custom_pkg'"),
+            "ModuleNotFoundError:custom_pkg",
+        ),
+        (
+            ModuleNotFoundError(
+                "No module named 'custom_pkg.submodule'", name="custom_pkg.submodule"
+            ),
+            "ModuleNotFoundError:custom_pkg.submodule",
+        ),
+        (
+            ImportError(
+                "cannot import name 'Widget' from 'custom_pkg'", name="custom_pkg"
+            ),
+            "ImportError:custom_pkg",
+        ),
+        (
+            AttributeError(
+                "module 'streamlit' has no attribute 'foo'", name="foo", obj=st
+            ),
+            "AttributeError:foo",
+        ),
+        (
+            AttributeError("module 'streamlit' has no attribute 'bar'"),
+            "AttributeError:bar",
+        ),
+        (
+            AttributeError("Widget has no attribute 'foo'", name="foo", obj=object()),
+            "AttributeError",
         ),
         (
             MediaFileStorageError("Error opening 'foo.png'"),
-            "MediaFileStorageError:open",
+            "MediaFileStorageError",
         ),
         (
             MediaFileStorageError("Callable execution failed"),
@@ -911,18 +929,21 @@ def test_gather_metrics_records_time_when_rerun_exception_raised() -> None:
     ids=[
         "unexpected-kwarg",
         "missing-positional",
-        "too-many-positional",
-        "too-many-positional-was-given",
-        "proto-type",
-        "proto-type-has-type",
-        "byteslike",
+        "unsupported-too-many-positional",
+        "unsupported-proto-type",
+        "unsupported-byteslike",
         "streamlit-value-error",
         "invalid-parameter-type",
         "invalid-context-no-command-suffix",
-        "modulenotfound-allowlisted",
-        "import-error-allowlisted",
-        "modulenotfound-other",
-        "media-file-open",
+        "modulenotfound-message-fallback",
+        "import-error-message-fallback",
+        "modulenotfound-custom",
+        "modulenotfound-structured-name",
+        "import-error-structured-name",
+        "streamlit-attribute-structured",
+        "streamlit-attribute-message-fallback",
+        "non-streamlit-attribute",
+        "media-file-storage",
         "media-file-other",
         "plain-value-error",
         "other-type-error",
@@ -931,16 +952,6 @@ def test_gather_metrics_records_time_when_rerun_exception_raised() -> None:
 def test_format_uncaught_exception(exc: BaseException, expected: str) -> None:
     """Return ``ExceptionType:<param>`` for known parameter failures; otherwise the bare type name."""
     assert metrics_util.format_uncaught_exception(exc) == expected
-
-
-def test_format_uncaught_exception_media_file_open_uses_isinstance() -> None:
-    """``:open`` applies only to the real ``MediaFileStorageError``, not a name lookalike."""
-
-    class MediaFileStorageError(Exception):
-        pass
-
-    lookalike = MediaFileStorageError("Error opening 'foo.png'")
-    assert metrics_util.format_uncaught_exception(lookalike) == "MediaFileStorageError"
 
 
 def test_format_uncaught_exception_swallows_enrichment_errors() -> None:

--- a/lib/tests/streamlit/runtime/metrics_util_test.py
+++ b/lib/tests/streamlit/runtime/metrics_util_test.py
@@ -34,7 +34,7 @@ from streamlit import config
 from streamlit.components.v1.custom_component import CustomComponent
 from streamlit.connections import SQLConnection
 from streamlit.errors import (
-    StreamlitInvalidContextError,
+    StreamlitInvalidLayoutContextError,
     StreamlitInvalidParameterTypeError,
     StreamlitValueError,
 )
@@ -876,12 +876,14 @@ def test_gather_metrics_records_time_when_rerun_exception_raised() -> None:
             "StreamlitValueError:width",
         ),
         (
-            StreamlitInvalidParameterTypeError("spec", "bad spec type"),
+            StreamlitInvalidParameterTypeError("spec", "str", ["int", "list"]),
             "StreamlitInvalidParameterTypeError:spec",
         ),
         (
-            StreamlitInvalidContextError("Forms cannot be nested in other forms."),
-            "StreamlitInvalidContextError",
+            StreamlitInvalidLayoutContextError(
+                "Forms cannot be nested in other forms."
+            ),
+            "StreamlitInvalidLayoutContextError",
         ),
         (
             ModuleNotFoundError("No module named 'pyarrow'"),

--- a/lib/tests/streamlit/runtime/metrics_util_test.py
+++ b/lib/tests/streamlit/runtime/metrics_util_test.py
@@ -887,19 +887,27 @@ def test_gather_metrics_records_time_when_rerun_exception_raised() -> None:
         ),
         (
             ModuleNotFoundError("No module named 'custom_pkg'"),
-            "ModuleNotFoundError:custom_pkg",
+            "ModuleNotFoundError",
         ),
         (
             ModuleNotFoundError(
-                "No module named 'custom_pkg.submodule'", name="custom_pkg.submodule"
+                "No module named 'streamlit.runtime.missing'",
+                name="streamlit.runtime.missing",
             ),
-            "ModuleNotFoundError:custom_pkg.submodule",
+            "ModuleNotFoundError:streamlit.runtime.missing",
+        ),
+        (
+            ImportError(
+                "cannot import name 'Engine' from 'sqlalchemy.engine'",
+                name="sqlalchemy.engine",
+            ),
+            "ImportError:sqlalchemy.engine",
         ),
         (
             ImportError(
                 "cannot import name 'Widget' from 'custom_pkg'", name="custom_pkg"
             ),
-            "ImportError:custom_pkg",
+            "ImportError",
         ),
         (
             AttributeError(
@@ -937,9 +945,10 @@ def test_gather_metrics_records_time_when_rerun_exception_raised() -> None:
         "invalid-context-no-command-suffix",
         "modulenotfound-message-fallback",
         "import-error-message-fallback",
-        "modulenotfound-custom",
-        "modulenotfound-structured-name",
-        "import-error-structured-name",
+        "modulenotfound-private-module",
+        "modulenotfound-streamlit-module",
+        "import-error-feature-dependency",
+        "import-error-private-module",
         "streamlit-attribute-structured",
         "streamlit-attribute-message-fallback",
         "non-streamlit-attribute",

--- a/lib/tests/streamlit/runtime/metrics_util_test.py
+++ b/lib/tests/streamlit/runtime/metrics_util_test.py
@@ -899,6 +899,10 @@ def test_gather_metrics_records_time_when_rerun_exception_raised() -> None:
             MediaFileStorageError("Error opening 'foo.png'"),
             "MediaFileStorageError:open",
         ),
+        (
+            MediaFileStorageError("Callable execution failed"),
+            "MediaFileStorageError",
+        ),
         (ValueError("boom"), "ValueError"),
         (TypeError("other"), "TypeError"),
     ],
@@ -917,6 +921,7 @@ def test_gather_metrics_records_time_when_rerun_exception_raised() -> None:
         "import-error-allowlisted",
         "modulenotfound-other",
         "media-file-open",
+        "media-file-other",
         "plain-value-error",
         "other-type-error",
     ],
@@ -924,6 +929,16 @@ def test_gather_metrics_records_time_when_rerun_exception_raised() -> None:
 def test_format_uncaught_exception(exc: BaseException, expected: str) -> None:
     """Return ``ExceptionType:<param>`` for known parameter failures; otherwise the bare type name."""
     assert metrics_util.format_uncaught_exception(exc) == expected
+
+
+def test_format_uncaught_exception_media_file_open_uses_isinstance() -> None:
+    """``:open`` applies only to the real ``MediaFileStorageError``, not a name lookalike."""
+
+    class MediaFileStorageError(Exception):
+        pass
+
+    lookalike = MediaFileStorageError("Error opening 'foo.png'")
+    assert metrics_util.format_uncaught_exception(lookalike) == "MediaFileStorageError"
 
 
 def test_format_uncaught_exception_swallows_enrichment_errors() -> None:

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -32,7 +32,7 @@ import streamlit as st
 import tests.streamlit.runtime.state.strategies as stst
 from streamlit.components.v2.bidi_component.main import _make_trigger_id
 from streamlit.errors import (
-    StreamlitAPIException,
+    StreamlitWidgetAlreadyInstantiatedError,
     UnserializableSessionStateError,
 )
 from streamlit.proto.Common_pb2 import (
@@ -1874,7 +1874,7 @@ class SessionStateMethodTests(unittest.TestCase):
             "streamlit.runtime.state.session_state.get_script_run_ctx",
             return_value=mock_ctx,
         ):
-            with pytest.raises(StreamlitAPIException) as e:
+            with pytest.raises(StreamlitWidgetAlreadyInstantiatedError) as e:
                 self.session_state._key_id_mapper.set_key_id_mapping(
                     {"widget_id": "widget_id"}
                 )
@@ -1890,7 +1890,7 @@ class SessionStateMethodTests(unittest.TestCase):
             "streamlit.runtime.state.session_state.get_script_run_ctx",
             return_value=mock_ctx,
         ):
-            with pytest.raises(StreamlitAPIException) as e:
+            with pytest.raises(StreamlitWidgetAlreadyInstantiatedError) as e:
                 self.session_state["form_id"] = "blah"
             assert "`st.session_state.form_id` cannot be modified" in str(e.value)
 

--- a/lib/tests/streamlit/string_util_test.py
+++ b/lib/tests/streamlit/string_util_test.py
@@ -46,6 +46,18 @@ class StringUtilTest(unittest.TestCase):
         """Test streamlit.string_util.is_emoji."""
         assert string_util.is_emoji(text) == expected
 
+    def test_to_str(self):
+        """``to_str`` leaves strings unchanged and stringifies other values."""
+        assert string_util.to_str("already") == "already"
+        assert string_util.to_str(123) == "123"
+        assert string_util.to_str(None) == "None"
+
+    def test_to_help_str(self):
+        """``to_help_str`` stringifies and dedents help text."""
+        assert string_util.to_help_str("already") == "already"
+        assert string_util.to_help_str(123) == "123"
+        assert string_util.to_help_str("    indented") == "indented"
+
     @parameterized.expand(
         [
             ("", ("", "")),


### PR DESCRIPTION
## Describe your changes

- Replaces several generic `StreamlitAPIException` and builtin `TypeError` failures with dedicated types so uncaught-exception telemetry can be counted without user keys, file paths, or command names.
- Coerces widget labels and help (and metric labels) to strings, and accepts numpy integers in `st.columns`, so protobuf `TypeError`s no longer dominate those call sites.
- Maps missing pages in `st.Page`, `st.switch_page`, and `st.page_link` to `StreamlitPageNotFoundError`, and fixes `st.page_link` `KeyError` when the default page registry omits `url_pathname`.
- Duplicate form keys now raise `StreamlitDuplicateElementKey`, matching other widgets.
- Wraps leftover pandas/Arrow conversion failures as `StreamlitDataframeConversionError`.

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- [x] Unit Tests (Python): new exception types, telemetry labels, label/help coercion, `st.columns` Integral spec, and `page_link` when `url_pathname` is omitted
- E2E Tests: not added; this is exception taxonomy and cheap coercion, covered by unit tests
- No additional JS tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.