### PR TITLE
[chore] Replace several frontend deps with in-house code

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,9 +32,6 @@ updates:
       - dependency-name: "react-map-gl"
         # The license was changed with the mapbox-gl update.
         versions: [">=5.4.0"]
-      - dependency-name: "ua-parser-js"
-        # The license was changed to AGPLv3 with the 2.0 major version update.
-        versions: [">=2.0.0"]
       - dependency-name: "react"
         # Updating react will need some extra work.
         versions: [">=19.0.0"]

--- a/Makefile
+++ b/Makefile
@@ -544,6 +544,7 @@ update-notices:
 	./scripts/append_license.sh frontend/lib/src/vendor/react-bootstrap-LICENSE.txt
 	./scripts/append_license.sh frontend/lib/src/vendor/fzy.js/fzyjs-LICENSE.txt
 	./scripts/append_license.sh frontend/lib/src/vendor/sprintf.js/sprintfjs-LICENSE.txt
+	./scripts/append_license.sh frontend/lib/src/vendor/decamelize/decamelize-LICENSE.txt
 
 .PHONY: update-headers
 # Update all license headers.

--- a/NOTICES
+++ b/NOTICES
@@ -1784,7 +1784,7 @@ THE SOFTWARE.
 
 -----
 
-The following software may be included in this product: @sindresorhus/is, @sindresorhus/slugify, @sindresorhus/transliterate, ansi-regex, ansi-styles, decamelize, escape-string-regexp, filter-obj, find-up, get-east-asian-width, get-stream, import-fresh, is-plain-obj, locate-path, p-limit, p-locate, parse-json, query-string, split-on-first, string-width, strip-ansi, wrap-ansi, yocto-queue. A copy of the source code may be downloaded from git+https://github.com/sindresorhus/is.git (@sindresorhus/is), git+https://github.com/sindresorhus/slugify.git (@sindresorhus/slugify), git+https://github.com/sindresorhus/transliterate.git (@sindresorhus/transliterate), git+https://github.com/chalk/ansi-regex.git (ansi-regex), git+https://github.com/chalk/ansi-styles.git (ansi-styles), git+https://github.com/sindresorhus/decamelize.git (decamelize), git+https://github.com/sindresorhus/escape-string-regexp.git (escape-string-regexp), git+https://github.com/sindresorhus/filter-obj.git (filter-obj), git+https://github.com/sindresorhus/find-up.git (find-up), git+https://github.com/sindresorhus/get-east-asian-width.git (get-east-asian-width), git+https://github.com/sindresorhus/get-stream.git (get-stream), git+https://github.com/sindresorhus/import-fresh.git (import-fresh), git+https://github.com/sindresorhus/is-plain-obj.git (is-plain-obj), git+https://github.com/sindresorhus/locate-path.git (locate-path), git+https://github.com/sindresorhus/p-limit.git (p-limit), git+https://github.com/sindresorhus/p-locate.git (p-locate), git+https://github.com/sindresorhus/parse-json.git (parse-json), git+https://github.com/sindresorhus/query-string.git (query-string), git+https://github.com/sindresorhus/split-on-first.git (split-on-first), git+https://github.com/sindresorhus/string-width.git (string-width), git+https://github.com/chalk/strip-ansi.git (strip-ansi), git+https://github.com/chalk/wrap-ansi.git (wrap-ansi), git+https://github.com/sindresorhus/yocto-queue.git (yocto-queue). This software contains the following license and notice below:
+The following software may be included in this product: @sindresorhus/is, @sindresorhus/slugify, @sindresorhus/transliterate, ansi-regex, ansi-styles, escape-string-regexp, filter-obj, find-up, get-east-asian-width, get-stream, import-fresh, is-plain-obj, locate-path, p-limit, p-locate, parse-json, query-string, split-on-first, string-width, strip-ansi, wrap-ansi, yocto-queue. A copy of the source code may be downloaded from git+https://github.com/sindresorhus/is.git (@sindresorhus/is), git+https://github.com/sindresorhus/slugify.git (@sindresorhus/slugify), git+https://github.com/sindresorhus/transliterate.git (@sindresorhus/transliterate), git+https://github.com/chalk/ansi-regex.git (ansi-regex), git+https://github.com/chalk/ansi-styles.git (ansi-styles), git+https://github.com/sindresorhus/escape-string-regexp.git (escape-string-regexp), git+https://github.com/sindresorhus/filter-obj.git (filter-obj), git+https://github.com/sindresorhus/find-up.git (find-up), git+https://github.com/sindresorhus/get-east-asian-width.git (get-east-asian-width), git+https://github.com/sindresorhus/get-stream.git (get-stream), git+https://github.com/sindresorhus/import-fresh.git (import-fresh), git+https://github.com/sindresorhus/is-plain-obj.git (is-plain-obj), git+https://github.com/sindresorhus/locate-path.git (locate-path), git+https://github.com/sindresorhus/p-limit.git (p-limit), git+https://github.com/sindresorhus/p-locate.git (p-locate), git+https://github.com/sindresorhus/parse-json.git (parse-json), git+https://github.com/sindresorhus/query-string.git (query-string), git+https://github.com/sindresorhus/split-on-first.git (split-on-first), git+https://github.com/sindresorhus/string-width.git (string-width), git+https://github.com/chalk/strip-ansi.git (strip-ansi), git+https://github.com/chalk/wrap-ansi.git (wrap-ansi), git+https://github.com/sindresorhus/yocto-queue.git (yocto-queue). This software contains the following license and notice below:
 
 MIT License
 
@@ -12561,32 +12561,6 @@ The following software may be included in this product: typedarray. A copy of th
 //
 // Variations:
 //  * Allows typed_array.get/set() as alias for subscripts (typed_array[])
-
------
-
-The following software may be included in this product: ua-parser-js. A copy of the source code may be downloaded from https://github.com/faisalman/ua-parser-js.git. This software contains the following license and notice below:
-
-MIT License
-
-Copyright (c) 2012-2025 Faisal Salman <<f@faisalman.com>>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
 
 -----
 

--- a/NOTICES
+++ b/NOTICES
@@ -13874,3 +13874,29 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+-----
+
+The following software may be included in this product: decamelize. This software contains the following license and notice below:
+
+MIT License
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -22,7 +22,6 @@
     "typesync:ci": "typesync --dry=fail"
   },
   "dependencies": {
-    "@babel/runtime": "^8.0.0",
     "@emotion-icons/emotion-icon": "^4.1.0",
     "@emotion-icons/material-outlined": "^3.14.0",
     "@emotion-icons/material-rounded": "^3.14.0",
@@ -35,7 +34,6 @@
     "@streamlit/lib": "workspace:^",
     "@streamlit/protobuf": "workspace:^",
     "@streamlit/utils": "workspace:^",
-    "classnames": "^2.3.2",
     "color2k": "^2.0.2",
     "hoist-non-react-statics": "^3.3.2",
     "iframe-resizer": "4.3.11",
@@ -47,11 +45,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-helmet-async": "^3.0.0",
-    "react-hot-keys": "^3.0.0",
     "react-transition-group": "^4.4.5",
-    "typed-signals": "^3.0.0",
-    "ua-parser-js": "^1.0.41",
-    "uuid": "^14.0.2"
+    "typed-signals": "^3.0.0"
   },
   "devDependencies": {
     "@swc/plugin-emotion": "^15.0.0",
@@ -66,7 +61,6 @@
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "@types/react-transition-group": "^4.4.12",
-    "@types/ua-parser-js": "^0.7.39",
     "@vitejs/plugin-react-swc": "^4.3.3",
     "chrome-launcher": "^1.2.1",
     "jsdom": "24.1.3",
@@ -81,8 +75,7 @@
   "typesync": {
     "ignorePackages": [
       "jsdom",
-      "react-helmet-async",
-      "uuid"
+      "react-helmet-async"
     ]
   },
   "resolutions": {
@@ -100,7 +93,6 @@
     "query-string": "^8.1.0",
     "set-value": "^4.0.1",
     "static-eval": "^2.0.5",
-    "ua-parser-js": "^1.0.40",
     "ws": "^8.11.0",
     "y18n": "^5.0.8"
   },

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -17,7 +17,6 @@
 import { act } from "react"
 
 import {
-  fireEvent,
   render,
   RenderResult,
   screen,
@@ -4230,30 +4229,13 @@ describe("App", () => {
     })
 
     it("stops screencast recording when Escape is released", async () => {
+      const user = userEvent.setup()
       const props = getProps()
       renderApp(props)
 
-      // hotkeys-js matches Escape via keyCode 27; userEvent does not set it.
-      /* eslint-disable testing-library/prefer-user-event */
-      fireEvent.keyDown(document, {
-        key: "Escape",
-        code: "Escape",
-        keyCode: 27,
-        which: 27,
-      })
-      fireEvent.keyUp(document, {
-        key: "Escape",
-        code: "Escape",
-        keyCode: 27,
-        which: 27,
-      })
-      /* eslint-enable testing-library/prefer-user-event */
+      await user.keyboard("{Escape}")
 
-      // react-hot-keys delivers onKeyUp from a document keyup listener on a
-      // 0ms timeout so hotkeys-js can drop the key from its pressed set.
-      await waitFor(() => {
-        expect(props.screenCast.stopRecording).toHaveBeenCalled()
-      })
+      expect(props.screenCast.stopRecording).toHaveBeenCalled()
     })
   })
 

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -16,14 +16,13 @@
 
 import { createRef, PureComponent, ReactNode } from "react"
 
-import classNames from "classnames"
 import { enableMapSet, enablePatches } from "immer"
 import { getLogger } from "loglevel"
 import { flushSync } from "react-dom"
-import Hotkeys from "react-hot-keys"
 
 import AppView from "@streamlit/app/src/components/AppView/AppView"
 import DeployButton from "@streamlit/app/src/components/DeployButton/DeployButton"
+import { GlobalHotkeys } from "@streamlit/app/src/components/GlobalHotkeys/GlobalHotkeys"
 import MainMenu from "@streamlit/app/src/components/MainMenu/MainMenu"
 import {
   isSkillsNudgeDismissed,
@@ -2688,13 +2687,6 @@ export class App extends PureComponent<Props, State> {
   }
 
   handleKeyDown = (keyName: string, keyboardEvent?: KeyboardEvent): void => {
-    // Ignore keyup events so a modified shortcut cannot become a bare-key
-    // shortcut when the user releases the modifier first (for example, Cmd+C).
-    // react-hot-keys binds keydown and keyup to the same onKeyDown handler.
-    if (keyboardEvent?.type === "keyup") {
-      return
-    }
-
     // See `isKeyboardEventFromEditableTarget` for editable/shadow DOM behavior.
     // We never fire global single-letter shortcuts while the user is typing.
     if (
@@ -2805,14 +2797,14 @@ export class App extends PureComponent<Props, State> {
       this.state.toolbarMode
     )
 
-    const outerDivClass = classNames(
+    const outerDivClass = [
       "stApp",
       getEmbeddingIdClassName(this.embeddingId),
-      {
-        "streamlit-embedded": isEmbed(),
-        "streamlit-wide": userSettings.wideMode,
-      }
-    )
+      isEmbed() && "streamlit-embedded",
+      userSettings.wideMode && "streamlit-wide",
+    ]
+      .filter(Boolean)
+      .join(" ")
 
     const renderedDialog: React.ReactNode = dialog
       ? StreamlitDialog({
@@ -2889,7 +2881,7 @@ export class App extends PureComponent<Props, State> {
         onInstallSkills={this.handleErrorCalloutInstall}
         onSkillsCalloutShown={this.handleErrorCalloutShown}
       >
-        <Hotkeys
+        <GlobalHotkeys
           keyName="r,c,esc"
           onKeyDown={this.handleKeyDown}
           onKeyUp={this.handleKeyUp}
@@ -2988,7 +2980,7 @@ export class App extends PureComponent<Props, State> {
             />
             {renderedDialog}
           </StyledApp>
-        </Hotkeys>
+        </GlobalHotkeys>
       </StreamlitContextProvider>
     )
   }

--- a/frontend/app/src/MetricsManager.test.ts
+++ b/frontend/app/src/MetricsManager.test.ts
@@ -17,8 +17,6 @@
 // Disable Typescript checking, since mm.track has private scope
 // @ts-nocheck
 
-import UAParser from "ua-parser-js"
-
 import {
   MetricsEvent,
   mockSessionInfo,
@@ -191,8 +189,6 @@ describe("initialize", () => {
 })
 
 describe("metrics helpers", () => {
-  const RESULT = new UAParser().getResult()
-
   const PAGE_PROFILE_DATA = {
     commands: [],
     execTime: 50,
@@ -203,7 +199,7 @@ describe("metrics helpers", () => {
     timezone: "('UTC', 'UTC')",
     headless: false,
     isFragmentRun: false,
-    os: RESULT.os.name || "Unknown",
+    os: "Test OS",
     appId: "mockAppId",
     numPages: 1,
     sessionId: "mockSessionId",
@@ -211,9 +207,9 @@ describe("metrics helpers", () => {
     pageScriptHash: "mockPageScriptHash",
     activeTheme: "Use system setting",
     totalLoadTime: 100,
-    browserName: RESULT.browser.name || "Unknown",
-    browserVersion: RESULT.browser.version || "Unknown",
-    deviceType: RESULT.device.type || "Unknown",
+    browserName: "Test Browser",
+    browserVersion: "1.2.3",
+    deviceType: "desktop",
     serverMode: "starlette-managed",
     installedSkills: [
       "home:claude:developing-with-streamlit",

--- a/frontend/app/src/MetricsManager.ts
+++ b/frontend/app/src/MetricsManager.ts
@@ -16,7 +16,6 @@
 
 import { pick } from "lodash-es"
 import { getLogger } from "loglevel"
-import { v4 as uuidv4 } from "uuid"
 
 import { IS_DEV_ENV } from "@streamlit/connection"
 import {
@@ -26,7 +25,11 @@ import {
   setCookie,
 } from "@streamlit/lib"
 import { IMetricsEvent, MetricsEvent } from "@streamlit/protobuf"
-import { getCookie, localStorageAvailable } from "@streamlit/utils"
+import {
+  generateUuid,
+  getCookie,
+  localStorageAvailable,
+} from "@streamlit/utils"
 
 // Default metrics config fetched when none provided by host config endpoint
 export const DEFAULT_METRICS_CONFIG = "https://data.streamlit.io/metrics.json"
@@ -338,7 +341,7 @@ export class MetricsManager {
 
       setCookie(anonymousIdKey, this.anonymousId, expiration)
     } else {
-      this.anonymousId = uuidv4()
+      this.anonymousId = generateUuid()
 
       setCookie(anonymousIdKey, this.anonymousId, expiration)
       if (isLocalStoreAvailable) {

--- a/frontend/app/src/components/GlobalHotkeys/GlobalHotkeys.test.tsx
+++ b/frontend/app/src/components/GlobalHotkeys/GlobalHotkeys.test.tsx
@@ -36,23 +36,57 @@ describe("GlobalHotkeys", () => {
     expect(onKeyUp.mock.calls.map(call => call[0])).toEqual(["r", "esc"])
   })
 
-  it("ignores modifier shortcuts, repeat events, and their keyup events", async () => {
-    const user = userEvent.setup()
+  it.each([
+    ["Meta", "{Meta>}c{/Meta}"],
+    ["Control", "{Control>}c{/Control}"],
+    ["Alt", "{Alt>}c{/Alt}"],
+  ])(
+    "ignores %s chords and their keyup events",
+    async (_modifier, sequence) => {
+      const user = userEvent.setup()
+      const onKeyDown = vi.fn()
+      const onKeyUp = vi.fn()
+      render(
+        <GlobalHotkeys keyName="c" onKeyDown={onKeyDown} onKeyUp={onKeyUp}>
+          <div>content</div>
+        </GlobalHotkeys>
+      )
+
+      await user.keyboard(sequence)
+
+      expect(onKeyDown).not.toHaveBeenCalled()
+      expect(onKeyUp).not.toHaveBeenCalled()
+    }
+  )
+
+  it("ignores repeat keydown events", () => {
     const onKeyDown = vi.fn()
-    const onKeyUp = vi.fn()
     render(
-      <GlobalHotkeys keyName="c" onKeyDown={onKeyDown} onKeyUp={onKeyUp}>
+      <GlobalHotkeys keyName="c" onKeyDown={onKeyDown}>
         <div>content</div>
       </GlobalHotkeys>
     )
 
-    await user.keyboard("{Meta>}c{/Meta}")
     document.dispatchEvent(
       new KeyboardEvent("keydown", { key: "c", repeat: true, bubbles: true })
     )
 
     expect(onKeyDown).not.toHaveBeenCalled()
-    expect(onKeyUp).not.toHaveBeenCalled()
+  })
+
+  it("removes document listeners on unmount", async () => {
+    const user = userEvent.setup()
+    const onKeyDown = vi.fn()
+    const { unmount } = render(
+      <GlobalHotkeys keyName="r" onKeyDown={onKeyDown}>
+        <div>content</div>
+      </GlobalHotkeys>
+    )
+
+    unmount()
+    await user.keyboard("r")
+
+    expect(onKeyDown).not.toHaveBeenCalled()
   })
 
   it("still fires letter shortcuts when Shift is held", async () => {

--- a/frontend/app/src/components/GlobalHotkeys/GlobalHotkeys.test.tsx
+++ b/frontend/app/src/components/GlobalHotkeys/GlobalHotkeys.test.tsx
@@ -69,6 +69,20 @@ describe("GlobalHotkeys", () => {
     expect(onKeyDown).toHaveBeenCalledWith("r", expect.any(KeyboardEvent))
   })
 
+  it("does not fire multi-character shortcuts when Shift is held", async () => {
+    const user = userEvent.setup()
+    const onKeyDown = vi.fn()
+    render(
+      <GlobalHotkeys keyName="esc" onKeyDown={onKeyDown}>
+        <div>content</div>
+      </GlobalHotkeys>
+    )
+
+    await user.keyboard("{Shift>}{Escape}{/Shift}")
+
+    expect(onKeyDown).not.toHaveBeenCalled()
+  })
+
   it("suppresses duplicate keydowns until keyup or window blur", () => {
     const onKeyDown = vi.fn()
     render(

--- a/frontend/app/src/components/GlobalHotkeys/GlobalHotkeys.test.tsx
+++ b/frontend/app/src/components/GlobalHotkeys/GlobalHotkeys.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+import { GlobalHotkeys } from "./GlobalHotkeys"
+
+describe("GlobalHotkeys", () => {
+  it("calls handlers for configured key presses", async () => {
+    const user = userEvent.setup()
+    const onKeyDown = vi.fn()
+    const onKeyUp = vi.fn()
+    render(
+      <GlobalHotkeys keyName="r,esc" onKeyDown={onKeyDown} onKeyUp={onKeyUp}>
+        <div>content</div>
+      </GlobalHotkeys>
+    )
+
+    await user.keyboard("r{Escape}")
+
+    expect(onKeyDown.mock.calls.map(call => call[0])).toEqual(["r", "esc"])
+    expect(onKeyUp.mock.calls.map(call => call[0])).toEqual(["r", "esc"])
+  })
+
+  it("ignores modifier shortcuts, repeat events, and their keyup events", async () => {
+    const user = userEvent.setup()
+    const onKeyDown = vi.fn()
+    const onKeyUp = vi.fn()
+    render(
+      <GlobalHotkeys keyName="c" onKeyDown={onKeyDown} onKeyUp={onKeyUp}>
+        <div>content</div>
+      </GlobalHotkeys>
+    )
+
+    await user.keyboard("{Meta>}c{/Meta}")
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "c", repeat: true, bubbles: true })
+    )
+
+    expect(onKeyDown).not.toHaveBeenCalled()
+    expect(onKeyUp).not.toHaveBeenCalled()
+  })
+
+  it("still fires letter shortcuts when Shift is held", async () => {
+    const user = userEvent.setup()
+    const onKeyDown = vi.fn()
+    render(
+      <GlobalHotkeys keyName="r,c" onKeyDown={onKeyDown}>
+        <div>content</div>
+      </GlobalHotkeys>
+    )
+
+    await user.keyboard("{Shift>}r{/Shift}")
+
+    expect(onKeyDown).toHaveBeenCalledWith("r", expect.any(KeyboardEvent))
+  })
+
+  it("suppresses duplicate keydowns until keyup or window blur", () => {
+    const onKeyDown = vi.fn()
+    render(
+      <GlobalHotkeys keyName="r" onKeyDown={onKeyDown}>
+        <div>content</div>
+      </GlobalHotkeys>
+    )
+
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "r", bubbles: true })
+    )
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "r", bubbles: true })
+    )
+    expect(onKeyDown).toHaveBeenCalledOnce()
+
+    window.dispatchEvent(new Event("blur"))
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "r", bubbles: true })
+    )
+    expect(onKeyDown).toHaveBeenCalledTimes(2)
+  })
+
+  it("ignores key presses from editable elements", async () => {
+    const user = userEvent.setup()
+    const onKeyDown = vi.fn()
+    render(
+      <GlobalHotkeys keyName="a" onKeyDown={onKeyDown}>
+        <input aria-label="editor" />
+      </GlobalHotkeys>
+    )
+
+    await user.type(screen.getByLabelText("editor"), "a")
+
+    expect(onKeyDown).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/app/src/components/GlobalHotkeys/GlobalHotkeys.tsx
+++ b/frontend/app/src/components/GlobalHotkeys/GlobalHotkeys.tsx
@@ -32,7 +32,7 @@ function normalizeKey(key: string): string {
   return key === "Escape" || key === "Esc" ? "esc" : key.toLowerCase()
 }
 
-/** Handles Streamlit's unmodified, single-key global shortcuts. */
+/** Handles Streamlit's single-key global shortcuts, ignoring Alt/Ctrl/Cmd chords. */
 export function GlobalHotkeys({
   keyName,
   onKeyDown,
@@ -41,6 +41,7 @@ export function GlobalHotkeys({
 }: GlobalHotkeysProps): ReactElement {
   const keyDownHandlerRef = useRef(onKeyDown)
   const keyUpHandlerRef = useRef(onKeyUp)
+  // Keep document listeners stable while dispatching to the latest callbacks.
   keyDownHandlerRef.current = onKeyDown
   keyUpHandlerRef.current = onKeyUp
 
@@ -54,8 +55,14 @@ export function GlobalHotkeys({
 
     const handleKeyDown = (event: KeyboardEvent): void => {
       const normalizedKey = normalizeKey(event.key)
-      // Shift is allowed so advertised shortcuts like R and C still work.
-      const hasModifier = event.altKey || event.ctrlKey || event.metaKey
+      // Shift is allowed on single-character keys so advertised shortcuts
+      // like R and C still work. Multi-character keys such as esc still
+      // require an unmodified match.
+      const hasModifier =
+        event.altKey ||
+        event.ctrlKey ||
+        event.metaKey ||
+        (event.shiftKey && normalizedKey.length !== 1)
       if (
         !configuredKeys.has(normalizedKey) ||
         activeKeys.has(normalizedKey) ||

--- a/frontend/app/src/components/GlobalHotkeys/GlobalHotkeys.tsx
+++ b/frontend/app/src/components/GlobalHotkeys/GlobalHotkeys.tsx
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ReactElement, ReactNode, useEffect, useRef } from "react"
+
+import { isKeyboardEventFromEditableTarget } from "@streamlit/lib"
+
+type HotkeyHandler = (keyName: string, event?: KeyboardEvent) => void
+
+interface GlobalHotkeysProps {
+  /** Comma-separated keys to listen for, for example `"r,c,esc"`. */
+  keyName: string
+  onKeyDown?: HotkeyHandler
+  onKeyUp?: HotkeyHandler
+  children: ReactNode
+}
+
+function normalizeKey(key: string): string {
+  return key === "Escape" || key === "Esc" ? "esc" : key.toLowerCase()
+}
+
+/** Handles Streamlit's unmodified, single-key global shortcuts. */
+export function GlobalHotkeys({
+  keyName,
+  onKeyDown,
+  onKeyUp,
+  children,
+}: GlobalHotkeysProps): ReactElement {
+  const keyDownHandlerRef = useRef(onKeyDown)
+  const keyUpHandlerRef = useRef(onKeyUp)
+  keyDownHandlerRef.current = onKeyDown
+  keyUpHandlerRef.current = onKeyUp
+
+  useEffect(() => {
+    const configuredKeys = new Set(
+      keyName.split(",").map(key => normalizeKey(key.trim()))
+    )
+    // Held keys are tracked so a repeated or stuck keydown cannot retrigger
+    // until keyup or the window loses focus.
+    const activeKeys = new Set<string>()
+
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      const normalizedKey = normalizeKey(event.key)
+      // Shift is allowed so advertised shortcuts like R and C still work.
+      const hasModifier = event.altKey || event.ctrlKey || event.metaKey
+      if (
+        !configuredKeys.has(normalizedKey) ||
+        activeKeys.has(normalizedKey) ||
+        event.repeat ||
+        hasModifier ||
+        isKeyboardEventFromEditableTarget(event)
+      ) {
+        return
+      }
+
+      activeKeys.add(normalizedKey)
+      keyDownHandlerRef.current?.(normalizedKey, event)
+    }
+
+    const handleKeyUp = (event: KeyboardEvent): void => {
+      const normalizedKey = normalizeKey(event.key)
+      if (!activeKeys.delete(normalizedKey)) {
+        return
+      }
+
+      keyUpHandlerRef.current?.(normalizedKey, event)
+    }
+
+    const handleWindowBlur = (): void => {
+      activeKeys.clear()
+    }
+
+    document.addEventListener("keydown", handleKeyDown)
+    document.addEventListener("keyup", handleKeyUp)
+    window.addEventListener("blur", handleWindowBlur)
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown)
+      document.removeEventListener("keyup", handleKeyUp)
+      window.removeEventListener("blur", handleWindowBlur)
+    }
+  }, [keyName])
+
+  return <>{children}</>
+}

--- a/frontend/app/src/components/MainMenu/MainMenu.tsx
+++ b/frontend/app/src/components/MainMenu/MainMenu.tsx
@@ -303,8 +303,8 @@ function buildMenuData({
  * Developer items: Rerun, and Auto-rerun toggle (dev mode only).
  *
  * Note: Keyboard shortcuts are displayed uppercase for design consistency.
- * The react-hot-keys library normalizes key presses to lowercase, so both
- * 'r' and 'R' trigger the Rerun action.
+ * GlobalHotkeys normalizes key presses to lowercase, so both 'r' and 'R'
+ * trigger the Rerun action.
  */
 function buildDevItems(
   developmentMode: boolean,
@@ -351,8 +351,8 @@ function buildDevItems(
  * Clear cache item (dev mode only, in its own section).
  *
  * Note: Keyboard shortcut displayed uppercase for design consistency.
- * The react-hot-keys library normalizes key presses to lowercase, so both
- * 'c' and 'C' trigger the Clear cache action.
+ * GlobalHotkeys normalizes key presses to lowercase, so both 'c' and 'C'
+ * trigger the Clear cache action.
  */
 function buildClearCacheItem(
   developmentMode: boolean,

--- a/frontend/app/src/components/StatusWidget/StatusWidget.test.tsx
+++ b/frontend/app/src/components/StatusWidget/StatusWidget.test.tsx
@@ -227,6 +227,28 @@ describe("StatusWidget element", () => {
 
     expect(rerunScript).toHaveBeenCalledWith(true)
   })
+
+  it("calls always rerun when the a shortcut is pressed", async () => {
+    const user = userEvent.setup()
+    const rerunScript = vi.fn()
+
+    render(
+      <StatusWidget
+        {...getProps({
+          rerunScript,
+          scriptRunState: ScriptRunState.NOT_RUNNING,
+          showScriptChangedActions: true,
+        })}
+      />
+    )
+
+    expect(await screen.findByText("Always rerun")).toBeVisible()
+
+    await user.keyboard("a")
+
+    expect(rerunScript).toHaveBeenCalledWith(true)
+    expect(rerunScript).not.toHaveBeenCalledWith(false)
+  })
 })
 
 describe("Running Icon", () => {

--- a/frontend/app/src/components/StatusWidget/StatusWidget.test.tsx
+++ b/frontend/app/src/components/StatusWidget/StatusWidget.test.tsx
@@ -228,7 +228,10 @@ describe("StatusWidget element", () => {
     expect(rerunScript).toHaveBeenCalledWith(true)
   })
 
-  it("calls always rerun when the a shortcut is pressed", async () => {
+  it.each([
+    ["A", "a"],
+    ["Shift+A", "{Shift>}a{/Shift}"],
+  ])("calls Always rerun when %s is pressed", async (_label, keys) => {
     const user = userEvent.setup()
     const rerunScript = vi.fn()
 
@@ -244,7 +247,7 @@ describe("StatusWidget element", () => {
 
     expect(await screen.findByText("Always rerun")).toBeVisible()
 
-    await user.keyboard("a")
+    await user.keyboard(keys)
 
     expect(rerunScript).toHaveBeenCalledWith(true)
     expect(rerunScript).not.toHaveBeenCalledWith(false)

--- a/frontend/app/src/components/StatusWidget/StatusWidget.tsx
+++ b/frontend/app/src/components/StatusWidget/StatusWidget.tsx
@@ -15,9 +15,9 @@
  */
 import { ReactElement, ReactNode, useEffect, useRef, useState } from "react"
 
-import Hotkeys from "react-hot-keys"
 import { CSSTransition } from "react-transition-group"
 
+import { GlobalHotkeys } from "@streamlit/app/src/components/GlobalHotkeys/GlobalHotkeys"
 import { ConnectionState } from "@streamlit/connection"
 import {
   BaseButton,
@@ -191,7 +191,7 @@ const StatusWidget: React.FC<StatusWidgetProps> = ({
   const renderRerunScriptPrompt = (): ReactNode => {
     const rerunRequested = scriptRunState === ScriptRunState.RERUN_REQUESTED
     return (
-      <Hotkeys keyName="a" onKeyDown={handleKeyDown}>
+      <GlobalHotkeys keyName="a" onKeyDown={handleKeyDown}>
         <StyledAppStatus>
           <DynamicIcon
             size="lg"
@@ -212,7 +212,7 @@ const StatusWidget: React.FC<StatusWidgetProps> = ({
             />
           )}
         </StyledAppStatus>
-      </Hotkeys>
+      </GlobalHotkeys>
     )
   }
 

--- a/frontend/app/src/util/getBrowserInfo.test.ts
+++ b/frontend/app/src/util/getBrowserInfo.test.ts
@@ -45,14 +45,14 @@ describe("getBrowserInfo", () => {
     })
   })
 
-  it("should detect Brave browser on macOS", () => {
+  it("should detect Chrome for Brave-like user agents without a unique token", () => {
     mockUserAgent(
       "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.107 Safari/537.36 Brave/92.0.4515.107"
     )
 
     const result = getBrowserInfo()
     expect(result).toEqual({
-      browserName: "Brave",
+      browserName: "Chrome",
       browserVersion: "92.0.4515.107",
       deviceType: "desktop",
       os: "Mac OS",

--- a/frontend/app/src/util/getBrowserInfo.ts
+++ b/frontend/app/src/util/getBrowserInfo.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import UAParser from "ua-parser-js"
+import { parseUserAgent } from "@streamlit/utils"
 
 function getBrowserInfo(): {
   browserName: string
@@ -22,20 +22,13 @@ function getBrowserInfo(): {
   deviceType: string
   os: string
 } {
-  const parser = new UAParser()
-  const result = parser.getResult()
+  const result = parseUserAgent(navigator.userAgent)
 
   return {
-    browserName: result.browser.name || "Unknown",
-    browserVersion: result.browser.version || "Unknown",
-    /**
-     * 'desktop' is not a valid value for device.type in ua-parser-js.
-     * We default to 'desktop' if the value is not present.
-     * Possible options from ua-parser-js are:
-     * 'mobile', 'tablet', 'smarttv', 'wearable', 'embedded', 'console'
-     */
-    deviceType: result.device.type || "desktop",
-    os: result.os.name || "Unknown",
+    browserName: result.browserName || "Unknown",
+    browserVersion: result.browserVersion || "Unknown",
+    deviceType: result.deviceType || "desktop",
+    os: result.os || "Unknown",
   }
 }
 

--- a/frontend/lib/package.json
+++ b/frontend/lib/package.json
@@ -70,10 +70,8 @@
     "@streamlit/utils": "workspace:^",
     "apache-arrow": "^21.2.0",
     "axios": "^1.19.0",
-    "classnames": "^2.3.2",
     "color2k": "^2.0.2",
     "d3-graphviz": "^5.6.0",
-    "decamelize": "^6.0.1",
     "dompurify": "^3.4.14",
     "hoist-non-react-statics": "^3.3.2",
     "hotkeys-js": "^4.0.5",
@@ -116,11 +114,9 @@
     "remark-math": "^6.0.0",
     "remend": "^1.2.2",
     "typed-signals": "^3.0.0",
-    "ua-parser-js": "^1.0.41",
     "unified": "^11.0.5",
     "unist-util-visit": "^5.1.0",
     "urlpattern-polyfill": "^10.1.0",
-    "uuid": "^14.0.2",
     "vega": "^6.4.0",
     "vega-embed": "^7.1.0",
     "vega-interpreter": "^2.3.2",
@@ -157,7 +153,6 @@
     "@types/react-color": "^3.0.13",
     "@types/react-dom": "^18.2.0",
     "@types/react-syntax-highlighter": "^15.5.5",
-    "@types/ua-parser-js": "^0.7.39",
     "@types/xxhashjs": "^0.2.2",
     "@vitejs/plugin-react-swc": "^4.3.3",
     "timezone-mock": "^1.4.3",
@@ -175,12 +170,8 @@
       "react-aria",
       "react-plotly.js",
       "react-stately",
-      "uuid",
       "vfile",
       "wavesurfer.js"
     ]
-  },
-  "resolutions": {
-    "ua-parser-js": "^1.0.40"
   }
 }

--- a/frontend/lib/src/BackendOperationClient.ts
+++ b/frontend/lib/src/BackendOperationClient.ts
@@ -15,7 +15,6 @@
  */
 
 import { getLogger } from "loglevel"
-import { v4 as uuidv4 } from "uuid"
 
 import {
   BackendOperationRequest,
@@ -24,6 +23,7 @@ import {
   IDataframeChunkRequestPayload,
   IDataframeChunkResponsePayload,
 } from "@streamlit/protobuf"
+import { generateUuid } from "@streamlit/utils"
 
 const LOG = getLogger("BackendOperationClient")
 
@@ -152,7 +152,7 @@ export class BackendOperationClient {
     payload: IBackendOperationRequest[typeof payloadField],
     timeoutMs?: number
   ): Promise<TResponse> {
-    const requestId = uuidv4()
+    const requestId = generateUuid()
     const effectiveTimeout = timeoutMs ?? this.timeoutMs
 
     const resolver = Promise.withResolvers<TResponse>()

--- a/frontend/lib/src/FileUploadClient.ts
+++ b/frontend/lib/src/FileUploadClient.ts
@@ -17,9 +17,9 @@
 import type { AxiosProgressEvent } from "axios"
 import { isEqual } from "lodash-es"
 import { getLogger } from "loglevel"
-import { v4 as uuidv4 } from "uuid"
 
 import { IFileURLs, IFileURLsResponse } from "@streamlit/protobuf"
+import { generateUuid } from "@streamlit/utils"
 
 import { SessionInfo } from "./SessionInfo"
 import { StreamlitEndpoints } from "./StreamlitEndpoints"
@@ -72,7 +72,7 @@ export class FileUploadClient {
   private readonly requestFileURLs?: (requestId: string, files: File[]) => void
 
   /**
-   * A map from request ID (a uuidv4) to the Resolver that should resolve once
+   * A map from request ID to the Resolver that should resolve once
    * the requested file URLs are received.
    */
   private readonly pendingFileURLsRequests = new Map<
@@ -148,7 +148,7 @@ export class FileUploadClient {
 
     const resolver = Promise.withResolvers<IFileURLs[]>()
 
-    const requestId = uuidv4()
+    const requestId = generateUuid()
     this.pendingFileURLsRequests.set(requestId, resolver)
     this.requestFileURLs(requestId, files)
 

--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -16,8 +16,6 @@
 
 import { ReactElement, useContext, useMemo } from "react"
 
-import classNames from "classnames"
-
 import { Block as BlockProto, streamlit } from "@streamlit/protobuf"
 
 import { BlockNode } from "~lib/AppNode"
@@ -225,10 +223,12 @@ export const FlexBoxContainer = (
     >
       <StyledFlexContainerBlock
         {...styles}
-        className={classNames(
+        className={[
           getClassnamePrefix(direction),
-          convertKeyToClassName(userKey)
-        )}
+          convertKeyToClassName(userKey),
+        ]
+          .filter(Boolean)
+          .join(" ")}
         data-testid={getClassnamePrefix(direction)}
         data-test-wrap={String(wrap)}
         ref={scrollContainerRef as React.RefObject<HTMLDivElement>}

--- a/frontend/lib/src/components/core/Block/ElementContainer.tsx
+++ b/frontend/lib/src/components/core/Block/ElementContainer.tsx
@@ -16,8 +16,6 @@
 
 import { memo, ReactElement, ReactNode, Suspense, useContext } from "react"
 
-import classNames from "classnames"
-
 import { ElementNode } from "~lib/AppNode"
 import { ViewStateContext } from "~lib/components/core/ViewStateContext"
 import { SquareSkeleton } from "~lib/components/elements/Skeleton/styled-components"
@@ -77,11 +75,13 @@ export const ElementContainer = memo(function ElementContainer({
 
   return (
     <StyledElementContainerLayoutWrapper
-      className={classNames(
+      className={[
         "stElementContainer",
         "element-container",
-        convertKeyToClassName(userKey)
-      )}
+        convertKeyToClassName(userKey),
+      ]
+        .filter(Boolean)
+        .join(" ")}
       data-testid="stElementContainer"
       data-stale={isStale}
       isStale={isStale && !isFullScreen}

--- a/frontend/lib/src/components/elements/Dialog/Dialog.test.tsx
+++ b/frontend/lib/src/components/elements/Dialog/Dialog.test.tsx
@@ -313,8 +313,8 @@ describe("Dialog container", () => {
           </Dialog>
         )
 
-        // react-hot-keys fires its handler on both keydown and keyup, so both
-        // must be suppressed for non-dismissible dialogs.
+        // Capture-phase listeners suppress R so the app-level shortcut cannot
+        // rerun (and close) a non-dismissible dialog.
         const event = new KeyboardEvent(eventType, {
           key: "r",
           bubbles: true,

--- a/frontend/lib/src/components/elements/Dialog/Dialog.test.tsx
+++ b/frontend/lib/src/components/elements/Dialog/Dialog.test.tsx
@@ -302,33 +302,30 @@ describe("Dialog container", () => {
   })
 
   describe("keyboard handling", () => {
-    it.each(["keydown", "keyup"] as const)(
-      "prevents R %s from triggering rerun when dialog is non-dismissible",
-      eventType => {
-        const props = getProps({ dismissible: false })
+    it("prevents R keydown from triggering rerun when dialog is non-dismissible", () => {
+      const props = getProps({ dismissible: false })
 
-        render(
-          <Dialog {...props}>
-            <div>test content</div>
-          </Dialog>
-        )
+      render(
+        <Dialog {...props}>
+          <div>test content</div>
+        </Dialog>
+      )
 
-        // Capture-phase listeners suppress R so the app-level shortcut cannot
-        // rerun (and close) a non-dismissible dialog.
-        const event = new KeyboardEvent(eventType, {
-          key: "r",
-          bubbles: true,
-          cancelable: true,
-        })
-        const stopImmediateSpy = vi.spyOn(event, "stopImmediatePropagation")
+      // Capture-phase keydown suppresses R so the app-level shortcut cannot
+      // rerun (and close) a non-dismissible dialog.
+      const event = new KeyboardEvent("keydown", {
+        key: "r",
+        bubbles: true,
+        cancelable: true,
+      })
+      const stopImmediateSpy = vi.spyOn(event, "stopImmediatePropagation")
 
-        const wasDefaultPrevented = !document.dispatchEvent(event)
+      const wasDefaultPrevented = !document.dispatchEvent(event)
 
-        expect(wasDefaultPrevented).toBe(true)
-        expect(stopImmediateSpy).toHaveBeenCalled()
-        expect(screen.getByText("test content")).toBeVisible()
-      }
-    )
+      expect(wasDefaultPrevented).toBe(true)
+      expect(stopImmediateSpy).toHaveBeenCalled()
+      expect(screen.getByText("test content")).toBeVisible()
+    })
 
     it("does not prevent R key when dialog is dismissible", () => {
       const props = getProps({ dismissible: true })

--- a/frontend/lib/src/components/elements/Dialog/Dialog.tsx
+++ b/frontend/lib/src/components/elements/Dialog/Dialog.tsx
@@ -104,18 +104,15 @@ const Dialog: React.FC<React.PropsWithChildren<Props>> = ({
     }
   }, [id, widgetMgr, fragmentId])
 
-  // Handler to suppress the R key when dialog is open and non-dismissible.
-  // Otherwise, R would dismiss the dialog by rerunning the script.
-  // react-hot-keys binds both keydown and keyup to the same handler, so we
-  // must intercept both — blocking only keydown still lets keyup trigger
-  // App.rerunScript (reproduced on WebKit after backdrop click).
+  // Suppress R while a non-dismissible dialog is open so the app-level
+  // shortcut cannot rerun (and close) the dialog. Capture-phase keydown
+  // must stopImmediatePropagation so GlobalHotkeys never sees the event.
   const handleRKeySuppress = useCallback(
     (e: KeyboardEvent): void => {
       if (isOpen && e.key.toLowerCase() === "r" && !element.dismissible) {
         const target = e.target as HTMLElement
 
-        // We don't want to prevent typing in input fields.
-        // This is the same check that is also done by react-hot-keys.
+        // Allow typing R in inputs, textareas, and contenteditable fields.
         if (
           target &&
           (target.isContentEditable ||
@@ -126,8 +123,6 @@ const Dialog: React.FC<React.PropsWithChildren<Props>> = ({
           return
         }
 
-        // stopImmediatePropagation so other listeners on the same target
-        // (hotkeys-js on document) are skipped too.
         e.preventDefault()
         e.stopImmediatePropagation()
       }

--- a/frontend/lib/src/components/elements/Dialog/Dialog.tsx
+++ b/frontend/lib/src/components/elements/Dialog/Dialog.tsx
@@ -135,11 +135,9 @@ const Dialog: React.FC<React.PropsWithChildren<Props>> = ({
     if (isOpen && !element.dismissible) {
       // capture=true to intercept before App-level hotkeys
       document.addEventListener("keydown", handleRKeySuppress, true)
-      document.addEventListener("keyup", handleRKeySuppress, true)
 
       return () => {
         document.removeEventListener("keydown", handleRKeySuppress, true)
-        document.removeEventListener("keyup", handleRKeySuppress, true)
       }
     }
     return undefined

--- a/frontend/lib/src/components/elements/Spinner/Spinner.tsx
+++ b/frontend/lib/src/components/elements/Spinner/Spinner.tsx
@@ -16,8 +16,6 @@
 
 import { memo, ReactElement, useEffect, useRef, useState } from "react"
 
-import classNames from "classnames"
-
 import { Spinner as SpinnerProto } from "@streamlit/protobuf"
 
 import { DynamicIcon } from "~lib/components/shared/Icon/DynamicIcon"
@@ -65,7 +63,7 @@ function Spinner({ element }: Readonly<SpinnerProps>): ReactElement {
 
   return (
     <StyledSpinner
-      className={classNames({ stSpinner: true, stCacheSpinner: cache })}
+      className={cache ? "stSpinner stCacheSpinner" : "stSpinner"}
       data-testid="stSpinner"
       cache={cache}
     >

--- a/frontend/lib/src/components/elements/Tabs/Tabs.tsx
+++ b/frontend/lib/src/components/elements/Tabs/Tabs.tsx
@@ -26,7 +26,6 @@ import {
 } from "react"
 
 import { ChevronLeft, ChevronRight } from "@emotion-icons/material-outlined"
-import classNames from "classnames"
 import { Key, SelectionIndicator } from "react-aria-components"
 
 import { AppNode, BlockNode } from "~lib/AppNode"
@@ -322,7 +321,9 @@ function Tabs(props: Readonly<TabProps>): ReactElement {
 
   return (
     <StyledTabContainer
-      className={classNames("stTabs", convertKeyToClassName(userKey))}
+      className={["stTabs", convertKeyToClassName(userKey)]
+        .filter(Boolean)
+        .join(" ")}
       data-testid="stTabs"
       isOverflowing={isOverflowing}
       width={width}

--- a/frontend/lib/src/components/widgets/BidiComponent/hooks/useHandleJsContent.ts
+++ b/frontend/lib/src/components/widgets/BidiComponent/hooks/useHandleJsContent.ts
@@ -16,13 +16,12 @@
 
 import { useEffect, useMemo, useRef } from "react"
 
-import { v4 as uuidv4 } from "uuid"
-
 import {
   CleanupFunction,
   FrontendRendererArgs,
   FrontendState,
 } from "@streamlit/component-v2-lib"
+import { generateUuid } from "@streamlit/utils"
 
 import { BidiComponentContext } from "~lib/components/widgets/BidiComponent/BidiComponentContext"
 import { blobUrlManager } from "~lib/components/widgets/BidiComponent/utils/blobUrl"
@@ -179,7 +178,7 @@ export const useHandleJsContent = ({
   setError: (error: Error) => void
   skip?: boolean
 }): void => {
-  const thisUuid = useMemo(() => uuidv4(), [])
+  const thisUuid = useMemo(() => generateUuid(), [])
   const componentId = `st-bidi-component-${thisUuid}`
 
   const {

--- a/frontend/lib/src/util/isMobile.test.ts
+++ b/frontend/lib/src/util/isMobile.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isMobile } from "./isMobile"
+
+describe("isMobile", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it.each([
+    {
+      label: "a mobile phone",
+      userAgent:
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) Mobile/15E148 Safari/604.1",
+      expected: true,
+    },
+    {
+      label: "an Android tablet",
+      userAgent:
+        "Mozilla/5.0 (Linux; Android 14; Tablet) AppleWebKit/537.36 Chrome/123.0 Safari/537.36",
+      expected: false,
+    },
+    {
+      label: "a desktop browser",
+      userAgent:
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/537.36 Chrome/123.0 Safari/537.36",
+      expected: false,
+    },
+  ])("returns $expected for $label", ({ userAgent, expected }) => {
+    vi.spyOn(window.navigator, "userAgent", "get").mockReturnValue(userAgent)
+
+    expect(isMobile()).toBe(expected)
+  })
+})

--- a/frontend/lib/src/util/isMobile.ts
+++ b/frontend/lib/src/util/isMobile.ts
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-import UAParser from "ua-parser-js"
-
-const parser = new UAParser()
+import { parseUserAgent } from "@streamlit/utils"
 
 /**
  * Utilizes user agent to determine if the user is on a mobile device.
@@ -25,6 +23,5 @@ const parser = new UAParser()
  * @returns true if the user is on a mobile device, false otherwise
  */
 export function isMobile(): boolean {
-  const result = parser.getResult()
-  return result.device.type === "mobile"
+  return parseUserAgent(navigator.userAgent).deviceType === "mobile"
 }

--- a/frontend/lib/src/util/utils.test.ts
+++ b/frontend/lib/src/util/utils.test.ts
@@ -495,6 +495,17 @@ describe("keysToSnakeCase", () => {
     })
   })
 
+  it("should preserve consecutive uppercase letters", () => {
+    expect(keysToSnakeCase({ testGUILabel: 1, XMLHttpRequest: 2 })).toEqual({
+      test_GUI_label: 1,
+      XML_http_request: 2,
+    })
+  })
+
+  it("should decamelize Unicode letters", () => {
+    expect(keysToSnakeCase({ déjàVu: true })).toEqual({ déjà_vu: true })
+  })
+
   it("should return an empty dictionary when passed an empty dictionary", () => {
     expect(keysToSnakeCase({})).toEqual({})
   })

--- a/frontend/lib/src/util/utils.ts
+++ b/frontend/lib/src/util/utils.ts
@@ -676,7 +676,8 @@ export function keysToSnakeCase(
   )
 }
 
-/** Convert camelCase to snake_case while keeping consecutive uppercase abbreviations intact. */
+/** Convert camelCase to snake_case, keeping consecutive uppercase abbreviations intact (`XMLHttpRequest` → `XML_http_request`).
+ *  Adapted from sindresorhus/decamelize (`preserveConsecutiveUppercase: true`), MIT. */
 function decamelizePreservingUppercase(value: string): string {
   if (value.length < 2) {
     return value

--- a/frontend/lib/src/util/utils.ts
+++ b/frontend/lib/src/util/utils.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import decamelize from "decamelize"
 import { get } from "lodash-es"
 import xxhash from "xxhashjs"
 
@@ -655,9 +654,7 @@ export function keysToSnakeCase(
 ): Record<string, unknown> {
   return Object.keys(obj).reduce(
     (acc, key) => {
-      const newKey = decamelize(key, {
-        preserveConsecutiveUppercase: true,
-      }).replace(".", "_")
+      const newKey = decamelizePreservingUppercase(key).replace(".", "_")
       let value = obj[key]
 
       if (value && typeof value === "object" && !Array.isArray(value)) {
@@ -676,6 +673,31 @@ export function keysToSnakeCase(
       return acc
     },
     {} as Record<string, unknown>
+  )
+}
+
+/** Convert camelCase to snake_case while keeping consecutive uppercase abbreviations intact. */
+function decamelizePreservingUppercase(value: string): string {
+  if (value.length < 2) {
+    return value
+  }
+
+  // Insert `_` between a lowercase letter or digit and an uppercase letter.
+  const separated = value.replace(
+    /([\p{Lowercase_Letter}\d])(\p{Uppercase_Letter})/gu,
+    "$1_$2"
+  )
+  // Lowercase isolated uppercase letters/digits so they are not treated as abbreviations.
+  const lowercasedSingleLetters = separated.replace(
+    /((?<![\p{Uppercase_Letter}\d])[\p{Uppercase_Letter}\d](?![\p{Uppercase_Letter}\d]))/gu,
+    character => character.toLowerCase()
+  )
+
+  // Split an abbreviation from the capitalized word that follows it (`XMLHttp` → `XML_http`).
+  return lowercasedSingleLetters.replace(
+    /(?<!\p{Uppercase_Letter})(\p{Uppercase_Letter}+)(\p{Uppercase_Letter}\p{Lowercase_Letter}+)/gu,
+    (_, uppercase: string, trailingWord: string) =>
+      `${uppercase}_${trailingWord.toLowerCase()}`
   )
 }
 

--- a/frontend/lib/src/vendor/decamelize/decamelize-LICENSE.txt
+++ b/frontend/lib/src/vendor/decamelize/decamelize-LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/frontend/utils/src/browser/index.test.ts
+++ b/frontend/utils/src/browser/index.test.ts
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 
-import { getCookie, localStorageAvailable } from "."
+import {
+  generateUuid,
+  getCookie,
+  localStorageAvailable,
+  parseUserAgent,
+} from "."
 
 describe("browser", () => {
   describe("localStorageAvailable", () => {
@@ -90,6 +95,57 @@ describe("browser", () => {
       document.cookie = "flavor=chocolatechip;"
       const cookie = getCookie("flavor")
       expect(cookie).toEqual("chocolatechip")
+    })
+  })
+
+  describe("generateUuid", () => {
+    afterEach(() => {
+      vi.unstubAllGlobals()
+      vi.restoreAllMocks()
+    })
+
+    it("uses crypto.randomUUID when available", () => {
+      const uuid = "123e4567-e89b-42d3-a456-426614174000"
+      vi.spyOn(globalThis.crypto, "randomUUID").mockReturnValue(uuid)
+
+      expect(generateUuid()).toBe(uuid)
+    })
+
+    it("generates a version 4 UUID with getRandomValues as a fallback", () => {
+      vi.stubGlobal("crypto", {
+        getRandomValues: (bytes: Uint8Array) => {
+          bytes.fill(0xff)
+          return bytes
+        },
+      })
+
+      expect(generateUuid()).toBe("ffffffff-ffff-4fff-bfff-ffffffffffff")
+    })
+  })
+
+  describe("parseUserAgent", () => {
+    it.each([
+      [
+        "Android phone",
+        "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 Chrome/123.0 Mobile Safari/537.36",
+        "mobile",
+      ],
+      [
+        "Android tablet",
+        "Mozilla/5.0 (Linux; Android 14; Tablet) AppleWebKit/537.36 Chrome/123.0 Safari/537.36",
+        "tablet",
+      ],
+    ])("classifies an %s as %s", (_label, userAgent, deviceType) => {
+      expect(parseUserAgent(userAgent).deviceType).toBe(deviceType)
+    })
+
+    it("returns empty fields for an unknown user agent", () => {
+      expect(parseUserAgent("custom-client")).toEqual({
+        browserName: undefined,
+        browserVersion: undefined,
+        deviceType: undefined,
+        os: undefined,
+      })
     })
   })
 })

--- a/frontend/utils/src/browser/index.test.ts
+++ b/frontend/utils/src/browser/index.test.ts
@@ -135,8 +135,44 @@ describe("browser", () => {
         "Mozilla/5.0 (Linux; Android 14; Tablet) AppleWebKit/537.36 Chrome/123.0 Safari/537.36",
         "tablet",
       ],
+      [
+        "Web0S TV",
+        "Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.79 Safari/537.36 DMOST/2.0.0 (; LGE; webOS TV)",
+        "smarttv",
+      ],
+      [
+        "legacy webOS TV",
+        "Mozilla/5.0 (webOS/1.4.2; U; en-US) AppleWebKit/532.2 (KHTML, like Gecko) Version/1.0 Safari/532.2 Pre/1.1",
+        "smarttv",
+      ],
     ])("classifies an %s as %s", (_label, userAgent, deviceType) => {
       expect(parseUserAgent(userAgent).deviceType).toBe(deviceType)
+    })
+
+    it("prefers Edge over Chrome when both tokens are present", () => {
+      expect(
+        parseUserAgent(
+          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0"
+        )
+      ).toEqual({
+        browserName: "Edge",
+        browserVersion: "120.0.0.0",
+        deviceType: undefined,
+        os: "Windows",
+      })
+    })
+
+    it("reports Ubuntu rather than Linux for Firefox on Ubuntu", () => {
+      expect(
+        parseUserAgent(
+          "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:121.0) Gecko/20100101 Firefox/121.0"
+        )
+      ).toEqual({
+        browserName: "Firefox",
+        browserVersion: "121.0",
+        deviceType: undefined,
+        os: "Ubuntu",
+      })
     })
 
     it("returns empty fields for an unknown user agent", () => {

--- a/frontend/utils/src/browser/index.test.ts
+++ b/frontend/utils/src/browser/index.test.ts
@@ -141,7 +141,9 @@ describe("browser", () => {
         "smarttv",
       ],
       [
-        "legacy webOS TV",
+        // Palm Pre phone; the coarse `webOS` token wins over mobile, unlike
+        // historical ua-parser-js which reported this as `mobile`.
+        "legacy webOS device",
         "Mozilla/5.0 (webOS/1.4.2; U; en-US) AppleWebKit/532.2 (KHTML, like Gecko) Version/1.0 Safari/532.2 Pre/1.1",
         "smarttv",
       ],
@@ -182,6 +184,17 @@ describe("browser", () => {
         deviceType: undefined,
         os: undefined,
       })
+    })
+
+    it("reuses a parse for the same user agent and refreshes when it changes", () => {
+      const phoneUa =
+        "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 Chrome/123.0 Mobile Safari/537.36"
+      const tabletUa =
+        "Mozilla/5.0 (Linux; Android 14; Tablet) AppleWebKit/537.36 Chrome/123.0 Safari/537.36"
+
+      expect(parseUserAgent(phoneUa)).toBe(parseUserAgent(phoneUa))
+      expect(parseUserAgent(tabletUa).deviceType).toBe("tablet")
+      expect(parseUserAgent(phoneUa).deviceType).toBe("mobile")
     })
   })
 })

--- a/frontend/utils/src/browser/index.ts
+++ b/frontend/utils/src/browser/index.ts
@@ -37,3 +37,124 @@ export function localStorageAvailable(): boolean {
   }
   return true
 }
+
+/** Generate an RFC 4122 version 4 UUID using the browser's cryptographic RNG. */
+export function generateUuid(): string {
+  if (typeof globalThis.crypto.randomUUID === "function") {
+    return globalThis.crypto.randomUUID()
+  }
+
+  const bytes = globalThis.crypto.getRandomValues(new Uint8Array(16))
+  // RFC 4122 version 4 (random) and IETF variant bits.
+  bytes[6] = (bytes[6] & 0x0f) | 0x40
+  bytes[8] = (bytes[8] & 0x3f) | 0x80
+
+  const hex = Array.from(bytes, byte =>
+    byte.toString(16).padStart(2, "0")
+  ).join("")
+  return [
+    hex.slice(0, 8),
+    hex.slice(8, 12),
+    hex.slice(12, 16),
+    hex.slice(16, 20),
+    hex.slice(20),
+  ].join("-")
+}
+
+type DeviceType =
+  | "mobile"
+  | "tablet"
+  | "smarttv"
+  | "wearable"
+  | "embedded"
+  | "console"
+
+interface UserAgentInfo {
+  browserName?: string
+  browserVersion?: string
+  deviceType?: DeviceType
+  os?: string
+}
+
+/**
+ * Browser tokens to match, in priority order. Many browsers also include
+ * Chrome or Safari in their user agent string, so more specific browsers
+ * must come first.
+ */
+const BROWSER_PATTERNS: Array<{ name: string; pattern: RegExp }> = [
+  { name: "Edge", pattern: /(?:EdgA|EdgiOS|Edg)\/([\d.]+)/i },
+  { name: "Opera", pattern: /(?:OPR|Opera)\/([\d.]+)/i },
+  { name: "Samsung Internet", pattern: /SamsungBrowser\/([\d.]+)/i },
+  { name: "UCBrowser", pattern: /(?:UCBrowser|UC Browser)\/([\d.]+)/i },
+  { name: "QQBrowser", pattern: /MQQBrowser\/([\d.]+)/i },
+  { name: "Maxthon", pattern: /Maxthon\/([\d.]+)/i },
+  { name: "Brave", pattern: /Brave\/([\d.]+)/i },
+  { name: "IE", pattern: /MSIE\s([\d.]+)/i },
+  { name: "IE", pattern: /Trident\/.*?rv:([\d.]+)/i },
+  { name: "Chrome", pattern: /(?:CriOS|Chrome)\/([\d.]+)/i },
+  { name: "Firefox", pattern: /(?:FxiOS|Firefox)\/([\d.]+)/i },
+]
+
+/** Ordered OS tokens; earlier entries win when several could match. */
+const OS_PATTERNS: Array<{ os: string; pattern: RegExp }> = [
+  { os: "iOS", pattern: /(?:iPhone|iPad|iPod)/i },
+  { os: "Windows Phone", pattern: /Windows Phone/i },
+  { os: "Windows", pattern: /Windows/i },
+  { os: "Android", pattern: /Android/i },
+  { os: "Chromium OS", pattern: /CrOS/i },
+  { os: "Mac OS", pattern: /(?:Macintosh|Mac OS X)/i },
+  { os: "Ubuntu", pattern: /Ubuntu/i },
+  { os: "Linux", pattern: /Linux/i },
+]
+
+/** Parse the browser, device class, and operating system fields Streamlit uses. */
+export function parseUserAgent(userAgent: string): UserAgentInfo {
+  let browserName: string | undefined
+  let browserVersion: string | undefined
+
+  for (const { name, pattern } of BROWSER_PATTERNS) {
+    const match = pattern.exec(userAgent)
+    if (match?.[1]) {
+      browserName = name
+      browserVersion = match[1]
+      break
+    }
+  }
+
+  // Safari has no unique product token, so identify it only after more
+  // specific browsers (Chrome, Edge, etc.) have failed to match.
+  if (!browserName && /Safari\//i.test(userAgent)) {
+    const safariVersion = /Version\/([\d.]+)/i.exec(userAgent)?.[1]
+    if (safariVersion) {
+      browserName = /(?:iPhone|iPad|iPod)/i.test(userAgent)
+        ? "Mobile Safari"
+        : "Safari"
+      browserVersion = safariVersion
+    }
+  }
+
+  let deviceType: DeviceType | undefined
+  if (/(?:SMART-TV|SmartTV|Tizen|Web0S)/i.test(userAgent)) {
+    deviceType = "smarttv"
+  } else if (/(?:Watch|Wear OS)/i.test(userAgent)) {
+    deviceType = "wearable"
+  } else if (/(?:Xbox|PlayStation|Nintendo)/i.test(userAgent)) {
+    deviceType = "console"
+  } else if (/(?:CrKey|Chromecast)/i.test(userAgent)) {
+    deviceType = "embedded"
+  } else if (
+    /(?:iPad|Tablet|PlayBook|Silk\/)/i.test(userAgent) ||
+    // Android tablets typically omit "Mobile", which phones include.
+    (/Android/i.test(userAgent) && !/Mobile/i.test(userAgent))
+  ) {
+    deviceType = "tablet"
+  } else if (
+    /(?:Mobi|iPhone|iPod|Windows Phone|IEMobile|Opera Mini)/i.test(userAgent)
+  ) {
+    deviceType = "mobile"
+  }
+
+  const os = OS_PATTERNS.find(({ pattern }) => pattern.test(userAgent))?.os
+
+  return { browserName, browserVersion, deviceType, os }
+}

--- a/frontend/utils/src/browser/index.ts
+++ b/frontend/utils/src/browser/index.ts
@@ -106,11 +106,19 @@ const OS_PATTERNS: Array<{ os: string; pattern: RegExp }> = [
   { os: "Linux", pattern: /Linux/i },
 ]
 
+/** Single-entry cache: the user agent is immutable for a page lifetime. */
+let cachedUserAgent: string | undefined
+let cachedUserAgentInfo: UserAgentInfo | undefined
+
 /**
  * Parse the browser, device class, and operating system fields Streamlit uses.
  * Names intentionally mirror ua-parser-js so historical telemetry stays comparable.
  */
 export function parseUserAgent(userAgent: string): UserAgentInfo {
+  if (cachedUserAgent === userAgent && cachedUserAgentInfo !== undefined) {
+    return cachedUserAgentInfo
+  }
+
   let browserName: string | undefined
   let browserVersion: string | undefined
 
@@ -157,6 +165,8 @@ export function parseUserAgent(userAgent: string): UserAgentInfo {
   }
 
   const os = OS_PATTERNS.find(({ pattern }) => pattern.test(userAgent))?.os
-
-  return { browserName, browserVersion, deviceType, os }
+  const info = { browserName, browserVersion, deviceType, os }
+  cachedUserAgent = userAgent
+  cachedUserAgentInfo = info
+  return info
 }

--- a/frontend/utils/src/browser/index.ts
+++ b/frontend/utils/src/browser/index.ts
@@ -88,7 +88,6 @@ const BROWSER_PATTERNS: Array<{ name: string; pattern: RegExp }> = [
   { name: "UCBrowser", pattern: /(?:UCBrowser|UC Browser)\/([\d.]+)/i },
   { name: "QQBrowser", pattern: /MQQBrowser\/([\d.]+)/i },
   { name: "Maxthon", pattern: /Maxthon\/([\d.]+)/i },
-  { name: "Brave", pattern: /Brave\/([\d.]+)/i },
   { name: "IE", pattern: /MSIE\s([\d.]+)/i },
   { name: "IE", pattern: /Trident\/.*?rv:([\d.]+)/i },
   { name: "Chrome", pattern: /(?:CriOS|Chrome)\/([\d.]+)/i },
@@ -107,7 +106,10 @@ const OS_PATTERNS: Array<{ os: string; pattern: RegExp }> = [
   { os: "Linux", pattern: /Linux/i },
 ]
 
-/** Parse the browser, device class, and operating system fields Streamlit uses. */
+/**
+ * Parse the browser, device class, and operating system fields Streamlit uses.
+ * Names intentionally mirror ua-parser-js so historical telemetry stays comparable.
+ */
 export function parseUserAgent(userAgent: string): UserAgentInfo {
   let browserName: string | undefined
   let browserVersion: string | undefined
@@ -134,9 +136,9 @@ export function parseUserAgent(userAgent: string): UserAgentInfo {
   }
 
   let deviceType: DeviceType | undefined
-  if (/(?:SMART-TV|SmartTV|Tizen|Web0S)/i.test(userAgent)) {
+  if (/(?:SMART-TV|SmartTV|Tizen|Web0S|webOS)/i.test(userAgent)) {
     deviceType = "smarttv"
-  } else if (/(?:Watch|Wear OS)/i.test(userAgent)) {
+  } else if (/(?:watchOS|Watch OS|Wear OS|Galaxy Watch)/i.test(userAgent)) {
     deviceType = "wearable"
   } else if (/(?:Xbox|PlayStation|Nintendo)/i.test(userAgent)) {
     deviceType = "console"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -207,13 +207,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "@babel/runtime@npm:8.0.0"
-  checksum: 10c0/450857cf52b3a3935d4aad505277201361c86185dad3bdd2ae083d78b76c6265c7fc7610e170c80de1b825d5bfdcfb50697f0853fff922b2661c91cff1fbbd81
-  languageName: node
-  linkType: hard
-
 "@babel/template@npm:^7.29.7":
   version: 7.29.7
   resolution: "@babel/template@npm:7.29.7"
@@ -3327,7 +3320,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@streamlit/app@workspace:app"
   dependencies:
-    "@babel/runtime": "npm:^8.0.0"
     "@emotion-icons/emotion-icon": "npm:^4.1.0"
     "@emotion-icons/material-outlined": "npm:^3.14.0"
     "@emotion-icons/material-rounded": "npm:^3.14.0"
@@ -3352,10 +3344,8 @@ __metadata:
     "@types/react": "npm:^18.2.0"
     "@types/react-dom": "npm:^18.2.0"
     "@types/react-transition-group": "npm:^4.4.12"
-    "@types/ua-parser-js": "npm:^0.7.39"
     "@vitejs/plugin-react-swc": "npm:^4.3.3"
     chrome-launcher: "npm:^1.2.1"
-    classnames: "npm:^2.3.2"
     color2k: "npm:^2.0.2"
     hoist-non-react-statics: "npm:^3.3.2"
     iframe-resizer: "npm:4.3.11"
@@ -3369,13 +3359,10 @@ __metadata:
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
     react-helmet-async: "npm:^3.0.0"
-    react-hot-keys: "npm:^3.0.0"
     react-transition-group: "npm:^4.4.5"
     tree-kill: "npm:^1.2.2"
     typed-signals: "npm:^3.0.0"
     typesync: "npm:^0.14.3"
-    ua-parser-js: "npm:^1.0.41"
-    uuid: "npm:^14.0.2"
     vite: "npm:^8.2.2"
     vite-bundle-analyzer: "npm:^1.3.9"
     vite-plugin-terminal: "npm:^1.4.0"
@@ -3467,15 +3454,12 @@ __metadata:
     "@types/react-color": "npm:^3.0.13"
     "@types/react-dom": "npm:^18.2.0"
     "@types/react-syntax-highlighter": "npm:^15.5.5"
-    "@types/ua-parser-js": "npm:^0.7.39"
     "@types/xxhashjs": "npm:^0.2.2"
     "@vitejs/plugin-react-swc": "npm:^4.3.3"
     apache-arrow: "npm:^21.2.0"
     axios: "npm:^1.19.0"
-    classnames: "npm:^2.3.2"
     color2k: "npm:^2.0.2"
     d3-graphviz: "npm:^5.6.0"
-    decamelize: "npm:^6.0.1"
     dompurify: "npm:^3.4.14"
     hoist-non-react-statics: "npm:^3.3.2"
     hotkeys-js: "npm:^4.0.5"
@@ -3520,11 +3504,9 @@ __metadata:
     timezone-mock: "npm:^1.4.3"
     typed-signals: "npm:^3.0.0"
     typesync: "npm:^0.14.3"
-    ua-parser-js: "npm:^1.0.41"
     unified: "npm:^11.0.5"
     unist-util-visit: "npm:^5.1.0"
     urlpattern-polyfill: "npm:^10.1.0"
-    uuid: "npm:^14.0.2"
     vega: "npm:^6.4.0"
     vega-embed: "npm:^7.1.0"
     vega-interpreter: "npm:^2.3.2"
@@ -4671,13 +4653,6 @@ __metadata:
   version: 2.0.7
   resolution: "@types/trusted-types@npm:2.0.7"
   checksum: 10c0/4c4855f10de7c6c135e0d32ce462419d8abbbc33713b31d294596c0cc34ae1fa6112a2f9da729c8f7a20707782b0d69da3b1f8df6645b0366d08825ca1522e0c
-  languageName: node
-  linkType: hard
-
-"@types/ua-parser-js@npm:^0.7.39":
-  version: 0.7.39
-  resolution: "@types/ua-parser-js@npm:0.7.39"
-  checksum: 10c0/fea522f42dfc2854d9c93144a13c3db3bbe1c791458451db06d46bec7e1dbbe945d1542e02bb38378e39a04bdb7810b43e2ead26f9e6c250832e187312522708
   languageName: node
   linkType: hard
 
@@ -6179,7 +6154,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"classnames@npm:^2.2.1, classnames@npm:^2.2.5, classnames@npm:^2.3.2":
+"classnames@npm:^2.2.1, classnames@npm:^2.2.5":
   version: 2.5.1
   resolution: "classnames@npm:2.5.1"
   checksum: 10c0/afff4f77e62cea2d79c39962980bf316bacb0d7c49e13a21adaadb9221e1c6b9d3cdb829d8bb1b23c406f4e740507f37e1dcf506f7e3b7113d17c5bab787aa69
@@ -7316,13 +7291,6 @@ __metadata:
   dependencies:
     ms: "npm:^2.1.1"
   checksum: 10c0/37d96ae42cbc71c14844d2ae3ba55adf462ec89fd3a999459dec3833944cd999af6007ff29c780f1c61153bcaaf2c842d1e4ce1ec621e4fc4923244942e4a02a
-  languageName: node
-  linkType: hard
-
-"decamelize@npm:^6.0.1":
-  version: 6.0.1
-  resolution: "decamelize@npm:6.0.1"
-  checksum: 10c0/c0a3a529591ebab1d1a9458b60684194e91d904e9b0a56367d3d507b2c8ab89dfd40c61423ca6a1eb2f70e2d44d2efe78f3342326395d3738d1d42592b1a6224
   languageName: node
   linkType: hard
 
@@ -9653,7 +9621,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hotkeys-js@npm:^4.0.2, hotkeys-js@npm:^4.0.5":
+"hotkeys-js@npm:^4.0.5":
   version: 4.0.5
   resolution: "hotkeys-js@npm:4.0.5"
   checksum: 10c0/541748a199e4908c091fd2a1a443b4d0741022558ed583b6ee191d5fa466930e17eb15cd2f5a0f741480775290547701305986ca55cc478b071259844e4dbbb5
@@ -13880,19 +13848,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-hot-keys@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "react-hot-keys@npm:3.0.0"
-  dependencies:
-    hotkeys-js: "npm:^4.0.2"
-  peerDependencies:
-    "@babel/runtime": ">=7.10.0"
-    react: ">=16.9.0"
-    react-dom: ">=16.9.0"
-  checksum: 10c0/546f4f47d623bdd49fc3b75e6c9c0b8a3ba56ec1af36e4cfc63644589e7bdefe3c876a93a236e20f35ffba4e235c0ada001ca9e37654008afb2edffcc6892a8e
-  languageName: node
-  linkType: hard
-
 "react-html-attributes@npm:^1.4.6":
   version: 1.4.6
   resolution: "react-html-attributes@npm:1.4.6"
@@ -16014,15 +15969,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ua-parser-js@npm:^1.0.41":
-  version: 1.0.41
-  resolution: "ua-parser-js@npm:1.0.41"
-  bin:
-    ua-parser-js: script/cli.js
-  checksum: 10c0/45dc1f7f3ce8248e0e64640d2e29c65c0ea1fc9cb105594de84af80e2a57bba4f718b9376098ca7a5b0ffe240f8995b0fa3714afa9d36861c41370a378f1a274
-  languageName: node
-  linkType: hard
-
 "uc.micro@npm:^2.0.0, uc.micro@npm:^2.1.0":
   version: 2.1.0
   resolution: "uc.micro@npm:2.1.0"
@@ -16424,7 +16370,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^11.1.0 || ^12 || ^13 || ^14.0.0, uuid@npm:^14.0.2":
+"uuid@npm:^11.1.0 || ^12 || ^13 || ^14.0.0":
   version: 14.0.2
   resolution: "uuid@npm:14.0.2"
   bin:

--- a/scripts/audit_frontend_licenses.py
+++ b/scripts/audit_frontend_licenses.py
@@ -102,12 +102,6 @@ PACKAGE_EXCEPTIONS: set[PackageInfo] = {
         "UNKNOWN",
     ),
     (
-        # Licenses has a typo, is meant to be BSD-3-Clause
-        # https://github.com/luizbarboza/splaytree-ts/blob/master/LICENSE
-        "splaytree-ts@npm:1.0.2",
-        "BDS-3-Clause",
-    ),
-    (
         # MIT license: https://github.com/fabiospampinato/khroma/blob/master/license
         # (npm metadata incorrectly shows "Proprietary")
         "khroma@npm:2.1.0",


### PR DESCRIPTION
## Describe your changes

Replaces several frontend libraries with small in-house helpers so Streamlit no longer depends on them directly.

- `uuid` → `generateUuid()`, `ua-parser-js` → `parseUserAgent()`, `classnames` → class-name joins, `decamelize` → a local helper, `react-hot-keys` → `GlobalHotkeys`
- Keyboard shortcuts (`r`, `c`, `esc`, `a`) still ignore Alt/Ctrl/Cmd chords and typing in inputs. Shift is now allowed on single-character keys, so Shift+R / Shift+C trigger the advertised menu shortcuts where `hotkeys-js` required an exact modifier match.
- Removing `react-hot-keys` also fixes two latent bugs: it overwrote Streamlit's global `hotkeys` filter (so `ensureHotkeysFilterConfigured` never took effect, and Ctrl-modified widget shortcuts were swallowed while typing), and `Hotkeys.unbind(keyName)` globally unbound user shortcuts on `a`/`esc`.
- Drops unused `@babel/runtime` from the app package and the stale `splaytree-ts` license exception

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- [x] Unit Tests (JS and/or Python)
  - `frontend/app/src/components/GlobalHotkeys/GlobalHotkeys.test.tsx` — modifiers, Shift, repeats, blur, editable targets
  - `frontend/app/src/components/StatusWidget/StatusWidget.test.tsx` — `a` always-rerun shortcut
  - `frontend/utils/src/browser/index.test.ts`, `frontend/lib/src/util/isMobile.test.ts`, `frontend/lib/src/util/utils.test.ts` — UUID, UA parsing, decamelize
- E2E Tests: no e2e files changed. Existing `e2e_playwright/app_hotkeys_test.py` covers the `r`/`c` shortcuts.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

Made with [Cursor](https://cursor.com)