### PR TITLE
[chore] Tune AI PR review models and review loop

### DIFF
--- a/.claude/skills/finalizing-pr/SKILL.md
+++ b/.claude/skills/finalizing-pr/SKILL.md
@@ -111,7 +111,7 @@ If relevant intermediate files exist (specs, plans, implementation notes in `wor
 
 ### 11. AI review and fix loop
 
-Run the AI review and fix loop up to 5 times. Always run `fixing-pr` for the review that was just completed, then stop if that review was approved:
+Run the AI review and fix loop up to 5 times. After each review, always run `fixing-pr` so it can wait for CI and address comments, then exit if that review was approved:
 
 ```
 for iteration 1 to 5:
@@ -150,7 +150,7 @@ The verdict section contains a bold keyword indicating the result:
 - **`**APPROVED**`** → exit loop, PR is ready
 - **`**CHANGES_REQUESTED**`** → continue iterating, address the feedback
 
-Do not start another iteration after an `APPROVED` verdict.
+Do not start another iteration after an `APPROVED` verdict, even if `fixing-pr` pushed follow-up CI fixes. Those commits are covered by CI but not by the AI review.
 
 ### 12. Post agent metrics
 

--- a/.claude/skills/finalizing-pr/SKILL.md
+++ b/.claude/skills/finalizing-pr/SKILL.md
@@ -111,15 +111,14 @@ If relevant intermediate files exist (specs, plans, implementation notes in `wor
 
 ### 11. AI review and fix loop
 
-Iterate through AI review and fixes until the review passes (max 5 iterations):
+Run the AI review and fix loop up to 5 times. Always run `fixing-pr` for the review that was just completed, then stop if that review was approved:
 
 ```
 for iteration 1 to 5:
     1. Trigger AI review by applying the "ai-review" label
     2. Run the `fixing-pr` subagent in foreground to wait for CI, fix failures, and address review comments
-    3. Check AI review verdict in the latest github-actions bot comment
-    4. If verdict is "approved" → exit loop
-    5. Otherwise → continue to next iteration
+    3. Check the latest AI review verdict
+    4. If it is "approved" → exit loop
 ```
 
 **Triggering AI review:**
@@ -151,7 +150,7 @@ The verdict section contains a bold keyword indicating the result:
 - **`**APPROVED**`** → exit loop, PR is ready
 - **`**CHANGES_REQUESTED**`** → continue iterating, address the feedback
 
-**Important:** After each `fixing-pr` run, re-check if changes were made. If changes were pushed, the AI review will be stale and needs re-triggering. Continue iterating until the review verdict is "approved" or max iterations reached.
+Do not start another iteration after an `APPROVED` verdict.
 
 ### 12. Post agent metrics
 

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -21,7 +21,7 @@ env:
   PR_NUMBER: ${{ github.event.inputs.pr_number || github.event.pull_request.number }}
   MODEL_INPUT: ${{ github.event.inputs.model || '' }}
   DEFAULT_AI_PR_REVIEW_MODELS: ${{ vars.AI_PR_REVIEW_MODELS || 'gpt-5.6-terra-xhigh,claude-opus-5-thinking-medium,cursor-grok-4.6-xhigh' }}
-  FINAL_AI_PR_REVIEW_MODELS: "gpt-5.6-sol-high,claude-opus-5-thinking-high,cursor-grok-4.6-xhigh"
+  FINAL_AI_PR_REVIEW_MODELS: "gpt-5.6-sol-high,claude-opus-5-thinking-high,gemini-3.7-flash-high,cursor-grok-4.6-xhigh"
 
 jobs:
   # Job 1: Parse model list and check for API key

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -20,8 +20,8 @@ on:
 env:
   PR_NUMBER: ${{ github.event.inputs.pr_number || github.event.pull_request.number }}
   MODEL_INPUT: ${{ github.event.inputs.model || '' }}
-  DEFAULT_AI_PR_REVIEW_MODELS: ${{ vars.AI_PR_REVIEW_MODELS || 'gpt-5.6-terra-xhigh,claude-opus-5-thinking-high,cursor-grok-4.6-xhigh' }}
-  FINAL_AI_PR_REVIEW_MODELS: "gpt-5.6-sol-xhigh,claude-opus-5-thinking-xhigh,cursor-grok-4.6-xhigh"
+  DEFAULT_AI_PR_REVIEW_MODELS: ${{ vars.AI_PR_REVIEW_MODELS || 'gpt-5.6-terra-xhigh,claude-opus-5-thinking-medium,cursor-grok-4.6-xhigh' }}
+  FINAL_AI_PR_REVIEW_MODELS: "gpt-5.6-sol-high,claude-opus-5-thinking-high,cursor-grok-4.6-xhigh"
 
 jobs:
   # Job 1: Parse model list and check for API key


### PR DESCRIPTION
## Describe your changes

Tunes AI PR reviews for cost and loop behavior: lower reasoning on selected models, add Gemini to the final-review set, and stop re-running AI review after an `APPROVED` verdict.

- Default Claude: `thinking-high` → `thinking-medium`. Terra and Grok stay at `xhigh`.
- Final review: Sol `xhigh` → `high`, Claude `thinking-xhigh` → `thinking-high`, and add `gemini-3.7-flash-high`. Grok stays last as the consolidation judge.
- After `APPROVED`, `finalizing-pr` still runs `fixing-pr` for CI and comments, but does not start another AI review iteration.

`DEFAULT_AI_PR_REVIEW_MODELS` still prefers the `AI_PR_REVIEW_MODELS` repository variable; update or clear that variable if labeled `ai-review` runs should use the new Claude suffix.

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- No library unit or E2E tests: this changes GitHub Actions model configuration and agent guidance. YAML is covered by pre-commit hooks.
- The labeled `ai-review` run validates the default model list. Trigger `ai-final-review` to confirm the new Sol/Claude/Gemini slugs resolve and that four reviews are produced (a rejected slug would skip auto-approve via the review-count gate).

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

Made with [Cursor](https://cursor.com)

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | checking-changes | 1 |
| skill | finalizing-pr | 1 |
| skill | reviewing-pr-description | 1 |
| subagent | fixing-pr | 1 |
| subagent | shell | 1 |

</details>
<!-- agent-metrics-end -->