### PR TITLE
[fix] Keep a time given before a date in st.datetime_input

### DIFF
--- a/e2e_playwright/st_datetime_input_test.py
+++ b/e2e_playwright/st_datetime_input_test.py
@@ -238,8 +238,10 @@ def test_keeps_time_given_before_a_date(app: Page):
     The field reports no value until every segment is filled, so a time entered
     while the date segments are still empty has to be read back out of the
     field's segment state when a date completes the value — otherwise it silently
-    becomes midnight. Covers both entry points: the inline segments and the
-    popover TimeField.
+    becomes midnight. Covers all three entry points: the inline segments, the
+    popover TimeField, and a date typed inline with the time given only in the
+    popover — the last dismissed by an outside click, which runs the commit path
+    twice.
     """
     datetime_input = get_datetime_input(app, "Datetime input 8 (empty)")
     datetime_field = datetime_input.get_by_test_id("stDateTimeInputField")

--- a/e2e_playwright/st_datetime_input_test.py
+++ b/e2e_playwright/st_datetime_input_test.py
@@ -112,22 +112,6 @@ def test_datetime_input_dropdown(app: Page, assert_snapshot: ImageCompareFunctio
     assert_snapshot(calendar, name="st_datetime_input-dropdown")
 
 
-def test_datetime_input_empty_dropdown(
-    app: Page, assert_snapshot: ImageCompareFunction
-):
-    """Test the calendar popover of an empty widget, where the time field is
-    interactive rather than disabled.
-    """
-    get_datetime_input(app, "Datetime input 8 (empty)").get_by_test_id(
-        "stDateTimeInputField"
-    ).get_by_role("spinbutton").first.click()
-
-    calendar = app.get_by_test_id("stDateTimeInputCalendar")
-    expect(calendar).to_be_visible()
-
-    assert_snapshot(calendar, name="st_datetime_input-empty_dropdown")
-
-
 def test_datetime_input_narrow_rendering(
     app: Page, assert_snapshot: ImageCompareFunction
 ):

--- a/e2e_playwright/st_datetime_input_test.py
+++ b/e2e_playwright/st_datetime_input_test.py
@@ -232,6 +232,60 @@ def test_clearable_datetime_input(app: Page):
     expect_markdown(app, "Value 8: None")
 
 
+def test_keeps_time_given_before_a_date(app: Page):
+    """A time given before any date survives the calendar date selection.
+
+    The field reports no value until every segment is filled, so a time entered
+    while the date segments are still empty has to be read back out of the
+    field's segment state when a date completes the value — otherwise it silently
+    becomes midnight. Covers both entry points: the inline segments and the
+    popover TimeField.
+    """
+    datetime_input = get_datetime_input(app, "Datetime input 8 (empty)")
+    datetime_field = datetime_input.get_by_test_id("stDateTimeInputField")
+    calendar = app.get_by_test_id("stDateTimeInputCalendar")
+    # Segments follow the default YYYY/MM/DD format: year, month, day, hour, minute.
+    segments = datetime_field.get_by_role("spinbutton")
+
+    # --- Time typed into the inline field, with the date left empty ---
+    segments.nth(3).press_sequentially("03")
+    segments.nth(4).press_sequentially("24")
+    expect(calendar).to_be_visible()
+
+    # A time on its own must not commit — the date is still incomplete.
+    expect_markdown(app, "Value 8: None")
+
+    # Any in-month day works: the assertions pin only the preserved time, so
+    # they must not depend on which month an empty widget opens on.
+    calendar.get_by_role("button", name=re.compile(r"\b15, ")).click()
+    app.get_by_text("Value 8:").click()
+    expect(calendar).not_to_be_visible()
+    wait_for_app_run(app)
+    expect_prefixed_markdown(app, "Value 8:", re.compile(r"\d{4}-\d{2}-\d{2} 03:24:00"))
+
+    datetime_input.get_by_test_id("stDateTimeInputClearButton").click()
+    wait_for_app_run(app)
+    expect_markdown(app, "Value 8: None")
+
+    # --- Time set in the popover TimeField, with no value committed yet ---
+    segments.first.click()
+    expect(calendar).to_be_visible()
+
+    popover_segments = app.get_by_test_id("stDateTimeInputPopoverTime").get_by_role(
+        "spinbutton"
+    )
+    popover_segments.first.press_sequentially("09")
+    popover_segments.last.press_sequentially("45")
+
+    calendar.get_by_role("button", name=re.compile(r"\b15, ")).click()
+    app.get_by_text("Value 8:").click()
+    expect(calendar).not_to_be_visible()
+    wait_for_app_run(app)
+    expect_prefixed_markdown(app, "Value 8:", re.compile(r"\d{4}-\d{2}-\d{2} 09:45:00"))
+    # The popover time must reach the value rather than being dropped to midnight.
+    expect(app.get_by_text(re.compile(r"Value 8: .* 00:00:00"))).not_to_be_visible()
+
+
 def test_callback_invoked(app: Page):
     datetime_field = get_datetime_input(
         app, "Datetime input 6 (with callback)"

--- a/e2e_playwright/st_datetime_input_test.py
+++ b/e2e_playwright/st_datetime_input_test.py
@@ -332,6 +332,47 @@ def test_form_submission_resets_value(app: Page):
     expect_markdown(app, "Form submitted value: 2025-12-24 12:00:00")
 
 
+def test_form_clear_empties_the_segments_and_keeps_focus(app: Page):
+    """A cleared form empties the field's segments, not just its value.
+
+    React Aria keeps display state for segments typed but not completed, so a
+    partial time could survive `clear_on_submit` and be committed with a later
+    date. Clearing remounts the field, which costs the focused segment — checked
+    here rather than only in unit tests, since focus and remount timing are
+    browser behavior.
+    """
+    form_field = get_datetime_input(app, "Datetime input 13 (form)").get_by_test_id(
+        "stDateTimeInputField"
+    )
+    segments = form_field.get_by_role("spinbutton")
+
+    # A time with no date: the field reports no value, so only the segments hold it.
+    segments.nth(3).press_sequentially("03")
+    segments.nth(4).press_sequentially("24")
+    expect(segments.nth(3)).to_have_text("03")
+
+    app.get_by_role("button", name="Submit datetime form").click()
+    wait_for_app_run(app)
+
+    # The time must not survive the clear, on screen or in the committed value.
+    expect(form_field.get_by_role("spinbutton").nth(3)).to_have_attribute(
+        "data-placeholder", "true"
+    )
+    expect_markdown(app, "Form submitted value: None")
+
+    # Submitting by button leaves focus on the button, so nothing is restored.
+    expect(form_field.get_by_role("spinbutton").first).not_to_be_focused()
+
+    # Enter-to-submit is the case where focus is in the field when the clear
+    # arrives, and the remount would otherwise drop the user to the page body.
+    type_date(form_field, "2025", "12", "24", "12", "00", commit=False)
+    form_field.get_by_role("spinbutton").last.press("Enter")
+    wait_for_app_run(app)
+
+    expect_markdown(app, "Form submitted value: 2025-12-24 12:00:00")
+    expect(form_field.get_by_role("spinbutton").first).to_be_focused()
+
+
 def test_fragment_reruns(app: Page):
     """Test that datetime input works correctly inside a fragment."""
     fragment_field = get_datetime_input(

--- a/e2e_playwright/st_datetime_input_test.py
+++ b/e2e_playwright/st_datetime_input_test.py
@@ -282,6 +282,28 @@ def test_keeps_time_given_before_a_date(app: Page):
     # The popover time must reach the value rather than being dropped to midnight.
     expect(app.get_by_text(re.compile(r"Value 8: .* 00:00:00"))).not_to_be_visible()
 
+    datetime_input.get_by_test_id("stDateTimeInputClearButton").click()
+    wait_for_app_run(app)
+    expect_markdown(app, "Value 8: None")
+
+    # --- Date typed inline, time set only in the popover, no calendar click ---
+    # Neither control reports a value in this state, so dismissal has to combine
+    # what is on screen. Worth covering here rather than only in unit tests: a
+    # real outside click commits on pointerdown and then fires blur, running the
+    # commit path twice, which jsdom does not reproduce.
+    segments.first.click()
+    expect(calendar).to_be_visible()
+    popover_segments.first.press_sequentially("07")
+    popover_segments.last.press_sequentially("30")
+    segments.nth(0).press_sequentially("2026")
+    segments.nth(1).press_sequentially("01")
+    segments.nth(2).press_sequentially("15")
+
+    app.get_by_text("Value 8:").click()
+    expect(calendar).not_to_be_visible()
+    wait_for_app_run(app)
+    expect_markdown(app, "Value 8: 2026-01-15 07:30:00")
+
 
 def test_callback_invoked(app: Page):
     datetime_field = get_datetime_input(

--- a/e2e_playwright/st_datetime_input_test.py
+++ b/e2e_playwright/st_datetime_input_test.py
@@ -112,6 +112,22 @@ def test_datetime_input_dropdown(app: Page, assert_snapshot: ImageCompareFunctio
     assert_snapshot(calendar, name="st_datetime_input-dropdown")
 
 
+def test_datetime_input_empty_dropdown(
+    app: Page, assert_snapshot: ImageCompareFunction
+):
+    """Test the calendar popover of an empty widget, where the time field is
+    interactive rather than disabled.
+    """
+    get_datetime_input(app, "Datetime input 8 (empty)").get_by_test_id(
+        "stDateTimeInputField"
+    ).get_by_role("spinbutton").first.click()
+
+    calendar = app.get_by_test_id("stDateTimeInputCalendar")
+    expect(calendar).to_be_visible()
+
+    assert_snapshot(calendar, name="st_datetime_input-empty_dropdown")
+
+
 def test_datetime_input_narrow_rendering(
     app: Page, assert_snapshot: ImageCompareFunction
 ):
@@ -251,9 +267,6 @@ def test_keeps_time_given_before_a_date(app: Page):
     segments.nth(3).press_sequentially("03")
     segments.nth(4).press_sequentially("24")
     expect(calendar).to_be_visible()
-
-    # A time on its own must not commit — the date is still incomplete.
-    expect_markdown(app, "Value 8: None")
 
     # Any in-month day works: the assertions pin only the preserved time, so
     # they must not depend on which month an empty widget opens on.

--- a/e2e_playwright/st_datetime_input_test.py
+++ b/e2e_playwright/st_datetime_input_test.py
@@ -281,8 +281,6 @@ def test_keeps_time_given_before_a_date(app: Page):
     expect(calendar).not_to_be_visible()
     wait_for_app_run(app)
     expect_prefixed_markdown(app, "Value 8:", re.compile(r"\d{4}-\d{2}-\d{2} 09:45:00"))
-    # The popover time must reach the value rather than being dropped to midnight.
-    expect(app.get_by_text(re.compile(r"Value 8: .* 00:00:00"))).not_to_be_visible()
 
     datetime_input.get_by_test_id("stDateTimeInputClearButton").click()
     wait_for_app_run(app)

--- a/e2e_playwright/st_datetime_input_test.py
+++ b/e2e_playwright/st_datetime_input_test.py
@@ -370,6 +370,16 @@ def test_form_clear_empties_the_segments_and_keeps_focus(app: Page):
     expect_markdown(app, "Form submitted value: 2025-12-24 12:00:00")
     expect(form_field.get_by_role("spinbutton").first).to_be_focused()
 
+    # Re-entering the value that was just submitted has to reach widget state
+    # again: the clear ends the interaction, so the commit-dedup memory must not
+    # carry over. If it did, Enter would submit with the cleared value and the
+    # display below would flip to None.
+    type_date(form_field, "2025", "12", "24", "12", "00", commit=False)
+    form_field.get_by_role("spinbutton").last.press("Enter")
+    wait_for_app_run(app)
+
+    expect_markdown(app, "Form submitted value: 2025-12-24 12:00:00")
+
 
 def test_fragment_reruns(app: Page):
     """Test that datetime input works correctly inside a fragment."""

--- a/frontend/lib/src/components/widgets/DateTimeInput/DateTimeInput.test.tsx
+++ b/frontend/lib/src/components/widgets/DateTimeInput/DateTimeInput.test.tsx
@@ -2387,6 +2387,236 @@ describe("DateTimeInput widget", () => {
       )
     })
 
+    it("completes a date typed inline with a time given in the popover", async () => {
+      const user = userEvent.setup()
+      const props = emptyProps()
+      const spy = vi.spyOn(props.widgetMgr, "setStringArrayValue")
+      render(
+        <div>
+          <DateTimeInput {...props} />
+          <button data-testid="outside">outside</button>
+        </div>
+      )
+      spy.mockClear()
+
+      // Time in the popover...
+      await user.click(screen.getAllByRole("spinbutton")[0])
+      await screen.findByTestId("stDateTimeInputCalendar")
+      await user.click(
+        within(screen.getByTestId("stDateTimeInputPopoverTime")).getAllByRole(
+          "spinbutton"
+        )[0]
+      )
+      await user.keyboard("0945")
+
+      // ...and only the date inline, so the field reports no value at all.
+      const inlineField = screen.getByTestId("stDateTimeInputField")
+      await user.click(within(inlineField).getAllByRole("spinbutton")[0])
+      await user.keyboard("20251119")
+
+      // Both halves are on screen, so dismissal must combine rather than
+      // discard them.
+      await user.click(screen.getByTestId("outside"))
+      await waitFor(() => {
+        expect(spy).toHaveBeenCalledWith(
+          props.element.id,
+          ["2025-11-19T09:45"],
+          {
+            formId: props.element.formId,
+            fragmentId: undefined,
+            fromUser: true,
+          }
+        )
+      })
+    })
+
+    it("still reverts when one segment of an existing value is cleared", async () => {
+      const user = userEvent.setup()
+      // A committed value, in a form so an Enter submit would be observable.
+      const props = getProps({
+        default: ["2025-11-19T16:45"],
+        min: "2025-11-01T00:00",
+        max: "2025-11-30T23:59",
+        format: "YYYY/MM/DD",
+      })
+      props.element.formId = "form"
+      props.widgetMgr.setFormSubmitBehaviors("form", true)
+      const spy = vi.spyOn(props.widgetMgr, "setStringArrayValue")
+      const submitSpy = vi.spyOn(props.widgetMgr, "submitForm")
+      render(
+        <div>
+          <DateTimeInput {...props} />
+          <button data-testid="outside">outside</button>
+        </div>
+      )
+      spy.mockClear()
+
+      // Clearing one segment leaves the date readable and the old time in state,
+      // but this is an edit in progress rather than two halves to combine.
+      const inlineField = screen.getByTestId("stDateTimeInputField")
+      const minute = within(inlineField)
+        .getAllByRole("spinbutton")
+        .find(s => s.getAttribute("data-type") === "minute") as HTMLElement
+      await clearSegment(user, minute)
+
+      // Submitting here would send the old minute the user just deleted.
+      await user.keyboard("{Enter}")
+      expect(submitSpy).not.toHaveBeenCalled()
+
+      await user.click(screen.getByTestId("outside"))
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId("stDateTimeInputCalendar")
+        ).not.toBeInTheDocument()
+      })
+      // Dismissal must not commit it either.
+      expect(spy).not.toHaveBeenCalled()
+    })
+
+    it("shows the merged value in the field when committing inside a form", async () => {
+      const user = userEvent.setup()
+      const props = emptyProps()
+      props.element.formId = "form"
+      props.widgetMgr.setFormSubmitBehaviors("form", true)
+      render(
+        <div>
+          <DateTimeInput {...props} />
+          <button data-testid="outside">outside</button>
+        </div>
+      )
+
+      await user.click(screen.getAllByRole("spinbutton")[0])
+      await screen.findByTestId("stDateTimeInputCalendar")
+      await user.click(
+        within(screen.getByTestId("stDateTimeInputPopoverTime")).getAllByRole(
+          "spinbutton"
+        )[0]
+      )
+      await user.keyboard("0945")
+      const inlineField = screen.getByTestId("stDateTimeInputField")
+      await user.click(within(inlineField).getAllByRole("spinbutton")[0])
+      await user.keyboard("20251119")
+      await user.click(screen.getByTestId("outside"))
+
+      // Nothing reruns inside a form, so the field must recover the committed
+      // value from the local round-trip alone — not from a server response.
+      await waitFor(() => {
+        const minute = within(inlineField)
+          .getAllByRole("spinbutton")
+          .find(s => s.getAttribute("data-type") === "minute")
+        expect(minute).not.toHaveAttribute("data-placeholder", "true")
+      })
+      expect(within(inlineField).getByText("45")).toBeVisible()
+    })
+
+    it("reverts a merged value that falls outside min/max", async () => {
+      const user = userEvent.setup()
+      const props = getProps({
+        default: [],
+        min: "2026-01-01T00:00",
+        max: "2026-12-31T23:59",
+        format: "YYYY/MM/DD",
+      })
+      const spy = vi.spyOn(props.widgetMgr, "setStringArrayValue")
+      render(
+        <div>
+          <DateTimeInput {...props} />
+          <button data-testid="outside">outside</button>
+        </div>
+      )
+      spy.mockClear()
+
+      await user.click(screen.getAllByRole("spinbutton")[0])
+      await screen.findByTestId("stDateTimeInputCalendar")
+      await user.click(
+        within(screen.getByTestId("stDateTimeInputPopoverTime")).getAllByRole(
+          "spinbutton"
+        )[0]
+      )
+      await user.keyboard("0945")
+
+      // 2025 is before min, so the merged value must not reach widget state.
+      const inlineField = screen.getByTestId("stDateTimeInputField")
+      await user.click(within(inlineField).getAllByRole("spinbutton")[0])
+      await user.keyboard("20251119")
+      await user.click(screen.getByTestId("outside"))
+
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId("stDateTimeInputCalendar")
+        ).not.toBeInTheDocument()
+      })
+      expect(spy).not.toHaveBeenCalled()
+    })
+
+    it("merges a lone popover hour as the top of that hour", async () => {
+      const user = userEvent.setup()
+      const props = emptyProps()
+      const spy = vi.spyOn(props.widgetMgr, "setStringArrayValue")
+      render(
+        <div>
+          <DateTimeInput {...props} />
+          <button data-testid="outside">outside</button>
+        </div>
+      )
+      spy.mockClear()
+
+      await user.click(screen.getAllByRole("spinbutton")[0])
+      await screen.findByTestId("stDateTimeInputCalendar")
+      await user.click(
+        within(screen.getByTestId("stDateTimeInputPopoverTime")).getAllByRole(
+          "spinbutton"
+        )[0]
+      )
+      await user.keyboard("09")
+
+      const inlineField = screen.getByTestId("stDateTimeInputField")
+      await user.click(within(inlineField).getAllByRole("spinbutton")[0])
+      await user.keyboard("20251119")
+      await user.click(screen.getByTestId("outside"))
+
+      // A half-given time is still a time the user typed, so it commits with the
+      // minute at zero — the same rule the calendar path uses. Only a time given
+      // nowhere at all reverts.
+      await waitFor(() => {
+        expect(spy).toHaveBeenCalledWith(
+          props.element.id,
+          ["2025-11-19T09:00"],
+          {
+            formId: props.element.formId,
+            fragmentId: undefined,
+            fromUser: true,
+          }
+        )
+      })
+    })
+
+    it("reverts a date typed inline when no time was given anywhere", async () => {
+      const user = userEvent.setup()
+      const props = emptyProps()
+      const spy = vi.spyOn(props.widgetMgr, "setStringArrayValue")
+      render(
+        <div>
+          <DateTimeInput {...props} />
+          <button data-testid="outside">outside</button>
+        </div>
+      )
+      spy.mockClear()
+
+      // A date with no time is still incomplete — midnight would be a guess.
+      const inlineField = screen.getByTestId("stDateTimeInputField")
+      await user.click(within(inlineField).getAllByRole("spinbutton")[0])
+      await user.keyboard("20251119")
+      await user.click(screen.getByTestId("outside"))
+
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId("stDateTimeInputCalendar")
+        ).not.toBeInTheDocument()
+      })
+      expect(spy).not.toHaveBeenCalled()
+    })
+
     it("keeps an inline time that is still on screen after dismissal", async () => {
       const user = userEvent.setup()
       const props = emptyProps()

--- a/frontend/lib/src/components/widgets/DateTimeInput/DateTimeInput.test.tsx
+++ b/frontend/lib/src/components/widgets/DateTimeInput/DateTimeInput.test.tsx
@@ -2695,6 +2695,54 @@ describe("DateTimeInput widget", () => {
       expect(spy).toHaveBeenCalledTimes(1)
     })
 
+    it("commits the same value again after a form clear", async () => {
+      const user = userEvent.setup()
+      const props = emptyProps()
+      props.element.formId = "form"
+      props.widgetMgr.setFormSubmitBehaviors("form", true)
+      const spy = vi.spyOn(props.widgetMgr, "setStringArrayValue")
+      render(
+        <div>
+          <DateTimeInput {...props} />
+          <button data-testid="outside">outside</button>
+        </div>
+      )
+
+      const enterSameValue = async (): Promise<void> => {
+        const field = screen.getByTestId("stDateTimeInputField")
+        await user.click(within(field).getAllByRole("spinbutton")[0])
+        await user.keyboard("20251119")
+        await user.keyboard("1200")
+        await user.click(screen.getByTestId("outside"))
+        await waitFor(() => {
+          expect(
+            screen.queryByTestId("stDateTimeInputCalendar")
+          ).not.toBeInTheDocument()
+        })
+      }
+
+      await enterSameValue()
+      act(() => {
+        props.widgetMgr.submitForm("form", undefined)
+      })
+      spy.mockClear()
+
+      // Re-entering the value that was just submitted has to reach widget state
+      // again — the dedup memory must not outlive the clear.
+      await enterSameValue()
+      await waitFor(() => {
+        expect(spy).toHaveBeenCalledWith(
+          props.element.id,
+          ["2025-11-19T12:00"],
+          {
+            formId: props.element.formId,
+            fragmentId: undefined,
+            fromUser: true,
+          }
+        )
+      })
+    })
+
     it("merges a lone popover hour as the top of that hour", async () => {
       const user = userEvent.setup()
       const props = emptyProps()

--- a/frontend/lib/src/components/widgets/DateTimeInput/DateTimeInput.test.tsx
+++ b/frontend/lib/src/components/widgets/DateTimeInput/DateTimeInput.test.tsx
@@ -2549,6 +2549,51 @@ describe("DateTimeInput widget", () => {
       expect(spy).not.toHaveBeenCalled()
     })
 
+    it("completes the value when Tab leaves the field, not just on dismissal", async () => {
+      const user = userEvent.setup()
+      const props = emptyProps()
+      const spy = vi.spyOn(props.widgetMgr, "setStringArrayValue")
+      render(
+        <div>
+          <DateTimeInput {...props} />
+          <button data-testid="outside">outside</button>
+        </div>
+      )
+      spy.mockClear()
+
+      await user.click(screen.getAllByRole("spinbutton")[0])
+      await screen.findByTestId("stDateTimeInputCalendar")
+      await user.click(
+        within(screen.getByTestId("stDateTimeInputPopoverTime")).getAllByRole(
+          "spinbutton"
+        )[0]
+      )
+      await user.keyboard("0945")
+
+      const inlineField = screen.getByTestId("stDateTimeInputField")
+      const inline = within(inlineField).getAllByRole("spinbutton")
+      await user.click(inline[0])
+      await user.keyboard("20251119")
+
+      // Tab off the last segment closes the popover, so the merge has to happen
+      // while it is still mounted — otherwise its half is unreadable and both
+      // halves are discarded.
+      await user.click(inline[inline.length - 1])
+      await user.tab()
+
+      await waitFor(() => {
+        expect(spy).toHaveBeenCalledWith(
+          props.element.id,
+          ["2025-11-19T09:45"],
+          {
+            formId: props.element.formId,
+            fragmentId: undefined,
+            fromUser: true,
+          }
+        )
+      })
+    })
+
     it("merges a lone popover hour as the top of that hour", async () => {
       const user = userEvent.setup()
       const props = emptyProps()

--- a/frontend/lib/src/components/widgets/DateTimeInput/DateTimeInput.test.tsx
+++ b/frontend/lib/src/components/widgets/DateTimeInput/DateTimeInput.test.tsx
@@ -2756,6 +2756,92 @@ describe("DateTimeInput widget", () => {
         )
       })
     })
+    it("forgets an inline time typed before a form clear", async () => {
+      const user = userEvent.setup()
+      const props = emptyProps()
+      props.element.formId = "form"
+      props.widgetMgr.setFormSubmitBehaviors("form", true)
+      const spy = vi.spyOn(props.widgetMgr, "setStringArrayValue")
+      render(
+        <div>
+          <DateTimeInput {...props} />
+          <button data-testid="outside">outside</button>
+        </div>
+      )
+
+      const inlineField = screen.getByTestId("stDateTimeInputField")
+      await user.click(within(inlineField).getAllByRole("spinbutton")[3])
+      await user.keyboard("0324")
+
+      act(() => {
+        props.widgetMgr.submitForm("form", undefined)
+      })
+
+      // clear_on_submit has to empty the segments too, not just the value —
+      // otherwise the time stays on screen and a later date selection commits it.
+      await waitFor(() => {
+        const hour = within(inlineField)
+          .getAllByRole("spinbutton")
+          .find(s => s.getAttribute("data-type") === "hour")
+        expect(hour).toHaveAttribute("data-placeholder", "true")
+      })
+
+      spy.mockClear()
+      await user.click(within(inlineField).getAllByRole("spinbutton")[0])
+      await screen.findByTestId("stDateTimeInputCalendar")
+      await user.click(screen.getByRole("button", { name: /November 19/ }))
+      await user.click(screen.getByTestId("outside"))
+
+      await waitFor(() => {
+        expect(spy).toHaveBeenCalledWith(
+          props.element.id,
+          ["2025-11-19T00:00"],
+          {
+            formId: props.element.formId,
+            fragmentId: undefined,
+            fromUser: true,
+          }
+        )
+      })
+      expect(spy).not.toHaveBeenCalledWith(
+        props.element.id,
+        ["2025-11-19T03:24"],
+        expect.anything()
+      )
+    })
+
+    it("keeps focus in the field after a form clear, with the calendar still open", async () => {
+      const user = userEvent.setup()
+      const props = emptyProps()
+      props.element.formId = "form"
+      props.widgetMgr.setFormSubmitBehaviors("form", true)
+      render(<DateTimeInput {...props} />)
+
+      const inlineField = screen.getByTestId("stDateTimeInputField")
+      const hour = within(inlineField)
+        .getAllByRole("spinbutton")
+        .find(s => s.getAttribute("data-type") === "hour") as HTMLElement
+      await user.click(hour)
+      await user.keyboard("0324")
+
+      act(() => {
+        props.widgetMgr.submitForm("form", undefined)
+      })
+
+      // Remounting the field to clear it must not cost the user their place —
+      // Enter-to-submit leaves focus here.
+      await waitFor(() => {
+        const first = within(
+          screen.getByTestId("stDateTimeInputField")
+        ).getAllByRole("spinbutton")[0]
+        expect(first).toHaveFocus()
+      })
+      expect(document.body).not.toHaveFocus()
+      // The popover stays open across a form clear, as it did before this change —
+      // focusing a segment is what opens it, so the restore cannot close it.
+      expect(screen.getByTestId("stDateTimeInputCalendar")).toBeVisible()
+    })
+
     it("drops a pending popover time when the form is reset", async () => {
       const user = userEvent.setup()
       const props = emptyProps()

--- a/frontend/lib/src/components/widgets/DateTimeInput/DateTimeInput.test.tsx
+++ b/frontend/lib/src/components/widgets/DateTimeInput/DateTimeInput.test.tsx
@@ -1982,9 +1982,9 @@ describe("DateTimeInput widget", () => {
   })
 
   describe("Time given before a date", () => {
-    /** Empty widget, so the date segments stay placeholders. min/max are pinned to
-     * November 2025 so the calendar clamps to a deterministic month rather than
-     * opening on today's, which is what makes the /November 19/ locator reliable. */
+    /** Pins the empty calendar to November 2025 so the `/November 19/` locator is
+     * deterministic rather than dependent on today's date. The widget starts empty,
+     * so its date segments stay placeholders. */
     const emptyProps = (): Props =>
       getProps({
         default: [],
@@ -2645,7 +2645,7 @@ describe("DateTimeInput widget", () => {
       })
     })
 
-    it("prefers the popover draft over an inline one when dismissed together", async () => {
+    it("prefers the popover time over an inline draft when both are on screen at dismissal", async () => {
       const user = userEvent.setup()
       const props = emptyProps()
       const spy = vi.spyOn(props.widgetMgr, "setStringArrayValue")

--- a/frontend/lib/src/components/widgets/DateTimeInput/DateTimeInput.test.tsx
+++ b/frontend/lib/src/components/widgets/DateTimeInput/DateTimeInput.test.tsx
@@ -2799,6 +2799,46 @@ describe("DateTimeInput widget", () => {
       )
     })
 
+    it("commits the same datetime again after Enter-submitting it", async () => {
+      const user = userEvent.setup()
+      const props = emptyProps()
+      props.element.formId = "form"
+      props.widgetMgr.setFormSubmitBehaviors("form", true)
+      // Mock only the gate — the real submitForm has to run so the clear fires.
+      vi.spyOn(props.widgetMgr, "allowFormEnterToSubmit").mockReturnValue(true)
+      const spy = vi.spyOn(props.widgetMgr, "setStringArrayValue")
+      render(<DateTimeInput {...props} />)
+
+      const typeAndEnter = async (): Promise<void> => {
+        const field = screen.getByTestId("stDateTimeInputField")
+        await user.click(within(field).getAllByRole("spinbutton")[0])
+        await user.keyboard("20251119")
+        await user.keyboard("1200")
+        await user.keyboard("{Enter}")
+      }
+
+      await typeAndEnter()
+      spy.mockClear()
+
+      // The clear ends the interaction, so re-entering the value just submitted
+      // has to reach widget state again. Nothing else resets the dedup memory on
+      // this path: the clear overwrites the pending value before `value` becomes
+      // the datetime, and the popover stays open across an Enter submit.
+      await typeAndEnter()
+
+      await waitFor(() => {
+        expect(spy).toHaveBeenCalledWith(
+          props.element.id,
+          ["2025-11-19T12:00"],
+          {
+            formId: props.element.formId,
+            fragmentId: undefined,
+            fromUser: true,
+          }
+        )
+      })
+    })
+
     it("merges a lone popover hour as the top of that hour", async () => {
       const user = userEvent.setup()
       const props = emptyProps()

--- a/frontend/lib/src/components/widgets/DateTimeInput/DateTimeInput.test.tsx
+++ b/frontend/lib/src/components/widgets/DateTimeInput/DateTimeInput.test.tsx
@@ -1980,4 +1980,478 @@ describe("DateTimeInput widget", () => {
       expect(reachedTimeField).toBe(true)
     })
   })
+
+  describe("Time given before a date", () => {
+    /** Empty widget, so the date segments stay placeholders — the state in which
+     * DateField reports no value at all. min/max are pinned to November 2025 so
+     * the calendar clamps to a deterministic month rather than opening on
+     * today's, which is what makes the /November 19/ day locator reliable. */
+    const emptyProps = (): Props =>
+      getProps({
+        default: [],
+        min: "2025-11-01T00:00",
+        max: "2025-11-30T23:59",
+        format: "YYYY/MM/DD",
+      })
+
+    it("keeps a time typed inline when a date is then picked in the calendar", async () => {
+      const user = userEvent.setup()
+      const props = emptyProps()
+      const spy = vi.spyOn(props.widgetMgr, "setStringArrayValue")
+      render(
+        <div>
+          <DateTimeInput {...props} />
+          <button data-testid="outside">outside</button>
+        </div>
+      )
+      spy.mockClear()
+
+      // Type only the time; the date segments stay empty.
+      const segments = screen.getAllByRole("spinbutton")
+      await user.click(segments[3])
+      await user.keyboard("03")
+      await user.keyboard("24")
+      expect(segments[3]).toHaveTextContent("03")
+      expect(segments[4]).toHaveTextContent("24")
+
+      await screen.findByTestId("stDateTimeInputCalendar")
+      await user.click(screen.getByRole("button", { name: /November 19/ }))
+      await user.click(screen.getByTestId("outside"))
+
+      await waitFor(() => {
+        expect(spy).toHaveBeenCalledWith(
+          props.element.id,
+          ["2025-11-19T03:24"],
+          {
+            formId: props.element.formId,
+            fragmentId: undefined,
+            fromUser: true,
+          }
+        )
+      })
+      // The typed time must not be discarded in favour of midnight.
+      expect(spy).not.toHaveBeenCalledWith(
+        props.element.id,
+        ["2025-11-19T00:00"],
+        expect.anything()
+      )
+    })
+
+    it("keeps an hour typed inline without a minute", async () => {
+      const user = userEvent.setup()
+      const props = emptyProps()
+      const spy = vi.spyOn(props.widgetMgr, "setStringArrayValue")
+      render(
+        <div>
+          <DateTimeInput {...props} />
+          <button data-testid="outside">outside</button>
+        </div>
+      )
+      spy.mockClear()
+
+      const segments = screen.getAllByRole("spinbutton")
+      await user.click(segments[3])
+      await user.keyboard("07")
+
+      await screen.findByTestId("stDateTimeInputCalendar")
+      await user.click(screen.getByRole("button", { name: /November 19/ }))
+      await user.click(screen.getByTestId("outside"))
+
+      await waitFor(() => {
+        expect(spy).toHaveBeenCalledWith(
+          props.element.id,
+          ["2025-11-19T07:00"],
+          {
+            formId: props.element.formId,
+            fragmentId: undefined,
+            fromUser: true,
+          }
+        )
+      })
+    })
+
+    it("keeps the popover TimeField interactive while the widget is empty", async () => {
+      const user = userEvent.setup()
+      render(<DateTimeInput {...emptyProps()} />)
+
+      await user.click(screen.getAllByRole("spinbutton")[0])
+      await screen.findByTestId("stDateTimeInputCalendar")
+
+      // Doubles as the guard for getTypedTimeFromDom's assumptions: exactly two
+      // segments in the whole popover means no dayPeriod segment (hourCycle 24)
+      // and no seconds segment, and that no other control there reports an
+      // hour/minute the resolver could pick up by mistake.
+      const popoverSegments = within(
+        screen.getByTestId("stDateTimeInputCalendar")
+      ).getAllByRole("spinbutton")
+      expect(popoverSegments).toHaveLength(2)
+      popoverSegments.forEach(seg => {
+        expect(seg).not.toHaveAttribute("aria-disabled", "true")
+      })
+    })
+
+    it("applies a time set in the popover when a date is picked afterwards", async () => {
+      const user = userEvent.setup()
+      const props = emptyProps()
+      const spy = vi.spyOn(props.widgetMgr, "setStringArrayValue")
+      render(
+        <div>
+          <DateTimeInput {...props} />
+          <button data-testid="outside">outside</button>
+        </div>
+      )
+      spy.mockClear()
+
+      await user.click(screen.getAllByRole("spinbutton")[0])
+      await screen.findByTestId("stDateTimeInputCalendar")
+
+      // Set the time in the popover before any date exists.
+      const timeRow = screen.getByTestId("stDateTimeInputPopoverTime")
+      const popoverHour = timeRow.querySelector<HTMLElement>(
+        '[data-type="hour"]'
+      ) as HTMLElement
+      await user.click(popoverHour)
+      await user.keyboard("09")
+      await user.keyboard("45")
+
+      await user.click(screen.getByRole("button", { name: /November 19/ }))
+      await user.click(screen.getByTestId("outside"))
+
+      await waitFor(() => {
+        expect(spy).toHaveBeenCalledWith(
+          props.element.id,
+          ["2025-11-19T09:45"],
+          {
+            formId: props.element.formId,
+            fragmentId: undefined,
+            fromUser: true,
+          }
+        )
+      })
+    })
+
+    it("does not commit a time on its own without a date", async () => {
+      const user = userEvent.setup()
+      const props = emptyProps()
+      const spy = vi.spyOn(props.widgetMgr, "setStringArrayValue")
+      render(
+        <div>
+          <DateTimeInput {...props} />
+          <button data-testid="outside">outside</button>
+        </div>
+      )
+      spy.mockClear()
+
+      const segments = screen.getAllByRole("spinbutton")
+      await user.click(segments[3])
+      await user.keyboard("03")
+      await user.keyboard("24")
+      await user.click(screen.getByTestId("outside"))
+
+      // A time with no date is a partially typed field, which reverts.
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId("stDateTimeInputCalendar")
+        ).not.toBeInTheDocument()
+      })
+      expect(spy).not.toHaveBeenCalled()
+    })
+
+    it("keeps a partial time set in the popover, without a minute", async () => {
+      const user = userEvent.setup()
+      const props = emptyProps()
+      const spy = vi.spyOn(props.widgetMgr, "setStringArrayValue")
+      render(
+        <div>
+          <DateTimeInput {...props} />
+          <button data-testid="outside">outside</button>
+        </div>
+      )
+      spy.mockClear()
+
+      await user.click(screen.getAllByRole("spinbutton")[0])
+      await screen.findByTestId("stDateTimeInputCalendar")
+
+      // Only the hour: TimeField withholds onChange until both its segments are
+      // filled, so this never reaches handlePopoverTimeChange.
+      const timeRow = screen.getByTestId("stDateTimeInputPopoverTime")
+      await user.click(within(timeRow).getAllByRole("spinbutton")[0])
+      await user.keyboard("09")
+
+      await user.click(screen.getByRole("button", { name: /November 19/ }))
+      await user.click(screen.getByTestId("outside"))
+
+      await waitFor(() => {
+        expect(spy).toHaveBeenCalledWith(
+          props.element.id,
+          ["2025-11-19T09:00"],
+          {
+            formId: props.element.formId,
+            fragmentId: undefined,
+            fromUser: true,
+          }
+        )
+      })
+    })
+
+    it("prefers the time control the user edited most recently", async () => {
+      const user = userEvent.setup()
+      const props = emptyProps()
+      const spy = vi.spyOn(props.widgetMgr, "setStringArrayValue")
+      render(
+        <div>
+          <DateTimeInput {...props} />
+          <button data-testid="outside">outside</button>
+        </div>
+      )
+      spy.mockClear()
+
+      // Type inline first, then override in the popover. Both hold a time at
+      // once and both are on screen, so the later edit is the one meant.
+      const segments = screen.getAllByRole("spinbutton")
+      await user.click(segments[3])
+      await user.keyboard("03")
+      await user.keyboard("24")
+      await screen.findByTestId("stDateTimeInputCalendar")
+
+      const timeRow = screen.getByTestId("stDateTimeInputPopoverTime")
+      const popoverSegments = within(timeRow).getAllByRole("spinbutton")
+      await user.click(popoverSegments[0])
+      await user.keyboard("09")
+      await user.keyboard("45")
+
+      await user.click(screen.getByRole("button", { name: /November 19/ }))
+      await user.click(screen.getByTestId("outside"))
+
+      await waitFor(() => {
+        expect(spy).toHaveBeenCalledWith(
+          props.element.id,
+          ["2025-11-19T09:45"],
+          {
+            formId: props.element.formId,
+            fragmentId: undefined,
+            fromUser: true,
+          }
+        )
+      })
+      // The earlier inline time must not win just because it was typed first.
+      expect(spy).not.toHaveBeenCalledWith(
+        props.element.id,
+        ["2025-11-19T03:24"],
+        expect.anything()
+      )
+    })
+
+    it("forgets a pending popover time once the inline field supplies its own", async () => {
+      const user = userEvent.setup()
+      const props = emptyProps()
+      render(<DateTimeInput {...props} />)
+
+      // Set a popover time with no date, so it is held as pending.
+      await user.click(screen.getAllByRole("spinbutton")[0])
+      await screen.findByTestId("stDateTimeInputCalendar")
+      await user.click(
+        within(screen.getByTestId("stDateTimeInputPopoverTime")).getAllByRole(
+          "spinbutton"
+        )[0]
+      )
+      await user.keyboard("0945")
+
+      // Complete the inline field, which supersedes the pending time...
+      const inlineField = screen.getByTestId("stDateTimeInputField")
+      const inlineSegments = within(inlineField).getAllByRole("spinbutton")
+      await user.click(inlineSegments[0])
+      await user.keyboard("20251119")
+      await user.keyboard("0300")
+
+      // ...then empty it again. The superseded 09:45 must not come back, which
+      // it would if the pending time had outlived the inline field's own value.
+      for (const segment of within(inlineField).getAllByRole("spinbutton")) {
+        await clearSegment(user, segment)
+      }
+      await screen.findByTestId("stDateTimeInputCalendar")
+      expect(
+        within(screen.getByTestId("stDateTimeInputPopoverTime")).getAllByRole(
+          "spinbutton"
+        )[0]
+      ).toHaveAttribute("data-placeholder", "true")
+    })
+
+    it("forgets a popover time the user clears again", async () => {
+      const user = userEvent.setup()
+      const props = emptyProps()
+      const spy = vi.spyOn(props.widgetMgr, "setStringArrayValue")
+      render(
+        <div>
+          <DateTimeInput {...props} />
+          <button data-testid="outside">outside</button>
+        </div>
+      )
+      spy.mockClear()
+
+      await user.click(screen.getAllByRole("spinbutton")[0])
+      await screen.findByTestId("stDateTimeInputCalendar")
+      const timeRow = screen.getByTestId("stDateTimeInputPopoverTime")
+      const popoverSegments = within(timeRow).getAllByRole("spinbutton")
+      await user.click(popoverSegments[0])
+      await user.keyboard("0945")
+      expect(popoverSegments[0]).toHaveTextContent("09")
+
+      // Backspace both segments away. React Aria re-seeds the field from its
+      // controlled value, so a retained pending time would reappear here.
+      await clearSegment(user, popoverSegments[1])
+      await clearSegment(user, popoverSegments[0])
+      expect(popoverSegments[0]).toHaveAttribute("data-placeholder", "true")
+      expect(popoverSegments[1]).toHaveAttribute("data-placeholder", "true")
+
+      // Picking a date must not resurrect the cleared time.
+      await user.click(screen.getByRole("button", { name: /November 19/ }))
+      await user.click(screen.getByTestId("outside"))
+
+      await waitFor(() => {
+        expect(spy).toHaveBeenCalledWith(
+          props.element.id,
+          ["2025-11-19T00:00"],
+          {
+            formId: props.element.formId,
+            fragmentId: undefined,
+            fromUser: true,
+          }
+        )
+      })
+      expect(spy).not.toHaveBeenCalledWith(
+        props.element.id,
+        ["2025-11-19T09:45"],
+        expect.anything()
+      )
+    })
+
+    it("forgets a popover time that was dismissed without being committed", async () => {
+      const user = userEvent.setup()
+      const props = emptyProps()
+      const spy = vi.spyOn(props.widgetMgr, "setStringArrayValue")
+      render(
+        <div>
+          <DateTimeInput {...props} />
+          <button data-testid="outside">outside</button>
+        </div>
+      )
+      spy.mockClear()
+
+      await user.click(screen.getAllByRole("spinbutton")[0])
+      await screen.findByTestId("stDateTimeInputCalendar")
+      const timeRow = screen.getByTestId("stDateTimeInputPopoverTime")
+      const popoverSegments = within(timeRow).getAllByRole("spinbutton")
+      await user.click(popoverSegments[0])
+      await user.keyboard("0945")
+      expect(popoverSegments[0]).toHaveTextContent("09")
+
+      // Dismissed with no date to attach the time to, so nothing commits.
+      await user.click(screen.getByTestId("outside"))
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId("stDateTimeInputCalendar")
+        ).not.toBeInTheDocument()
+      })
+      expect(spy).not.toHaveBeenCalled()
+
+      // The next session starts empty rather than showing the discarded time.
+      await user.click(screen.getAllByRole("spinbutton")[0])
+      await screen.findByTestId("stDateTimeInputCalendar")
+      expect(
+        within(screen.getByTestId("stDateTimeInputPopoverTime")).getAllByRole(
+          "spinbutton"
+        )[0]
+      ).toHaveAttribute("data-placeholder", "true")
+    })
+
+    it("does not apply a dismissed popover time to a later date selection", async () => {
+      const user = userEvent.setup()
+      const props = emptyProps()
+      const spy = vi.spyOn(props.widgetMgr, "setStringArrayValue")
+      render(
+        <div>
+          <DateTimeInput {...props} />
+          <button data-testid="outside">outside</button>
+        </div>
+      )
+      spy.mockClear()
+
+      await user.click(screen.getAllByRole("spinbutton")[0])
+      await screen.findByTestId("stDateTimeInputCalendar")
+      await user.click(
+        within(screen.getByTestId("stDateTimeInputPopoverTime")).getAllByRole(
+          "spinbutton"
+        )[0]
+      )
+      await user.keyboard("0945")
+      await user.click(screen.getByTestId("outside"))
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId("stDateTimeInputCalendar")
+        ).not.toBeInTheDocument()
+      })
+
+      // A fresh session touching only the calendar: the time from the discarded
+      // session must not reappear in the committed value, where nothing on
+      // screen would explain it.
+      await user.click(screen.getAllByRole("spinbutton")[0])
+      await screen.findByTestId("stDateTimeInputCalendar")
+      await user.click(screen.getByRole("button", { name: /November 19/ }))
+      await user.click(screen.getByTestId("outside"))
+
+      await waitFor(() => {
+        expect(spy).toHaveBeenCalledWith(
+          props.element.id,
+          ["2025-11-19T00:00"],
+          {
+            formId: props.element.formId,
+            fragmentId: undefined,
+            fromUser: true,
+          }
+        )
+      })
+      expect(spy).not.toHaveBeenCalledWith(
+        props.element.id,
+        ["2025-11-19T09:45"],
+        expect.anything()
+      )
+    })
+
+    it("drops a pending popover time when the form is reset", async () => {
+      const user = userEvent.setup()
+      const props = emptyProps()
+      props.element.formId = "form"
+      props.widgetMgr.setFormSubmitBehaviors("form", true)
+      const spy = vi.spyOn(props.widgetMgr, "setStringArrayValue")
+      render(
+        <div>
+          <DateTimeInput {...props} />
+          <button data-testid="outside">outside</button>
+        </div>
+      )
+      spy.mockClear()
+
+      await user.click(screen.getAllByRole("spinbutton")[0])
+      await screen.findByTestId("stDateTimeInputCalendar")
+      const timeRow = screen.getByTestId("stDateTimeInputPopoverTime")
+      const popoverSegments = within(timeRow).getAllByRole("spinbutton")
+      await user.click(popoverSegments[0])
+      await user.keyboard("09")
+      await user.keyboard("45")
+
+      // A form reset clears buffered edits, including the pending time.
+      act(() => {
+        props.widgetMgr.submitForm("form", undefined)
+      })
+
+      await user.click(screen.getAllByRole("spinbutton")[0])
+      await screen.findByTestId("stDateTimeInputCalendar")
+      expect(
+        within(screen.getByTestId("stDateTimeInputPopoverTime")).getAllByRole(
+          "spinbutton"
+        )[0]
+      ).toHaveAttribute("data-placeholder", "true")
+    })
+  })
 })

--- a/frontend/lib/src/components/widgets/DateTimeInput/DateTimeInput.test.tsx
+++ b/frontend/lib/src/components/widgets/DateTimeInput/DateTimeInput.test.tsx
@@ -2194,7 +2194,7 @@ describe("DateTimeInput widget", () => {
       })
     })
 
-    it("prefers the time control the user edited most recently", async () => {
+    it("prefers the time control the user focused most recently", async () => {
       const user = userEvent.setup()
       const props = emptyProps()
       const spy = vi.spyOn(props.widgetMgr, "setStringArrayValue")
@@ -2326,7 +2326,7 @@ describe("DateTimeInput widget", () => {
       )
     })
 
-    it("forgets a popover time that was dismissed without being committed", async () => {
+    it("forgets a dismissed popover time, on screen and on commit", async () => {
       const user = userEvent.setup()
       const props = emptyProps()
       const spy = vi.spyOn(props.widgetMgr, "setStringArrayValue")
@@ -2340,8 +2340,9 @@ describe("DateTimeInput widget", () => {
 
       await user.click(screen.getAllByRole("spinbutton")[0])
       await screen.findByTestId("stDateTimeInputCalendar")
-      const timeRow = screen.getByTestId("stDateTimeInputPopoverTime")
-      const popoverSegments = within(timeRow).getAllByRole("spinbutton")
+      const popoverSegments = within(
+        screen.getByTestId("stDateTimeInputPopoverTime")
+      ).getAllByRole("spinbutton")
       await user.click(popoverSegments[0])
       await user.keyboard("0945")
       expect(popoverSegments[0]).toHaveTextContent("09")
@@ -2355,7 +2356,7 @@ describe("DateTimeInput widget", () => {
       })
       expect(spy).not.toHaveBeenCalled()
 
-      // The next session starts empty rather than showing the discarded time.
+      // The next session starts empty rather than showing the discarded time...
       await user.click(screen.getAllByRole("spinbutton")[0])
       await screen.findByTestId("stDateTimeInputCalendar")
       expect(
@@ -2363,43 +2364,11 @@ describe("DateTimeInput widget", () => {
           "spinbutton"
         )[0]
       ).toHaveAttribute("data-placeholder", "true")
-    })
 
-    it("does not apply a dismissed popover time to a later date selection", async () => {
-      const user = userEvent.setup()
-      const props = emptyProps()
-      const spy = vi.spyOn(props.widgetMgr, "setStringArrayValue")
-      render(
-        <div>
-          <DateTimeInput {...props} />
-          <button data-testid="outside">outside</button>
-        </div>
-      )
-      spy.mockClear()
-
-      await user.click(screen.getAllByRole("spinbutton")[0])
-      await screen.findByTestId("stDateTimeInputCalendar")
-      await user.click(
-        within(screen.getByTestId("stDateTimeInputPopoverTime")).getAllByRole(
-          "spinbutton"
-        )[0]
-      )
-      await user.keyboard("0945")
-      await user.click(screen.getByTestId("outside"))
-      await waitFor(() => {
-        expect(
-          screen.queryByTestId("stDateTimeInputCalendar")
-        ).not.toBeInTheDocument()
-      })
-
-      // A fresh session touching only the calendar: the time from the discarded
-      // session must not reappear in the committed value, where nothing on
-      // screen would explain it.
-      await user.click(screen.getAllByRole("spinbutton")[0])
-      await screen.findByTestId("stDateTimeInputCalendar")
+      // ...and a date picked in that session must not resurrect it either,
+      // where nothing on screen would explain the time.
       await user.click(screen.getByRole("button", { name: /November 19/ }))
       await user.click(screen.getByTestId("outside"))
-
       await waitFor(() => {
         expect(spy).toHaveBeenCalledWith(
           props.element.id,
@@ -2418,6 +2387,48 @@ describe("DateTimeInput widget", () => {
       )
     })
 
+    it("keeps an inline time that is still on screen after dismissal", async () => {
+      const user = userEvent.setup()
+      const props = emptyProps()
+      const spy = vi.spyOn(props.widgetMgr, "setStringArrayValue")
+      render(
+        <div>
+          <DateTimeInput {...props} />
+          <button data-testid="outside">outside</button>
+        </div>
+      )
+      spy.mockClear()
+
+      // Unlike the popover field, the inline segments do not unmount on
+      // dismissal, so the time stays visible — and a later date pick commits it.
+      const segments = screen.getAllByRole("spinbutton")
+      await user.click(segments[3])
+      await user.keyboard("0324")
+      await user.click(screen.getByTestId("outside"))
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId("stDateTimeInputCalendar")
+        ).not.toBeInTheDocument()
+      })
+      expect(segments[3]).toHaveTextContent("03")
+
+      await user.click(segments[0])
+      await screen.findByTestId("stDateTimeInputCalendar")
+      await user.click(screen.getByRole("button", { name: /November 19/ }))
+      await user.click(screen.getByTestId("outside"))
+
+      await waitFor(() => {
+        expect(spy).toHaveBeenCalledWith(
+          props.element.id,
+          ["2025-11-19T03:24"],
+          {
+            formId: props.element.formId,
+            fragmentId: undefined,
+            fromUser: true,
+          }
+        )
+      })
+    })
     it("drops a pending popover time when the form is reset", async () => {
       const user = userEvent.setup()
       const props = emptyProps()

--- a/frontend/lib/src/components/widgets/DateTimeInput/DateTimeInput.test.tsx
+++ b/frontend/lib/src/components/widgets/DateTimeInput/DateTimeInput.test.tsx
@@ -2934,8 +2934,8 @@ describe("DateTimeInput widget", () => {
         expect(first).toHaveFocus()
       })
       expect(document.body).not.toHaveFocus()
-      // The popover stays open across a form clear, as it did before this change —
-      // focusing a segment is what opens it, so the restore cannot close it.
+      // The popover stays open across a form clear: focusing a segment is what
+      // opens it, so the focus restore cannot close it.
       expect(screen.getByTestId("stDateTimeInputCalendar")).toBeVisible()
     })
 

--- a/frontend/lib/src/components/widgets/DateTimeInput/DateTimeInput.test.tsx
+++ b/frontend/lib/src/components/widgets/DateTimeInput/DateTimeInput.test.tsx
@@ -16,6 +16,7 @@
 
 import { act, screen, waitFor, within } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
+import type { MockInstance } from "vitest"
 
 import {
   DateTimeInput as DateTimeInputProto,
@@ -1993,9 +1994,24 @@ describe("DateTimeInput widget", () => {
         format: "YYYY/MM/DD",
       })
 
-    it("keeps a time typed inline when a date is then picked in the calendar", async () => {
+    /** Puts the widget in a form whose submit clears it. */
+    const inAForm = (props: Props): void => {
+      props.element.formId = "form"
+      props.widgetMgr.setFormSubmitBehaviors("form", true)
+    }
+
+    /** Renders an empty widget alongside an outside target to dismiss into, with
+     * the commit spy already cleared of anything the mount itself recorded. */
+    const renderEmpty = (
+      configure?: (props: Props) => void
+    ): {
+      user: ReturnType<typeof userEvent.setup>
+      props: Props
+      spy: MockInstance<WidgetStateManager["setStringArrayValue"]>
+    } => {
       const user = userEvent.setup()
       const props = emptyProps()
+      configure?.(props)
       const spy = vi.spyOn(props.widgetMgr, "setStringArrayValue")
       render(
         <div>
@@ -2004,6 +2020,26 @@ describe("DateTimeInput widget", () => {
         </div>
       )
       spy.mockClear()
+      return { user, props, spy }
+    }
+
+    /** Asserts the widget committed exactly `iso` to widget state. */
+    const expectCommitted = async (
+      spy: MockInstance<WidgetStateManager["setStringArrayValue"]>,
+      props: Props,
+      iso: string
+    ): Promise<void> => {
+      await waitFor(() => {
+        expect(spy).toHaveBeenCalledWith(props.element.id, [iso], {
+          formId: props.element.formId,
+          fragmentId: undefined,
+          fromUser: true,
+        })
+      })
+    }
+
+    it("keeps a time typed inline when a date is then picked in the calendar", async () => {
+      const { user, props, spy } = renderEmpty()
 
       // Type only the time; the date segments stay empty.
       const segments = screen.getAllByRole("spinbutton")
@@ -2017,17 +2053,7 @@ describe("DateTimeInput widget", () => {
       await user.click(screen.getByRole("button", { name: /November 19/ }))
       await user.click(screen.getByTestId("outside"))
 
-      await waitFor(() => {
-        expect(spy).toHaveBeenCalledWith(
-          props.element.id,
-          ["2025-11-19T03:24"],
-          {
-            formId: props.element.formId,
-            fragmentId: undefined,
-            fromUser: true,
-          }
-        )
-      })
+      await expectCommitted(spy, props, "2025-11-19T03:24")
       // The typed time must not be discarded in favour of midnight.
       expect(spy).not.toHaveBeenCalledWith(
         props.element.id,
@@ -2036,17 +2062,9 @@ describe("DateTimeInput widget", () => {
       )
     })
 
+    // eslint-disable-next-line vitest/expect-expect -- asserts via expectCommitted
     it("keeps an hour typed inline without a minute", async () => {
-      const user = userEvent.setup()
-      const props = emptyProps()
-      const spy = vi.spyOn(props.widgetMgr, "setStringArrayValue")
-      render(
-        <div>
-          <DateTimeInput {...props} />
-          <button data-testid="outside">outside</button>
-        </div>
-      )
-      spy.mockClear()
+      const { user, props, spy } = renderEmpty()
 
       const segments = screen.getAllByRole("spinbutton")
       await user.click(segments[3])
@@ -2056,17 +2074,7 @@ describe("DateTimeInput widget", () => {
       await user.click(screen.getByRole("button", { name: /November 19/ }))
       await user.click(screen.getByTestId("outside"))
 
-      await waitFor(() => {
-        expect(spy).toHaveBeenCalledWith(
-          props.element.id,
-          ["2025-11-19T07:00"],
-          {
-            formId: props.element.formId,
-            fragmentId: undefined,
-            fromUser: true,
-          }
-        )
-      })
+      await expectCommitted(spy, props, "2025-11-19T07:00")
     })
 
     it("keeps the popover TimeField interactive while the widget is empty", async () => {
@@ -2089,17 +2097,9 @@ describe("DateTimeInput widget", () => {
       })
     })
 
+    // eslint-disable-next-line vitest/expect-expect -- asserts via expectCommitted
     it("applies a time set in the popover when a date is picked afterwards", async () => {
-      const user = userEvent.setup()
-      const props = emptyProps()
-      const spy = vi.spyOn(props.widgetMgr, "setStringArrayValue")
-      render(
-        <div>
-          <DateTimeInput {...props} />
-          <button data-testid="outside">outside</button>
-        </div>
-      )
-      spy.mockClear()
+      const { user, props, spy } = renderEmpty()
 
       await user.click(screen.getAllByRole("spinbutton")[0])
       await screen.findByTestId("stDateTimeInputCalendar")
@@ -2116,30 +2116,11 @@ describe("DateTimeInput widget", () => {
       await user.click(screen.getByRole("button", { name: /November 19/ }))
       await user.click(screen.getByTestId("outside"))
 
-      await waitFor(() => {
-        expect(spy).toHaveBeenCalledWith(
-          props.element.id,
-          ["2025-11-19T09:45"],
-          {
-            formId: props.element.formId,
-            fragmentId: undefined,
-            fromUser: true,
-          }
-        )
-      })
+      await expectCommitted(spy, props, "2025-11-19T09:45")
     })
 
     it("does not commit a time on its own without a date", async () => {
-      const user = userEvent.setup()
-      const props = emptyProps()
-      const spy = vi.spyOn(props.widgetMgr, "setStringArrayValue")
-      render(
-        <div>
-          <DateTimeInput {...props} />
-          <button data-testid="outside">outside</button>
-        </div>
-      )
-      spy.mockClear()
+      const { user, spy } = renderEmpty()
 
       const segments = screen.getAllByRole("spinbutton")
       await user.click(segments[3])
@@ -2156,17 +2137,9 @@ describe("DateTimeInput widget", () => {
       expect(spy).not.toHaveBeenCalled()
     })
 
+    // eslint-disable-next-line vitest/expect-expect -- asserts via expectCommitted
     it("keeps a partial time set in the popover, without a minute", async () => {
-      const user = userEvent.setup()
-      const props = emptyProps()
-      const spy = vi.spyOn(props.widgetMgr, "setStringArrayValue")
-      render(
-        <div>
-          <DateTimeInput {...props} />
-          <button data-testid="outside">outside</button>
-        </div>
-      )
-      spy.mockClear()
+      const { user, props, spy } = renderEmpty()
 
       await user.click(screen.getAllByRole("spinbutton")[0])
       await screen.findByTestId("stDateTimeInputCalendar")
@@ -2180,30 +2153,11 @@ describe("DateTimeInput widget", () => {
       await user.click(screen.getByRole("button", { name: /November 19/ }))
       await user.click(screen.getByTestId("outside"))
 
-      await waitFor(() => {
-        expect(spy).toHaveBeenCalledWith(
-          props.element.id,
-          ["2025-11-19T09:00"],
-          {
-            formId: props.element.formId,
-            fragmentId: undefined,
-            fromUser: true,
-          }
-        )
-      })
+      await expectCommitted(spy, props, "2025-11-19T09:00")
     })
 
     it("prefers the time control the user focused most recently", async () => {
-      const user = userEvent.setup()
-      const props = emptyProps()
-      const spy = vi.spyOn(props.widgetMgr, "setStringArrayValue")
-      render(
-        <div>
-          <DateTimeInput {...props} />
-          <button data-testid="outside">outside</button>
-        </div>
-      )
-      spy.mockClear()
+      const { user, props, spy } = renderEmpty()
 
       // Type inline first, then override in the popover. Both hold a time at
       // once and both are on screen, so the control focused most recently wins.
@@ -2222,17 +2176,7 @@ describe("DateTimeInput widget", () => {
       await user.click(screen.getByRole("button", { name: /November 19/ }))
       await user.click(screen.getByTestId("outside"))
 
-      await waitFor(() => {
-        expect(spy).toHaveBeenCalledWith(
-          props.element.id,
-          ["2025-11-19T09:45"],
-          {
-            formId: props.element.formId,
-            fragmentId: undefined,
-            fromUser: true,
-          }
-        )
-      })
+      await expectCommitted(spy, props, "2025-11-19T09:45")
       // The earlier inline time must not win just because it was typed first.
       expect(spy).not.toHaveBeenCalledWith(
         props.element.id,
@@ -2277,16 +2221,7 @@ describe("DateTimeInput widget", () => {
     })
 
     it("forgets a popover time the user clears again", async () => {
-      const user = userEvent.setup()
-      const props = emptyProps()
-      const spy = vi.spyOn(props.widgetMgr, "setStringArrayValue")
-      render(
-        <div>
-          <DateTimeInput {...props} />
-          <button data-testid="outside">outside</button>
-        </div>
-      )
-      spy.mockClear()
+      const { user, props, spy } = renderEmpty()
 
       await user.click(screen.getAllByRole("spinbutton")[0])
       await screen.findByTestId("stDateTimeInputCalendar")
@@ -2307,17 +2242,7 @@ describe("DateTimeInput widget", () => {
       await user.click(screen.getByRole("button", { name: /November 19/ }))
       await user.click(screen.getByTestId("outside"))
 
-      await waitFor(() => {
-        expect(spy).toHaveBeenCalledWith(
-          props.element.id,
-          ["2025-11-19T00:00"],
-          {
-            formId: props.element.formId,
-            fragmentId: undefined,
-            fromUser: true,
-          }
-        )
-      })
+      await expectCommitted(spy, props, "2025-11-19T00:00")
       expect(spy).not.toHaveBeenCalledWith(
         props.element.id,
         ["2025-11-19T09:45"],
@@ -2326,16 +2251,7 @@ describe("DateTimeInput widget", () => {
     })
 
     it("forgets a dismissed popover time, on screen and on commit", async () => {
-      const user = userEvent.setup()
-      const props = emptyProps()
-      const spy = vi.spyOn(props.widgetMgr, "setStringArrayValue")
-      render(
-        <div>
-          <DateTimeInput {...props} />
-          <button data-testid="outside">outside</button>
-        </div>
-      )
-      spy.mockClear()
+      const { user, props, spy } = renderEmpty()
 
       await user.click(screen.getAllByRole("spinbutton")[0])
       await screen.findByTestId("stDateTimeInputCalendar")
@@ -2368,17 +2284,7 @@ describe("DateTimeInput widget", () => {
       // where nothing on screen would explain the time.
       await user.click(screen.getByRole("button", { name: /November 19/ }))
       await user.click(screen.getByTestId("outside"))
-      await waitFor(() => {
-        expect(spy).toHaveBeenCalledWith(
-          props.element.id,
-          ["2025-11-19T00:00"],
-          {
-            formId: props.element.formId,
-            fragmentId: undefined,
-            fromUser: true,
-          }
-        )
-      })
+      await expectCommitted(spy, props, "2025-11-19T00:00")
       expect(spy).not.toHaveBeenCalledWith(
         props.element.id,
         ["2025-11-19T09:45"],
@@ -2386,17 +2292,9 @@ describe("DateTimeInput widget", () => {
       )
     })
 
+    // eslint-disable-next-line vitest/expect-expect -- asserts via expectCommitted
     it("completes a date typed inline with a time given in the popover", async () => {
-      const user = userEvent.setup()
-      const props = emptyProps()
-      const spy = vi.spyOn(props.widgetMgr, "setStringArrayValue")
-      render(
-        <div>
-          <DateTimeInput {...props} />
-          <button data-testid="outside">outside</button>
-        </div>
-      )
-      spy.mockClear()
+      const { user, props, spy } = renderEmpty()
 
       // Time in the popover...
       await user.click(screen.getAllByRole("spinbutton")[0])
@@ -2416,17 +2314,7 @@ describe("DateTimeInput widget", () => {
       // Both halves are on screen, so dismissal must combine rather than
       // discard them.
       await user.click(screen.getByTestId("outside"))
-      await waitFor(() => {
-        expect(spy).toHaveBeenCalledWith(
-          props.element.id,
-          ["2025-11-19T09:45"],
-          {
-            formId: props.element.formId,
-            fragmentId: undefined,
-            fromUser: true,
-          }
-        )
-      })
+      await expectCommitted(spy, props, "2025-11-19T09:45")
     })
 
     it("still reverts when one segment of an existing value is cleared", async () => {
@@ -2473,16 +2361,7 @@ describe("DateTimeInput widget", () => {
     })
 
     it("shows the merged value in the field when committing inside a form", async () => {
-      const user = userEvent.setup()
-      const props = emptyProps()
-      props.element.formId = "form"
-      props.widgetMgr.setFormSubmitBehaviors("form", true)
-      render(
-        <div>
-          <DateTimeInput {...props} />
-          <button data-testid="outside">outside</button>
-        </div>
-      )
+      const { user } = renderEmpty(inAForm)
 
       await user.click(screen.getAllByRole("spinbutton")[0])
       await screen.findByTestId("stDateTimeInputCalendar")
@@ -2549,16 +2428,7 @@ describe("DateTimeInput widget", () => {
     })
 
     it("keeps a popover time when Enter leaves the popover open", async () => {
-      const user = userEvent.setup()
-      const props = emptyProps()
-      const spy = vi.spyOn(props.widgetMgr, "setStringArrayValue")
-      render(
-        <div>
-          <DateTimeInput {...props} />
-          <button data-testid="outside">outside</button>
-        </div>
-      )
-      spy.mockClear()
+      const { user, props, spy } = renderEmpty()
 
       await user.click(screen.getAllByRole("spinbutton")[0])
       await screen.findByTestId("stDateTimeInputCalendar")
@@ -2582,17 +2452,7 @@ describe("DateTimeInput widget", () => {
       await user.click(screen.getByRole("button", { name: /November 19/ }))
       await user.click(screen.getByTestId("outside"))
 
-      await waitFor(() => {
-        expect(spy).toHaveBeenCalledWith(
-          props.element.id,
-          ["2025-11-19T09:45"],
-          {
-            formId: props.element.formId,
-            fragmentId: undefined,
-            fromUser: true,
-          }
-        )
-      })
+      await expectCommitted(spy, props, "2025-11-19T09:45")
       expect(spy).not.toHaveBeenCalledWith(
         props.element.id,
         ["2025-11-19T00:00"],
@@ -2600,17 +2460,9 @@ describe("DateTimeInput widget", () => {
       )
     })
 
+    // eslint-disable-next-line vitest/expect-expect -- asserts via expectCommitted
     it("completes the value when Tab leaves the field, not just on dismissal", async () => {
-      const user = userEvent.setup()
-      const props = emptyProps()
-      const spy = vi.spyOn(props.widgetMgr, "setStringArrayValue")
-      render(
-        <div>
-          <DateTimeInput {...props} />
-          <button data-testid="outside">outside</button>
-        </div>
-      )
-      spy.mockClear()
+      const { user, props, spy } = renderEmpty()
 
       await user.click(screen.getAllByRole("spinbutton")[0])
       await screen.findByTestId("stDateTimeInputCalendar")
@@ -2632,30 +2484,11 @@ describe("DateTimeInput widget", () => {
       await user.click(inline[inline.length - 1])
       await user.tab()
 
-      await waitFor(() => {
-        expect(spy).toHaveBeenCalledWith(
-          props.element.id,
-          ["2025-11-19T09:45"],
-          {
-            formId: props.element.formId,
-            fragmentId: undefined,
-            fromUser: true,
-          }
-        )
-      })
+      await expectCommitted(spy, props, "2025-11-19T09:45")
     })
 
     it("prefers the popover time over an inline draft when both are on screen at dismissal", async () => {
-      const user = userEvent.setup()
-      const props = emptyProps()
-      const spy = vi.spyOn(props.widgetMgr, "setStringArrayValue")
-      render(
-        <div>
-          <DateTimeInput {...props} />
-          <button data-testid="outside">outside</button>
-        </div>
-      )
-      spy.mockClear()
+      const { user, props, spy } = renderEmpty()
 
       // A complete date plus an hour inline, so the field still reports nothing
       // and holds an 03:00 draft of its own.
@@ -2675,17 +2508,7 @@ describe("DateTimeInput widget", () => {
 
       await user.click(screen.getByTestId("outside"))
 
-      await waitFor(() => {
-        expect(spy).toHaveBeenCalledWith(
-          props.element.id,
-          ["2025-11-19T09:45"],
-          {
-            formId: props.element.formId,
-            fragmentId: undefined,
-            fromUser: true,
-          }
-        )
-      })
+      await expectCommitted(spy, props, "2025-11-19T09:45")
       // The inline draft must not win, and must not commit as a second value.
       expect(spy).not.toHaveBeenCalledWith(
         props.element.id,
@@ -2696,17 +2519,7 @@ describe("DateTimeInput widget", () => {
     })
 
     it("commits the same value again after a form clear", async () => {
-      const user = userEvent.setup()
-      const props = emptyProps()
-      props.element.formId = "form"
-      props.widgetMgr.setFormSubmitBehaviors("form", true)
-      const spy = vi.spyOn(props.widgetMgr, "setStringArrayValue")
-      render(
-        <div>
-          <DateTimeInput {...props} />
-          <button data-testid="outside">outside</button>
-        </div>
-      )
+      const { user, props, spy } = renderEmpty(inAForm)
 
       const enterSameValue = async (): Promise<void> => {
         const field = screen.getByTestId("stDateTimeInputField")
@@ -2730,31 +2543,11 @@ describe("DateTimeInput widget", () => {
       // Re-entering the value that was just submitted has to reach widget state
       // again — the dedup memory must not outlive the clear.
       await enterSameValue()
-      await waitFor(() => {
-        expect(spy).toHaveBeenCalledWith(
-          props.element.id,
-          ["2025-11-19T12:00"],
-          {
-            formId: props.element.formId,
-            fragmentId: undefined,
-            fromUser: true,
-          }
-        )
-      })
+      await expectCommitted(spy, props, "2025-11-19T12:00")
     })
 
     it("forgets an incomplete popover time across a form clear", async () => {
-      const user = userEvent.setup()
-      const props = emptyProps()
-      props.element.formId = "form"
-      props.widgetMgr.setFormSubmitBehaviors("form", true)
-      const spy = vi.spyOn(props.widgetMgr, "setStringArrayValue")
-      render(
-        <div>
-          <DateTimeInput {...props} />
-          <button data-testid="outside">outside</button>
-        </div>
-      )
+      const { user, props, spy } = renderEmpty(inAForm)
 
       // A complete value inline, which populates the popover time field...
       const inlineField = screen.getByTestId("stDateTimeInputField")
@@ -2781,17 +2574,7 @@ describe("DateTimeInput widget", () => {
       await user.click(screen.getByRole("button", { name: /November 19/ }))
       await user.click(screen.getByTestId("outside"))
 
-      await waitFor(() => {
-        expect(spy).toHaveBeenCalledWith(
-          props.element.id,
-          ["2025-11-19T00:00"],
-          {
-            formId: props.element.formId,
-            fragmentId: undefined,
-            fromUser: true,
-          }
-        )
-      })
+      await expectCommitted(spy, props, "2025-11-19T00:00")
       expect(spy).not.toHaveBeenCalledWith(
         props.element.id,
         ["2025-11-19T12:00"],
@@ -2799,6 +2582,7 @@ describe("DateTimeInput widget", () => {
       )
     })
 
+    // eslint-disable-next-line vitest/expect-expect -- asserts via expectCommitted
     it("commits the same datetime again after Enter-submitting it", async () => {
       const user = userEvent.setup()
       const props = emptyProps()
@@ -2826,30 +2610,12 @@ describe("DateTimeInput widget", () => {
       // the datetime, and the popover stays open across an Enter submit.
       await typeAndEnter()
 
-      await waitFor(() => {
-        expect(spy).toHaveBeenCalledWith(
-          props.element.id,
-          ["2025-11-19T12:00"],
-          {
-            formId: props.element.formId,
-            fragmentId: undefined,
-            fromUser: true,
-          }
-        )
-      })
+      await expectCommitted(spy, props, "2025-11-19T12:00")
     })
 
+    // eslint-disable-next-line vitest/expect-expect -- asserts via expectCommitted
     it("merges a lone popover hour as the top of that hour", async () => {
-      const user = userEvent.setup()
-      const props = emptyProps()
-      const spy = vi.spyOn(props.widgetMgr, "setStringArrayValue")
-      render(
-        <div>
-          <DateTimeInput {...props} />
-          <button data-testid="outside">outside</button>
-        </div>
-      )
-      spy.mockClear()
+      const { user, props, spy } = renderEmpty()
 
       await user.click(screen.getAllByRole("spinbutton")[0])
       await screen.findByTestId("stDateTimeInputCalendar")
@@ -2868,30 +2634,11 @@ describe("DateTimeInput widget", () => {
       // A half-given time is still a time the user typed, so it commits with the
       // minute at zero — the same rule the calendar path uses. Only a time given
       // nowhere at all reverts.
-      await waitFor(() => {
-        expect(spy).toHaveBeenCalledWith(
-          props.element.id,
-          ["2025-11-19T09:00"],
-          {
-            formId: props.element.formId,
-            fragmentId: undefined,
-            fromUser: true,
-          }
-        )
-      })
+      await expectCommitted(spy, props, "2025-11-19T09:00")
     })
 
     it("reverts a date typed inline when no time was given anywhere", async () => {
-      const user = userEvent.setup()
-      const props = emptyProps()
-      const spy = vi.spyOn(props.widgetMgr, "setStringArrayValue")
-      render(
-        <div>
-          <DateTimeInput {...props} />
-          <button data-testid="outside">outside</button>
-        </div>
-      )
-      spy.mockClear()
+      const { user, spy } = renderEmpty()
 
       // A date with no time is still incomplete — midnight would be a guess.
       const inlineField = screen.getByTestId("stDateTimeInputField")
@@ -2908,16 +2655,7 @@ describe("DateTimeInput widget", () => {
     })
 
     it("keeps an inline time that is still on screen after dismissal", async () => {
-      const user = userEvent.setup()
-      const props = emptyProps()
-      const spy = vi.spyOn(props.widgetMgr, "setStringArrayValue")
-      render(
-        <div>
-          <DateTimeInput {...props} />
-          <button data-testid="outside">outside</button>
-        </div>
-      )
-      spy.mockClear()
+      const { user, props, spy } = renderEmpty()
 
       // Unlike the popover field, the inline segments do not unmount on
       // dismissal, so the time stays visible — and a later date pick commits it.
@@ -2937,30 +2675,10 @@ describe("DateTimeInput widget", () => {
       await user.click(screen.getByRole("button", { name: /November 19/ }))
       await user.click(screen.getByTestId("outside"))
 
-      await waitFor(() => {
-        expect(spy).toHaveBeenCalledWith(
-          props.element.id,
-          ["2025-11-19T03:24"],
-          {
-            formId: props.element.formId,
-            fragmentId: undefined,
-            fromUser: true,
-          }
-        )
-      })
+      await expectCommitted(spy, props, "2025-11-19T03:24")
     })
     it("forgets an inline time typed before a form clear", async () => {
-      const user = userEvent.setup()
-      const props = emptyProps()
-      props.element.formId = "form"
-      props.widgetMgr.setFormSubmitBehaviors("form", true)
-      const spy = vi.spyOn(props.widgetMgr, "setStringArrayValue")
-      render(
-        <div>
-          <DateTimeInput {...props} />
-          <button data-testid="outside">outside</button>
-        </div>
-      )
+      const { user, props, spy } = renderEmpty(inAForm)
 
       const inlineField = screen.getByTestId("stDateTimeInputField")
       await user.click(within(inlineField).getAllByRole("spinbutton")[3])
@@ -2985,17 +2703,7 @@ describe("DateTimeInput widget", () => {
       await user.click(screen.getByRole("button", { name: /November 19/ }))
       await user.click(screen.getByTestId("outside"))
 
-      await waitFor(() => {
-        expect(spy).toHaveBeenCalledWith(
-          props.element.id,
-          ["2025-11-19T00:00"],
-          {
-            formId: props.element.formId,
-            fragmentId: undefined,
-            fromUser: true,
-          }
-        )
-      })
+      await expectCommitted(spy, props, "2025-11-19T00:00")
       expect(spy).not.toHaveBeenCalledWith(
         props.element.id,
         ["2025-11-19T03:24"],
@@ -3036,18 +2744,7 @@ describe("DateTimeInput widget", () => {
     })
 
     it("drops a pending popover time when the form is reset", async () => {
-      const user = userEvent.setup()
-      const props = emptyProps()
-      props.element.formId = "form"
-      props.widgetMgr.setFormSubmitBehaviors("form", true)
-      const spy = vi.spyOn(props.widgetMgr, "setStringArrayValue")
-      render(
-        <div>
-          <DateTimeInput {...props} />
-          <button data-testid="outside">outside</button>
-        </div>
-      )
-      spy.mockClear()
+      const { user, props, spy } = renderEmpty(inAForm)
 
       await user.click(screen.getAllByRole("spinbutton")[0])
       await screen.findByTestId("stDateTimeInputCalendar")

--- a/frontend/lib/src/components/widgets/DateTimeInput/DateTimeInput.test.tsx
+++ b/frontend/lib/src/components/widgets/DateTimeInput/DateTimeInput.test.tsx
@@ -2743,6 +2743,62 @@ describe("DateTimeInput widget", () => {
       })
     })
 
+    it("forgets an incomplete popover time across a form clear", async () => {
+      const user = userEvent.setup()
+      const props = emptyProps()
+      props.element.formId = "form"
+      props.widgetMgr.setFormSubmitBehaviors("form", true)
+      const spy = vi.spyOn(props.widgetMgr, "setStringArrayValue")
+      render(
+        <div>
+          <DateTimeInput {...props} />
+          <button data-testid="outside">outside</button>
+        </div>
+      )
+
+      // A complete value inline, which populates the popover time field...
+      const inlineField = screen.getByTestId("stDateTimeInputField")
+      await user.click(within(inlineField).getAllByRole("spinbutton")[0])
+      await user.keyboard("20251119")
+      await user.keyboard("1200")
+      await screen.findByTestId("stDateTimeInputCalendar")
+
+      // ...then clear one of its segments, which is neither cleared nor complete,
+      // so React Aria reports nothing and `pendingTime` never learns about it.
+      const popover = within(
+        screen.getByTestId("stDateTimeInputPopoverTime")
+      ).getAllByRole("spinbutton")
+      await clearSegment(user, popover[1])
+      expect(popover[0]).toHaveTextContent("12")
+
+      // Enter keeps the popover mounted across the clear, so the leftover hour
+      // must not survive to be merged into a date picked afterwards.
+      act(() => {
+        props.widgetMgr.submitForm("form", undefined)
+      })
+      spy.mockClear()
+
+      await user.click(screen.getByRole("button", { name: /November 19/ }))
+      await user.click(screen.getByTestId("outside"))
+
+      await waitFor(() => {
+        expect(spy).toHaveBeenCalledWith(
+          props.element.id,
+          ["2025-11-19T00:00"],
+          {
+            formId: props.element.formId,
+            fragmentId: undefined,
+            fromUser: true,
+          }
+        )
+      })
+      expect(spy).not.toHaveBeenCalledWith(
+        props.element.id,
+        ["2025-11-19T12:00"],
+        expect.anything()
+      )
+    })
+
     it("merges a lone popover hour as the top of that hour", async () => {
       const user = userEvent.setup()
       const props = emptyProps()

--- a/frontend/lib/src/components/widgets/DateTimeInput/DateTimeInput.test.tsx
+++ b/frontend/lib/src/components/widgets/DateTimeInput/DateTimeInput.test.tsx
@@ -2549,6 +2549,58 @@ describe("DateTimeInput widget", () => {
       expect(spy).not.toHaveBeenCalled()
     })
 
+    it("keeps a popover time when Enter leaves the popover open", async () => {
+      const user = userEvent.setup()
+      const props = emptyProps()
+      const spy = vi.spyOn(props.widgetMgr, "setStringArrayValue")
+      render(
+        <div>
+          <DateTimeInput {...props} />
+          <button data-testid="outside">outside</button>
+        </div>
+      )
+      spy.mockClear()
+
+      await user.click(screen.getAllByRole("spinbutton")[0])
+      await screen.findByTestId("stDateTimeInputCalendar")
+      const popoverSegments = within(
+        screen.getByTestId("stDateTimeInputPopoverTime")
+      ).getAllByRole("spinbutton")
+      await user.click(popoverSegments[0])
+      await user.keyboard("0945")
+
+      // Enter from the inline field commits without closing the popover, so the
+      // time is still on screen and must not be forgotten out from under it.
+      await user.click(
+        within(screen.getByTestId("stDateTimeInputField")).getAllByRole(
+          "spinbutton"
+        )[0]
+      )
+      await user.keyboard("{Enter}")
+      expect(screen.getByTestId("stDateTimeInputCalendar")).toBeVisible()
+      expect(popoverSegments[0]).toHaveTextContent("09")
+
+      await user.click(screen.getByRole("button", { name: /November 19/ }))
+      await user.click(screen.getByTestId("outside"))
+
+      await waitFor(() => {
+        expect(spy).toHaveBeenCalledWith(
+          props.element.id,
+          ["2025-11-19T09:45"],
+          {
+            formId: props.element.formId,
+            fragmentId: undefined,
+            fromUser: true,
+          }
+        )
+      })
+      expect(spy).not.toHaveBeenCalledWith(
+        props.element.id,
+        ["2025-11-19T00:00"],
+        expect.anything()
+      )
+    })
+
     it("completes the value when Tab leaves the field, not just on dismissal", async () => {
       const user = userEvent.setup()
       const props = emptyProps()
@@ -2738,6 +2790,13 @@ describe("DateTimeInput widget", () => {
           "spinbutton"
         )[0]
       ).toHaveAttribute("data-placeholder", "true")
+      // A blank display could also mean it committed and was then reset, so pin
+      // that the time never reached widget state.
+      expect(spy).not.toHaveBeenCalledWith(
+        props.element.id,
+        expect.arrayContaining([expect.stringContaining("09:45")]),
+        expect.anything()
+      )
     })
   })
 })

--- a/frontend/lib/src/components/widgets/DateTimeInput/DateTimeInput.test.tsx
+++ b/frontend/lib/src/components/widgets/DateTimeInput/DateTimeInput.test.tsx
@@ -1982,10 +1982,9 @@ describe("DateTimeInput widget", () => {
   })
 
   describe("Time given before a date", () => {
-    /** Empty widget, so the date segments stay placeholders — the state in which
-     * DateField reports no value at all. min/max are pinned to November 2025 so
-     * the calendar clamps to a deterministic month rather than opening on
-     * today's, which is what makes the /November 19/ day locator reliable. */
+    /** Empty widget, so the date segments stay placeholders. min/max are pinned to
+     * November 2025 so the calendar clamps to a deterministic month rather than
+     * opening on today's, which is what makes the /November 19/ locator reliable. */
     const emptyProps = (): Props =>
       getProps({
         default: [],
@@ -2207,7 +2206,7 @@ describe("DateTimeInput widget", () => {
       spy.mockClear()
 
       // Type inline first, then override in the popover. Both hold a time at
-      // once and both are on screen, so the later edit is the one meant.
+      // once and both are on screen, so the control focused most recently wins.
       const segments = screen.getAllByRole("spinbutton")
       await user.click(segments[3])
       await user.keyboard("03")
@@ -2644,6 +2643,56 @@ describe("DateTimeInput widget", () => {
           }
         )
       })
+    })
+
+    it("prefers the popover draft over an inline one when dismissed together", async () => {
+      const user = userEvent.setup()
+      const props = emptyProps()
+      const spy = vi.spyOn(props.widgetMgr, "setStringArrayValue")
+      render(
+        <div>
+          <DateTimeInput {...props} />
+          <button data-testid="outside">outside</button>
+        </div>
+      )
+      spy.mockClear()
+
+      // A complete date plus an hour inline, so the field still reports nothing
+      // and holds an 03:00 draft of its own.
+      const inlineField = screen.getByTestId("stDateTimeInputField")
+      await user.click(within(inlineField).getAllByRole("spinbutton")[0])
+      await user.keyboard("20251119")
+      await user.keyboard("03")
+
+      // Then a different, complete time in the popover — focused last, so it wins.
+      await screen.findByTestId("stDateTimeInputCalendar")
+      await user.click(
+        within(screen.getByTestId("stDateTimeInputPopoverTime")).getAllByRole(
+          "spinbutton"
+        )[0]
+      )
+      await user.keyboard("0945")
+
+      await user.click(screen.getByTestId("outside"))
+
+      await waitFor(() => {
+        expect(spy).toHaveBeenCalledWith(
+          props.element.id,
+          ["2025-11-19T09:45"],
+          {
+            formId: props.element.formId,
+            fragmentId: undefined,
+            fromUser: true,
+          }
+        )
+      })
+      // The inline draft must not win, and must not commit as a second value.
+      expect(spy).not.toHaveBeenCalledWith(
+        props.element.id,
+        ["2025-11-19T03:00"],
+        expect.anything()
+      )
+      expect(spy).toHaveBeenCalledTimes(1)
     })
 
     it("merges a lone popover hour as the top of that hour", async () => {

--- a/frontend/lib/src/components/widgets/DateTimeInput/SingleDateTimeInput.tsx
+++ b/frontend/lib/src/components/widgets/DateTimeInput/SingleDateTimeInput.tsx
@@ -67,6 +67,7 @@ import {
   getTypedDateFromDom,
   getTypedTimeFromDom,
   parsePastedDateTime,
+  SEGMENT_SELECTOR,
   validateDateTime,
 } from "./dateTimeInputUtils"
 import {
@@ -88,10 +89,6 @@ import {
   StyledTrailingIcons,
   StyledVisuallyHidden,
 } from "./styled-components"
-
-/** Editable segments. Matched on `data-type` rather than `role`, which React Aria
- * replaces with `textbox` on iOS. Literals are the separators between segments. */
-const SEGMENT_SELECTOR = '[data-type]:not([data-type="literal"])'
 
 interface SingleDateTimeInputProps {
   value: CalendarDateTime | null
@@ -160,13 +157,14 @@ function SingleDateTimeInput({
   const activeOriginRef = useRef<HTMLElement | null>(null)
   const popoverRef = useRef<HTMLDivElement | null>(null)
 
-  // Three React Aria constraints shape the state below, referred to by name:
-  // - WITHHELD ONCHANGE: `DateField` and `TimeField` report no value until every
-  //   one of their segments is filled, so a partial entry reaches no handler.
-  // - RE-SEED: a controlled `value` resets the field's segment display state, and
-  //   an unchanged `value` leaves whatever the user typed in place.
-  // - IOS ROLES: segments render as textboxes rather than spinbuttons there, so
-  //   `role`-based queries find nothing and `aria-valuenow` is dropped.
+  // Three React Aria constraints shape the state below:
+  // - `DateField` and `TimeField` report no value until every one of their segments
+  //   is filled, so a partial entry reaches no handler. This is why what commits is
+  //   re-read from the rendered segments rather than taken from `onChange`.
+  // - A controlled `value` resets the field's segment display state, while an
+  //   unchanged `value` leaves whatever the user typed in place.
+  // - On iOS, segments render as textboxes rather than spinbuttons, so `role`-based
+  //   queries find nothing and `aria-valuenow` is dropped.
 
   // --- Two-layer state ---
   const [displayValue, setDisplayValue] = useState<CalendarDateTime | null>(
@@ -181,15 +179,21 @@ function SingleDateTimeInput({
 
   // Resolves conflicting visible times by preferring the control that received
   // focus most recently, falling back to the other when that one is empty. Focus
-  // rather than edit, so merely tabbing through flips it — harmless, because an
-  // untouched control reads as null and the fallback applies.
+  // rather than edit, so tabbing onto a control also selects it; an empty control
+  // still falls back to the other, so tabbing onto an unused TimeField does not
+  // change what commits.
+  //
+  // Known limitation: React Aria advances focus from `day` to `hour` as a date is
+  // typed, so typing the date last reselects the inline control. If an abandoned
+  // inline draft is still in those segments, it outranks a newer popover time.
   const lastTimeSourceRef = useRef<"inline" | "popover">("inline")
   // A complete time set in the popover before any date exists — without holding it
-  // here, RE-SEED would blank the segments as the user finished typing.
+  // here, React Aria would reset the field's typed-but-incomplete segments and
+  // blank them as the user finished typing.
   //
-  // Display buffer only: `resolveGivenTime` never reads it, since WITHHELD ONCHANGE
-  // means a partial popover time never lands here. What commits is re-read from
-  // the rendered segments.
+  // Display buffer only: `resolveGivenTime` never reads it, because a partial
+  // popover time never lands here — the field withholds `onChange` until every
+  // segment is filled. What commits is re-read from the rendered segments.
   const [pendingTime, setPendingTime] = useState<Time | null>(null)
 
   const [prevValue, setPrevValue] = useState(value)
@@ -218,6 +222,12 @@ function SingleDateTimeInput({
     // `prevValue !== value` never fires — and the popover stays open, so the
     // open-effect reset does not run either.
     lastCommittedRef.current = undefined
+    // Reading the DOM during render is safe here specifically because this write
+    // sits inside the same condition that advances `prevResetKey`. A render that
+    // never commits leaves that state update behind too, so the condition is still
+    // true on the retry and the flag is recomputed against live focus rather than
+    // surviving as a stale `true`. A double-invoked render computes the same value
+    // twice, since focus cannot move between two synchronous passes.
     shouldRestoreFocusRef.current = !!triggerRef.current?.contains(
       document.activeElement
     )
@@ -264,7 +274,7 @@ function SingleDateTimeInput({
 
   /** The datetime the two controls describe between them when the field itself
    * holds no value: a complete date read from the inline segments, plus a time
-   * from whichever control the user last touched. Null unless both halves are
+   * from whichever control the user focused most recently. Null unless both halves are
    * present — a date alone gives nothing to commit, and defaulting its time
    * would be inventing one. */
   const completeFromVisibleParts = useCallback((): CalendarDateTime | null => {
@@ -280,10 +290,14 @@ function SingleDateTimeInput({
     )
   }, [resolveGivenTime])
 
-  /** Validate and commit the pending value, or revert to the last committed
-   * value. Returns true if the field holds a valid (committed or unchanged)
-   * value, false if it was reverted. Calls both onChange (React state) and
-   * formCommit (sync WM write) to prevent the form-submit race. */
+  /** Validate and commit the pending value, or revert to the last committed value.
+   * When the field itself has no value, first try to complete one from the visible
+   * date and time halves. Returns true if the field holds a valid (committed or
+   * unchanged) value, false if it was reverted. Calls both onChange (React state)
+   * and formCommit (sync WM write) to prevent the form-submit race.
+   *
+   * @param popoverStaysOpen - When true, keeps a popover time that is still on
+   * screen (Enter commits without dismissing). */
   const commitOrRevert = useCallback(
     ({ popoverStaysOpen = false } = {}): boolean => {
       if (!triggerRef.current) return false
@@ -297,11 +311,11 @@ function SingleDateTimeInput({
       // placeholder. Complete the value from what is on screen instead of
       // discarding halves the user can see.
       //
-      // Keyed off the field having no value rather than off `isPartiallyTyped`,
-      // for two reasons: clearing one segment of an existing value also reads as
-      // partially typed, and that is an edit in progress rather than two halves to
-      // combine; and `getSegmentState` matches nothing under IOS ROLES, where the
-      // readers still work.
+      // Keyed off the field having no value rather than off `isPartiallyTyped`:
+      // - Clearing one segment of an existing value also reads as partially typed,
+      //   and that is an edit in progress, not two halves to combine.
+      // - `getSegmentState` matches nothing on iOS, where React Aria renders
+      //   segments as textboxes, while the readers below still work.
       //
       // Read before `setPendingTime(null)` below, so the merge never depends on
       // React batching that clear: flushing it would blank the popover's segments.
@@ -567,7 +581,8 @@ function SingleDateTimeInput({
       current: CalendarDateTime | null
     ): void => {
       if (e.key !== "ArrowUp" && e.key !== "ArrowDown") return
-      // No date yet: nothing to snap against, so React Aria's default ±1 applies.
+      // No committed date yet, and this snaps a `CalendarDateTime`, so React Aria's
+      // default ±1 applies until a date exists.
       if (!current) return
       const target = e.target as HTMLElement
       const segmentType = target.getAttribute("data-type")
@@ -785,8 +800,8 @@ function SingleDateTimeInput({
               // Remount on form clear. React Aria keeps its own display state
               // for segments the user has typed but not completed, and with
               // `value` already null there is no prop change to re-seed it — so a
-              // time typed before `clear_on_submit` would stay on screen, and now
-              // that dismissal completes a value from what is visible, it would
+              // time typed before `clear_on_submit` would stay on screen, and
+              // because dismissal completes a value from what is visible, it would
               // also commit.
               key={formResetKey}
               aria-label={label}
@@ -895,9 +910,10 @@ function SingleDateTimeInput({
                 <I18nProvider locale="en-US">
                   <StyledPopoverTimeField
                     // Remount on form clear, like the inline field. Segments the
-                    // user typed but did not complete are RE-SEEDed only when the
-                    // controlled value changes, so this does not depend on
-                    // `popoverTimeValue` happening to differ across the clear.
+                    // React Aria only resets typed-but-incomplete segments when the
+                    // controlled value changes, and `popoverTimeValue` can be
+                    // unchanged across a clear, so this does not depend on those
+                    // two happening to differ.
                     key={formResetKey}
                     aria-labelledby={`${id}-time-label`}
                     aria-describedby={error ? errorId : undefined}

--- a/frontend/lib/src/components/widgets/DateTimeInput/SingleDateTimeInput.tsx
+++ b/frontend/lib/src/components/widgets/DateTimeInput/SingleDateTimeInput.tsx
@@ -909,11 +909,10 @@ function SingleDateTimeInput({
                 </StyledPopoverTimeLabel>
                 <I18nProvider locale="en-US">
                   <StyledPopoverTimeField
-                    // Remount on form clear, like the inline field. Segments the
-                    // React Aria only resets typed-but-incomplete segments when the
-                    // controlled value changes, and `popoverTimeValue` can be
-                    // unchanged across a clear, so this does not depend on those
-                    // two happening to differ.
+                    // Remount on form clear, like the inline field. React Aria only
+                    // resets typed-but-incomplete segments when the controlled value
+                    // changes, and `popoverTimeValue` can be unchanged across a clear,
+                    // so this does not depend on those two happening to differ.
                     key={formResetKey}
                     aria-labelledby={`${id}-time-label`}
                     aria-describedby={error ? errorId : undefined}

--- a/frontend/lib/src/components/widgets/DateTimeInput/SingleDateTimeInput.tsx
+++ b/frontend/lib/src/components/widgets/DateTimeInput/SingleDateTimeInput.tsx
@@ -568,6 +568,10 @@ function SingleDateTimeInput({
         (!e.shiftKey && e.target === segments[segments.length - 1]) ||
         (e.shiftKey && e.target === segments[0])
       if (isLeavingField) {
+        // Commit before closing, as the popover's own Tab handler does. Leaving
+        // it to the blur that follows would run the commit after the popover has
+        // unmounted, and a time given only there would be unreadable by then.
+        commitOrRevert()
         setIsOpen(false)
       }
     },

--- a/frontend/lib/src/components/widgets/DateTimeInput/SingleDateTimeInput.tsx
+++ b/frontend/lib/src/components/widgets/DateTimeInput/SingleDateTimeInput.tsx
@@ -207,6 +207,11 @@ function SingleDateTimeInput({
     setPrevResetKey(formResetKey)
     setDisplayValue(value)
     setPendingTime(null)
+    // A clear ends the interaction, so the dedup memory goes with it: re-entering
+    // the value that was just submitted has to commit again. In practice the
+    // clear also changes `value`, which resets this in the block above, but that
+    // is a coincidence of the two paths rather than something to rely on.
+    lastCommittedRef.current = undefined
     shouldRestoreFocusRef.current = !!triggerRef.current?.contains(
       document.activeElement
     )

--- a/frontend/lib/src/components/widgets/DateTimeInput/SingleDateTimeInput.tsx
+++ b/frontend/lib/src/components/widgets/DateTimeInput/SingleDateTimeInput.tsx
@@ -166,10 +166,10 @@ function SingleDateTimeInput({
     undefined
   )
 
-  // Which time control the user focused last. The inline segments and the
-  // popover TimeField can hold different times at once, so the later edit wins.
-  // Focus alone flips this, which is harmless: an untouched control reads as
-  // null and `resolveGivenTime` falls back to the other.
+  // Resolves conflicting visible times by preferring the control that received
+  // focus most recently, falling back to the other when that one is empty. Focus
+  // rather than edit, so merely tabbing through flips it — harmless, because an
+  // untouched control reads as null and the fallback applies.
   const lastTimeSourceRef = useRef<"inline" | "popover">("inline")
   // A complete time set in the popover before any date exists. React Aria resets
   // the TimeField's segments from its controlled `value` the moment they
@@ -202,8 +202,10 @@ function SingleDateTimeInput({
   /** The time to merge into a date the user selects: the buffered display
    * value's if the field already holds one, otherwise whichever of the two time
    * controls they focused most recently, falling back to the other if that one
-   * is empty. Null when they have given no time at all, in which case the caller
-   * defaults to midnight.
+   * is empty. Null when they have given no time at all — what that means is the
+   * caller's choice: `handleCalendarChange` substitutes midnight, because picking
+   * a day is an affirmative selection, while `completeFromVisibleParts` declines
+   * to complete at all, because dismissing a field is not.
    *
    * Both controls are read from their rendered segments, because neither reports
    * a partial time through `onChange`. Reading them here rather than tracking
@@ -256,72 +258,75 @@ function SingleDateTimeInput({
    * value. Returns true if the field holds a valid (committed or unchanged)
    * value, false if it was reverted. Calls both onChange (React state) and
    * formCommit (sync WM write) to prevent the form-submit race. */
-  const commitOrRevert = useCallback((): boolean => {
-    if (!triggerRef.current) return false
-    const { isPartiallyTyped, isFullyCleared } = getSegmentState(
-      triggerRef.current
-    )
+  const commitOrRevert = useCallback(
+    ({ popoverStaysOpen = false } = {}): boolean => {
+      if (!triggerRef.current) return false
+      const { isPartiallyTyped, isFullyCleared } = getSegmentState(
+        triggerRef.current
+      )
 
-    // A date typed inline with its time given only in the popover reads as
-    // partially typed, because the field withholds onChange while the hour and
-    // minute are placeholders. Both halves are on screen, so complete the value
-    // from them rather than discarding a date and time the user can see.
-    //
-    // The gate also requires the field to hold no value of its own. Clearing one
-    // segment of an existing value reads as partially typed too — React Aria
-    // reports nothing unless every segment is cleared — and that is an edit in
-    // progress, not two halves to combine, so it still reverts.
-    //
-    // Read before `setPendingTime(null)` below, so the merge never depends on
-    // React batching that clear: flushing it would blank the popover's segments.
-    const completedFromParts =
-      isPartiallyTyped && !displayValueRef.current
-        ? completeFromVisibleParts()
-        : null
+      // When the field reports no value of its own, the two controls may still
+      // describe one between them — a date typed inline with its time given only in
+      // the popover — because the field withholds onChange while any segment is a
+      // placeholder. Complete the value from what is on screen instead of
+      // discarding halves the user can see.
+      //
+      // Keyed off the field having no value rather than off `isPartiallyTyped`:
+      // clearing one segment of an existing value also reads as partially typed
+      // (React Aria reports nothing unless every segment is cleared), and that is
+      // an edit in progress rather than two halves to combine. Using the readers
+      // also keeps this working on iOS, where `getSegmentState` matches nothing.
+      //
+      // Read before `setPendingTime(null)` below, so the merge never depends on
+      // React batching that clear: flushing it would blank the popover's segments.
+      const completedFromParts = displayValueRef.current
+        ? null
+        : completeFromVisibleParts()
 
-    // A time given in the popover lives only as long as that popover session:
-    // every path here either commits it into the value or discards it. Without
-    // this, a dismissed time would be restored into the remounted TimeField and
-    // then merged into a date picked in a later session, with nothing on screen
-    // explaining where it came from.
-    setPendingTime(null)
+      // A time given in the popover lives only as long as that popover session:
+      // once it closes, every path here has either committed the time or discarded
+      // it, and a dismissed one must not come back in a later session. Enter
+      // commits without closing, so it keeps a time that is still on screen.
+      if (!popoverStaysOpen) setPendingTime(null)
 
-    // Safe to reach twice: an outside click commits on pointerdown and the
-    // browser then fires blur, by which point the popover is unmounted and its
-    // half unreadable. This branch touches only local display and error state, so
-    // it cannot undo the commit that just happened.
-    if (
-      (isPartiallyTyped && !completedFromParts) ||
-      (isFullyCleared && !clearable)
-    ) {
-      setDisplayValue(value)
-      onCloseRef.current(true)
-      return false
-    }
+      // Safe to reach twice: an outside click commits on pointerdown and the
+      // browser then fires blur, by which point the popover is unmounted and its
+      // half unreadable. This branch touches only local display and error state, so
+      // it cannot undo the commit that just happened.
+      if (
+        (isPartiallyTyped && !completedFromParts) ||
+        (isFullyCleared && !clearable)
+      ) {
+        setDisplayValue(value)
+        onCloseRef.current(true)
+        return false
+      }
 
-    const pending =
-      completedFromParts ?? (isFullyCleared ? null : displayValueRef.current)
+      const pending =
+        completedFromParts ?? (isFullyCleared ? null : displayValueRef.current)
 
-    if (validateDateTime(pending, minDateTime, maxDateTime)) {
-      setDisplayValue(value)
-      onCloseRef.current(true)
-      return false
-    }
+      if (validateDateTime(pending, minDateTime, maxDateTime)) {
+        setDisplayValue(value)
+        onCloseRef.current(true)
+        return false
+      }
 
-    if (dateTimesEqual(pending, value)) return true
+      if (dateTimesEqual(pending, value)) return true
 
-    if (
-      lastCommittedRef.current !== undefined &&
-      dateTimesEqual(pending, lastCommittedRef.current)
-    ) {
+      if (
+        lastCommittedRef.current !== undefined &&
+        dateTimesEqual(pending, lastCommittedRef.current)
+      ) {
+        return true
+      }
+
+      lastCommittedRef.current = pending
+      onChangeRef.current(pending)
+      formCommitRef.current?.(pending)
       return true
-    }
-
-    lastCommittedRef.current = pending
-    onChangeRef.current(pending)
-    formCommitRef.current?.(pending)
-    return true
-  }, [value, clearable, minDateTime, maxDateTime, completeFromVisibleParts])
+    },
+    [value, clearable, minDateTime, maxDateTime, completeFromVisibleParts]
+  )
 
   // Reset state when the popover opens: clear the commit-dedup guard and
   // sync the calendar's focused month to the committed value so a prior
@@ -547,7 +552,9 @@ function SingleDateTimeInput({
 
       if (e.key === "Enter") {
         e.preventDefault()
-        const valid = commitOrRevert()
+        // Enter commits without dismissing, so a popover time that is still on
+        // screen has to survive the commit.
+        const valid = commitOrRevert({ popoverStaysOpen: true })
         if (valid && !error) formSubmit?.()
         return
       }

--- a/frontend/lib/src/components/widgets/DateTimeInput/SingleDateTimeInput.tsx
+++ b/frontend/lib/src/components/widgets/DateTimeInput/SingleDateTimeInput.tsx
@@ -212,9 +212,11 @@ function SingleDateTimeInput({
     setDisplayValue(value)
     setPendingTime(null)
     // A clear ends the interaction, so the dedup memory goes with it: re-entering
-    // the value that was just submitted has to commit again. In practice the
-    // clear also changes `value`, which resets this in the block above, but that
-    // is a coincidence of the two paths rather than something to rely on.
+    // the value that was just submitted has to commit again. The block above does
+    // not cover this — on Enter-to-submit the clear overwrites the pending value
+    // with the default before `value` ever becomes the datetime, so
+    // `prevValue !== value` never fires — and the popover stays open, so the
+    // open-effect reset does not run either.
     lastCommittedRef.current = undefined
     shouldRestoreFocusRef.current = !!triggerRef.current?.contains(
       document.activeElement
@@ -616,9 +618,7 @@ function SingleDateTimeInput({
       if (e.key !== "Tab" || !isOpen) return
       const wrapper = triggerRef.current
       if (!wrapper) return
-      const segments = wrapper.querySelectorAll<HTMLElement>(
-        '[role="spinbutton"]'
-      )
+      const segments = wrapper.querySelectorAll<HTMLElement>(SEGMENT_SELECTOR)
       const isLeavingField =
         (!e.shiftKey && e.target === segments[segments.length - 1]) ||
         (e.shiftKey && e.target === segments[0])
@@ -895,6 +895,11 @@ function SingleDateTimeInput({
                 </StyledPopoverTimeLabel>
                 <I18nProvider locale="en-US">
                   <StyledPopoverTimeField
+                    // Remount on form clear, like the inline field. Segments the
+                    // user typed but did not complete are RE-SEEDed only when the
+                    // controlled value changes, so this does not depend on
+                    // `popoverTimeValue` happening to differ across the clear.
+                    key={formResetKey}
                     aria-labelledby={`${id}-time-label`}
                     aria-describedby={error ? errorId : undefined}
                     isInvalid={!!error}

--- a/frontend/lib/src/components/widgets/DateTimeInput/SingleDateTimeInput.tsx
+++ b/frontend/lib/src/components/widgets/DateTimeInput/SingleDateTimeInput.tsx
@@ -156,6 +156,14 @@ function SingleDateTimeInput({
   const activeOriginRef = useRef<HTMLElement | null>(null)
   const popoverRef = useRef<HTMLDivElement | null>(null)
 
+  // Three React Aria constraints shape the state below, referred to by name:
+  // - WITHHELD ONCHANGE: `DateField` and `TimeField` report no value until every
+  //   one of their segments is filled, so a partial entry reaches no handler.
+  // - RE-SEED: a controlled `value` resets the field's segment display state, and
+  //   an unchanged `value` leaves whatever the user typed in place.
+  // - IOS ROLES: segments render as textboxes rather than spinbuttons there, so
+  //   `role`-based queries find nothing and `aria-valuenow` is dropped.
+
   // --- Two-layer state ---
   const [displayValue, setDisplayValue] = useState<CalendarDateTime | null>(
     value
@@ -172,14 +180,12 @@ function SingleDateTimeInput({
   // rather than edit, so merely tabbing through flips it — harmless, because an
   // untouched control reads as null and the fallback applies.
   const lastTimeSourceRef = useRef<"inline" | "popover">("inline")
-  // A complete time set in the popover before any date exists. React Aria resets
-  // the TimeField's segments from its controlled `value` the moment they
-  // complete, so without holding the time here it would blank out as the user
-  // finished typing it.
+  // A complete time set in the popover before any date exists — without holding it
+  // here, RE-SEED would blank the segments as the user finished typing.
   //
-  // Display buffer only: `resolveGivenTime` never reads it, because a *partial*
-  // popover time never reaches `onChange` and so never lands here. What commits
-  // is always re-read from the rendered segments.
+  // Display buffer only: `resolveGivenTime` never reads it, since WITHHELD ONCHANGE
+  // means a partial popover time never lands here. What commits is re-read from
+  // the rendered segments.
   const [pendingTime, setPendingTime] = useState<Time | null>(null)
 
   const [prevValue, setPrevValue] = useState(value)
@@ -281,11 +287,11 @@ function SingleDateTimeInput({
       // placeholder. Complete the value from what is on screen instead of
       // discarding halves the user can see.
       //
-      // Keyed off the field having no value rather than off `isPartiallyTyped`:
-      // clearing one segment of an existing value also reads as partially typed
-      // (React Aria reports nothing unless every segment is cleared), and that is
-      // an edit in progress rather than two halves to combine. Using the readers
-      // also keeps this working on iOS, where `getSegmentState` matches nothing.
+      // Keyed off the field having no value rather than off `isPartiallyTyped`,
+      // for two reasons: clearing one segment of an existing value also reads as
+      // partially typed, and that is an edit in progress rather than two halves to
+      // combine; and `getSegmentState` matches nothing under IOS ROLES, where the
+      // readers still work.
       //
       // Read before `setPendingTime(null)` below, so the merge never depends on
       // React batching that clear: flushing it would blank the popover's segments.
@@ -331,6 +337,14 @@ function SingleDateTimeInput({
       }
 
       lastCommittedRef.current = pending
+      // Keep the latest-value ref in step with what was just committed, rather
+      // than waiting for the value round-trip. An outside click commits on
+      // pointerdown and the browser then fires blur, so a second pass can run
+      // before that round-trip lands; without this it would re-read the DOM with
+      // the popover already unmounted and could commit a different draft. Not
+      // test-pinned — jsdom flushes renders between events, so it cannot order
+      // the two.
+      displayValueRef.current = pending
       onChangeRef.current(pending)
       formCommitRef.current?.(pending)
       return true
@@ -403,9 +417,9 @@ function SingleDateTimeInput({
 
   const { refs, floatingStyles } = useFloatingOverlay(overlayOptions)
 
-  // Matches segments on `role`, unlike the form-clear effect above: this path
-  // predates it and shares the iOS gap tracked for `getSegmentState`, where React
-  // Aria renders segments as textboxes and neither query finds them.
+  // Matches segments on `role`, unlike the form-clear effect above, and so shares
+  // the iOS gap tracked for `getSegmentState`: React Aria renders segments as
+  // textboxes there and neither query finds them.
   const restoreFocusToField = useCallback((): void => {
     isRestoringFocusRef.current = true
     if (isCalendarActiveRef.current && activeOriginRef.current) {

--- a/frontend/lib/src/components/widgets/DateTimeInput/SingleDateTimeInput.tsx
+++ b/frontend/lib/src/components/widgets/DateTimeInput/SingleDateTimeInput.tsx
@@ -145,8 +145,9 @@ function SingleDateTimeInput({
   const triggerRef = useRef<HTMLDivElement | null>(null)
   const clearButtonRef = useRef<HTMLButtonElement | null>(null)
   const safeLocale = useMemo(() => getSafeLocale(locale), [locale])
-  // Guards against `handleFocus` reopening the popover it's in the middle
-  // of closing — see `restoreFocusToField` below.
+  // Suppresses `handleFocus` while focus is being moved programmatically, so a
+  // restore is not mistaken for the user arriving in the field — see
+  // `restoreFocusToField` and the form-clear effect below.
   const isRestoringFocusRef = useRef(false)
 
   const [isCalendarActive, setIsCalendarActive] = useState(false)
@@ -189,11 +190,20 @@ function SingleDateTimeInput({
     lastCommittedRef.current = undefined
   }
 
+  // Whether focus was inside the field when a form clear remounted it, so the
+  // effect below can put focus back. Captured here rather than in that effect
+  // because the remount has already happened by the time effects run, taking the
+  // focused segment with it.
+  const shouldRestoreFocusRef = useRef(false)
+
   const [prevResetKey, setPrevResetKey] = useState(formResetKey)
   if (prevResetKey !== formResetKey) {
     setPrevResetKey(formResetKey)
     setDisplayValue(value)
     setPendingTime(null)
+    shouldRestoreFocusRef.current = !!triggerRef.current?.contains(
+      document.activeElement
+    )
   }
 
   const displayValueRef = useRef(displayValue)
@@ -342,6 +352,26 @@ function SingleDateTimeInput({
     wasOpenRef.current = isOpen
   }, [isOpen, value, onFocusChange])
 
+  // Put focus back after a form clear: Enter-to-submit leaves focus in the field,
+  // and the remount (see the DateField's `key`) discards the focused segment.
+  // Flagged as a restore so `handleFocus` does not treat it as the user arriving.
+  //
+  // Cleared synchronously rather than after a frame, unlike `restoreFocusToField`:
+  // `.focus()` dispatches `focusin` synchronously, so `handleFocus` has already
+  // run by the next line, and a deferred clear could be skipped — a hidden tab
+  // throttles rAF indefinitely — leaving the flag stuck and the field inert.
+  //
+  // Matched on `data-type` rather than `role`, which React Aria replaces on iOS.
+  useEffect(() => {
+    if (!shouldRestoreFocusRef.current) return
+    shouldRestoreFocusRef.current = false
+    isRestoringFocusRef.current = true
+    triggerRef.current
+      ?.querySelector<HTMLElement>('[data-type]:not([data-type="literal"])')
+      ?.focus()
+    isRestoringFocusRef.current = false
+  }, [formResetKey])
+
   // Focus active calendar cell on active mode entry.
   useEffect(() => {
     if (!isCalendarActive || !isOpen) return
@@ -373,6 +403,9 @@ function SingleDateTimeInput({
 
   const { refs, floatingStyles } = useFloatingOverlay(overlayOptions)
 
+  // Matches segments on `role`, unlike the form-clear effect above: this path
+  // predates it and shares the iOS gap tracked for `getSegmentState`, where React
+  // Aria renders segments as textboxes and neither query finds them.
   const restoreFocusToField = useCallback((): void => {
     isRestoringFocusRef.current = true
     if (isCalendarActiveRef.current && activeOriginRef.current) {
@@ -735,6 +768,13 @@ function SingleDateTimeInput({
         <I18nProvider locale="en-US">
           <StyledDateField>
             <DateField<CalendarDateTime>
+              // Remount on form clear. React Aria keeps its own display state
+              // for segments the user has typed but not completed, and with
+              // `value` already null there is no prop change to re-seed it — so a
+              // time typed before `clear_on_submit` would stay on screen, and now
+              // that dismissal completes a value from what is visible, it would
+              // also commit.
+              key={formResetKey}
               aria-label={label}
               aria-describedby={error ? errorId : undefined}
               isInvalid={!!error}

--- a/frontend/lib/src/components/widgets/DateTimeInput/SingleDateTimeInput.tsx
+++ b/frontend/lib/src/components/widgets/DateTimeInput/SingleDateTimeInput.tsx
@@ -174,6 +174,10 @@ function SingleDateTimeInput({
   // the TimeField's segments from its controlled `value` the moment they
   // complete, so without holding the time here it would blank out as the user
   // finished typing it.
+  //
+  // Display buffer only: `resolveGivenTime` never reads it, because a *partial*
+  // popover time never reaches `onChange` and so never lands here. What commits
+  // is always re-read from the rendered segments.
   const [pendingTime, setPendingTime] = useState<Time | null>(null)
 
   const [prevValue, setPrevValue] = useState(value)
@@ -206,6 +210,11 @@ function SingleDateTimeInput({
   const resolveGivenTime = useCallback((): Time | null => {
     const buffered = displayValueRef.current
     if (buffered) return new Time(buffered.hour, buffered.minute)
+    // Dismissing clears `pendingTime` but leaves the inline segments alone, so
+    // a time typed there survives into a later date pick while a popover one
+    // does not. That asymmetry is deliberate: the popover unmounts with its
+    // value, whereas the inline draft is still on screen, and committing what is
+    // visible is the whole point of reading here.
     const popover = getTypedTimeFromDom(popoverRef.current)
     const inline = getTypedTimeFromDom(triggerRef.current)
     return lastTimeSourceRef.current === "popover"
@@ -585,6 +594,13 @@ function SingleDateTimeInput({
   }, [displayValue])
 
   // Popover TimeField value: the committed time, or one set before a date.
+  //
+  // Before a date exists the two time controls can show different times: a time
+  // typed inline is not mirrored here, and one typed here is not mirrored into
+  // the inline segments. Neither can be: the inline `DateField` cannot be given
+  // a time-only value, and mirroring the other way would mean reading the DOM
+  // during render. `resolveGivenTime` picks between them at commit, so the
+  // divergence is visual only.
   const popoverTimeValue = useMemo((): Time | null => {
     if (!displayValue) return pendingTime
     return new Time(displayValue.hour, displayValue.minute)
@@ -596,9 +612,9 @@ function SingleDateTimeInput({
     (time: TimeValue | null): void => {
       const current = displayValueRef.current
       if (!current) {
-        // Mirror clears too. With no date, `pendingTime` is the only record of
-        // this time and it feeds the field's own value, so ignoring null here
-        // would restore the time into the field the user just emptied.
+        // Drop pendingTime when the user empties the field; otherwise the
+        // controlled value puts the time back. With no date, that state is the
+        // field's only record of the time.
         setPendingTime(time ? new Time(time.hour, time.minute) : null)
         return
       }

--- a/frontend/lib/src/components/widgets/DateTimeInput/SingleDateTimeInput.tsx
+++ b/frontend/lib/src/components/widgets/DateTimeInput/SingleDateTimeInput.tsx
@@ -64,6 +64,7 @@ import {
   computeStepSnap,
   dateTimesEqual,
   getSegmentState,
+  getTypedTimeFromDom,
   parsePastedDateTime,
   validateDateTime,
 } from "./dateTimeInputUtils"
@@ -164,10 +165,22 @@ function SingleDateTimeInput({
     undefined
   )
 
+  // Which time control the user focused last. The inline segments and the
+  // popover TimeField can hold different times at once, so the later edit wins.
+  // Focus alone flips this, which is harmless: an untouched control reads as
+  // null and `resolveGivenTime` falls back to the other.
+  const lastTimeSourceRef = useRef<"inline" | "popover">("inline")
+  // A complete time set in the popover before any date exists. React Aria resets
+  // the TimeField's segments from its controlled `value` the moment they
+  // complete, so without holding the time here it would blank out as the user
+  // finished typing it.
+  const [pendingTime, setPendingTime] = useState<Time | null>(null)
+
   const [prevValue, setPrevValue] = useState(value)
   if (prevValue !== value) {
     setPrevValue(value)
     setDisplayValue(value)
+    setPendingTime(null)
     lastCommittedRef.current = undefined
   }
 
@@ -175,10 +188,30 @@ function SingleDateTimeInput({
   if (prevResetKey !== formResetKey) {
     setPrevResetKey(formResetKey)
     setDisplayValue(value)
+    setPendingTime(null)
   }
 
   const displayValueRef = useRef(displayValue)
   displayValueRef.current = displayValue
+
+  /** The time to merge into a date the user selects: the buffered display
+   * value's if the field already holds one, otherwise whichever of the two time
+   * controls they focused most recently, falling back to the other if that one
+   * is empty. Null when they have given no time at all, in which case the caller
+   * defaults to midnight.
+   *
+   * Both controls are read from their rendered segments, because neither reports
+   * a partial time through `onChange`. Reading them here rather than tracking
+   * them in state means there is no buffered copy to go stale. */
+  const resolveGivenTime = useCallback((): Time | null => {
+    const buffered = displayValueRef.current
+    if (buffered) return new Time(buffered.hour, buffered.minute)
+    const popover = getTypedTimeFromDom(popoverRef.current)
+    const inline = getTypedTimeFromDom(triggerRef.current)
+    return lastTimeSourceRef.current === "popover"
+      ? (popover ?? inline)
+      : (inline ?? popover)
+  }, [])
 
   const onCloseRef = useRef(onClose)
   onCloseRef.current = onClose
@@ -197,6 +230,12 @@ function SingleDateTimeInput({
    * formCommit (sync WM write) to prevent the form-submit race. */
   const commitOrRevert = useCallback((): boolean => {
     if (!triggerRef.current) return false
+    // A time given in the popover lives only as long as that popover session:
+    // every path here either commits it into the value or discards it. Without
+    // this, a dismissed time would be restored into the remounted TimeField and
+    // then merged into a date picked in a later session, with nothing on screen
+    // explaining where it came from.
+    setPendingTime(null)
     const { isPartiallyTyped, isFullyCleared } = getSegmentState(
       triggerRef.current
     )
@@ -334,18 +373,21 @@ function SingleDateTimeInput({
       setDisplayValue(date)
       onValidate(date)
       if (date) {
+        // The field now carries its own time, superseding any pending one.
+        setPendingTime(null)
         onFocusChange(new CalendarDate(date.year, date.month, date.day))
       }
     },
     [onFocusChange, onValidate]
   )
 
-  // Calendar date selection: merge with existing time and enter active mode
-  // so Tab cycles within the popover (reaching the TimeField) instead of
-  // dismissing.
+  // Calendar date selection: merge the date with whatever time the user has
+  // already given — the buffered display value's, else one given before any date
+  // existed — and enter active mode so Tab cycles within the popover (reaching
+  // the TimeField) instead of dismissing.
   const handleCalendarChange = useCallback(
     (date: CalendarDate): void => {
-      const currentTime = displayValueRef.current
+      const currentTime = resolveGivenTime()
       const merged = new CalendarDateTime(
         date.year,
         date.month,
@@ -354,17 +396,23 @@ function SingleDateTimeInput({
         currentTime?.minute ?? 0
       )
       setDisplayValue(merged)
+      setPendingTime(null)
       onValidate(merged)
       setIsCalendarActive(true)
       activeOriginRef.current = null
     },
-    [onValidate]
+    [onValidate, resolveGivenTime]
   )
 
   const handleFocus = useCallback((): void => {
+    lastTimeSourceRef.current = "inline"
     if (isRestoringFocusRef.current) return
     if (!disabled) setIsOpen(true)
   }, [disabled])
+
+  const handlePopoverTimeFocus = useCallback((): void => {
+    lastTimeSourceRef.current = "popover"
+  }, [])
 
   const handleClickCapture = useCallback(
     (e: MouseEvent<HTMLDivElement>): void => {
@@ -377,6 +425,7 @@ function SingleDateTimeInput({
 
   const handleClear = useCallback((): void => {
     setDisplayValue(null)
+    setPendingTime(null)
     lastCommittedRef.current = null
     onChange(null)
     formCommitRef.current?.(null)
@@ -410,6 +459,7 @@ function SingleDateTimeInput({
       current: CalendarDateTime | null
     ): void => {
       if (e.key !== "ArrowUp" && e.key !== "ArrowDown") return
+      // No date yet: nothing to snap against, so React Aria's default ±1 applies.
       if (!current) return
       const target = e.target as HTMLElement
       const segmentType = target.getAttribute("data-type")
@@ -534,18 +584,26 @@ function SingleDateTimeInput({
     )
   }, [displayValue])
 
-  // Popover TimeField value: extract time from displayValue.
+  // Popover TimeField value: the committed time, or one set before a date.
   const popoverTimeValue = useMemo((): Time | null => {
-    if (!displayValue) return null
+    if (!displayValue) return pendingTime
     return new Time(displayValue.hour, displayValue.minute)
-  }, [displayValue])
+  }, [displayValue, pendingTime])
 
-  // Popover TimeField change: merge new time with existing date.
+  // Popover TimeField change: merge new time with existing date, or hold it as
+  // pending until a date selection can complete the value.
   const handlePopoverTimeChange = useCallback(
     (time: TimeValue | null): void => {
-      if (!time) return
       const current = displayValueRef.current
-      if (!current) return
+      if (!current) {
+        // Mirror clears too. With no date, `pendingTime` is the only record of
+        // this time and it feeds the field's own value, so ignoring null here
+        // would restore the time into the field the user just emptied.
+        setPendingTime(time ? new Time(time.hour, time.minute) : null)
+        return
+      }
+      // A CalendarDateTime always has a time, so there is nothing to clear.
+      if (!time) return
       const merged = new CalendarDateTime(
         current.year,
         current.month,
@@ -703,6 +761,7 @@ function SingleDateTimeInput({
               <StyledPopoverTimeRow
                 data-testid="stDateTimeInputPopoverTime"
                 onKeyDownCapture={handlePopoverTimeKeyDown}
+                onFocus={handlePopoverTimeFocus}
               >
                 <StyledPopoverTimeLabel id={`${id}-time-label`}>
                   Time
@@ -717,7 +776,7 @@ function SingleDateTimeInput({
                     granularity="minute"
                     hourCycle={24}
                     shouldForceLeadingZeros
-                    isDisabled={!displayValue}
+                    isDisabled={disabled}
                   >
                     <StyledPopoverTimeFieldInput>
                       {segment => (

--- a/frontend/lib/src/components/widgets/DateTimeInput/SingleDateTimeInput.tsx
+++ b/frontend/lib/src/components/widgets/DateTimeInput/SingleDateTimeInput.tsx
@@ -89,6 +89,10 @@ import {
   StyledVisuallyHidden,
 } from "./styled-components"
 
+/** Editable segments, matched on `data-type` rather than `role` so IOS ROLES does
+ * not hide them. Literals are the separators between segments. */
+const SEGMENT_SELECTOR = '[data-type]:not([data-type="literal"])'
+
 interface SingleDateTimeInputProps {
   value: CalendarDateTime | null
   onChange: (value: CalendarDateTime | null) => void
@@ -346,9 +350,7 @@ function SingleDateTimeInput({
       // than waiting for the value round-trip. An outside click commits on
       // pointerdown and the browser then fires blur, so a second pass can run
       // before that round-trip lands; without this it would re-read the DOM with
-      // the popover already unmounted and could commit a different draft. Not
-      // test-pinned — jsdom flushes renders between events, so it cannot order
-      // the two.
+      // the popover already unmounted and could commit a different draft.
       displayValueRef.current = pending
       onChangeRef.current(pending)
       formCommitRef.current?.(pending)
@@ -385,9 +387,7 @@ function SingleDateTimeInput({
     if (!shouldRestoreFocusRef.current) return
     shouldRestoreFocusRef.current = false
     isRestoringFocusRef.current = true
-    triggerRef.current
-      ?.querySelector<HTMLElement>('[data-type]:not([data-type="literal"])')
-      ?.focus()
+    triggerRef.current?.querySelector<HTMLElement>(SEGMENT_SELECTOR)?.focus()
     isRestoringFocusRef.current = false
   }, [formResetKey])
 
@@ -422,17 +422,13 @@ function SingleDateTimeInput({
 
   const { refs, floatingStyles } = useFloatingOverlay(overlayOptions)
 
-  // Matches segments on `role`, unlike the form-clear effect above, and so shares
-  // the iOS gap tracked for `getSegmentState`: React Aria renders segments as
-  // textboxes there and neither query finds them.
   const restoreFocusToField = useCallback((): void => {
     isRestoringFocusRef.current = true
     if (isCalendarActiveRef.current && activeOriginRef.current) {
       activeOriginRef.current.focus()
     } else {
-      const segments = triggerRef.current?.querySelectorAll<HTMLElement>(
-        '[role="spinbutton"]'
-      )
+      const segments =
+        triggerRef.current?.querySelectorAll<HTMLElement>(SEGMENT_SELECTOR)
       const lastSegment = segments?.[segments.length - 1]
       if (lastSegment) {
         lastSegment.focus()

--- a/frontend/lib/src/components/widgets/DateTimeInput/SingleDateTimeInput.tsx
+++ b/frontend/lib/src/components/widgets/DateTimeInput/SingleDateTimeInput.tsx
@@ -64,6 +64,7 @@ import {
   computeStepSnap,
   dateTimesEqual,
   getSegmentState,
+  getTypedDateFromDom,
   getTypedTimeFromDom,
   parsePastedDateTime,
   validateDateTime,
@@ -233,29 +234,73 @@ function SingleDateTimeInput({
 
   const [isOpen, setIsOpen] = useState(false)
 
+  /** The datetime the two controls describe between them when the field itself
+   * holds no value: a complete date read from the inline segments, plus a time
+   * from whichever control the user last touched. Null unless both halves are
+   * present — a date alone gives nothing to commit, and defaulting its time
+   * would be inventing one. */
+  const completeFromVisibleParts = useCallback((): CalendarDateTime | null => {
+    const date = getTypedDateFromDom(triggerRef.current)
+    const time = resolveGivenTime()
+    if (!date || !time) return null
+    return new CalendarDateTime(
+      date.year,
+      date.month,
+      date.day,
+      time.hour,
+      time.minute
+    )
+  }, [resolveGivenTime])
+
   /** Validate and commit the pending value, or revert to the last committed
    * value. Returns true if the field holds a valid (committed or unchanged)
    * value, false if it was reverted. Calls both onChange (React state) and
    * formCommit (sync WM write) to prevent the form-submit race. */
   const commitOrRevert = useCallback((): boolean => {
     if (!triggerRef.current) return false
+    const { isPartiallyTyped, isFullyCleared } = getSegmentState(
+      triggerRef.current
+    )
+
+    // A date typed inline with its time given only in the popover reads as
+    // partially typed, because the field withholds onChange while the hour and
+    // minute are placeholders. Both halves are on screen, so complete the value
+    // from them rather than discarding a date and time the user can see.
+    //
+    // The gate also requires the field to hold no value of its own. Clearing one
+    // segment of an existing value reads as partially typed too — React Aria
+    // reports nothing unless every segment is cleared — and that is an edit in
+    // progress, not two halves to combine, so it still reverts.
+    //
+    // Read before `setPendingTime(null)` below, so the merge never depends on
+    // React batching that clear: flushing it would blank the popover's segments.
+    const completedFromParts =
+      isPartiallyTyped && !displayValueRef.current
+        ? completeFromVisibleParts()
+        : null
+
     // A time given in the popover lives only as long as that popover session:
     // every path here either commits it into the value or discards it. Without
     // this, a dismissed time would be restored into the remounted TimeField and
     // then merged into a date picked in a later session, with nothing on screen
     // explaining where it came from.
     setPendingTime(null)
-    const { isPartiallyTyped, isFullyCleared } = getSegmentState(
-      triggerRef.current
-    )
 
-    if (isPartiallyTyped || (isFullyCleared && !clearable)) {
+    // Safe to reach twice: an outside click commits on pointerdown and the
+    // browser then fires blur, by which point the popover is unmounted and its
+    // half unreadable. This branch touches only local display and error state, so
+    // it cannot undo the commit that just happened.
+    if (
+      (isPartiallyTyped && !completedFromParts) ||
+      (isFullyCleared && !clearable)
+    ) {
       setDisplayValue(value)
       onCloseRef.current(true)
       return false
     }
 
-    const pending = isFullyCleared ? null : displayValueRef.current
+    const pending =
+      completedFromParts ?? (isFullyCleared ? null : displayValueRef.current)
 
     if (validateDateTime(pending, minDateTime, maxDateTime)) {
       setDisplayValue(value)
@@ -276,7 +321,7 @@ function SingleDateTimeInput({
     onChangeRef.current(pending)
     formCommitRef.current?.(pending)
     return true
-  }, [value, clearable, minDateTime, maxDateTime])
+  }, [value, clearable, minDateTime, maxDateTime, completeFromVisibleParts])
 
   // Reset state when the popover opens: clear the commit-dedup guard and
   // sync the calendar's focused month to the committed value so a prior

--- a/frontend/lib/src/components/widgets/DateTimeInput/SingleDateTimeInput.tsx
+++ b/frontend/lib/src/components/widgets/DateTimeInput/SingleDateTimeInput.tsx
@@ -89,8 +89,8 @@ import {
   StyledVisuallyHidden,
 } from "./styled-components"
 
-/** Editable segments, matched on `data-type` rather than `role` so IOS ROLES does
- * not hide them. Literals are the separators between segments. */
+/** Editable segments. Matched on `data-type` rather than `role`, which React Aria
+ * replaces with `textbox` on iOS. Literals are the separators between segments. */
 const SEGMENT_SELECTOR = '[data-type]:not([data-type="literal"])'
 
 interface SingleDateTimeInputProps {
@@ -226,13 +226,12 @@ function SingleDateTimeInput({
   const displayValueRef = useRef(displayValue)
   displayValueRef.current = displayValue
 
-  /** The time to merge into a date the user selects: the buffered display
-   * value's if the field already holds one, otherwise whichever of the two time
-   * controls they focused most recently, falling back to the other if that one
-   * is empty. Null when they have given no time at all — what that means is the
-   * caller's choice: `handleCalendarChange` substitutes midnight, because picking
-   * a day is an affirmative selection, while `completeFromVisibleParts` declines
-   * to complete at all, because dismissing a field is not.
+  /** The time to merge into a date the user selects: the field's own if it has
+   * one, otherwise whichever time control they focused most recently, falling back
+   * to the other if that one is empty. Null when no time was given at all, and
+   * callers decide what that means — `handleCalendarChange` uses midnight because
+   * picking a day is an affirmative selection, `completeFromVisibleParts` declines
+   * to complete because dismissing a field is not.
    *
    * Both controls are read from their rendered segments, because neither reports
    * a partial time through `onChange`. Reading them here rather than tracking

--- a/frontend/lib/src/components/widgets/DateTimeInput/dateTimeInputUtils.test.ts
+++ b/frontend/lib/src/components/widgets/DateTimeInput/dateTimeInputUtils.test.ts
@@ -442,9 +442,8 @@ describe("getTypedTimeFromDom", () => {
   })
 
   it("prefers the placeholder marker over a value on the same segment", () => {
-    // Defensive: for hour and minute React Aria omits `aria-valuenow` on a
-    // placeholder, so it never emits this shape — but other segment types
-    // (`era`) do carry a value while placeholdered.
+    // Defensive: React Aria omits `aria-valuenow` on an hour or minute
+    // placeholder, so it never emits this shape.
     const el = document.createElement("div")
     el.innerHTML =
       '<div role="spinbutton" data-type="hour" data-placeholder="true" aria-valuenow="7">07</div>'

--- a/frontend/lib/src/components/widgets/DateTimeInput/dateTimeInputUtils.test.ts
+++ b/frontend/lib/src/components/widgets/DateTimeInput/dateTimeInputUtils.test.ts
@@ -28,6 +28,7 @@ import {
   createDateTimeErrorMessage,
   dateTimesEqual,
   formatCalendarDateTime,
+  getSegmentState,
   getTypedDateFromDom,
   getTypedTimeFromDom,
   isoToCalendarDateTime,
@@ -405,6 +406,51 @@ const renderSegments = (
     .join("")
   return el
 }
+
+describe("getSegmentState", () => {
+  it("reports a fully cleared field", () => {
+    expect(
+      getSegmentState(renderSegments({ year: null, month: null, day: null }))
+    ).toMatchObject({ isPartiallyTyped: false, isFullyCleared: true })
+  })
+
+  it("reports a partially typed field", () => {
+    expect(
+      getSegmentState(renderSegments({ year: 2025, month: null, day: null }))
+    ).toMatchObject({ isPartiallyTyped: true, isFullyCleared: false })
+  })
+
+  it("reports a fully typed field as neither", () => {
+    expect(
+      getSegmentState(renderSegments({ year: 2025, month: 11, day: 19 }))
+    ).toMatchObject({ isPartiallyTyped: false, isFullyCleared: false })
+  })
+
+  it("counts segments on iOS, where they render as textboxes", () => {
+    // Matching on `role="spinbutton"` found nothing here, so `totalSegments` was 0
+    // and `isFullyCleared` could never be true — clearing every segment could not
+    // commit null on iOS.
+    const el = document.createElement("div")
+    el.innerHTML =
+      '<div role="textbox" data-type="hour" data-placeholder="true">––</div>' +
+      '<div role="textbox" data-type="literal">:</div>' +
+      '<div role="textbox" data-type="minute" data-placeholder="true">––</div>'
+    expect(getSegmentState(el)).toMatchObject({
+      totalSegments: 2,
+      placeholderCount: 2,
+      isFullyCleared: true,
+    })
+  })
+
+  it("does not count the literal separators between segments", () => {
+    const el = document.createElement("div")
+    el.innerHTML =
+      '<div role="spinbutton" data-type="hour" aria-valuenow="9">09</div>' +
+      '<div data-type="literal">:</div>' +
+      '<div role="spinbutton" data-type="minute" aria-valuenow="45">45</div>'
+    expect(getSegmentState(el)).toMatchObject({ totalSegments: 2 })
+  })
+})
 
 describe("getTypedTimeFromDom", () => {
   it("returns null for a missing container", () => {

--- a/frontend/lib/src/components/widgets/DateTimeInput/dateTimeInputUtils.test.ts
+++ b/frontend/lib/src/components/widgets/DateTimeInput/dateTimeInputUtils.test.ts
@@ -387,24 +387,26 @@ describe("computeStepSnap", () => {
   })
 })
 
-describe("getTypedTimeFromDom", () => {
-  /** Builds a container of rendered segments in the shape React Aria produces:
-   * a numeric `aria-valuenow` once the user has typed, and `data-placeholder`
-   * with no `aria-valuenow` until then. */
-  const renderTimeSegments = (
-    segments: Partial<Record<"year" | "hour" | "minute", number | null>>
-  ): HTMLElement => {
-    const el = document.createElement("div")
-    el.innerHTML = Object.entries(segments)
-      .map(([type, value]) =>
-        value === null || value === undefined
-          ? `<div role="spinbutton" data-type="${type}" data-placeholder="true">––</div>`
-          : `<div role="spinbutton" data-type="${type}" aria-valuenow="${value}">${value}</div>`
-      )
-      .join("")
-    return el
-  }
+/** Builds segments in the shape `DateFieldState.segments` exposes. React Aria
+ * leaves `value` undefined and `isPlaceholder` true until the user types into the
+ * segment, and drops `aria-valuenow` entirely on iOS. */
+const renderSegments = (
+  segments: Partial<
+    Record<"year" | "month" | "day" | "hour" | "minute", number | null>
+  >
+): HTMLElement => {
+  const el = document.createElement("div")
+  el.innerHTML = Object.entries(segments)
+    .map(([type, value]) =>
+      value === null || value === undefined
+        ? `<div role="spinbutton" data-type="${type}" data-placeholder="true">––</div>`
+        : `<div role="spinbutton" data-type="${type}" aria-valuenow="${value}">${value}</div>`
+    )
+    .join("")
+  return el
+}
 
+describe("getTypedTimeFromDom", () => {
   it("returns null for a missing container", () => {
     expect(getTypedTimeFromDom(null)).toBeNull()
   })
@@ -412,38 +414,36 @@ describe("getTypedTimeFromDom", () => {
   it("returns null when neither hour nor minute is typed", () => {
     expect(
       getTypedTimeFromDom(
-        renderTimeSegments({ year: null, hour: null, minute: null })
+        renderSegments({ year: null, hour: null, minute: null })
       )
     ).toBeNull()
   })
 
   it("reads a time typed while the date segments are still placeholders", () => {
     expect(
-      getTypedTimeFromDom(
-        renderTimeSegments({ year: null, hour: 3, minute: 24 })
-      )
+      getTypedTimeFromDom(renderSegments({ year: null, hour: 3, minute: 24 }))
     ).toMatchObject({ hour: 3, minute: 24 })
   })
 
   it("treats an untyped half of the pair as zero", () => {
     expect(
-      getTypedTimeFromDom(renderTimeSegments({ hour: 3, minute: null }))
+      getTypedTimeFromDom(renderSegments({ hour: 3, minute: null }))
     ).toMatchObject({ hour: 3, minute: 0 })
     expect(
-      getTypedTimeFromDom(renderTimeSegments({ hour: null, minute: 24 }))
+      getTypedTimeFromDom(renderSegments({ hour: null, minute: 24 }))
     ).toMatchObject({ hour: 0, minute: 24 })
   })
 
   it("reads hour 0 as typed rather than as absent", () => {
     expect(
-      getTypedTimeFromDom(renderTimeSegments({ hour: 0, minute: 30 }))
+      getTypedTimeFromDom(renderSegments({ hour: 0, minute: 30 }))
     ).toMatchObject({ hour: 0, minute: 30 })
   })
 
   it("returns null when only the date segments are typed", () => {
     expect(
       getTypedTimeFromDom(
-        renderTimeSegments({ year: 2025, hour: null, minute: null })
+        renderSegments({ year: 2025, hour: null, minute: null })
       )
     ).toBeNull()
   })
@@ -474,20 +474,6 @@ describe("getTypedTimeFromDom", () => {
 })
 
 describe("getTypedDateFromDom", () => {
-  const renderSegments = (
-    segments: Partial<Record<"year" | "month" | "day", number | null>>
-  ): HTMLElement => {
-    const el = document.createElement("div")
-    el.innerHTML = Object.entries(segments)
-      .map(([type, value]) =>
-        value === null || value === undefined
-          ? `<div role="spinbutton" data-type="${type}" data-placeholder="true">––</div>`
-          : `<div role="spinbutton" data-type="${type}" aria-valuenow="${value}">${value}</div>`
-      )
-      .join("")
-    return el
-  }
-
   it("returns null for a missing container", () => {
     expect(getTypedDateFromDom(null)).toBeNull()
   })

--- a/frontend/lib/src/components/widgets/DateTimeInput/dateTimeInputUtils.test.ts
+++ b/frontend/lib/src/components/widgets/DateTimeInput/dateTimeInputUtils.test.ts
@@ -28,6 +28,7 @@ import {
   createDateTimeErrorMessage,
   dateTimesEqual,
   formatCalendarDateTime,
+  getTypedDateFromDom,
   getTypedTimeFromDom,
   isoToCalendarDateTime,
   parsePastedDateTime,
@@ -463,5 +464,64 @@ describe("getTypedTimeFromDom", () => {
     const el = document.createElement("div")
     el.innerHTML = '<div role="textbox" data-type="hour">––</div>'
     expect(getTypedTimeFromDom(el)).toBeNull()
+  })
+})
+
+describe("getTypedDateFromDom", () => {
+  const renderSegments = (
+    segments: Partial<Record<"year" | "month" | "day", number | null>>
+  ): HTMLElement => {
+    const el = document.createElement("div")
+    el.innerHTML = Object.entries(segments)
+      .map(([type, value]) =>
+        value === null || value === undefined
+          ? `<div role="spinbutton" data-type="${type}" data-placeholder="true">––</div>`
+          : `<div role="spinbutton" data-type="${type}" aria-valuenow="${value}">${value}</div>`
+      )
+      .join("")
+    return el
+  }
+
+  it("returns null for a missing container", () => {
+    expect(getTypedDateFromDom(null)).toBeNull()
+  })
+
+  it("reads a fully typed date", () => {
+    expect(
+      getTypedDateFromDom(renderSegments({ year: 2025, month: 11, day: 19 }))
+    ).toMatchObject({ year: 2025, month: 11, day: 19 })
+  })
+
+  it("returns null unless every part is filled", () => {
+    expect(
+      getTypedDateFromDom(renderSegments({ year: 2025, month: 11, day: null }))
+    ).toBeNull()
+    expect(
+      getTypedDateFromDom(renderSegments({ year: null, month: 11, day: 19 }))
+    ).toBeNull()
+  })
+
+  it("rejects a day that does not exist in its month", () => {
+    // The day segment's maximum is the longest month, not the current one, so
+    // this combination is typeable and must be rejected rather than clamped to
+    // Feb 28.
+    expect(
+      getTypedDateFromDom(renderSegments({ year: 2025, month: 2, day: 30 }))
+    ).toBeNull()
+  })
+
+  it("accepts a leap day in a leap year and rejects it otherwise", () => {
+    expect(
+      getTypedDateFromDom(renderSegments({ year: 2024, month: 2, day: 29 }))
+    ).toMatchObject({ year: 2024, month: 2, day: 29 })
+    expect(
+      getTypedDateFromDom(renderSegments({ year: 2025, month: 2, day: 29 }))
+    ).toBeNull()
+  })
+
+  it("rejects a zero part", () => {
+    expect(
+      getTypedDateFromDom(renderSegments({ year: 2025, month: 0, day: 19 }))
+    ).toBeNull()
   })
 })

--- a/frontend/lib/src/components/widgets/DateTimeInput/dateTimeInputUtils.test.ts
+++ b/frontend/lib/src/components/widgets/DateTimeInput/dateTimeInputUtils.test.ts
@@ -28,6 +28,7 @@ import {
   createDateTimeErrorMessage,
   dateTimesEqual,
   formatCalendarDateTime,
+  getTypedTimeFromDom,
   isoToCalendarDateTime,
   parsePastedDateTime,
   snapTimeStep,
@@ -382,5 +383,86 @@ describe("computeStepSnap", () => {
       hour: 10,
       minute: 15,
     })
+  })
+})
+
+describe("getTypedTimeFromDom", () => {
+  /** Builds a container of rendered segments in the shape React Aria produces:
+   * a numeric `aria-valuenow` once the user has typed, and `data-placeholder`
+   * with no `aria-valuenow` until then. */
+  const container = (
+    segments: Partial<Record<"year" | "hour" | "minute", number | null>>
+  ): HTMLElement => {
+    const el = document.createElement("div")
+    el.innerHTML = Object.entries(segments)
+      .map(([type, value]) =>
+        value === null || value === undefined
+          ? `<div role="spinbutton" data-type="${type}" data-placeholder="true">––</div>`
+          : `<div role="spinbutton" data-type="${type}" aria-valuenow="${value}">${value}</div>`
+      )
+      .join("")
+    return el
+  }
+
+  it("returns null for a missing container", () => {
+    expect(getTypedTimeFromDom(null)).toBeNull()
+  })
+
+  it("returns null when neither hour nor minute is typed", () => {
+    expect(
+      getTypedTimeFromDom(container({ year: null, hour: null, minute: null }))
+    ).toBeNull()
+  })
+
+  it("reads a time typed while the date segments are still placeholders", () => {
+    expect(
+      getTypedTimeFromDom(container({ year: null, hour: 3, minute: 24 }))
+    ).toMatchObject({ hour: 3, minute: 24 })
+  })
+
+  it("treats an untyped half of the pair as zero", () => {
+    expect(
+      getTypedTimeFromDom(container({ hour: 3, minute: null }))
+    ).toMatchObject({ hour: 3, minute: 0 })
+    expect(
+      getTypedTimeFromDom(container({ hour: null, minute: 24 }))
+    ).toMatchObject({ hour: 0, minute: 24 })
+  })
+
+  it("reads hour 0 as typed rather than as absent", () => {
+    expect(
+      getTypedTimeFromDom(container({ hour: 0, minute: 30 }))
+    ).toMatchObject({ hour: 0, minute: 30 })
+  })
+
+  it("returns null when only the date segments are typed", () => {
+    expect(
+      getTypedTimeFromDom(container({ year: 2025, hour: null, minute: null }))
+    ).toBeNull()
+  })
+
+  it("prefers the placeholder marker over a value on the same segment", () => {
+    // Defensive: for hour and minute React Aria omits `aria-valuenow` on a
+    // placeholder, so it never emits this shape — but other segment types
+    // (`era`) do carry a value while placeholdered.
+    const el = document.createElement("div")
+    el.innerHTML =
+      '<div role="spinbutton" data-type="hour" data-placeholder="true" aria-valuenow="7">07</div>'
+    expect(getTypedTimeFromDom(el)).toBeNull()
+  })
+
+  it("falls back to the rendered text where aria-valuenow is absent", () => {
+    // React Aria renders segments as textboxes with no aria-valuenow on iOS.
+    const el = document.createElement("div")
+    el.innerHTML =
+      '<div role="textbox" data-type="hour">09</div>' +
+      '<div role="textbox" data-type="minute">45</div>'
+    expect(getTypedTimeFromDom(el)).toMatchObject({ hour: 9, minute: 45 })
+  })
+
+  it("ignores a non-numeric segment value", () => {
+    const el = document.createElement("div")
+    el.innerHTML = '<div role="textbox" data-type="hour">––</div>'
+    expect(getTypedTimeFromDom(el)).toBeNull()
   })
 })

--- a/frontend/lib/src/components/widgets/DateTimeInput/dateTimeInputUtils.test.ts
+++ b/frontend/lib/src/components/widgets/DateTimeInput/dateTimeInputUtils.test.ts
@@ -391,7 +391,7 @@ describe("getTypedTimeFromDom", () => {
   /** Builds a container of rendered segments in the shape React Aria produces:
    * a numeric `aria-valuenow` once the user has typed, and `data-placeholder`
    * with no `aria-valuenow` until then. */
-  const container = (
+  const renderTimeSegments = (
     segments: Partial<Record<"year" | "hour" | "minute", number | null>>
   ): HTMLElement => {
     const el = document.createElement("div")
@@ -411,34 +411,40 @@ describe("getTypedTimeFromDom", () => {
 
   it("returns null when neither hour nor minute is typed", () => {
     expect(
-      getTypedTimeFromDom(container({ year: null, hour: null, minute: null }))
+      getTypedTimeFromDom(
+        renderTimeSegments({ year: null, hour: null, minute: null })
+      )
     ).toBeNull()
   })
 
   it("reads a time typed while the date segments are still placeholders", () => {
     expect(
-      getTypedTimeFromDom(container({ year: null, hour: 3, minute: 24 }))
+      getTypedTimeFromDom(
+        renderTimeSegments({ year: null, hour: 3, minute: 24 })
+      )
     ).toMatchObject({ hour: 3, minute: 24 })
   })
 
   it("treats an untyped half of the pair as zero", () => {
     expect(
-      getTypedTimeFromDom(container({ hour: 3, minute: null }))
+      getTypedTimeFromDom(renderTimeSegments({ hour: 3, minute: null }))
     ).toMatchObject({ hour: 3, minute: 0 })
     expect(
-      getTypedTimeFromDom(container({ hour: null, minute: 24 }))
+      getTypedTimeFromDom(renderTimeSegments({ hour: null, minute: 24 }))
     ).toMatchObject({ hour: 0, minute: 24 })
   })
 
   it("reads hour 0 as typed rather than as absent", () => {
     expect(
-      getTypedTimeFromDom(container({ hour: 0, minute: 30 }))
+      getTypedTimeFromDom(renderTimeSegments({ hour: 0, minute: 30 }))
     ).toMatchObject({ hour: 0, minute: 30 })
   })
 
   it("returns null when only the date segments are typed", () => {
     expect(
-      getTypedTimeFromDom(container({ year: 2025, hour: null, minute: null }))
+      getTypedTimeFromDom(
+        renderTimeSegments({ year: 2025, hour: null, minute: null })
+      )
     ).toBeNull()
   })
 

--- a/frontend/lib/src/components/widgets/DateTimeInput/dateTimeInputUtils.ts
+++ b/frontend/lib/src/components/widgets/DateTimeInput/dateTimeInputUtils.ts
@@ -236,18 +236,19 @@ export function getSegmentState(container: HTMLElement): SegmentState {
 }
 
 /**
- * The time held by a container's rendered `hour` and `minute` segments, ignoring
- * placeholders. Returns null when neither is filled.
+ * Read hour and minute from a container's rendered segments, for the window
+ * before the field has emitted an `onChange`. Returns null when neither is
+ * filled.
  *
  * `DateField` and `TimeField` both withhold `onChange` until every one of their
  * segments is filled, so a time entered while its partner segments are still
  * placeholders reaches no handler — the rendered segments are its only record.
  * An unfilled half of the pair counts as 0, so a lone hour survives.
  *
- * Reads `aria-valuenow`, which React Aria sets from the segment's numeric value
- * and omits for an hour or minute placeholder. The `data-placeholder` filter
- * covers segment types where that does not hold — an `era` placeholder does
- * carry a value.
+ * The `data-placeholder` filter is belt-and-braces on `aria-valuenow`, which
+ * React Aria already omits for an hour or minute placeholder — but it also
+ * guards the `textContent` fallback below, where a placeholder's dashes would
+ * otherwise be parsed.
  *
  * Assumes a 24-hour cycle and no seconds segment: with `hourCycle={12}` the hour
  * reports 1–12 and needs the `dayPeriod` segment to disambiguate, and a `second`

--- a/frontend/lib/src/components/widgets/DateTimeInput/dateTimeInputUtils.ts
+++ b/frontend/lib/src/components/widgets/DateTimeInput/dateTimeInputUtils.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { CalendarDateTime, Time } from "@internationalized/date"
+import { CalendarDate, CalendarDateTime, Time } from "@internationalized/date"
 
 import { DateTimeInput as DateTimeInputProto } from "@streamlit/protobuf"
 
@@ -218,8 +218,8 @@ export interface SegmentState {
 /** Query spinbutton segments in a container to determine their placeholder state.
  *
  * Matches on `role`, which React Aria replaces with `textbox` on iOS, so this
- * finds no segments there. `getTypedTimeFromDom` below matches `data-type`
- * instead, which is emitted on every platform. */
+ * finds no segments there. `readSegment` below matches `data-type` instead,
+ * which is emitted on every platform. */
 export function getSegmentState(container: HTMLElement): SegmentState {
   const segments = container.querySelectorAll('[role="spinbutton"]')
   const placeholders = container.querySelectorAll(
@@ -236,6 +236,48 @@ export function getSegmentState(container: HTMLElement): SegmentState {
 }
 
 /**
+ * Read one segment's numeric value from a container, or null when it is absent,
+ * a placeholder, or outside `max`.
+ *
+ * Matches on `data-type` rather than `role`, because React Aria renders segments
+ * as textboxes, not spinbuttons, on iOS — and falls back to the rendered text,
+ * because it drops `aria-valuenow` there too. Safe to parse: both fields are
+ * pinned to en-US so the digits are ASCII, and `shouldForceLeadingZeros` only
+ * ever prefixes a zero.
+ *
+ * The `data-placeholder` filter also guards the text fallback, where a
+ * placeholder's dashes would otherwise parse.
+ *
+ * Range-guarded so a value the caller cannot represent degrades to "not given"
+ * rather than reaching a `Time` or `CalendarDate` constructor: `Time` stores
+ * whatever it is handed, and `CalendarDate` silently clamps.
+ */
+const SEGMENT_MAX = {
+  hour: 23,
+  minute: 59,
+  year: 9999,
+  month: 12,
+  day: 31,
+} as const
+
+function readSegment(
+  container: HTMLElement | null,
+  type: keyof typeof SEGMENT_MAX
+): number | null {
+  const max = SEGMENT_MAX[type]
+  const segment = container?.querySelector(
+    `[data-type="${type}"]:not([data-placeholder="true"])`
+  )
+  if (!segment) return null
+  const raw = segment.getAttribute("aria-valuenow") ?? segment.textContent
+  if (!raw) return null
+  const parsed = Number(raw)
+  return Number.isInteger(parsed) && parsed >= 0 && parsed <= max
+    ? parsed
+    : null
+}
+
+/**
  * Read hour and minute from a container's rendered segments, for the window
  * before the field has emitted an `onChange`. Returns null when neither is
  * filled.
@@ -245,11 +287,6 @@ export function getSegmentState(container: HTMLElement): SegmentState {
  * placeholders reaches no handler — the rendered segments are its only record.
  * An unfilled half of the pair counts as 0, so a lone hour survives.
  *
- * The `data-placeholder` filter is belt-and-braces on `aria-valuenow`, which
- * React Aria already omits for an hour or minute placeholder — but it also
- * guards the `textContent` fallback below, where a placeholder's dashes would
- * otherwise be parsed.
- *
  * Assumes a 24-hour cycle and no seconds segment: with `hourCycle={12}` the hour
  * reports 1–12 and needs the `dayPeriod` segment to disambiguate, and a `second`
  * segment would be ignored.
@@ -257,31 +294,32 @@ export function getSegmentState(container: HTMLElement): SegmentState {
 export function getTypedTimeFromDom(
   container: HTMLElement | null
 ): Time | null {
-  const readSegment = (type: "hour" | "minute"): number | null => {
-    // Match on `data-type` rather than `role`: React Aria renders segments as
-    // textboxes, not spinbuttons, on iOS.
-    const segment = container?.querySelector(
-      `[data-type="${type}"]:not([data-placeholder="true"])`
-    )
-    if (!segment) return null
-    // React Aria also drops `aria-valuenow` on iOS, so fall back to the rendered
-    // text. Safe to parse: both fields are pinned to en-US, so the digits are
-    // ASCII, and `shouldForceLeadingZeros` only ever prefixes a zero.
-    const raw = segment.getAttribute("aria-valuenow") ?? segment.textContent
-    if (!raw) return null
-    const parsed = Number(raw)
-    // Range-guarded so a value this function can't represent degrades to "no
-    // time given" rather than reaching `new Time`, which does not validate.
-    const max = type === "hour" ? 23 : 59
-    return Number.isInteger(parsed) && parsed >= 0 && parsed <= max
-      ? parsed
-      : null
-  }
-
-  const hour = readSegment("hour")
-  const minute = readSegment("minute")
+  const hour = readSegment(container, "hour")
+  const minute = readSegment(container, "minute")
   if (hour === null && minute === null) return null
   return new Time(hour ?? 0, minute ?? 0)
+}
+
+/**
+ * Read year, month and day from a container's rendered segments, before the
+ * field has emitted an `onChange`. Returns null unless all three are filled and
+ * form a real date.
+ *
+ * Unlike a time, a date has nothing to default: a missing part means no date.
+ * The day segment's maximum is the longest month rather than the current one, so
+ * `2025/02/30` is typeable — the `CalendarDate` constructor clamps it to Feb 28,
+ * so reading the day back out rejects it. Same check `isoToCalendarDateTime` uses.
+ */
+export function getTypedDateFromDom(
+  container: HTMLElement | null
+): CalendarDate | null {
+  const year = readSegment(container, "year")
+  const month = readSegment(container, "month")
+  const day = readSegment(container, "day")
+  if (year === null || month === null || day === null) return null
+  if (year < 1 || month < 1 || day < 1) return null
+  const result = new CalendarDate(year, month, day)
+  return result.day === day ? result : null
 }
 
 // --- useBasicWidgetState integration ---

--- a/frontend/lib/src/components/widgets/DateTimeInput/dateTimeInputUtils.ts
+++ b/frontend/lib/src/components/widgets/DateTimeInput/dateTimeInputUtils.ts
@@ -215,15 +215,15 @@ export interface SegmentState {
   isFullyCleared: boolean
 }
 
-/** Query spinbutton segments in a container to determine their placeholder state.
- *
- * Matches on `role`, which React Aria replaces with `textbox` on iOS, so this
- * finds no segments there. `readSegment` below matches `data-type` instead,
- * which is emitted on every platform. */
+/** Editable segments. Matched on `data-type` rather than `role`, which React Aria
+ * replaces with `textbox` on iOS. Literals are the separators between segments. */
+export const SEGMENT_SELECTOR = '[data-type]:not([data-type="literal"])'
+
+/** Query the editable segments in a container to determine their placeholder state. */
 export function getSegmentState(container: HTMLElement): SegmentState {
-  const segments = container.querySelectorAll('[role="spinbutton"]')
+  const segments = container.querySelectorAll(SEGMENT_SELECTOR)
   const placeholders = container.querySelectorAll(
-    '[role="spinbutton"][data-placeholder="true"]'
+    `${SEGMENT_SELECTOR}[data-placeholder="true"]`
   )
   const totalSegments = segments.length
   const placeholderCount = placeholders.length
@@ -284,7 +284,7 @@ function readSegment(
  * `DateField` and `TimeField` both withhold `onChange` until every one of their
  * segments is filled, so a time entered while its partner segments are still
  * placeholders reaches no handler — the rendered segments are its only record.
- * An unfilled half of the pair counts as 0, so a lone hour survives.
+ * An unfilled half of the pair counts as 0, so a lone hour or minute survives.
  *
  * Assumes a 24-hour cycle and no seconds segment: with `hourCycle={12}` the hour
  * reports 1–12 and needs the `dayPeriod` segment to disambiguate, and a `second`

--- a/frontend/lib/src/components/widgets/DateTimeInput/dateTimeInputUtils.ts
+++ b/frontend/lib/src/components/widgets/DateTimeInput/dateTimeInputUtils.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { CalendarDateTime } from "@internationalized/date"
+import { CalendarDateTime, Time } from "@internationalized/date"
 
 import { DateTimeInput as DateTimeInputProto } from "@streamlit/protobuf"
 
@@ -215,7 +215,11 @@ export interface SegmentState {
   isFullyCleared: boolean
 }
 
-/** Query spinbutton segments in a container to determine their placeholder state. */
+/** Query spinbutton segments in a container to determine their placeholder state.
+ *
+ * Matches on `role`, which React Aria replaces with `textbox` on iOS, so this
+ * finds no segments there. `getTypedTimeFromDom` below matches `data-type`
+ * instead, which is emitted on every platform. */
 export function getSegmentState(container: HTMLElement): SegmentState {
   const segments = container.querySelectorAll('[role="spinbutton"]')
   const placeholders = container.querySelectorAll(
@@ -229,6 +233,54 @@ export function getSegmentState(container: HTMLElement): SegmentState {
     isPartiallyTyped: placeholderCount > 0 && placeholderCount < totalSegments,
     isFullyCleared: totalSegments > 0 && placeholderCount === totalSegments,
   }
+}
+
+/**
+ * The time held by a container's rendered `hour` and `minute` segments, ignoring
+ * placeholders. Returns null when neither is filled.
+ *
+ * `DateField` and `TimeField` both withhold `onChange` until every one of their
+ * segments is filled, so a time entered while its partner segments are still
+ * placeholders reaches no handler — the rendered segments are its only record.
+ * An unfilled half of the pair counts as 0, so a lone hour survives.
+ *
+ * Reads `aria-valuenow`, which React Aria sets from the segment's numeric value
+ * and omits for an hour or minute placeholder. The `data-placeholder` filter
+ * covers segment types where that does not hold — an `era` placeholder does
+ * carry a value.
+ *
+ * Assumes a 24-hour cycle and no seconds segment: with `hourCycle={12}` the hour
+ * reports 1–12 and needs the `dayPeriod` segment to disambiguate, and a `second`
+ * segment would be ignored.
+ */
+export function getTypedTimeFromDom(
+  container: HTMLElement | null
+): Time | null {
+  const readSegment = (type: "hour" | "minute"): number | null => {
+    // Match on `data-type` rather than `role`: React Aria renders segments as
+    // textboxes, not spinbuttons, on iOS.
+    const segment = container?.querySelector(
+      `[data-type="${type}"]:not([data-placeholder="true"])`
+    )
+    if (!segment) return null
+    // React Aria also drops `aria-valuenow` on iOS, so fall back to the rendered
+    // text. Safe to parse: both fields are pinned to en-US, so the digits are
+    // ASCII, and `shouldForceLeadingZeros` only ever prefixes a zero.
+    const raw = segment.getAttribute("aria-valuenow") ?? segment.textContent
+    if (!raw) return null
+    const parsed = Number(raw)
+    // Range-guarded so a value this function can't represent degrades to "no
+    // time given" rather than reaching `new Time`, which does not validate.
+    const max = type === "hour" ? 23 : 59
+    return Number.isInteger(parsed) && parsed >= 0 && parsed <= max
+      ? parsed
+      : null
+  }
+
+  const hour = readSegment("hour")
+  const minute = readSegment("minute")
+  if (hour === null && minute === null) return null
+  return new Time(hour ?? 0, minute ?? 0)
 }
 
 // --- useBasicWidgetState integration ---

--- a/frontend/lib/src/components/widgets/DateTimeInput/dateTimeInputUtils.ts
+++ b/frontend/lib/src/components/widgets/DateTimeInput/dateTimeInputUtils.ts
@@ -235,23 +235,6 @@ export function getSegmentState(container: HTMLElement): SegmentState {
   }
 }
 
-/**
- * Read one segment's numeric value from a container, or null when it is absent,
- * a placeholder, or outside `max`.
- *
- * Matches on `data-type` rather than `role`, because React Aria renders segments
- * as textboxes, not spinbuttons, on iOS — and falls back to the rendered text,
- * because it drops `aria-valuenow` there too. Safe to parse: both fields are
- * pinned to en-US so the digits are ASCII, and `shouldForceLeadingZeros` only
- * ever prefixes a zero.
- *
- * The `data-placeholder` filter also guards the text fallback, where a
- * placeholder's dashes would otherwise parse.
- *
- * Range-guarded so a value the caller cannot represent degrades to "not given"
- * rather than reaching a `Time` or `CalendarDate` constructor: `Time` stores
- * whatever it is handed, and `CalendarDate` silently clamps.
- */
 const SEGMENT_MAX = {
   hour: 23,
   minute: 59,
@@ -260,6 +243,22 @@ const SEGMENT_MAX = {
   day: 31,
 } as const
 
+/**
+ * Recover one segment's value from the DOM, for the window before the field has
+ * emitted an `onChange`. Null when the segment is absent, still a placeholder, or
+ * outside its range.
+ *
+ * Matches on `data-type` rather than `role`, so iOS is included: React Aria
+ * renders segments there as textboxes, not spinbuttons, and drops
+ * `aria-valuenow`, hence the `textContent` fallback. Safe to parse — both fields
+ * are pinned to en-US so the digits are ASCII, and `shouldForceLeadingZeros` only
+ * ever prefixes a zero. The `data-placeholder` filter also guards that fallback,
+ * where a placeholder's dashes would otherwise parse.
+ *
+ * Range-guarded so a value the caller cannot represent degrades to "not given"
+ * rather than reaching a `Time` or `CalendarDate` constructor: `Time` stores
+ * whatever it is handed, and `CalendarDate` silently clamps.
+ */
 function readSegment(
   container: HTMLElement | null,
   type: keyof typeof SEGMENT_MAX


### PR DESCRIPTION
## Describe your changes

`st.datetime_input` now keeps a time entered before a date, so completing the date commits what is on screen instead of midnight.

Three fixes, all from the React Aria migration in #16501: the time-before-date loss, the popover time field being disabled while the widget is empty, and `clear_on_submit` leaving typed segments in place.

A time entered before a date was discarded. `DateField` withholds `onChange` until every segment is filled, so a time typed while the date segments were still empty never reached a handler, and choosing a day committed midnight over it. The time is now read from the rendered segments when a date completes the value, so what commits is what is on screen — whether the time was typed inline or set in the popover, and whether the date came from the calendar or was typed inline.

The popover time field is no longer disabled while the widget is empty. It was gated on the same complete-value check (`isDisabled={!displayValue}`), so it could not be used until a date existed, where the BaseWeb time select it replaced had no such gate. Its disabled styling also resolved to `color: inherit`, so it rendered less faded than a normal placeholder while ignoring every keystroke.

A `clear_on_submit` form now empties the field's segments, not just its value. React Aria keeps display state for segments typed but not completed, and with the value already null there is no prop change to re-seed it — so a time typed before the clear stayed on screen, and could then be committed with a later date. Clearing remounts the field, and focus returns to it so Enter-to-submit does not drop the user to the page body.

A time given with no date anywhere still commits nothing. The widget cannot represent it, and substituting midnight is the bug being fixed.

A *partial* time does commit, with the missing half as `00` — a lone hour becomes `hh:00`, a lone minute `00:MM`. That is a deliberate change from `develop`, which reverts instead, and from `st.date_input`. One rule for one helper was preferred over two rules depending on caller: requiring both halves would also mean discarding a digit the user typed and can see.

This includes a time still being typed: a user who has entered a full date and a single `0`, intending `09`, commits `00:00` where `develop` would have reverted. So being interrupted after the day segment reverts, while being interrupted one keystroke later commits. That asymmetry is accepted rather than special-cased — a rule that depended on how many digits an hour has would give two users different outcomes from the same visible state.

To reproduce on `develop`: add `st.datetime_input("When", value=None)`, type `03:24` into the time segments, then click a day in the calendar — the time resets to `00:00`. The popover's own time field stays greyed out throughout.

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- [x] Unit Tests (JS and/or Python) — added to `DateTimeInput.test.tsx` and `dateTimeInputUtils.test.ts`. Each behavioral test was confirmed to fail with only its own fix removed.
- [x] E2E Tests — `test_keeps_time_given_before_a_date` covers the inline segments, the popover time field, and a date typed inline with the time given only in the popover. `test_form_clear_empties_the_segments_and_keeps_focus` covers the form clear by both submit paths, since focus and remount timing are browser behavior.
- [ ] Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core commit/revert and form-reset paths for a widely used widget, with nuanced focus and DOM-read behavior, though behavior is heavily test-covered.
> 
> **Overview**
> Fixes **`st.datetime_input`** so a time entered before a date is committed with that date instead of defaulting to midnight, and addresses related React Aria migration regressions.
> 
> **Time-before-date:** Because `DateField`/`TimeField` only fire `onChange` when all segments are filled, the widget now reads partial date/time from the DOM (`getTypedDateFromDom`, `getTypedTimeFromDom`) and merges inline segments, popover time, and calendar picks on commit/dismiss. Calendar selection uses **`resolveGivenTime`** (most recently focused inline vs popover control). Dismissal can **`completeFromVisibleParts`** when date and time are split across controls; time-only or date-only without the other half still does not commit (calendar day pick still uses midnight as an explicit choice).
> 
> **Popover time while empty:** The popover `TimeField` is enabled when the widget has no value (`isDisabled={disabled}`), with **`pendingTime`** holding a complete popover time until a date exists.
> 
> **Forms:** **`clear_on_submit`** remounts inline and popover fields via **`key={formResetKey}`** so partial segment display clears, restores focus after Enter submit, and resets commit dedup so the same value can be submitted again.
> 
> **Robustness:** Segment queries use **`data-type`** (not `role="spinbutton"`) for iOS; Tab-off and double-dismiss (outside click + blur) commit before the popover unmounts and keep **`displayValueRef`** in sync.
> 
> Extensive unit tests in `DateTimeInput.test.tsx` / `dateTimeInputUtils.test.ts` and Playwright coverage for the three entry paths and form clear/focus.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80cacec6c98190f57d525b6ba1466116ccddf07a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->





