### PR TITLE
[docs] Recommend icons for navigation pages

### DIFF
--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/best-practices.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/best-practices.md
@@ -97,7 +97,7 @@ with st.container(border=True):
 
 ## Navigation and pages
 
-Use `st.navigation` with an `app_pages/` directory, and give every `st.Page` a context-appropriate Material Symbol icon. Avoid the legacy `pages/` auto-discovery pattern and app-body navigation built from `st.page_link`.
+Use `st.navigation` with an `app_pages/` directory. Give every `st.Page` a context-appropriate Material Symbols icon. Avoid the legacy `pages/` auto-discovery pattern and app-body navigation built from `st.page_link`.
 
 ```python
 # GOOD: streamlit_app.py

--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/best-practices.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/best-practices.md
@@ -97,7 +97,7 @@ with st.container(border=True):
 
 ## Navigation and pages
 
-Use `st.navigation` with an `app_pages/` directory. Avoid the legacy `pages/` auto-discovery pattern and app-body navigation built from `st.page_link`.
+Use `st.navigation` with an `app_pages/` directory, and give every `st.Page` a context-appropriate Material Symbol icon. Avoid the legacy `pages/` auto-discovery pattern and app-body navigation built from `st.page_link`.
 
 ```python
 # GOOD: streamlit_app.py

--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/multipage-apps.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/multipage-apps.md
@@ -15,9 +15,9 @@ app_pages/
 
 **Important:** Name your pages directory `app_pages/` (not `pages/`). Using `pages/` conflicts with Streamlit's old auto-discovery API and can cause unexpected behavior.
 
-Give every `st.Page` a context-appropriate Material Symbol icon using the `:material/icon_name:` syntax so navigation is easy to scan.
-
 ## Main module
+
+Give every `st.Page` a context-appropriate Material Symbols icon so navigation is easy to scan.
 
 ```python
 # streamlit_app.py

--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/multipage-apps.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/multipage-apps.md
@@ -15,6 +15,8 @@ app_pages/
 
 **Important:** Name your pages directory `app_pages/` (not `pages/`). Using `pages/` conflicts with Streamlit's old auto-discovery API and can cause unexpected behavior.
 
+Give every `st.Page` a context-appropriate Material Symbol icon using the `:material/icon_name:` syntax so navigation is easy to scan.
+
 ## Main module
 
 ```python
@@ -50,7 +52,16 @@ page.run()
 **Few pages (3-7) → Top navigation:**
 
 ```python
-page = st.navigation([...], position="top")
+page = st.navigation(
+    [
+        st.Page("app_pages/home.py", title="Home", icon=":material/home:"),
+        st.Page(
+            "app_pages/analytics.py", title="Analytics", icon=":material/bar_chart:"
+        ),
+        st.Page("app_pages/settings.py", title="Settings", icon=":material/settings:"),
+    ],
+    position="top",
+)
 ```
 
 Creates a clean horizontal menu. Great for simple apps. Sections are supported too—they appear as dropdowns in the top nav.
@@ -61,12 +72,18 @@ Creates a clean horizontal menu. Great for simple apps. Sections are supported t
 page = st.navigation(
     {
         "Main": [
-            st.Page("app_pages/home.py", title="Home"),
-            st.Page("app_pages/analytics.py", title="Analytics"),
+            st.Page("app_pages/home.py", title="Home", icon=":material/home:"),
+            st.Page(
+                "app_pages/analytics.py",
+                title="Analytics",
+                icon=":material/bar_chart:",
+            ),
         ],
         "Admin": [
-            st.Page("app_pages/settings.py", title="Settings"),
-            st.Page("app_pages/users.py", title="Users"),
+            st.Page(
+                "app_pages/settings.py", title="Settings", icon=":material/settings:"
+            ),
+            st.Page("app_pages/users.py", title="Users", icon=":material/group:"),
         ],
     },
     position="sidebar",
@@ -81,12 +98,20 @@ Use an empty string key `""` for pages that shouldn't be in a section. These ung
 page = st.navigation(
     {
         "": [
-            st.Page("app_pages/home.py", title="Home"),
-            st.Page("app_pages/about.py", title="About"),
+            st.Page("app_pages/home.py", title="Home", icon=":material/home:"),
+            st.Page("app_pages/about.py", title="About", icon=":material/info:"),
         ],
         "Analytics": [
-            st.Page("app_pages/dashboard.py", title="Dashboard"),
-            st.Page("app_pages/reports.py", title="Reports"),
+            st.Page(
+                "app_pages/dashboard.py",
+                title="Dashboard",
+                icon=":material/dashboard:",
+            ),
+            st.Page(
+                "app_pages/reports.py",
+                title="Reports",
+                icon=":material/description:",
+            ),
         ],
     },
     position="top",

--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/multipage-apps.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/multipage-apps.md
@@ -17,7 +17,7 @@ app_pages/
 
 ## Main module
 
-Give every `st.Page` a context-appropriate Material Symbols icon so navigation is easy to scan.
+Give every `st.Page` a context-appropriate Material Symbols icon (`:material/icon_name:`) so navigation is easy to scan. Choose a name from the [supported icon list](https://raw.githubusercontent.com/streamlit/streamlit/refs/heads/develop/lib/streamlit/material_icon_names.py) because unsupported names raise an error.
 
 ```python
 # streamlit_app.py


### PR DESCRIPTION
## Describe your changes

Recommends context-appropriate Material Symbols for every `st.Page` so agent-generated multipage apps have consistent, scannable navigation.

- Adds verified icons to the top, sidebar, and grouped navigation examples in the bundled Streamlit skill.

## GitHub Issue Link (if applicable)

Not applicable.

## Testing Plan

- Documentation-only changes; no unit or E2E tests are needed.
- `make autofix`
- `make check`
- Embedded-skill validation and Material icon registry verification

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
