### PR TITLE
[fix] Encode download filenames unsafe in a quoted header

### DIFF
--- a/lib/streamlit/web/server/starlette/starlette_routes.py
+++ b/lib/streamlit/web/server/starlette/starlette_routes.py
@@ -698,12 +698,13 @@ def create_media_routes(
                     f"streamlit_download"
                     f"{get_extension_for_mimetype(media_file.mimetype)}"
                 )
-            # Use the readable quoted form only when the name is safe unescaped inside
-            # it. Everything else takes the RFC 5987 form, which percent-encodes and so
-            # cannot break out of the parameter: names needing an escape, and names that
-            # are not ASCII, whose raw bytes a client cannot decode from a header
-            # reliably. A space or a semicolon needs neither, since the parameter
-            # delimiter does not apply within the quotes.
+            # Keep the readable quoted form only when the name is safe unescaped
+            # inside it. Use the RFC 5987 `filename*` form, which percent-encodes and
+            # so cannot break out of the parameter, for:
+            #   - names containing `"`, `\`, or a control character
+            #   - non-ASCII names, whose raw bytes a client cannot decode reliably
+            # Spaces and semicolons stay quoted: the parameter delimiter does not
+            # apply inside the quotes.
             #
             # `safe=""` is required: `quote` leaves `/` alone by default, but it is not
             # an RFC 5987 attr-char, and a raw one truncates the name a client reads

--- a/lib/streamlit/web/server/starlette/starlette_routes.py
+++ b/lib/streamlit/web/server/starlette/starlette_routes.py
@@ -66,10 +66,13 @@ if TYPE_CHECKING:
 
 _LOGGER: Final = get_logger(__name__)
 
-# Characters that a download filename cannot carry unescaped inside the quoted-string
-# form of a Content-Disposition ``filename`` parameter. A double quote closes the value
-# early and a backslash begins an escape sequence, so either one changes the name the
-# client reads; control characters are not legal in a header value at all.
+# Characters that a download filename should not carry unescaped inside the
+# quoted-string form of a Content-Disposition ``filename`` parameter. A double quote
+# closes the value early and a backslash begins an escape sequence, so either one
+# changes the name the client reads. Control characters are swept in deliberately
+# rather than out of necessity: CR and LF must never reach a header value, and the rest
+# are encoded conservatively because they have no place in a filename -- note that
+# RFC 7230 ``qdtext`` does in fact permit HTAB, which this class also encodes.
 _QUOTED_FILENAME_UNSAFE: Final = re.compile(r'["\\\x00-\x1f\x7f]')
 
 # TTL for the cached cache_memory_bytes result. Short enough that scrapers

--- a/lib/streamlit/web/server/starlette/starlette_routes.py
+++ b/lib/streamlit/web/server/starlette/starlette_routes.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import re
 import time
 from typing import TYPE_CHECKING, Final
 from urllib.parse import quote
@@ -64,6 +65,12 @@ if TYPE_CHECKING:
     from streamlit.runtime.stats import Stat, StatsManager
 
 _LOGGER: Final = get_logger(__name__)
+
+# Characters that a download filename cannot carry unescaped inside the quoted-string
+# form of a Content-Disposition ``filename`` parameter. A double quote closes the value
+# early and a backslash begins an escape sequence, so either one changes the name the
+# client reads; control characters are not legal in a header value at all.
+_QUOTED_FILENAME_UNSAFE: Final = re.compile(r'["\\\x00-\x1f\x7f]')
 
 # TTL for the cached cache_memory_bytes result. Short enough that scrapers
 # (Prometheus default interval is 15 s) still see fresh data; long enough to
@@ -691,11 +698,20 @@ def create_media_routes(
                     f"streamlit_download"
                     f"{get_extension_for_mimetype(media_file.mimetype)}"
                 )
-            try:
-                filename.encode("latin1")
+            # Use the readable quoted form only when the name is safe unescaped inside
+            # it. Everything else takes the RFC 5987 form, which percent-encodes and so
+            # cannot break out of the parameter: names needing an escape, and names that
+            # are not ASCII, whose raw bytes a client cannot decode from a header
+            # reliably. A space or a semicolon needs neither, since the parameter
+            # delimiter does not apply within the quotes.
+            #
+            # `safe=""` is required: `quote` leaves `/` alone by default, but it is not
+            # an RFC 5987 attr-char, and a raw one truncates the name a client reads
+            # (`café/x.pdf` arrives as `café`).
+            if filename.isascii() and not _QUOTED_FILENAME_UNSAFE.search(filename):
                 disposition = f'filename="{filename}"'
-            except UnicodeEncodeError:
-                disposition = f"filename*=utf-8''{quote(filename)}"
+            else:
+                disposition = f"filename*=utf-8''{quote(filename, safe='')}"
             headers["Content-Disposition"] = f"attachment; {disposition}"
 
         # Ensure support for range requests (e.g. for video files)

--- a/lib/tests/streamlit/web/server/starlette/starlette_routes_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_routes_test.py
@@ -658,6 +658,10 @@ def test_media_endpoint_downloadable_filename_survives_round_trip(
     header = _content_disposition_for(filename)
 
     assert _filename_from_header(header) == filename
+    # Pin the branch too. The round-trip alone does not: a quoted
+    # `filename="café.pdf"` also recovers `café.pdf` from this parser, so without
+    # this the latin-1 non-ASCII case could pass while staying on the quoted path.
+    assert "filename*=utf-8''" in header
 
 
 @pytest.mark.parametrize(

--- a/lib/tests/streamlit/web/server/starlette/starlette_routes_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_routes_test.py
@@ -716,8 +716,13 @@ def test_media_endpoint_downloadable_safe_filename_stays_quoted(
 
 def test_media_endpoint_downloadable_filename_cannot_inject_headers() -> None:
     """A CR or LF in the name is encoded rather than emitted into the header."""
-    header = _content_disposition_for("a\r\nX-Evil: 1.txt")
+    filename = "a\r\nX-Evil: 1.txt"
 
+    header = _content_disposition_for(filename)
+
+    # The name still has to arrive intact; a header that merely looks clean because a
+    # client stack split or dropped the injected line would satisfy the checks below.
+    assert _filename_from_header(header) == filename
     assert "\r" not in header
     assert "\n" not in header
 

--- a/lib/tests/streamlit/web/server/starlette/starlette_routes_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_routes_test.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import asyncio
 import string
+from email.message import EmailMessage
 from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, patch
 
@@ -625,6 +626,100 @@ def test_media_endpoint_downloadable_non_latin1_filename_uses_utf8() -> None:
 
     assert response.status_code == 200
     assert "filename*=utf-8''" in response.headers["content-disposition"]
+
+
+def _content_disposition_for(filename: str) -> str:
+    """Return the Content-Disposition the media endpoint emits for a download name.
+
+    Parameters
+    ----------
+    filename
+        The name the app set on the downloadable media file.
+
+    Returns
+    -------
+    str
+        The raw header value served for that file.
+    """
+    storage = MemoryMediaFileStorage("/media")
+    file_id = storage.load_and_get_id(
+        b"payload", "text/plain", MediaFileKind.DOWNLOADABLE, filename
+    )
+    response = _client_for(create_media_routes(storage, "")).get(f"/media/{file_id}")
+
+    assert response.status_code == 200
+    return response.headers["content-disposition"]
+
+
+def _filename_from_header(header: str) -> str | None:
+    """Recover the filename a conforming client would read from the header.
+
+    Parameters
+    ----------
+    header
+        A Content-Disposition header value.
+
+    Returns
+    -------
+    str or None
+        The decoded filename parameter, handling the RFC 5987 ``filename*`` form.
+    """
+    message = EmailMessage()
+    message["Content-Disposition"] = header
+    return message.get_filename()
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        # A double quote closes the quoted parameter early, so everything after it
+        # becomes stray tokens. Inch marks in a name are enough to hit this.
+        '5" x 7" print.jpg',
+        # A backslash is the quoted-string escape character, so it silently drops.
+        "a\\b.txt",
+        # Latin-1 encodable but not ASCII: served raw, the bytes are not valid UTF-8.
+        "café.pdf",
+        # Not latin-1 encodable, which already took the percent-encoded path.
+        "文件.txt",
+        # A slash is not an RFC 5987 attr-char, so leaving it raw in the encoded form
+        # truncates the name at the slash.
+        "café/x.pdf",
+    ],
+)
+def test_media_endpoint_downloadable_filename_survives_round_trip(
+    filename: str,
+) -> None:
+    """A name needing escapes is carried faithfully to a conforming client."""
+    header = _content_disposition_for(filename)
+
+    assert _filename_from_header(header) == filename
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "report.pdf",
+        # A space is legal inside a quoted string, so it must not force encoding.
+        "quarterly report.pdf",
+        # So is a semicolon: the parameter delimiter only applies outside the quotes.
+        "a;b.txt",
+    ],
+)
+def test_media_endpoint_downloadable_safe_filename_stays_quoted(
+    filename: str,
+) -> None:
+    """A name that needs no escaping keeps the readable quoted form."""
+    header = _content_disposition_for(filename)
+
+    assert header == f'attachment; filename="{filename}"'
+
+
+def test_media_endpoint_downloadable_filename_cannot_inject_headers() -> None:
+    """A CR or LF in the name is encoded rather than emitted into the header."""
+    header = _content_disposition_for("a\r\nX-Evil: 1.txt")
+
+    assert "\r" not in header
+    assert "\n" not in header
 
 
 def test_media_options_returns_no_content() -> None:

--- a/lib/tests/streamlit/web/server/starlette/starlette_routes_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_routes_test.py
@@ -62,6 +62,25 @@ def _client_for(routes: list[BaseRoute]) -> TestClient:
     return TestClient(Starlette(routes=routes))
 
 
+def _content_disposition_for(filename: str) -> str:
+    """Return the Content-Disposition the media endpoint emits for a download name."""
+    storage = MemoryMediaFileStorage("/media")
+    file_id = storage.load_and_get_id(
+        b"payload", "text/plain", MediaFileKind.DOWNLOADABLE, filename
+    )
+    response = _client_for(create_media_routes(storage, "")).get(f"/media/{file_id}")
+
+    assert response.status_code == 200
+    return response.headers["content-disposition"]
+
+
+def _filename_from_header(header: str) -> str | None:
+    """Recover the filename a conforming client would read from the header."""
+    message = EmailMessage()
+    message["Content-Disposition"] = header
+    return message.get_filename()
+
+
 def _endpoint_for(routes: list[BaseRoute], method: str) -> Callable[..., Any]:
     """Return the handler of the first route that accepts the given HTTP method."""
     for route in routes:
@@ -612,61 +631,6 @@ def test_media_endpoint_downloadable_without_filename_uses_default() -> None:
 
     assert response.status_code == 200
     assert "streamlit_download" in response.headers["content-disposition"]
-
-
-def test_media_endpoint_downloadable_non_latin1_filename_uses_utf8() -> None:
-    """A filename that cannot be latin-1 encoded uses the RFC 5987 utf-8 form."""
-    storage = MemoryMediaFileStorage("/media")
-    file_id = storage.load_and_get_id(
-        b"payload", "text/plain", MediaFileKind.DOWNLOADABLE, "\u6587\u4ef6.txt"
-    )
-    routes = create_media_routes(storage, "")
-
-    response = _client_for(routes).get(f"/media/{file_id}")
-
-    assert response.status_code == 200
-    assert "filename*=utf-8''" in response.headers["content-disposition"]
-
-
-def _content_disposition_for(filename: str) -> str:
-    """Return the Content-Disposition the media endpoint emits for a download name.
-
-    Parameters
-    ----------
-    filename
-        The name the app set on the downloadable media file.
-
-    Returns
-    -------
-    str
-        The raw header value served for that file.
-    """
-    storage = MemoryMediaFileStorage("/media")
-    file_id = storage.load_and_get_id(
-        b"payload", "text/plain", MediaFileKind.DOWNLOADABLE, filename
-    )
-    response = _client_for(create_media_routes(storage, "")).get(f"/media/{file_id}")
-
-    assert response.status_code == 200
-    return response.headers["content-disposition"]
-
-
-def _filename_from_header(header: str) -> str | None:
-    """Recover the filename a conforming client would read from the header.
-
-    Parameters
-    ----------
-    header
-        A Content-Disposition header value.
-
-    Returns
-    -------
-    str or None
-        The decoded filename parameter, handling the RFC 5987 ``filename*`` form.
-    """
-    message = EmailMessage()
-    message["Content-Disposition"] = header
-    return message.get_filename()
 
 
 @pytest.mark.parametrize(

--- a/lib/tests/streamlit/web/server/starlette/starlette_routes_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_routes_test.py
@@ -641,9 +641,10 @@ def test_media_endpoint_downloadable_without_filename_uses_default() -> None:
         '5" x 7" print.jpg',
         # A backslash is the quoted-string escape character, so it silently drops.
         "a\\b.txt",
-        # Latin-1 encodable but not ASCII: served raw, the bytes are not valid UTF-8.
+        # Latin-1 encodable but not ASCII, so it must be percent-encoded to be
+        # decoded reliably.
         "café.pdf",
-        # Not latin-1 encodable, which already took the percent-encoded path.
+        # Not encodable as latin-1, so the header must carry it percent-encoded.
         "文件.txt",
         # A slash is not an RFC 5987 attr-char, so leaving it raw in the encoded form
         # truncates the name at the slash.
@@ -653,7 +654,7 @@ def test_media_endpoint_downloadable_without_filename_uses_default() -> None:
 def test_media_endpoint_downloadable_filename_survives_round_trip(
     filename: str,
 ) -> None:
-    """A name needing escapes is carried faithfully to a conforming client."""
+    """A name unsafe in the quoted form reaches the client intact."""
     header = _content_disposition_for(filename)
 
     assert _filename_from_header(header) == filename


### PR DESCRIPTION
## Describe your changes

`st.download_button` served a malformed `Content-Disposition` header whenever the filename contained a double quote. The media endpoint picked the quoted form for any latin-1 encodable name, and a `"` is latin-1, so it closed the parameter early:

```
name    : 5" x 7" print.jpg
emitted : attachment; filename="5" x 7" print.jpg"
```

Parsed by a conforming client, the filename is `5` — so the browser saves the wrong name. Three neighbouring cases in the same branch were wrong for the same reason:

| filename | before | after |
|---|---|---|
| `5" x 7" print.jpg` | `filename="5" x 7" print.jpg"` → reads as `5` | `filename*=utf-8''5%22%20x%207%22%20print.jpg` |
| `a\b.txt` | `filename="a\b.txt"` → escape drops the `\` | `filename*=utf-8''a%5Cb.txt` |
| `a\r\nX-Evil: 1.txt` | CR/LF emitted into the header value raw | `filename*=utf-8''a%0D%0AX-Evil%3A%201.txt` |
| `café.pdf` | latin-1 bytes; not decodable as UTF-8 | `filename*=utf-8''caf%C3%A9.pdf` |

The branch is now selected on whether the name is genuinely safe unescaped inside a quoted string — ASCII with no quote, backslash or control character — rather than on latin-1 encodability. Anything else takes the RFC 5987 `filename*=` form that already existed for non-latin-1 names.

**Spaces and semicolons deliberately stay on the quoted path.** Neither needs escaping inside the quotes: the parameter delimiter does not apply there. Starlette's `FileResponse` uses a stricter `quote(name) == name` test, which the issue suggested adopting, but that re-encodes every filename containing a space — very common — for no correctness gain. `test_media_endpoint_downloadable_safe_filename_stays_quoted` pins the narrower behaviour, and fails if the rule is widened.

Two notes for the reviewer, both corrections to the issue writeup:

- It states existing tests cover "a space-containing quoted name". They don't — there were only two assertions, for the generated default name and the non-latin-1 branch. Nothing pinned the space case before this PR.
- It suggests a lone `;` can introduce extra header parameters. Inside the quotes it cannot, which is why `a;b.txt` is left on the quoted path.

The `café.pdf` case was not in the report. It currently raises `UnicodeDecodeError` when the response headers are read, so an ordinary accented filename is broken today too.

## GitHub Issue Link

Fixes #16631

## Testing Plan

- Unit tests in `lib/tests/streamlit/web/server/starlette/starlette_routes_test.py`, driving the real media route in-process:
  - `test_media_endpoint_downloadable_filename_survives_round_trip` — parses the emitted header with `email.message.EmailMessage` and asserts the recovered filename equals the original, for the quote, backslash, latin-1-accent and non-latin-1 cases. This asserts the user-visible outcome (the saved name) rather than a header substring.
  - `test_media_endpoint_downloadable_safe_filename_stays_quoted` — `report.pdf`, `quarterly report.pdf`, `a;b.txt` keep the readable quoted form.
  - `test_media_endpoint_downloadable_filename_cannot_inject_headers` — no raw CR or LF reaches the header value.
- Mutation-verified both directions: reverting to the latin-1 branch fails the 4 round-trip/injection tests; switching to Starlette's `quote(name) == name` rule fails the 2 "stays quoted" tests.
- Full Python suite: `11387 passed, 76 skipped`. `ruff format`, `ruff check` and `ty` clean; `mypy`'s single error (`e2e_playwright/load_testing/test_load.py` unreachable statement) reproduces on unmodified `develop`.
- No frontend or protobuf surface, so no e2e coverage added.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches HTTP response headers for all downloadable media; behavior change is intentional and narrowly scoped, but wrong encoding logic would affect every `st.download_button` filename edge case.
> 
> **Overview**
> Fixes malformed **`Content-Disposition`** headers on the Starlette media download route when filenames contain characters that break quoted `filename="..."` values (e.g. inch marks in `5" x 7" print.jpg`), which caused browsers to save the wrong name.
> 
> **Selection logic** no longer uses “latin-1 encodable” as the gate for the quoted form. Names that are **ASCII** and free of `"`, `\`, and control characters keep the readable `filename="..."` form (including spaces and semicolons). Everything else uses **RFC 5987** `filename*=utf-8''` with **`quote(..., safe='')`** so slashes and non-ASCII names encode correctly and CR/LF cannot inject extra header lines.
> 
> **Tests** add round-trip parsing via `EmailMessage`, pin safe names on the quoted branch, and assert no raw CR/LF in the header value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ed97de616d42b6406832ba3f381be0e252ad51a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->