### PR TITLE
[refactor] Adopt shared parameter exception types

### DIFF
--- a/.cursor/rules/python_lib.mdc
+++ b/.cursor/rules/python_lib.mdc
@@ -136,8 +136,9 @@ generic `StreamlitAPIException` with a one-off message.
   API. Prefer a more specific subclass when one fits.
 - `StreamlitValueError(parameter, valid_values, *, detail=None)`: use when a
   parameter receives an invalid value from a known finite set (Literal /
-  enum-like options). Optional `detail` is overlay-only and is not appended
-  in uncaught-exception telemetry. Example:
+  enum-like options). `parameter` is appended in uncaught-exception telemetry
+  (`StreamlitValueError:<parameter>`); optional `detail` appears in the error
+  message only. Example:
   `raise StreamlitValueError("type", ["'primary'", "'secondary'", "'tertiary'"])`.
 - `StreamlitMissingRequiredParameterError(parameter, *, detail=None)`:
   use when a required parameter is missing, `None`, or empty, including an
@@ -145,12 +146,12 @@ generic `StreamlitAPIException` with a one-off message.
   (`StreamlitMissingRequiredParameterError:<parameter>`). Example:
   `raise StreamlitMissingRequiredParameterError("label")`.
 - `StreamlitIncompatibleParametersError(*uses, *, explanation=None)`: use
-  when two or more parameter uses cannot be combined. Pass the value when
-  the conflict depends on it (`wrap=False`), or the bare parameter name
-  when merely providing it conflicts (`on_change`). Uses are overlay-only;
-  uncaught-exception telemetry is the type name with no suffix. Optional
-  `explanation` is appended when the generic "cannot be used together"
-  message needs more context. Example:
+  when two or more parameter uses cannot be combined. Pass `parameter=value`
+  when the conflict depends on a value (`wrap=False`), or the bare parameter
+  name when merely providing it conflicts (`on_change`). These strings appear
+  only in the displayed error; uncaught-exception telemetry records only the
+  exception type. Optional `explanation` is appended when the generic
+  "cannot be used together" message needs more context. Example:
   `raise StreamlitIncompatibleParametersError("wrap=False", "horizontal=False")`.
 - `StreamlitInvalidParameterTypeError(parameter, provided_type, expected_types)`:
   use when a parameter has an unsupported type. `parameter` is appended in
@@ -166,13 +167,15 @@ generic `StreamlitAPIException` with a one-off message.
     date/time bounds)
   - `StreamlitInvalidFormCallbackError` (form callback policy)
   - `StreamlitInvalidLayoutContextError` (command used in a disallowed layout,
-    form, or dialog context, including opening a second dialog in the same run)
+    form, dialog, or fragment context — including opening a second dialog in the
+    same run, or writing to a container across a parallel-fragment boundary)
   - `StreamlitDuplicateElementKey` (duplicate user `key`, including `st.form`)
   - `StreamlitWidgetAlreadyInstantiatedError` (session state assigned after the
     widget with that key is instantiated this run)
   - `StreamlitDefaultNotInOptionsError` (default/index not in `options`)
   - `StreamlitPageNotFoundError` (missing page path, `st.Page` file, `switch_page`,
     `page_link`)
+- Do not raise the deprecated aliases.
 
 Reserve bare `StreamlitAPIException` for one-off cases that no shared type
 covers and that users are expected to hit uncommonly (serialization failures

--- a/.cursor/rules/python_lib.mdc
+++ b/.cursor/rules/python_lib.mdc
@@ -135,17 +135,19 @@ generic `StreamlitAPIException` with a one-off message.
 - `StreamlitAPIException`: base for malformed user interaction with the Streamlit
   API. Prefer a more specific subclass when one fits.
 - `StreamlitValueError(parameter, valid_values, *, detail=None)`: use when a
-  parameter receives an invalid value from a known finite set (Literal /
-  enum-like options). `parameter` is appended in uncaught-exception telemetry
-  (`StreamlitValueError:<parameter>`); optional `detail` appears in the error
-  message only. Example:
+  parameter receives an invalid value from a known set of options or an
+  accepted range. `valid_values` is the user-facing list of supported values:
+  Literal / enum-like options, or a short range description (for example
+  `"a positive duration"`). `parameter` is appended in uncaught-exception
+  telemetry (`StreamlitValueError:<parameter>`); optional `detail` appears in
+  the error message only. Example:
   `raise StreamlitValueError("type", ["'primary'", "'secondary'", "'tertiary'"])`.
 - `StreamlitMissingRequiredParameterError(parameter, *, detail=None)`:
   use when a required parameter is missing, `None`, or empty, including an
   empty sequence. `parameter` is appended in uncaught-exception telemetry
   (`StreamlitMissingRequiredParameterError:<parameter>`). Example:
   `raise StreamlitMissingRequiredParameterError("label")`.
-- `StreamlitIncompatibleParametersError(*uses, *, explanation=None)`: use
+- `StreamlitIncompatibleParametersError(first_use, second_use, *other_uses, *, explanation=None)`: use
   when two or more parameter uses cannot be combined. Pass `parameter=value`
   when the conflict depends on a value (`wrap=False`), or the bare parameter
   name when merely providing it conflicts (`on_change`). These strings appear

--- a/.cursor/rules/python_lib.mdc
+++ b/.cursor/rules/python_lib.mdc
@@ -134,12 +134,24 @@ generic `StreamlitAPIException` with a one-off message.
 
 - `StreamlitAPIException`: base for malformed user interaction with the Streamlit
   API. Prefer a more specific subclass when one fits.
-- `StreamlitValueError(parameter, valid_values)`: use when a parameter receives
-  an invalid value from a known finite set (Literal / enum-like options). Example:
+- `StreamlitValueError(parameter, valid_values, *, detail=None)`: use when a
+  parameter receives an invalid value from a known finite set (Literal /
+  enum-like options). Optional `detail` is overlay-only and is not appended
+  in uncaught-exception telemetry. Example:
   `raise StreamlitValueError("type", ["'primary'", "'secondary'", "'tertiary'"])`.
-- `StreamlitMissingRequiredParameterError(command, parameter, *, detail=None)`:
-  use when a required parameter is missing, `None`, or empty. Example:
-  `raise StreamlitMissingRequiredParameterError("st.expander", "label")`.
+- `StreamlitMissingRequiredParameterError(parameter, *, detail=None)`:
+  use when a required parameter is missing, `None`, or empty, including an
+  empty sequence. `parameter` is appended in uncaught-exception telemetry
+  (`StreamlitMissingRequiredParameterError:<parameter>`). Example:
+  `raise StreamlitMissingRequiredParameterError("label")`.
+- `StreamlitIncompatibleParametersError(*uses, *, explanation=None)`: use
+  when two or more parameter uses cannot be combined. Pass the value when
+  the conflict depends on it (`wrap=False`), or the bare parameter name
+  when merely providing it conflicts (`on_change`). Uses are overlay-only;
+  uncaught-exception telemetry is the type name with no suffix. Optional
+  `explanation` is appended when the generic "cannot be used together"
+  message needs more context. Example:
+  `raise StreamlitIncompatibleParametersError("wrap=False", "horizontal=False")`.
 - `StreamlitInvalidParameterTypeError(parameter, provided_type, expected_types)`:
   use when a parameter has an unsupported type. `parameter` is appended in
   uncaught-exception telemetry (`StreamlitInvalidParameterTypeError:<parameter>`).
@@ -147,28 +159,23 @@ generic `StreamlitAPIException` with a one-off message.
   `raise StreamlitInvalidParameterTypeError("step", "str", ["int", "timedelta"])`.
 - Prefer other shared validators/errors when they already exist for the
   parameter, including:
-  - `StreamlitInvalidWidthError` / `StreamlitInvalidHeightError` /
-    `StreamlitInvalidSizeError` (layout sizing helpers)
+  - `StreamlitInvalidWidthError` / `StreamlitInvalidHeightError`
+    (layout sizing helpers)
   - `StreamlitInvalidColorError`
-  - `StreamlitInvalidVerticalAlignmentError` /
-    `StreamlitInvalidHorizontalAlignmentError` /
-    `StreamlitInvalidColumnGapError` (layout alignment/gap; these keep
-    element-type context in the message)
   - `StreamlitValueBelowMinError` / `StreamlitValueAboveMaxError` (numeric /
     date/time bounds)
   - `StreamlitInvalidFormCallbackError` (form callback policy)
-  - `StreamlitInvalidLayoutContextError` (command used in a disallowed layout
-    or form context)
+  - `StreamlitInvalidLayoutContextError` (command used in a disallowed layout,
+    form, or dialog context, including opening a second dialog in the same run)
   - `StreamlitDuplicateElementKey` (duplicate user `key`, including `st.form`)
   - `StreamlitWidgetAlreadyInstantiatedError` (session state assigned after the
     widget with that key is instantiated this run)
   - `StreamlitDefaultNotInOptionsError` (default/index not in `options`)
   - `StreamlitPageNotFoundError` (missing page path, `st.Page` file, `switch_page`,
     `page_link`)
-- Do not raise the deprecated aliases.
 
-Reserve bare `StreamlitAPIException` for cases that are not covered by a shared
-type (incompatible option combinations, nesting rules, serialization failures,
+Reserve bare `StreamlitAPIException` for one-off cases that no shared type
+covers and that users are expected to hit uncommonly (serialization failures
 and similar).
 
 ## Theming and Layout

--- a/.cursor/rules/python_lib.mdc
+++ b/.cursor/rules/python_lib.mdc
@@ -172,7 +172,9 @@ generic `StreamlitAPIException` with a one-off message.
   - `StreamlitDuplicateElementKey` (duplicate user `key`, including `st.form`)
   - `StreamlitWidgetAlreadyInstantiatedError` (session state assigned after the
     widget with that key is instantiated this run)
-  - `StreamlitDefaultNotInOptionsError` (default/index not in `options`)
+  - `StreamlitDefaultNotInOptionsError` (default/index not in widget `options`;
+    `st.tabs` `default` uses `StreamlitValueError` because this message is
+    worded for widget options, not tab labels)
   - `StreamlitPageNotFoundError` (missing page path, `st.Page` file, `switch_page`,
     `page_link`)
 - Do not raise the deprecated aliases.

--- a/.github/instructions/python_lib.instructions.md
+++ b/.github/instructions/python_lib.instructions.md
@@ -133,17 +133,19 @@ generic `StreamlitAPIException` with a one-off message.
 - `StreamlitAPIException`: base for malformed user interaction with the Streamlit
   API. Prefer a more specific subclass when one fits.
 - `StreamlitValueError(parameter, valid_values, *, detail=None)`: use when a
-  parameter receives an invalid value from a known finite set (Literal /
-  enum-like options). `parameter` is appended in uncaught-exception telemetry
-  (`StreamlitValueError:<parameter>`); optional `detail` appears in the error
-  message only. Example:
+  parameter receives an invalid value from a known set of options or an
+  accepted range. `valid_values` is the user-facing list of supported values:
+  Literal / enum-like options, or a short range description (for example
+  `"a positive duration"`). `parameter` is appended in uncaught-exception
+  telemetry (`StreamlitValueError:<parameter>`); optional `detail` appears in
+  the error message only. Example:
   `raise StreamlitValueError("type", ["'primary'", "'secondary'", "'tertiary'"])`.
 - `StreamlitMissingRequiredParameterError(parameter, *, detail=None)`:
   use when a required parameter is missing, `None`, or empty, including an
   empty sequence. `parameter` is appended in uncaught-exception telemetry
   (`StreamlitMissingRequiredParameterError:<parameter>`). Example:
   `raise StreamlitMissingRequiredParameterError("label")`.
-- `StreamlitIncompatibleParametersError(*uses, *, explanation=None)`: use
+- `StreamlitIncompatibleParametersError(first_use, second_use, *other_uses, *, explanation=None)`: use
   when two or more parameter uses cannot be combined. Pass `parameter=value`
   when the conflict depends on a value (`wrap=False`), or the bare parameter
   name when merely providing it conflicts (`on_change`). These strings appear

--- a/.github/instructions/python_lib.instructions.md
+++ b/.github/instructions/python_lib.instructions.md
@@ -134,8 +134,9 @@ generic `StreamlitAPIException` with a one-off message.
   API. Prefer a more specific subclass when one fits.
 - `StreamlitValueError(parameter, valid_values, *, detail=None)`: use when a
   parameter receives an invalid value from a known finite set (Literal /
-  enum-like options). Optional `detail` is overlay-only and is not appended
-  in uncaught-exception telemetry. Example:
+  enum-like options). `parameter` is appended in uncaught-exception telemetry
+  (`StreamlitValueError:<parameter>`); optional `detail` appears in the error
+  message only. Example:
   `raise StreamlitValueError("type", ["'primary'", "'secondary'", "'tertiary'"])`.
 - `StreamlitMissingRequiredParameterError(parameter, *, detail=None)`:
   use when a required parameter is missing, `None`, or empty, including an
@@ -143,12 +144,12 @@ generic `StreamlitAPIException` with a one-off message.
   (`StreamlitMissingRequiredParameterError:<parameter>`). Example:
   `raise StreamlitMissingRequiredParameterError("label")`.
 - `StreamlitIncompatibleParametersError(*uses, *, explanation=None)`: use
-  when two or more parameter uses cannot be combined. Pass the value when
-  the conflict depends on it (`wrap=False`), or the bare parameter name
-  when merely providing it conflicts (`on_change`). Uses are overlay-only;
-  uncaught-exception telemetry is the type name with no suffix. Optional
-  `explanation` is appended when the generic "cannot be used together"
-  message needs more context. Example:
+  when two or more parameter uses cannot be combined. Pass `parameter=value`
+  when the conflict depends on a value (`wrap=False`), or the bare parameter
+  name when merely providing it conflicts (`on_change`). These strings appear
+  only in the displayed error; uncaught-exception telemetry records only the
+  exception type. Optional `explanation` is appended when the generic
+  "cannot be used together" message needs more context. Example:
   `raise StreamlitIncompatibleParametersError("wrap=False", "horizontal=False")`.
 - `StreamlitInvalidParameterTypeError(parameter, provided_type, expected_types)`:
   use when a parameter has an unsupported type. `parameter` is appended in
@@ -164,13 +165,15 @@ generic `StreamlitAPIException` with a one-off message.
     date/time bounds)
   - `StreamlitInvalidFormCallbackError` (form callback policy)
   - `StreamlitInvalidLayoutContextError` (command used in a disallowed layout,
-    form, or dialog context, including opening a second dialog in the same run)
+    form, dialog, or fragment context — including opening a second dialog in the
+    same run, or writing to a container across a parallel-fragment boundary)
   - `StreamlitDuplicateElementKey` (duplicate user `key`, including `st.form`)
   - `StreamlitWidgetAlreadyInstantiatedError` (session state assigned after the
     widget with that key is instantiated this run)
   - `StreamlitDefaultNotInOptionsError` (default/index not in `options`)
   - `StreamlitPageNotFoundError` (missing page path, `st.Page` file, `switch_page`,
     `page_link`)
+- Do not raise the deprecated aliases.
 
 Reserve bare `StreamlitAPIException` for one-off cases that no shared type
 covers and that users are expected to hit uncommonly (serialization failures

--- a/.github/instructions/python_lib.instructions.md
+++ b/.github/instructions/python_lib.instructions.md
@@ -170,7 +170,9 @@ generic `StreamlitAPIException` with a one-off message.
   - `StreamlitDuplicateElementKey` (duplicate user `key`, including `st.form`)
   - `StreamlitWidgetAlreadyInstantiatedError` (session state assigned after the
     widget with that key is instantiated this run)
-  - `StreamlitDefaultNotInOptionsError` (default/index not in `options`)
+  - `StreamlitDefaultNotInOptionsError` (default/index not in widget `options`;
+    `st.tabs` `default` uses `StreamlitValueError` because this message is
+    worded for widget options, not tab labels)
   - `StreamlitPageNotFoundError` (missing page path, `st.Page` file, `switch_page`,
     `page_link`)
 - Do not raise the deprecated aliases.

--- a/.github/instructions/python_lib.instructions.md
+++ b/.github/instructions/python_lib.instructions.md
@@ -132,12 +132,24 @@ generic `StreamlitAPIException` with a one-off message.
 
 - `StreamlitAPIException`: base for malformed user interaction with the Streamlit
   API. Prefer a more specific subclass when one fits.
-- `StreamlitValueError(parameter, valid_values)`: use when a parameter receives
-  an invalid value from a known finite set (Literal / enum-like options). Example:
+- `StreamlitValueError(parameter, valid_values, *, detail=None)`: use when a
+  parameter receives an invalid value from a known finite set (Literal /
+  enum-like options). Optional `detail` is overlay-only and is not appended
+  in uncaught-exception telemetry. Example:
   `raise StreamlitValueError("type", ["'primary'", "'secondary'", "'tertiary'"])`.
-- `StreamlitMissingRequiredParameterError(command, parameter, *, detail=None)`:
-  use when a required parameter is missing, `None`, or empty. Example:
-  `raise StreamlitMissingRequiredParameterError("st.expander", "label")`.
+- `StreamlitMissingRequiredParameterError(parameter, *, detail=None)`:
+  use when a required parameter is missing, `None`, or empty, including an
+  empty sequence. `parameter` is appended in uncaught-exception telemetry
+  (`StreamlitMissingRequiredParameterError:<parameter>`). Example:
+  `raise StreamlitMissingRequiredParameterError("label")`.
+- `StreamlitIncompatibleParametersError(*uses, *, explanation=None)`: use
+  when two or more parameter uses cannot be combined. Pass the value when
+  the conflict depends on it (`wrap=False`), or the bare parameter name
+  when merely providing it conflicts (`on_change`). Uses are overlay-only;
+  uncaught-exception telemetry is the type name with no suffix. Optional
+  `explanation` is appended when the generic "cannot be used together"
+  message needs more context. Example:
+  `raise StreamlitIncompatibleParametersError("wrap=False", "horizontal=False")`.
 - `StreamlitInvalidParameterTypeError(parameter, provided_type, expected_types)`:
   use when a parameter has an unsupported type. `parameter` is appended in
   uncaught-exception telemetry (`StreamlitInvalidParameterTypeError:<parameter>`).
@@ -145,28 +157,23 @@ generic `StreamlitAPIException` with a one-off message.
   `raise StreamlitInvalidParameterTypeError("step", "str", ["int", "timedelta"])`.
 - Prefer other shared validators/errors when they already exist for the
   parameter, including:
-  - `StreamlitInvalidWidthError` / `StreamlitInvalidHeightError` /
-    `StreamlitInvalidSizeError` (layout sizing helpers)
+  - `StreamlitInvalidWidthError` / `StreamlitInvalidHeightError`
+    (layout sizing helpers)
   - `StreamlitInvalidColorError`
-  - `StreamlitInvalidVerticalAlignmentError` /
-    `StreamlitInvalidHorizontalAlignmentError` /
-    `StreamlitInvalidColumnGapError` (layout alignment/gap; these keep
-    element-type context in the message)
   - `StreamlitValueBelowMinError` / `StreamlitValueAboveMaxError` (numeric /
     date/time bounds)
   - `StreamlitInvalidFormCallbackError` (form callback policy)
-  - `StreamlitInvalidLayoutContextError` (command used in a disallowed layout
-    or form context)
+  - `StreamlitInvalidLayoutContextError` (command used in a disallowed layout,
+    form, or dialog context, including opening a second dialog in the same run)
   - `StreamlitDuplicateElementKey` (duplicate user `key`, including `st.form`)
   - `StreamlitWidgetAlreadyInstantiatedError` (session state assigned after the
     widget with that key is instantiated this run)
   - `StreamlitDefaultNotInOptionsError` (default/index not in `options`)
   - `StreamlitPageNotFoundError` (missing page path, `st.Page` file, `switch_page`,
     `page_link`)
-- Do not raise the deprecated aliases.
 
-Reserve bare `StreamlitAPIException` for cases that are not covered by a shared
-type (incompatible option combinations, nesting rules, serialization failures,
+Reserve bare `StreamlitAPIException` for one-off cases that no shared type
+covers and that users are expected to hit uncommonly (serialization failures
 and similar).
 
 ## Theming and Layout

--- a/e2e_playwright/st_dialog_test.py
+++ b/e2e_playwright/st_dialog_test.py
@@ -567,7 +567,8 @@ def test_nested_dialogs(app: Page):
     """Test that st.dialog may not be nested inside other dialogs."""
     open_nested_dialogs(app)
     expect_exception(
-        app, "StreamlitAPIException: Dialogs may not be nested inside other dialogs."
+        app,
+        "StreamlitInvalidLayoutContextError: Dialogs may not be nested inside other dialogs.",
     )
 
 
@@ -586,7 +587,8 @@ def test_dialogs_have_different_fragment_ids(app: Page):
     open_nested_dialogs(app)
     nested_dialog_fragment_id = get_markdown(app, "Fragment Id:").text_content()
     expect_exception(
-        app, "StreamlitAPIException: Dialogs may not be nested inside other dialogs."
+        app,
+        "StreamlitInvalidLayoutContextError: Dialogs may not be nested inside other dialogs.",
     )
 
     click_to_dismiss(app)

--- a/lib/streamlit/AGENTS.md
+++ b/lib/streamlit/AGENTS.md
@@ -127,17 +127,19 @@ generic `StreamlitAPIException` with a one-off message.
 - `StreamlitAPIException`: base for malformed user interaction with the Streamlit
   API. Prefer a more specific subclass when one fits.
 - `StreamlitValueError(parameter, valid_values, *, detail=None)`: use when a
-  parameter receives an invalid value from a known finite set (Literal /
-  enum-like options). `parameter` is appended in uncaught-exception telemetry
-  (`StreamlitValueError:<parameter>`); optional `detail` appears in the error
-  message only. Example:
+  parameter receives an invalid value from a known set of options or an
+  accepted range. `valid_values` is the user-facing list of supported values:
+  Literal / enum-like options, or a short range description (for example
+  `"a positive duration"`). `parameter` is appended in uncaught-exception
+  telemetry (`StreamlitValueError:<parameter>`); optional `detail` appears in
+  the error message only. Example:
   `raise StreamlitValueError("type", ["'primary'", "'secondary'", "'tertiary'"])`.
 - `StreamlitMissingRequiredParameterError(parameter, *, detail=None)`:
   use when a required parameter is missing, `None`, or empty, including an
   empty sequence. `parameter` is appended in uncaught-exception telemetry
   (`StreamlitMissingRequiredParameterError:<parameter>`). Example:
   `raise StreamlitMissingRequiredParameterError("label")`.
-- `StreamlitIncompatibleParametersError(*uses, *, explanation=None)`: use
+- `StreamlitIncompatibleParametersError(first_use, second_use, *other_uses, *, explanation=None)`: use
   when two or more parameter uses cannot be combined. Pass `parameter=value`
   when the conflict depends on a value (`wrap=False`), or the bare parameter
   name when merely providing it conflicts (`on_change`). These strings appear

--- a/lib/streamlit/AGENTS.md
+++ b/lib/streamlit/AGENTS.md
@@ -164,7 +164,9 @@ generic `StreamlitAPIException` with a one-off message.
   - `StreamlitDuplicateElementKey` (duplicate user `key`, including `st.form`)
   - `StreamlitWidgetAlreadyInstantiatedError` (session state assigned after the
     widget with that key is instantiated this run)
-  - `StreamlitDefaultNotInOptionsError` (default/index not in `options`)
+  - `StreamlitDefaultNotInOptionsError` (default/index not in widget `options`;
+    `st.tabs` `default` uses `StreamlitValueError` because this message is
+    worded for widget options, not tab labels)
   - `StreamlitPageNotFoundError` (missing page path, `st.Page` file, `switch_page`,
     `page_link`)
 - Do not raise the deprecated aliases.

--- a/lib/streamlit/AGENTS.md
+++ b/lib/streamlit/AGENTS.md
@@ -128,8 +128,9 @@ generic `StreamlitAPIException` with a one-off message.
   API. Prefer a more specific subclass when one fits.
 - `StreamlitValueError(parameter, valid_values, *, detail=None)`: use when a
   parameter receives an invalid value from a known finite set (Literal /
-  enum-like options). Optional `detail` is overlay-only and is not appended
-  in uncaught-exception telemetry. Example:
+  enum-like options). `parameter` is appended in uncaught-exception telemetry
+  (`StreamlitValueError:<parameter>`); optional `detail` appears in the error
+  message only. Example:
   `raise StreamlitValueError("type", ["'primary'", "'secondary'", "'tertiary'"])`.
 - `StreamlitMissingRequiredParameterError(parameter, *, detail=None)`:
   use when a required parameter is missing, `None`, or empty, including an
@@ -137,12 +138,12 @@ generic `StreamlitAPIException` with a one-off message.
   (`StreamlitMissingRequiredParameterError:<parameter>`). Example:
   `raise StreamlitMissingRequiredParameterError("label")`.
 - `StreamlitIncompatibleParametersError(*uses, *, explanation=None)`: use
-  when two or more parameter uses cannot be combined. Pass the value when
-  the conflict depends on it (`wrap=False`), or the bare parameter name
-  when merely providing it conflicts (`on_change`). Uses are overlay-only;
-  uncaught-exception telemetry is the type name with no suffix. Optional
-  `explanation` is appended when the generic "cannot be used together"
-  message needs more context. Example:
+  when two or more parameter uses cannot be combined. Pass `parameter=value`
+  when the conflict depends on a value (`wrap=False`), or the bare parameter
+  name when merely providing it conflicts (`on_change`). These strings appear
+  only in the displayed error; uncaught-exception telemetry records only the
+  exception type. Optional `explanation` is appended when the generic
+  "cannot be used together" message needs more context. Example:
   `raise StreamlitIncompatibleParametersError("wrap=False", "horizontal=False")`.
 - `StreamlitInvalidParameterTypeError(parameter, provided_type, expected_types)`:
   use when a parameter has an unsupported type. `parameter` is appended in
@@ -158,13 +159,15 @@ generic `StreamlitAPIException` with a one-off message.
     date/time bounds)
   - `StreamlitInvalidFormCallbackError` (form callback policy)
   - `StreamlitInvalidLayoutContextError` (command used in a disallowed layout,
-    form, or dialog context, including opening a second dialog in the same run)
+    form, dialog, or fragment context — including opening a second dialog in the
+    same run, or writing to a container across a parallel-fragment boundary)
   - `StreamlitDuplicateElementKey` (duplicate user `key`, including `st.form`)
   - `StreamlitWidgetAlreadyInstantiatedError` (session state assigned after the
     widget with that key is instantiated this run)
   - `StreamlitDefaultNotInOptionsError` (default/index not in `options`)
   - `StreamlitPageNotFoundError` (missing page path, `st.Page` file, `switch_page`,
     `page_link`)
+- Do not raise the deprecated aliases.
 
 Reserve bare `StreamlitAPIException` for one-off cases that no shared type
 covers and that users are expected to hit uncommonly (serialization failures

--- a/lib/streamlit/AGENTS.md
+++ b/lib/streamlit/AGENTS.md
@@ -126,12 +126,24 @@ generic `StreamlitAPIException` with a one-off message.
 
 - `StreamlitAPIException`: base for malformed user interaction with the Streamlit
   API. Prefer a more specific subclass when one fits.
-- `StreamlitValueError(parameter, valid_values)`: use when a parameter receives
-  an invalid value from a known finite set (Literal / enum-like options). Example:
+- `StreamlitValueError(parameter, valid_values, *, detail=None)`: use when a
+  parameter receives an invalid value from a known finite set (Literal /
+  enum-like options). Optional `detail` is overlay-only and is not appended
+  in uncaught-exception telemetry. Example:
   `raise StreamlitValueError("type", ["'primary'", "'secondary'", "'tertiary'"])`.
-- `StreamlitMissingRequiredParameterError(command, parameter, *, detail=None)`:
-  use when a required parameter is missing, `None`, or empty. Example:
-  `raise StreamlitMissingRequiredParameterError("st.expander", "label")`.
+- `StreamlitMissingRequiredParameterError(parameter, *, detail=None)`:
+  use when a required parameter is missing, `None`, or empty, including an
+  empty sequence. `parameter` is appended in uncaught-exception telemetry
+  (`StreamlitMissingRequiredParameterError:<parameter>`). Example:
+  `raise StreamlitMissingRequiredParameterError("label")`.
+- `StreamlitIncompatibleParametersError(*uses, *, explanation=None)`: use
+  when two or more parameter uses cannot be combined. Pass the value when
+  the conflict depends on it (`wrap=False`), or the bare parameter name
+  when merely providing it conflicts (`on_change`). Uses are overlay-only;
+  uncaught-exception telemetry is the type name with no suffix. Optional
+  `explanation` is appended when the generic "cannot be used together"
+  message needs more context. Example:
+  `raise StreamlitIncompatibleParametersError("wrap=False", "horizontal=False")`.
 - `StreamlitInvalidParameterTypeError(parameter, provided_type, expected_types)`:
   use when a parameter has an unsupported type. `parameter` is appended in
   uncaught-exception telemetry (`StreamlitInvalidParameterTypeError:<parameter>`).
@@ -139,28 +151,23 @@ generic `StreamlitAPIException` with a one-off message.
   `raise StreamlitInvalidParameterTypeError("step", "str", ["int", "timedelta"])`.
 - Prefer other shared validators/errors when they already exist for the
   parameter, including:
-  - `StreamlitInvalidWidthError` / `StreamlitInvalidHeightError` /
-    `StreamlitInvalidSizeError` (layout sizing helpers)
+  - `StreamlitInvalidWidthError` / `StreamlitInvalidHeightError`
+    (layout sizing helpers)
   - `StreamlitInvalidColorError`
-  - `StreamlitInvalidVerticalAlignmentError` /
-    `StreamlitInvalidHorizontalAlignmentError` /
-    `StreamlitInvalidColumnGapError` (layout alignment/gap; these keep
-    element-type context in the message)
   - `StreamlitValueBelowMinError` / `StreamlitValueAboveMaxError` (numeric /
     date/time bounds)
   - `StreamlitInvalidFormCallbackError` (form callback policy)
-  - `StreamlitInvalidLayoutContextError` (command used in a disallowed layout
-    or form context)
+  - `StreamlitInvalidLayoutContextError` (command used in a disallowed layout,
+    form, or dialog context, including opening a second dialog in the same run)
   - `StreamlitDuplicateElementKey` (duplicate user `key`, including `st.form`)
   - `StreamlitWidgetAlreadyInstantiatedError` (session state assigned after the
     widget with that key is instantiated this run)
   - `StreamlitDefaultNotInOptionsError` (default/index not in `options`)
   - `StreamlitPageNotFoundError` (missing page path, `st.Page` file, `switch_page`,
     `page_link`)
-- Do not raise the deprecated aliases.
 
-Reserve bare `StreamlitAPIException` for cases that are not covered by a shared
-type (incompatible option combinations, nesting rules, serialization failures,
+Reserve bare `StreamlitAPIException` for one-off cases that no shared type
+covers and that users are expected to hit uncommonly (serialization failures
 and similar).
 
 ## Theming and Layout

--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -106,7 +106,11 @@ from streamlit.elements.widgets.slider import SliderMixin
 from streamlit.elements.widgets.text_widgets import TextWidgetsMixin
 from streamlit.elements.widgets.time_widgets import TimeWidgetsMixin
 from streamlit.elements.write import WriteMixin
-from streamlit.errors import NoSessionContext, StreamlitAPIException
+from streamlit.errors import (
+    NoSessionContext,
+    StreamlitAPIException,
+    StreamlitInvalidLayoutContextError,
+)
 from streamlit.proto import Block_pb2
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.proto.RootContainer_pb2 import RootContainer
@@ -540,7 +544,7 @@ class DeltaGenerator(
                 if fragment_path and not _is_inside_fragment_path(
                     cursor_path, fragment_path
                 ):
-                    raise StreamlitAPIException(
+                    raise StreamlitInvalidLayoutContextError(
                         "Writing to containers outside a parallel fragment is not "
                         "allowed during the initial page load, because parallel "
                         "fragments run concurrently on separate threads and "
@@ -828,7 +832,7 @@ def _get_or_create_outside_wrapper(
     if ctx.fragment_ids_this_run and (
         dg._creating_fragment_id not in ctx.fragment_ids_this_run
     ):
-        raise StreamlitAPIException(
+        raise StreamlitInvalidLayoutContextError(
             "A fragment tried to write to a container created outside the "
             "fragment, but that container was not written to during the initial "
             "run, so Streamlit could not reserve a stable position for it.\n\n"

--- a/lib/streamlit/elements/arrow.py
+++ b/lib/streamlit/elements/arrow.py
@@ -54,7 +54,11 @@ from streamlit.elements.lib.layout_utils import (
 from streamlit.elements.lib.pandas_styler_utils import marshall_styler
 from streamlit.elements.lib.policies import check_widget_policies
 from streamlit.elements.lib.utils import Key, compute_and_register_element_id, to_key
-from streamlit.errors import StreamlitAPIException, StreamlitValueError
+from streamlit.errors import (
+    StreamlitAPIException,
+    StreamlitIncompatibleParametersError,
+    StreamlitValueError,
+)
 from streamlit.proto.Dataframe_pb2 import (
     Dataframe as DataframeProto,
 )
@@ -1061,8 +1065,13 @@ class ArrowMixin:
         selection_mode_set: set[SelectionMode] = set()
 
         if selection_default is not None and not is_selection_activated:
-            raise StreamlitAPIException(
-                "selection_default can only be used when on_select is not 'ignore'."
+            raise StreamlitIncompatibleParametersError(
+                "selection_default",
+                "on_select='ignore'",
+                explanation=(
+                    "Set `on_select` to `'rerun'` or a callback to use "
+                    "`selection_default`."
+                ),
             )
 
         if is_selection_activated:

--- a/lib/streamlit/elements/bottom.py
+++ b/lib/streamlit/elements/bottom.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from streamlit.delta_generator_singletons import context_dg_stack
-from streamlit.errors import StreamlitAPIException
+from streamlit.errors import StreamlitInvalidLayoutContextError
 from streamlit.proto.RootContainer_pb2 import RootContainer
 
 if TYPE_CHECKING:
@@ -42,7 +42,7 @@ class BottomContainerProxy:
         object.__setattr__(self, "_bottom_dg", bottom_dg)
 
     def _check_context(self) -> None:
-        """Raise StreamlitAPIException if st.bottom is used in an invalid context."""
+        """Raise ``StreamlitInvalidLayoutContextError`` if ``st.bottom`` is used outside the main app area."""
         current_stack = context_dg_stack.get()
         if not current_stack:
             return
@@ -51,19 +51,19 @@ class BottomContainerProxy:
         root_container = current_dg._root_container
 
         if root_container == RootContainer.SIDEBAR:
-            raise StreamlitAPIException(
+            raise StreamlitInvalidLayoutContextError(
                 "`st.bottom` cannot be used inside `st.sidebar`. "
                 "The bottom container is only available in the main app area."
             )
         # Check for dialog first since dialogs use EVENT root container
         # but should get a more specific error message
         if "dialog" in current_dg._ancestor_block_types:
-            raise StreamlitAPIException(
+            raise StreamlitInvalidLayoutContextError(
                 "`st.bottom` cannot be used inside a dialog. "
                 "The bottom container is only available in the main app area."
             )
         if root_container == RootContainer.EVENT:
-            raise StreamlitAPIException(
+            raise StreamlitInvalidLayoutContextError(
                 "`st.bottom` cannot be used inside event containers. "
                 "The bottom container is only available in the main app area."
             )

--- a/lib/streamlit/elements/dialog_decorator.py
+++ b/lib/streamlit/elements/dialog_decorator.py
@@ -23,7 +23,7 @@ from streamlit.delta_generator_singletons import (
     get_last_dg_added_to_context_stack,
 )
 from streamlit.errors import (
-    StreamlitAPIException,
+    StreamlitInvalidLayoutContextError,
     StreamlitMissingRequiredParameterError,
 )
 from streamlit.runtime.fragment import _check_not_parallel_worker, _fragment
@@ -49,14 +49,16 @@ def _assert_no_nested_dialogs() -> None:
 
     Raises
     ------
-    StreamlitAPIException
+    StreamlitInvalidLayoutContextError
         Raised if the user tries to nest dialogs inside of each other.
     """
     last_dg_in_current_context = get_last_dg_added_to_context_stack()
     if last_dg_in_current_context and "dialog" in set(
         last_dg_in_current_context._ancestor_block_types
     ):
-        raise StreamlitAPIException("Dialogs may not be nested inside other dialogs.")
+        raise StreamlitInvalidLayoutContextError(
+            "Dialogs may not be nested inside other dialogs."
+        )
 
 
 F = TypeVar("F", bound=Callable[..., Any])
@@ -73,7 +75,6 @@ def _dialog_decorator(
 ) -> F:
     if title is None or title == "":
         raise StreamlitMissingRequiredParameterError(
-            "st.dialog",
             "title",
             detail='For example: `@st.dialog("Example Title")`.',
         )

--- a/lib/streamlit/elements/html.py
+++ b/lib/streamlit/elements/html.py
@@ -145,7 +145,7 @@ class HtmlMixin:
             html_content = clean_text(cast("SupportsStr", body))
 
         if html_content == "":
-            raise StreamlitMissingRequiredParameterError("st.html", "body")
+            raise StreamlitMissingRequiredParameterError("body")
 
         layout_config = create_layout_config(width=width, allow_content_width=True)
 

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -390,7 +390,6 @@ class LayoutsMixin:
                 "wrap=False",
                 "horizontal=False",
                 explanation=(
-                    "`wrap=False` can only be used with `horizontal=True`. "
                     "A vertical container has no horizontal row of elements to "
                     "keep in a single, scrolling row. Set `horizontal=True` to "
                     "use `wrap=False`, or remove the `wrap` argument."
@@ -695,6 +694,7 @@ class LayoutsMixin:
             raise StreamlitValueError(
                 "vertical_alignment",
                 [f"'{alignment}'" for alignment in vertical_alignment_mapping],
+                detail=f"Got {vertical_alignment!r}.",
             )
 
         gap_config = get_gap_config(gap)

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -42,10 +42,9 @@ from streamlit.elements.lib.layout_utils import (
 from streamlit.elements.lib.policies import check_widget_policies
 from streamlit.elements.lib.utils import Key, compute_and_register_element_id, to_key
 from streamlit.errors import (
-    StreamlitAPIException,
+    StreamlitIncompatibleParametersError,
     StreamlitInvalidColumnSpecError,
     StreamlitInvalidParameterTypeError,
-    StreamlitInvalidVerticalAlignmentError,
     StreamlitMissingRequiredParameterError,
     StreamlitValueError,
 )
@@ -382,18 +381,20 @@ class LayoutsMixin:
         block_proto = BlockProto()
         block_proto.allow_empty = False
         block_proto.flex_container.border = border or False
-        block_proto.flex_container.gap_config.CopyFrom(
-            get_gap_config(gap, "st.container")
-        )
+        block_proto.flex_container.gap_config.CopyFrom(get_gap_config(gap))
 
         validate_horizontal_alignment(horizontal_alignment)
         validate_vertical_alignment(vertical_alignment)
         if wrap is False and not horizontal:
-            raise StreamlitAPIException(
-                "`wrap=False` can only be used with `horizontal=True`. "
-                "A vertical container has no horizontal row of elements to keep "
-                "in a single, scrolling row. Set `horizontal=True` to use "
-                "`wrap=False`, or remove the `wrap` argument."
+            raise StreamlitIncompatibleParametersError(
+                "wrap=False",
+                "horizontal=False",
+                explanation=(
+                    "`wrap=False` can only be used with `horizontal=True`. "
+                    "A vertical container has no horizontal row of elements to "
+                    "keep in a single, scrolling row. Set `horizontal=True` to "
+                    "use `wrap=False`, or remove the `wrap` argument."
+                ),
             )
         if horizontal:
             # `wrap=True` (default) keeps the default horizontal behavior of
@@ -691,12 +692,12 @@ class LayoutsMixin:
         }
 
         if vertical_alignment not in vertical_alignment_mapping:
-            raise StreamlitInvalidVerticalAlignmentError(
-                vertical_alignment=vertical_alignment,
-                element_type="st.columns",
+            raise StreamlitValueError(
+                "vertical_alignment",
+                [f"'{alignment}'" for alignment in vertical_alignment_mapping],
             )
 
-        gap_config = get_gap_config(gap, "st.columns")
+        gap_config = get_gap_config(gap)
 
         def column_proto(normalized_weight: float) -> BlockProto:
             col_proto = BlockProto()
@@ -989,19 +990,25 @@ class LayoutsMixin:
 
         """
         if not tabs:
-            raise StreamlitAPIException(
-                "The input argument to st.tabs must contain at least one tab label."
+            raise StreamlitMissingRequiredParameterError(
+                "tabs", detail="Provide at least one tab label."
             )
 
         if default and default not in tabs:
-            raise StreamlitAPIException(
-                f"The default tab '{default}' is not in the list of tabs."
+            raise StreamlitValueError(
+                "default",
+                ["a tab label from `tabs`"],
+                detail=f"`{default}` is not in the list of tabs.",
             )
 
-        if any(not isinstance(tab, str) for tab in tabs):
-            raise StreamlitAPIException(
-                "The tabs input list to st.tabs is only allowed to contain strings."
-            )
+        for tab in tabs:
+            if not isinstance(tab, str):
+                raise StreamlitInvalidParameterTypeError(
+                    "tabs",
+                    type(tab).__name__,
+                    ["str"],
+                    detail="Each tab label must be a string.",
+                )
 
         if not callable(on_change) and on_change not in {"ignore", "rerun"}:
             raise StreamlitValueError(
@@ -1378,7 +1385,7 @@ class LayoutsMixin:
 
         """
         if label is None:
-            raise StreamlitMissingRequiredParameterError("st.expander", "label")
+            raise StreamlitMissingRequiredParameterError("label")
 
         if not callable(on_change) and on_change not in {"ignore", "rerun"}:
             raise StreamlitValueError(
@@ -1765,7 +1772,7 @@ class LayoutsMixin:
 
         """
         if label is None:
-            raise StreamlitMissingRequiredParameterError("st.popover", "label")
+            raise StreamlitMissingRequiredParameterError("label")
 
         if use_container_width is not None:
             width = "stretch" if use_container_width else "content"

--- a/lib/streamlit/elements/layouts.py
+++ b/lib/streamlit/elements/layouts.py
@@ -1006,8 +1006,7 @@ class LayoutsMixin:
                 raise StreamlitInvalidParameterTypeError(
                     "tabs",
                     type(tab).__name__,
-                    ["str"],
-                    detail="Each tab label must be a string.",
+                    ["a string for each tab label"],
                 )
 
         if not callable(on_change) and on_change not in {"ignore", "rerun"}:

--- a/lib/streamlit/elements/lib/column_types.py
+++ b/lib/streamlit/elements/lib/column_types.py
@@ -3475,7 +3475,6 @@ def ButtonColumn(
     # Raise an error if callbacks are provided without a key
     if on_click is not None or args is not None or kwargs is not None:
         raise StreamlitMissingRequiredParameterError(
-            "st.column_config.ButtonColumn",
             "key",
             detail=(
                 "Callbacks passed via `on_click`, `args`, or `kwargs` need a unique "

--- a/lib/streamlit/elements/lib/dialog.py
+++ b/lib/streamlit/elements/lib/dialog.py
@@ -20,7 +20,7 @@ from typing_extensions import Self
 
 from streamlit.delta_generator import DeltaGenerator
 from streamlit.elements.lib.utils import compute_and_register_element_id
-from streamlit.errors import StreamlitAPIException, StreamlitValueError
+from streamlit.errors import StreamlitInvalidLayoutContextError, StreamlitValueError
 from streamlit.proto.Block_pb2 import Block as BlockProto
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.runtime.scriptrunner_utils.script_run_context import (
@@ -63,7 +63,7 @@ def _assert_first_dialog_to_be_opened(should_open: bool) -> None:
 
     Raises
     ------
-    StreamlitAPIException
+    StreamlitInvalidLayoutContextError
         Raised when a dialog has already been opened in the current script run.
     """
     script_run_ctx = get_script_run_ctx()
@@ -72,7 +72,7 @@ def _assert_first_dialog_to_be_opened(should_open: bool) -> None:
     # this might need to change.
     if should_open and script_run_ctx:
         if script_run_ctx.has_dialog_opened:
-            raise StreamlitAPIException(
+            raise StreamlitInvalidLayoutContextError(
                 "Only one dialog is allowed to be opened at the same time. "
                 "Please make sure to not call a dialog-decorated function more than once in a script run."
             )

--- a/lib/streamlit/elements/lib/layout_utils.py
+++ b/lib/streamlit/elements/lib/layout_utils.py
@@ -17,11 +17,7 @@ from dataclasses import dataclass
 from typing import Final, Literal, TypeAlias, cast
 
 from streamlit.errors import (
-    StreamlitInvalidColumnGapError,
     StreamlitInvalidHeightError,
-    StreamlitInvalidHorizontalAlignmentError,
-    StreamlitInvalidSizeError,
-    StreamlitInvalidVerticalAlignmentError,
     StreamlitInvalidWidthError,
     StreamlitValueError,
 )
@@ -60,6 +56,11 @@ SIZE_TO_REM_MAPPING = {
     "xlarge": 6,  # Aligns with gap "xlarge" (96px)
     "xxlarge": 8,  # Aligns with gap "xxlarge" (128px)
 }
+_VALID_SPACE_SIZE_STRINGS: Final = ("stretch", *SIZE_TO_REM_MAPPING)
+_VALID_SPACE_SIZE_VALUES: Final = [
+    *[f"'{size}'" for size in _VALID_SPACE_SIZE_STRINGS],
+    "a positive integer",
+]
 
 # Shared by st.expander and st.status, which render through the same proto.
 ExpandableType: TypeAlias = Literal["default", "compact", "step"]
@@ -245,27 +246,23 @@ def validate_space_size(size: SpaceSize) -> None:
 
     Raises
     ------
-    StreamlitInvalidSizeError
+    StreamlitValueError
         If the size value is invalid.
     """
     if not isinstance(size, (int, str)):
-        raise StreamlitInvalidSizeError(size)
+        raise StreamlitValueError(
+            "size", _VALID_SPACE_SIZE_VALUES, detail=f"Got {size!r}."
+        )
 
     if isinstance(size, str):
-        valid_strings = [
-            "stretch",
-            "xxsmall",
-            "xsmall",
-            "small",
-            "medium",
-            "large",
-            "xlarge",
-            "xxlarge",
-        ]
-        if size not in valid_strings:
-            raise StreamlitInvalidSizeError(size)
+        if size not in _VALID_SPACE_SIZE_STRINGS:
+            raise StreamlitValueError(
+                "size", _VALID_SPACE_SIZE_VALUES, detail=f"Got {size!r}."
+            )
     elif isinstance(size, int) and size <= 0:
-        raise StreamlitInvalidSizeError(size)
+        raise StreamlitValueError(
+            "size", _VALID_SPACE_SIZE_VALUES, detail=f"Got {size!r}."
+        )
 
 
 def get_width_config(width: Width | SpaceSize) -> WidthConfig:
@@ -303,9 +300,14 @@ _GAP_STRING_MAPPING: dict[str, GapSize.ValueType] = {
     "xlarge": GapSize.XLARGE,
     "xxlarge": GapSize.XXLARGE,
 }
+_VALID_GAP_VALUES: Final = [
+    *[f"'{size}'" for size in _GAP_STRING_MAPPING],
+    "None",
+    "a non-negative integer",
+]
 
 
-def get_gap_config(gap: Gap | None, element_type: str) -> GapConfig:
+def get_gap_config(gap: Gap | None) -> GapConfig:
     """Convert a gap value to a ``GapConfig`` proto.
 
     ``gap`` may be one of the string enum values (``"xxsmall"``, ``"xsmall"``,
@@ -316,12 +318,10 @@ def get_gap_config(gap: Gap | None, element_type: str) -> GapConfig:
     ----------
     gap : Gap or None
         The gap value to convert.
-    element_type : str
-        The element type used in error messages.
 
     Raises
     ------
-    StreamlitInvalidColumnGapError
+    StreamlitValueError
         If ``gap`` is not a valid gap value.
     """
     gap_config = GapConfig()
@@ -340,21 +340,35 @@ def get_gap_config(gap: Gap | None, element_type: str) -> GapConfig:
         gap_config.gap_size = _GAP_STRING_MAPPING[gap.lower()]
         return gap_config
 
-    raise StreamlitInvalidColumnGapError(gap=gap, element_type=element_type)
+    raise StreamlitValueError("gap", _VALID_GAP_VALUES, detail=f"Got {gap!r}.")
+
+
+_VALID_HORIZONTAL_ALIGNMENTS: Final = ["left", "center", "right", "distribute"]
+_VALID_HORIZONTAL_ALIGNMENT_VALUES: Final = [
+    f"'{alignment}'" for alignment in _VALID_HORIZONTAL_ALIGNMENTS
+]
+_VALID_VERTICAL_ALIGNMENTS: Final = ["top", "center", "bottom", "distribute"]
+_VALID_VERTICAL_ALIGNMENT_VALUES: Final = [
+    f"'{alignment}'" for alignment in _VALID_VERTICAL_ALIGNMENTS
+]
 
 
 def validate_horizontal_alignment(horizontal_alignment: HorizontalAlignment) -> None:
-    valid_horizontal_alignments = ["left", "center", "right", "distribute"]
-    if horizontal_alignment not in valid_horizontal_alignments:
-        raise StreamlitInvalidHorizontalAlignmentError(
-            horizontal_alignment, "st.container"
+    if horizontal_alignment not in _VALID_HORIZONTAL_ALIGNMENTS:
+        raise StreamlitValueError(
+            "horizontal_alignment",
+            _VALID_HORIZONTAL_ALIGNMENT_VALUES,
+            detail=f"Got {horizontal_alignment!r}.",
         )
 
 
 def validate_vertical_alignment(vertical_alignment: VerticalAlignment) -> None:
-    valid_vertical_alignments = ["top", "center", "bottom", "distribute"]
-    if vertical_alignment not in valid_vertical_alignments:
-        raise StreamlitInvalidVerticalAlignmentError(vertical_alignment, "st.container")
+    if vertical_alignment not in _VALID_VERTICAL_ALIGNMENTS:
+        raise StreamlitValueError(
+            "vertical_alignment",
+            _VALID_VERTICAL_ALIGNMENT_VALUES,
+            detail=f"Got {vertical_alignment!r}.",
+        )
 
 
 def validate_text_alignment(text_alignment: TextAlignment) -> None:

--- a/lib/streamlit/elements/lib/layout_utils.py
+++ b/lib/streamlit/elements/lib/layout_utils.py
@@ -249,17 +249,10 @@ def validate_space_size(size: SpaceSize) -> None:
     StreamlitValueError
         If the size value is invalid.
     """
-    if not isinstance(size, (int, str)):
-        raise StreamlitValueError(
-            "size", _VALID_SPACE_SIZE_VALUES, detail=f"Got {size!r}."
-        )
-
-    if isinstance(size, str):
-        if size not in _VALID_SPACE_SIZE_STRINGS:
-            raise StreamlitValueError(
-                "size", _VALID_SPACE_SIZE_VALUES, detail=f"Got {size!r}."
-            )
-    elif isinstance(size, int) and size <= 0:
+    is_valid_size = (isinstance(size, str) and size in _VALID_SPACE_SIZE_STRINGS) or (
+        isinstance(size, int) and size > 0
+    )
+    if not is_valid_size:
         raise StreamlitValueError(
             "size", _VALID_SPACE_SIZE_VALUES, detail=f"Got {size!r}."
         )
@@ -303,7 +296,7 @@ _GAP_STRING_MAPPING: dict[str, GapSize.ValueType] = {
 _VALID_GAP_VALUES: Final = [
     *[f"'{size}'" for size in _GAP_STRING_MAPPING],
     "None",
-    "a non-negative integer",
+    "a non-negative integer (pixels)",
 ]
 
 

--- a/lib/streamlit/elements/lib/options_selector_utils.py
+++ b/lib/streamlit/elements/lib/options_selector_utils.py
@@ -76,7 +76,12 @@ def validate_select_widget_filter_mode(
 
     if filter_mode is None and accept_new_options:
         raise StreamlitIncompatibleParametersError(
-            "filter_mode=None", "accept_new_options=True"
+            "filter_mode=None",
+            "accept_new_options=True",
+            explanation=(
+                "`filter_mode` cannot be `None` when `accept_new_options=True`. "
+                "Set `filter_mode` to `fuzzy`, `contains`, or `prefix`."
+            ),
         )
 
     return _SELECT_WIDGET_FILTER_MODE_PROTO_MAP[filter_mode]

--- a/lib/streamlit/elements/lib/options_selector_utils.py
+++ b/lib/streamlit/elements/lib/options_selector_utils.py
@@ -21,8 +21,8 @@ from typing import TYPE_CHECKING, Any, Final, Literal, TypeVar, cast, overload
 from streamlit import config, logger
 from streamlit.dataframe_util import OptionSequence, convert_anything_to_list
 from streamlit.errors import (
-    StreamlitAPIException,
     StreamlitDefaultNotInOptionsError,
+    StreamlitIncompatibleParametersError,
     StreamlitValueError,
 )
 from streamlit.proto.SelectWidgetFilterMode_pb2 import (
@@ -61,7 +61,6 @@ def validate_select_widget_filter_mode(
     filter_mode: SelectWidgetFilterMode,
     *,
     accept_new_options: bool,
-    command: Literal["st.selectbox", "st.multiselect"],
 ) -> ProtoSelectWidgetFilterMode.ValueType:
     """Validate ``filter_mode`` and return the protobuf enum value."""
     try:
@@ -76,9 +75,8 @@ def validate_select_widget_filter_mode(
         )
 
     if filter_mode is None and accept_new_options:
-        raise StreamlitAPIException(
-            f"The `filter_mode` argument to `{command}` cannot be None when "
-            "`accept_new_options=True`."
+        raise StreamlitIncompatibleParametersError(
+            "filter_mode=None", "accept_new_options=True"
         )
 
     return _SELECT_WIDGET_FILTER_MODE_PROTO_MAP[filter_mode]

--- a/lib/streamlit/elements/pdf.py
+++ b/lib/streamlit/elements/pdf.py
@@ -105,7 +105,6 @@ class PdfMixin:
         # Validate data parameter early
         if data is None:
             raise StreamlitMissingRequiredParameterError(
-                "st.pdf",
                 "data",
                 detail=(
                     "Please provide a valid PDF file path, URL, bytes data, "

--- a/lib/streamlit/elements/toast.py
+++ b/lib/streamlit/elements/toast.py
@@ -32,7 +32,6 @@ if TYPE_CHECKING:
 def validate_text(toast_text: SupportsStr) -> SupportsStr:
     if str(toast_text) == "":
         raise StreamlitMissingRequiredParameterError(
-            "st.toast",
             "body",
             detail="Please provide a message.",
         )

--- a/lib/streamlit/elements/widgets/button.py
+++ b/lib/streamlit/elements/widgets/button.py
@@ -1645,7 +1645,6 @@ class ButtonMixin:
             if is_url(page):
                 if label is None or label == "":
                     raise StreamlitMissingRequiredParameterError(
-                        "st.page_link",
                         "label",
                         detail="Streamlit cannot infer a label for an external URL.",
                     )

--- a/lib/streamlit/elements/widgets/button_group.py
+++ b/lib/streamlit/elements/widgets/button_group.py
@@ -53,7 +53,11 @@ from streamlit.elements.lib.utils import (
     save_for_app_testing,
     to_key,
 )
-from streamlit.errors import StreamlitAPIException, StreamlitValueError
+from streamlit.errors import (
+    StreamlitAPIException,
+    StreamlitIncompatibleParametersError,
+    StreamlitValueError,
+)
 from streamlit.proto.ButtonGroup_pb2 import ButtonGroup as ButtonGroupProto
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner_utils.script_run_context import get_script_run_ctx
@@ -1094,9 +1098,10 @@ class ButtonGroupMixin:
 
         # Validate required with multi-select
         if required and selection_mode == "multi":
-            raise StreamlitAPIException(
-                "The `required` argument cannot be used with `selection_mode='multi'`. "
-                "The `required` parameter is only supported for single-select mode."
+            raise StreamlitIncompatibleParametersError(
+                "required=True",
+                "selection_mode='multi'",
+                explanation="`required` is only supported for single-select mode.",
             )
 
         # Use str as default format_func

--- a/lib/streamlit/elements/widgets/chat.py
+++ b/lib/streamlit/elements/widgets/chat.py
@@ -55,6 +55,7 @@ from streamlit.elements.lib.utils import (
 from streamlit.elements.widgets.audio_input import ALLOWED_SAMPLE_RATES
 from streamlit.errors import (
     StreamlitAPIException,
+    StreamlitInvalidLayoutContextError,
     StreamlitMissingRequiredParameterError,
     StreamlitValueError,
 )
@@ -527,7 +528,7 @@ class ChatMixin:
 
         """
         if name is None:
-            raise StreamlitMissingRequiredParameterError("st.chat_message", "name")
+            raise StreamlitMissingRequiredParameterError("name")
 
         if avatar is None and (
             name.lower() in {item.value for item in PresetNames} or is_emoji(name)
@@ -1027,7 +1028,7 @@ class ChatMixin:
         # We omit this check for scripts running outside streamlit, because
         # they will have no script_run_ctx.
         if runtime.exists() and is_in_form(self.dg):
-            raise StreamlitAPIException(
+            raise StreamlitInvalidLayoutContextError(
                 "`st.chat_input()` can't be used in a `st.form()`."
             )
 

--- a/lib/streamlit/elements/widgets/multiselect.py
+++ b/lib/streamlit/elements/widgets/multiselect.py
@@ -629,7 +629,6 @@ class MultiSelectMixin:
         proto_filter_mode = validate_select_widget_filter_mode(
             filter_mode,
             accept_new_options=accept_new_options,
-            command="st.multiselect",
         )
 
         form_id = current_form_id(self.dg)

--- a/lib/streamlit/elements/widgets/selectbox.py
+++ b/lib/streamlit/elements/widgets/selectbox.py
@@ -649,7 +649,6 @@ class SelectboxMixin:
         proto_filter_mode = validate_select_widget_filter_mode(
             filter_mode,
             accept_new_options=accept_new_options,
-            command="st.selectbox",
         )
 
         formatted_options, formatted_option_to_option_index = create_mappings(

--- a/lib/streamlit/elements/widgets/text_widgets.py
+++ b/lib/streamlit/elements/widgets/text_widgets.py
@@ -34,7 +34,11 @@ from streamlit.elements.lib.utils import (
     get_label_visibility_proto_value,
     to_key,
 )
-from streamlit.errors import StreamlitAPIException, StreamlitValueError
+from streamlit.errors import (
+    StreamlitAPIException,
+    StreamlitIncompatibleParametersError,
+    StreamlitValueError,
+)
 from streamlit.proto.TextArea_pb2 import TextArea as TextAreaProto
 from streamlit.proto.TextInput_pb2 import TextInput as TextInputProto
 from streamlit.runtime.metrics_util import gather_metrics
@@ -745,9 +749,10 @@ class TextWidgetsMixin:
 
         # Prevent binding password inputs to query params (exposes secrets in URL)
         if bind == "query-params" and type == "password":
-            raise StreamlitAPIException(
-                "Cannot use `bind='query-params'` with `type='password'`. "
-                "Password values must not appear in URLs."
+            raise StreamlitIncompatibleParametersError(
+                "bind='query-params'",
+                "type='password'",
+                explanation="Password values must not appear in URLs.",
             )
 
         # Set query param key if bound

--- a/lib/streamlit/errors.py
+++ b/lib/streamlit/errors.py
@@ -193,6 +193,13 @@ class StreamlitModuleNotFoundError(StreamlitAPIWarning):
 
 
 class LocalizableStreamlitException(StreamlitAPIException):
+    """API exception with a format-string message and kwargs for localization.
+
+    Users can localize the message from ``exec_kwargs``, for example in an
+    ``on_script_error`` handler on ``st.App``. Kwargs are used for telemetry
+    only in a few specific cases (for example ``parameter``).
+    """
+
     def __init__(self, message: str, **kwargs: Any) -> None:
         super().__init__((message).format(**kwargs))
         self._exec_kwargs = kwargs
@@ -428,19 +435,51 @@ class StreamlitInvalidNumberFormatError(LocalizableStreamlitException):
 
 
 class StreamlitMissingRequiredParameterError(LocalizableStreamlitException):
-    """Raised when a required parameter is missing, ``None``, or empty."""
+    """Raised when a required parameter is missing, ``None``, or empty.
 
-    def __init__(
-        self, command: str, parameter: str, *, detail: str | None = None
-    ) -> None:
-        message = "The `{parameter}` parameter is required for `{command}`."
+    Uncaught-exception telemetry appends the parameter name, for example
+    ``StreamlitMissingRequiredParameterError:label``.
+    """
+
+    def __init__(self, parameter: str, *, detail: str | None = None) -> None:
+        message = "The `{parameter}` parameter is required."
         if detail:
             message += " {detail}"
         super().__init__(
             message,
-            command=command,
             parameter=parameter,
             detail=detail,
+        )
+
+
+class StreamlitIncompatibleParametersError(LocalizableStreamlitException):
+    """Raised when two or more parameter uses cannot be combined.
+
+    Pass the value when the conflict depends on it (for example
+    ``wrap=False``), or the bare parameter name when merely providing it
+    conflicts (for example ``on_change``).
+    Uses are overlay-only; uncaught-exception telemetry is the type name
+    with no suffix.
+    """
+
+    def __init__(self, *uses: str, explanation: str | None = None) -> None:
+        if len(uses) < 2:
+            raise ValueError(
+                "StreamlitIncompatibleParametersError requires at least two "
+                "parameter uses."
+            )
+        quoted = [f"`{use}`" for use in uses]
+        if len(quoted) == 2:
+            uses_text = f"{quoted[0]} and {quoted[1]}"
+        else:
+            uses_text = ", ".join(quoted[:-1]) + f", and {quoted[-1]}"
+        message = "{uses_text} cannot be used together."
+        if explanation:
+            message += " {explanation}"
+        super().__init__(
+            message,
+            uses_text=uses_text,
+            explanation=explanation,
         )
 
 
@@ -557,7 +596,7 @@ class StreamlitInvalidFormCallbackError(LocalizableStreamlitException):
 
 
 class StreamlitInvalidLayoutContextError(StreamlitAPIException):
-    """Raised when a command is used in a disallowed layout context."""
+    """Raised when a command is used in a disallowed layout, form, or dialog context."""
 
 
 class StreamlitValueAssignmentNotAllowedError(LocalizableStreamlitException):
@@ -656,11 +695,21 @@ class StreamlitInvalidSizeError(LocalizableStreamlitException):
 class StreamlitValueError(LocalizableStreamlitException):
     """Raised when a parameter receives a value outside a known finite set."""
 
-    def __init__(self, parameter: str, valid_values: list[str]) -> None:
+    def __init__(
+        self,
+        parameter: str,
+        valid_values: list[str],
+        *,
+        detail: str | None = None,
+    ) -> None:
+        message = "Invalid `{parameter}` value. Supported values: {valid_values}."
+        if detail:
+            message += " {detail}"
         super().__init__(
-            "Invalid `{parameter}` value. Supported values: {valid_values}.",
+            message,
             parameter=parameter,
             valid_values=", ".join(valid_values),
+            detail=detail,
         )
 
 
@@ -668,14 +717,25 @@ class StreamlitInvalidParameterTypeError(LocalizableStreamlitException):
     """Raised when a parameter has an unsupported type."""
 
     def __init__(
-        self, parameter: str, provided_type: str, expected_types: list[str]
+        self,
+        parameter: str,
+        provided_type: str,
+        expected_types: list[str],
+        *,
+        detail: str | None = None,
     ) -> None:
-        super().__init__(
+        message = (
             "Invalid `{parameter}` type. Expected one of: {expected_types}. "
-            "Provided type: {provided_type}.",
+            "Provided type: {provided_type}."
+        )
+        if detail:
+            message += " {detail}"
+        super().__init__(
+            message,
             parameter=parameter,
             expected_types=", ".join(expected_types),
             provided_type=provided_type,
+            detail=detail,
         )
 
 

--- a/lib/streamlit/errors.py
+++ b/lib/streamlit/errors.py
@@ -254,47 +254,6 @@ class StreamlitInvalidColumnSpecError(LocalizableStreamlitException):
         )
 
 
-class StreamlitInvalidVerticalAlignmentError(LocalizableStreamlitException):
-    """Exception raised when an invalid value is specified for vertical_alignment."""
-
-    def __init__(self, vertical_alignment: str, element_type: str) -> None:
-        super().__init__(
-            "The `vertical_alignment` argument to `{element_type}` must be "
-            '`"top"`, `"center"`, `"bottom"`, or `"distribute"`. \n'
-            "The argument passed was {vertical_alignment}.",
-            vertical_alignment=vertical_alignment,
-            element_type=element_type,
-        )
-
-
-class StreamlitInvalidColumnGapError(LocalizableStreamlitException):
-    """Exception raised when an invalid value is specified for gap."""
-
-    def __init__(self, gap: object, element_type: str) -> None:
-        super().__init__(
-            'The `gap` argument to `{element_type}` must be `"xxsmall"`, '
-            '`"xsmall"`, `"small"`, `"medium"`, `"large"`, `"xlarge"`, '
-            '`"xxlarge"`, `None`, or a non-negative integer specifying '
-            "the gap in pixels. \n"
-            "The argument passed was {gap}.",
-            gap=gap,
-            element_type=element_type,
-        )
-
-
-class StreamlitInvalidHorizontalAlignmentError(LocalizableStreamlitException):
-    """Exception raised when an invalid value is specified for horizontal_alignment."""
-
-    def __init__(self, horizontal_alignment: str, element_type: str) -> None:
-        super().__init__(
-            "The `horizontal_alignment` argument to `{element_type}` must be "
-            '`"left"`, `"center"`, `"right"`, or `"distribute"`. \n'
-            "The argument passed was {horizontal_alignment}.",
-            horizontal_alignment=horizontal_alignment,
-            element_type=element_type,
-        )
-
-
 # st.multiselect
 class StreamlitSelectionCountExceedsMaxError(LocalizableStreamlitException):
     """Exception raised when there are more default selections specified than the max allowable selections."""
@@ -455,11 +414,11 @@ class StreamlitMissingRequiredParameterError(LocalizableStreamlitException):
 class StreamlitIncompatibleParametersError(LocalizableStreamlitException):
     """Raised when two or more parameter uses cannot be combined.
 
-    Pass the value when the conflict depends on it (for example
-    ``wrap=False``), or the bare parameter name when merely providing it
-    conflicts (for example ``on_change``).
-    Uses are overlay-only; uncaught-exception telemetry is the type name
-    with no suffix.
+    Describe each conflict as a string. Include ``parameter=value`` when the
+    conflict depends on a value (for example ``wrap=False``); otherwise pass
+    only the parameter name (for example ``on_change``). These strings appear
+    only in the displayed error; uncaught-exception telemetry records only
+    the exception type.
     """
 
     def __init__(self, *uses: str, explanation: str | None = None) -> None:
@@ -681,19 +640,13 @@ class StreamlitInvalidHeightError(LocalizableStreamlitException):
         )
 
 
-class StreamlitInvalidSizeError(LocalizableStreamlitException):
-    """Exception raised when an invalid size value is provided."""
-
-    def __init__(self, size: Any) -> None:
-        super().__init__(
-            "Invalid size value: {size}. Size must be either a positive integer (pixels), "
-            "'stretch', 'small', 'medium', or 'large'.",
-            size=repr(size),
-        )
-
-
 class StreamlitValueError(LocalizableStreamlitException):
-    """Raised when a parameter receives a value outside a known finite set."""
+    """Raised when a parameter receives a value outside a known finite set.
+
+    Uncaught-exception telemetry appends the parameter name, for example
+    ``StreamlitValueError:width``. Optional ``detail`` appears in the error
+    message only.
+    """
 
     def __init__(
         self,
@@ -793,6 +746,18 @@ StreamlitInvalidBindValueError = (  # Replaced: StreamlitValueError.
     StreamlitValueError
 )
 StreamlitInvalidPersistStateError = (  # Replaced: StreamlitValueError.
+    StreamlitValueError
+)
+StreamlitInvalidSizeError = (  # Replaced: StreamlitValueError.
+    StreamlitValueError
+)
+StreamlitInvalidVerticalAlignmentError = (  # Replaced: StreamlitValueError.
+    StreamlitValueError
+)
+StreamlitInvalidColumnGapError = (  # Replaced: StreamlitValueError.
+    StreamlitValueError
+)
+StreamlitInvalidHorizontalAlignmentError = (  # Replaced: StreamlitValueError.
     StreamlitValueError
 )
 StreamlitMissingPageLabelError = (  # Replaced: StreamlitMissingRequiredParameterError.

--- a/lib/streamlit/errors.py
+++ b/lib/streamlit/errors.py
@@ -421,12 +421,14 @@ class StreamlitIncompatibleParametersError(LocalizableStreamlitException):
     the exception type.
     """
 
-    def __init__(self, *uses: str, explanation: str | None = None) -> None:
-        if len(uses) < 2:
-            raise ValueError(
-                "StreamlitIncompatibleParametersError requires at least two "
-                "parameter uses."
-            )
+    def __init__(
+        self,
+        first_use: str,
+        second_use: str,
+        *other_uses: str,
+        explanation: str | None = None,
+    ) -> None:
+        uses = (first_use, second_use, *other_uses)
         quoted = [f"`{use}`" for use in uses]
         if len(quoted) == 2:
             uses_text = f"{quoted[0]} and {quoted[1]}"
@@ -642,11 +644,13 @@ class StreamlitInvalidHeightError(LocalizableStreamlitException):
 
 
 class StreamlitValueError(LocalizableStreamlitException):
-    """Raised when a parameter receives a value outside a known finite set.
+    """Raised when a parameter receives a value outside a known set or range.
 
-    Uncaught-exception telemetry appends the parameter name, for example
-    ``StreamlitValueError:width``. Optional ``detail`` appears in the error
-    message only.
+    ``valid_values`` is the user-facing list of supported values: Literal /
+    enum-like options, or a short description of an accepted range (for
+    example ``a positive duration``). Uncaught-exception telemetry appends
+    the parameter name, for example ``StreamlitValueError:width``. Optional
+    ``detail`` appears in the error message only.
     """
 
     def __init__(
@@ -737,6 +741,10 @@ class StreamlitInvalidThemeSectionError(LocalizableStreamlitException):
 
 
 # Deprecated aliases kept only for backward compatibility.
+# Identity aliases preserve `except OldName` for migrated raises, but also
+# catch every instance of the replacement type. Several names below shipped
+# as distinct classes in 1.62.0 (including StreamlitInvalidSizeError and the
+# gap/alignment errors); do not delete them as unused.
 StreamlitInvalidPageLayoutError = (  # Replaced: StreamlitValueError.
     StreamlitValueError
 )

--- a/lib/streamlit/errors.py
+++ b/lib/streamlit/errors.py
@@ -438,6 +438,7 @@ class StreamlitIncompatibleParametersError(LocalizableStreamlitException):
         super().__init__(
             message,
             uses_text=uses_text,
+            uses=list(uses),
             explanation=explanation,
         )
 

--- a/lib/streamlit/navigation/page.py
+++ b/lib/streamlit/navigation/page.py
@@ -267,7 +267,6 @@ class Page:
         if isinstance(page, str) and is_url(page):
             if title is None or title.strip() == "":
                 raise StreamlitMissingRequiredParameterError(
-                    "st.Page",
                     "title",
                     detail=(
                         "External URL pages require a non-empty title. "
@@ -342,7 +341,6 @@ class Page:
             # not exist. In that case, we should inform the user the title is
             # mandatory.
             raise StreamlitMissingRequiredParameterError(
-                "st.Page",
                 "title",
                 detail="Streamlit cannot infer a title from this callable.",
             )
@@ -357,7 +355,6 @@ class Page:
 
         if self._title.strip() == "":
             raise StreamlitMissingRequiredParameterError(
-                "st.Page",
                 "title",
                 detail="It cannot be empty or consist of underscores/spaces only.",
             )

--- a/lib/streamlit/runtime/caching/cache_data_api.py
+++ b/lib/streamlit/runtime/caching/cache_data_api.py
@@ -33,7 +33,7 @@ from typing_extensions import ParamSpec
 
 import streamlit as st
 from streamlit import runtime
-from streamlit.errors import StreamlitAPIException, StreamlitValueError
+from streamlit.errors import StreamlitIncompatibleParametersError, StreamlitValueError
 from streamlit.logger import get_logger
 from streamlit.runtime.caching import cache_utils
 from streamlit.runtime.caching.cache_errors import CacheError, CacheKeyNotFoundError
@@ -714,16 +714,19 @@ class CacheDataAPI:
             raise StreamlitValueError("scope", ["'global'", "'session'"])
 
         validate_refresh_mode(
-            refresh_mode, time_to_seconds(ttl, coerce_none_to_inf=False)
+            refresh_mode,
+            time_to_seconds(ttl, coerce_none_to_inf=False),
         )
 
         if refresh_mode == "background" and persist_string is not None:
-            raise StreamlitAPIException(
-                "The 'refresh_mode=\"background\"' option is not compatible with "
-                "'persist' caching. Persisted (disk) caches do not support TTL-based "
-                "expiration, which background refresh requires. Use persist=None (the "
-                'default) with refresh_mode="background", or use '
-                'refresh_mode="foreground".'
+            raise StreamlitIncompatibleParametersError(
+                "refresh_mode='background'",
+                f"persist={persist!r}",
+                explanation=(
+                    "Persisted (disk) caches do not support TTL-based expiration, "
+                    "which background refresh requires. Use `persist=None` with "
+                    '`refresh_mode="background"`, or use `refresh_mode="foreground"`.'
+                ),
             )
 
         def wrapper(f: Callable[P, R]) -> CachedFunc[P, R]:

--- a/lib/streamlit/runtime/caching/cache_resource_api.py
+++ b/lib/streamlit/runtime/caching/cache_resource_api.py
@@ -642,7 +642,8 @@ class CacheResourceAPI:
             raise StreamlitValueError("scope", ["'global'", "'session'"])
 
         validate_refresh_mode(
-            refresh_mode, time_to_seconds(ttl, coerce_none_to_inf=False)
+            refresh_mode,
+            time_to_seconds(ttl, coerce_none_to_inf=False),
         )
 
         # Support passing the params via function decorator, e.g.

--- a/lib/streamlit/runtime/caching/cache_utils.py
+++ b/lib/streamlit/runtime/caching/cache_utils.py
@@ -42,7 +42,11 @@ from typing_extensions import ParamSpec
 from streamlit import type_util, util
 from streamlit.dataframe_util import is_unevaluated_data_object
 from streamlit.delta_generator_singletons import get_dg_singleton_instance
-from streamlit.errors import StreamlitAPIException, StreamlitValueError
+from streamlit.errors import (
+    StreamlitAPIException,
+    StreamlitMissingRequiredParameterError,
+    StreamlitValueError,
+)
 from streamlit.logger import get_logger
 from streamlit.runtime.caching import cache_background_refresh
 from streamlit.runtime.caching.cache_errors import (
@@ -127,19 +131,32 @@ def validate_refresh_mode(refresh_mode: str, ttl_seconds: float | None) -> None:
     Raises
     ------
     StreamlitValueError
-        Raised if ``refresh_mode`` is not a valid value.
-    StreamlitAPIException
-        Raised if ``refresh_mode="background"`` is used without a positive ttl.
+        Raised if ``refresh_mode`` is not a valid value, or if
+        ``refresh_mode="background"`` is used with a non-positive ttl.
+    StreamlitMissingRequiredParameterError
+        Raised if ``refresh_mode="background"`` is used without a ttl.
     """
     if refresh_mode not in {"foreground", "background"}:
         raise StreamlitValueError("refresh_mode", ["foreground", "background"])
 
-    if refresh_mode == "background" and (ttl_seconds is None or ttl_seconds <= 0):
-        raise StreamlitAPIException(
-            "The 'refresh_mode=\"background\"' option requires a 'ttl' value. "
-            "Background refresh only makes sense when cache entries can expire. Set "
-            'a \'ttl\' (e.g. ttl="1h") or use refresh_mode="foreground".'
-        )
+    if refresh_mode == "background":
+        if ttl_seconds is None:
+            raise StreamlitMissingRequiredParameterError(
+                "ttl",
+                detail=(
+                    'Set a positive `ttl` (for example `ttl="1h"`) or use '
+                    '`refresh_mode="foreground"`.'
+                ),
+            )
+        if ttl_seconds <= 0:
+            raise StreamlitValueError(
+                "ttl",
+                ["a positive duration"],
+                detail=(
+                    "Background refresh requires a positive `ttl` (for example "
+                    '`ttl="1h"`) or `refresh_mode="foreground"`.'
+                ),
+            )
 
 
 def get_session_id_or_throw() -> str:

--- a/lib/streamlit/runtime/state/widgets.py
+++ b/lib/streamlit/runtime/state/widgets.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING
 
 from streamlit.errors import (
     StreamlitAPIException,
+    StreamlitIncompatibleParametersError,
     StreamlitValueError,
 )
 from streamlit.runtime.scriptrunner_utils.script_run_context import (
@@ -155,9 +156,7 @@ def register_widget(
         to be used in a non-streamlit setting.
     """
     if on_change_handler is not None and callbacks is not None:
-        raise StreamlitAPIException(
-            "Cannot provide both `on_change` and `callbacks` to a widget."
-        )
+        raise StreamlitIncompatibleParametersError("on_change", "callbacks")
 
     # Validate bind parameter value
     if bind is not None and bind != "query-params":

--- a/lib/tests/streamlit/delta_generator_singletons_test.py
+++ b/lib/tests/streamlit/delta_generator_singletons_test.py
@@ -27,7 +27,7 @@ from streamlit.delta_generator_singletons import (
     get_last_dg_added_to_context_stack,
 )
 from streamlit.elements.lib.skeleton_placeholder import SkeletonPlaceholder
-from streamlit.errors import StreamlitAPIException
+from streamlit.errors import StreamlitInvalidLayoutContextError
 from streamlit.proto.RootContainer_pb2 import RootContainer
 
 
@@ -110,7 +110,7 @@ class BottomContainerProxyTest(unittest.TestCase):
 def test_bottom_raises_exception_inside_sidebar(use_context_manager: bool) -> None:
     """Verify st.bottom raises inside st.sidebar."""
     with st.sidebar:
-        with pytest.raises(StreamlitAPIException, match=r"st\.sidebar"):
+        with pytest.raises(StreamlitInvalidLayoutContextError, match=r"`st.sidebar`"):
             if use_context_manager:
                 with st.bottom:
                     pass
@@ -122,7 +122,9 @@ def test_bottom_raises_exception_inside_nested_sidebar() -> None:
     """Verify st.bottom raises in nested containers within sidebar."""
     with st.sidebar:
         with st.container():
-            with pytest.raises(StreamlitAPIException, match=r"st\.sidebar"):
+            with pytest.raises(
+                StreamlitInvalidLayoutContextError, match=r"`st.sidebar`"
+            ):
                 st.bottom.markdown("test")
 
 
@@ -142,7 +144,7 @@ def test_bottom_raises_exception_inside_dialog(use_context_manager: bool) -> Non
     )
     token = context_dg_stack.set((*context_dg_stack.get(), dialog_dg))
     try:
-        with pytest.raises(StreamlitAPIException, match=r"dialog"):
+        with pytest.raises(StreamlitInvalidLayoutContextError, match=r"dialog"):
             if use_context_manager:
                 with st.bottom:
                     pass
@@ -160,7 +162,9 @@ def test_bottom_raises_exception_inside_event_container() -> None:
     )
     token = context_dg_stack.set((*context_dg_stack.get(), event_dg))
     try:
-        with pytest.raises(StreamlitAPIException, match=r"event containers"):
+        with pytest.raises(
+            StreamlitInvalidLayoutContextError, match=r"event containers"
+        ):
             st.bottom.write("test")
     finally:
         context_dg_stack.reset(token)

--- a/lib/tests/streamlit/delta_generator_test.py
+++ b/lib/tests/streamlit/delta_generator_test.py
@@ -41,6 +41,7 @@ from streamlit.errors import (
     StreamlitAPIException,
     StreamlitDuplicateElementId,
     StreamlitDuplicateElementKey,
+    StreamlitInvalidLayoutContextError,
 )
 from streamlit.logger import get_logger
 from streamlit.proto import Block_pb2
@@ -1256,10 +1257,11 @@ class ParallelWorkerExternalContainerWriteTest(DeltaGeneratorTestCase):
                 cursor=outside_cursor,
             )
 
-            with pytest.raises(StreamlitAPIException) as exc_info:
+            with pytest.raises(
+                StreamlitInvalidLayoutContextError,
+                match="outside a parallel fragment",
+            ):
                 outside_dg._enqueue("text", TextProto())
-
-            assert "outside a parallel fragment" in str(exc_info.value)
         finally:
             ThreadState.update(is_parallel_worker=False, delta_path=())
 
@@ -1612,9 +1614,11 @@ class OutsideWrapperCreationTest(DeltaGeneratorTestCase):
         self.script_run_ctx.fragment_ids_this_run = ["frag"]
         _enter_fragment(self)
 
-        with pytest.raises(StreamlitAPIException) as exc_info:
+        with pytest.raises(
+            StreamlitInvalidLayoutContextError,
+            match="could not reserve a stable position",
+        ):
             outside.markdown("hi")
-        assert "could not reserve a stable position" in str(exc_info.value)
 
     def test_fragment_rerun_allows_wrapper_for_container_created_by_running_fragment(
         self,

--- a/lib/tests/streamlit/elements/arrow_dataframe_test.py
+++ b/lib/tests/streamlit/elements/arrow_dataframe_test.py
@@ -45,7 +45,11 @@ from streamlit.elements.lib.column_config_utils import (
     ButtonClickSerde,
     ButtonColumnClickState,
 )
-from streamlit.errors import StreamlitAPIException, StreamlitValueError
+from streamlit.errors import (
+    StreamlitAPIException,
+    StreamlitIncompatibleParametersError,
+    StreamlitValueError,
+)
 from streamlit.proto.Dataframe_pb2 import Dataframe as DataframeProto
 from streamlit.proto.Dataframe_pb2 import LazyDataframe as LazyDataframeProto
 from streamlit.testing.v1 import AppTest
@@ -469,7 +473,10 @@ class ArrowDataFrameProtoTest(DeltaGeneratorTestCase):
         """Test that selection_default requires on_select to be activated."""
         df = pd.DataFrame([[1, 2], [3, 4]], columns=["col1", "col2"])
 
-        with pytest.raises(StreamlitAPIException):
+        with pytest.raises(
+            StreamlitIncompatibleParametersError,
+            match=r"Set `on_select` to `'rerun'` or a callback",
+        ):
             st.dataframe(df, selection_default={"selection": {"rows": [0]}})
 
     def test_row_selection_auto_hides_range_index(self):

--- a/lib/tests/streamlit/elements/button_group_test.py
+++ b/lib/tests/streamlit/elements/button_group_test.py
@@ -2184,7 +2184,10 @@ class RequiredParameterTest(DeltaGeneratorTestCase):
         self, command: Callable[..., Any]
     ):
         """Test that required=True with selection_mode='multi' raises an exception."""
-        with pytest.raises(StreamlitIncompatibleParametersError):
+        with pytest.raises(
+            StreamlitIncompatibleParametersError,
+            match=r"`required` is only supported for single-select mode",
+        ):
             command("label", ["a", "b", "c"], selection_mode="multi", required=True)
 
     @parameterized.expand([(st.pills,), (st.segmented_control,)])

--- a/lib/tests/streamlit/elements/button_group_test.py
+++ b/lib/tests/streamlit/elements/button_group_test.py
@@ -33,6 +33,7 @@ from streamlit.elements.widgets.button_group import (
 from streamlit.errors import (
     StreamlitAPIException,
     StreamlitDuplicateElementId,
+    StreamlitIncompatibleParametersError,
     StreamlitValueError,
 )
 from streamlit.proto.ButtonGroup_pb2 import ButtonGroup as ButtonGroupProto
@@ -2183,10 +2184,7 @@ class RequiredParameterTest(DeltaGeneratorTestCase):
         self, command: Callable[..., Any]
     ):
         """Test that required=True with selection_mode='multi' raises an exception."""
-        with pytest.raises(
-            StreamlitAPIException,
-            match=r"cannot be used with.*selection_mode='multi'",
-        ):
+        with pytest.raises(StreamlitIncompatibleParametersError):
             command("label", ["a", "b", "c"], selection_mode="multi", required=True)
 
     @parameterized.expand([(st.pills,), (st.segmented_control,)])

--- a/lib/tests/streamlit/elements/chat_test.py
+++ b/lib/tests/streamlit/elements/chat_test.py
@@ -30,6 +30,7 @@ from streamlit.elements.widgets.chat import (
 from streamlit.errors import (
     StreamlitAPIException,
     StreamlitInvalidHeightError,
+    StreamlitInvalidLayoutContextError,
     StreamlitInvalidWidthError,
     StreamlitMissingRequiredParameterError,
     StreamlitValueError,
@@ -168,13 +169,8 @@ class ChatTest(DeltaGeneratorTestCase):
 
     def test_chat_not_allowed_in_form(self):
         """Test that it disallows being called in a form."""
-        with pytest.raises(StreamlitAPIException) as exception_message:
+        with pytest.raises(StreamlitInvalidLayoutContextError):
             st.form("Form Key").chat_input()
-
-        assert (
-            str(exception_message.value)
-            == "`st.chat_input()` can't be used in a `st.form()`."
-        )
 
     @parameterized.expand(
         [

--- a/lib/tests/streamlit/elements/chat_test.py
+++ b/lib/tests/streamlit/elements/chat_test.py
@@ -169,7 +169,10 @@ class ChatTest(DeltaGeneratorTestCase):
 
     def test_chat_not_allowed_in_form(self):
         """Test that it disallows being called in a form."""
-        with pytest.raises(StreamlitInvalidLayoutContextError):
+        with pytest.raises(
+            StreamlitInvalidLayoutContextError,
+            match=r"`st.chat_input\(\)` can't be used in a `st.form\(\)`",
+        ):
             st.form("Form Key").chat_input()
 
     @parameterized.expand(

--- a/lib/tests/streamlit/elements/html_test.py
+++ b/lib/tests/streamlit/elements/html_test.py
@@ -75,10 +75,8 @@ class StHtmlAPITest(DeltaGeneratorTestCase):
 
     def test_st_html_empty_body_throws_error(self):
         """Test st.html with empty body throws error."""
-        with pytest.raises(StreamlitMissingRequiredParameterError) as ctx:
+        with pytest.raises(StreamlitMissingRequiredParameterError):
             st.html("")
-
-        assert "The `body` parameter is required for `st.html`" in str(ctx.value)
 
     def test_st_html_with_style_tag_only(self):
         """Test st.html with only a style tag."""

--- a/lib/tests/streamlit/elements/layouts_test.py
+++ b/lib/tests/streamlit/elements/layouts_test.py
@@ -117,7 +117,7 @@ class ColumnsTest(DeltaGeneratorTestCase):
 
     def test_columns_with_invalid_vertical_alignment(self):
         """Test that it throws an error on invalid vertical_alignment argument"""
-        with pytest.raises(StreamlitValueError):
+        with pytest.raises(StreamlitValueError, match=r"Got 'invalid'\."):
             st.columns(3, vertical_alignment="invalid")
 
     def test_not_equal_width_int_columns(self):
@@ -322,7 +322,7 @@ class ColumnsTest(DeltaGeneratorTestCase):
     )
     def test_columns_with_invalid_gap(self, invalid_gap):
         """Test that it throws an error on invalid gap argument"""
-        with pytest.raises(StreamlitValueError):
+        with pytest.raises(StreamlitValueError, match=r"`gap`"):
             st.columns(3, gap=invalid_gap)
 
     def test_columns_with_border(self):
@@ -409,7 +409,10 @@ class ExpanderTest(DeltaGeneratorTestCase):
 
     def test_label_none_raises(self):
         """Test that an explicit label=None raises StreamlitMissingRequiredParameterError."""
-        with pytest.raises(StreamlitMissingRequiredParameterError):
+        with pytest.raises(
+            StreamlitMissingRequiredParameterError,
+            match=r"The `label` parameter is required",
+        ):
             st.expander(None)
 
     def test_just_label(self):
@@ -932,7 +935,7 @@ class ContainerTest(DeltaGeneratorTestCase):
         """Test that st.container raises for wrap=False without horizontal=True."""
         with pytest.raises(
             StreamlitIncompatibleParametersError,
-            match=r"`wrap=False` can only be used with `horizontal=True`",
+            match=r"Set `horizontal=True` to use `wrap=False`",
         ):
             st.container(horizontal=False, wrap=False)
 
@@ -974,7 +977,7 @@ class ContainerTest(DeltaGeneratorTestCase):
     @parameterized.expand([("invalid",), (-1,), (True,)])
     def test_container_invalid_gap(self, invalid_gap) -> None:
         """Test that st.container raises on invalid gap values."""
-        with pytest.raises(StreamlitValueError):
+        with pytest.raises(StreamlitValueError, match=r"`gap`"):
             st.container(gap=invalid_gap)
 
     @parameterized.expand(
@@ -985,7 +988,7 @@ class ContainerTest(DeltaGeneratorTestCase):
     )
     def test_container_invalid_horizontal_alignment(self, horizontal_alignment) -> None:
         """Test that st.container raises on invalid horizontal_alignment."""
-        with pytest.raises(StreamlitValueError):
+        with pytest.raises(StreamlitValueError, match=r"`horizontal_alignment`"):
             st.container(horizontal=True, horizontal_alignment=horizontal_alignment)
 
     @parameterized.expand(
@@ -996,7 +999,7 @@ class ContainerTest(DeltaGeneratorTestCase):
     )
     def test_container_invalid_vertical_alignment(self, vertical_alignment) -> None:
         """Test that st.container raises on invalid vertical_alignment."""
-        with pytest.raises(StreamlitValueError):
+        with pytest.raises(StreamlitValueError, match=r"`vertical_alignment`"):
             st.container(horizontal=True, vertical_alignment=vertical_alignment)
 
     @parameterized.expand(
@@ -1039,7 +1042,10 @@ class PopoverContainerTest(DeltaGeneratorTestCase):
 
     def test_label_none_raises(self):
         """Test that an explicit label=None raises StreamlitMissingRequiredParameterError."""
-        with pytest.raises(StreamlitMissingRequiredParameterError):
+        with pytest.raises(
+            StreamlitMissingRequiredParameterError,
+            match=r"The `label` parameter is required",
+        ):
             st.popover(None)
 
     def test_invalid_type_raises(self):
@@ -2334,7 +2340,10 @@ class DialogTest(DeltaGeneratorTestCase):
             "dialog_decorator() missing 1 required positional argument: 'title'"
         )
 
-        with pytest.raises(StreamlitMissingRequiredParameterError):
+        with pytest.raises(
+            StreamlitMissingRequiredParameterError,
+            match=r"The `title` parameter is required",
+        ):
 
             @st.dialog("")
             def dialog():
@@ -2379,7 +2388,10 @@ class DialogTest(DeltaGeneratorTestCase):
         def level1_dialog():
             level2_dialog()
 
-        with pytest.raises(FragmentHandledException):
+        with pytest.raises(
+            FragmentHandledException,
+            match=r"Dialogs may not be nested inside other dialogs\.",
+        ):
             level1_dialog()
 
     def test_only_one_dialog_can_be_opened_at_same_time(self):
@@ -2391,7 +2403,10 @@ class DialogTest(DeltaGeneratorTestCase):
         def dialog2():
             st.empty()
 
-        with pytest.raises(StreamlitInvalidLayoutContextError):
+        with pytest.raises(
+            StreamlitInvalidLayoutContextError,
+            match=r"Only one dialog is allowed to be opened at the same time\.",
+        ):
             dialog1()
             dialog2()
 

--- a/lib/tests/streamlit/elements/layouts_test.py
+++ b/lib/tests/streamlit/elements/layouts_test.py
@@ -25,11 +25,10 @@ from streamlit.errors import (
     FragmentHandledException,
     StreamlitAPIException,
     StreamlitDuplicateElementId,
-    StreamlitInvalidColumnGapError,
+    StreamlitIncompatibleParametersError,
     StreamlitInvalidFormCallbackError,
-    StreamlitInvalidHorizontalAlignmentError,
+    StreamlitInvalidLayoutContextError,
     StreamlitInvalidParameterTypeError,
-    StreamlitInvalidVerticalAlignmentError,
     StreamlitMissingRequiredParameterError,
     StreamlitValueError,
 )
@@ -118,7 +117,7 @@ class ColumnsTest(DeltaGeneratorTestCase):
 
     def test_columns_with_invalid_vertical_alignment(self):
         """Test that it throws an error on invalid vertical_alignment argument"""
-        with pytest.raises(StreamlitAPIException):
+        with pytest.raises(StreamlitValueError):
             st.columns(3, vertical_alignment="invalid")
 
     def test_not_equal_width_int_columns(self):
@@ -323,7 +322,7 @@ class ColumnsTest(DeltaGeneratorTestCase):
     )
     def test_columns_with_invalid_gap(self, invalid_gap):
         """Test that it throws an error on invalid gap argument"""
-        with pytest.raises(StreamlitInvalidColumnGapError):
+        with pytest.raises(StreamlitValueError):
             st.columns(3, gap=invalid_gap)
 
     def test_columns_with_border(self):
@@ -410,9 +409,8 @@ class ExpanderTest(DeltaGeneratorTestCase):
 
     def test_label_none_raises(self):
         """Test that an explicit label=None raises StreamlitMissingRequiredParameterError."""
-        with pytest.raises(StreamlitMissingRequiredParameterError) as e:
+        with pytest.raises(StreamlitMissingRequiredParameterError):
             st.expander(None)
-        assert "The `label` parameter is required for `st.expander`" in str(e.value)
 
     def test_just_label(self):
         """Test that it can be called with no params"""
@@ -932,9 +930,11 @@ class ContainerTest(DeltaGeneratorTestCase):
 
     def test_container_wrap_false_without_horizontal_raises(self) -> None:
         """Test that st.container raises for wrap=False without horizontal=True."""
-        with pytest.raises(StreamlitAPIException) as exc:
+        with pytest.raises(
+            StreamlitIncompatibleParametersError,
+            match=r"`wrap=False` can only be used with `horizontal=True`",
+        ):
             st.container(horizontal=False, wrap=False)
-        assert "horizontal=True" in str(exc.value)
 
     def test_container_wrap_true_without_horizontal_allowed(self) -> None:
         """Test that wrap=True on a vertical container is a no-op, not an error."""
@@ -974,7 +974,7 @@ class ContainerTest(DeltaGeneratorTestCase):
     @parameterized.expand([("invalid",), (-1,), (True,)])
     def test_container_invalid_gap(self, invalid_gap) -> None:
         """Test that st.container raises on invalid gap values."""
-        with pytest.raises(StreamlitInvalidColumnGapError):
+        with pytest.raises(StreamlitValueError):
             st.container(gap=invalid_gap)
 
     @parameterized.expand(
@@ -985,7 +985,7 @@ class ContainerTest(DeltaGeneratorTestCase):
     )
     def test_container_invalid_horizontal_alignment(self, horizontal_alignment) -> None:
         """Test that st.container raises on invalid horizontal_alignment."""
-        with pytest.raises(StreamlitInvalidHorizontalAlignmentError):
+        with pytest.raises(StreamlitValueError):
             st.container(horizontal=True, horizontal_alignment=horizontal_alignment)
 
     @parameterized.expand(
@@ -996,7 +996,7 @@ class ContainerTest(DeltaGeneratorTestCase):
     )
     def test_container_invalid_vertical_alignment(self, vertical_alignment) -> None:
         """Test that st.container raises on invalid vertical_alignment."""
-        with pytest.raises(StreamlitInvalidVerticalAlignmentError):
+        with pytest.raises(StreamlitValueError):
             st.container(horizontal=True, vertical_alignment=vertical_alignment)
 
     @parameterized.expand(
@@ -1039,9 +1039,8 @@ class PopoverContainerTest(DeltaGeneratorTestCase):
 
     def test_label_none_raises(self):
         """Test that an explicit label=None raises StreamlitMissingRequiredParameterError."""
-        with pytest.raises(StreamlitMissingRequiredParameterError) as e:
+        with pytest.raises(StreamlitMissingRequiredParameterError):
             st.popover(None)
-        assert "The `label` parameter is required for `st.popover`" in str(e.value)
 
     def test_invalid_type_raises(self):
         """Test that an unsupported button type raises a StreamlitValueError."""
@@ -1780,15 +1779,24 @@ class TabsTest(DeltaGeneratorTestCase):
         with pytest.raises(TypeError):
             st.tabs()
 
-        with pytest.raises(StreamlitAPIException):
+        with pytest.raises(
+            StreamlitMissingRequiredParameterError,
+            match="Provide at least one tab label",
+        ):
             st.tabs([])
 
     def test_only_label_strings_allowed(self):
         """Test that only strings are allowed as tab labels."""
-        with pytest.raises(StreamlitAPIException):
+        with pytest.raises(
+            StreamlitInvalidParameterTypeError,
+            match="Each tab label must be a string",
+        ):
             st.tabs(["tab1", True])
 
-        with pytest.raises(StreamlitAPIException):
+        with pytest.raises(
+            StreamlitInvalidParameterTypeError,
+            match="Each tab label must be a string",
+        ):
             st.tabs(["tab1", 10])
 
     def test_returns_all_expected_tabs(self):
@@ -1824,12 +1832,10 @@ class TabsTest(DeltaGeneratorTestCase):
         tabs = ["Tab 1", "Tab 2", "Tab 3"]
         default_tab = "Tab 4"
 
-        with pytest.raises(StreamlitAPIException) as context:
+        with pytest.raises(
+            StreamlitValueError, match=r"`Tab 4` is not in the list of tabs"
+        ):
             st.tabs(tabs, default=default_tab)
-
-        assert "The default tab 'Tab 4' is not in the list of tabs." in str(
-            context.value
-        )
 
     def test_valid_default_tab(self):
         """Test that a valid default tab sets the correct index."""
@@ -2328,15 +2334,13 @@ class DialogTest(DeltaGeneratorTestCase):
             "dialog_decorator() missing 1 required positional argument: 'title'"
         )
 
-        with pytest.raises(StreamlitAPIException) as e:
+        with pytest.raises(StreamlitMissingRequiredParameterError):
 
             @st.dialog("")
             def dialog():
                 return None
 
             dialog()
-
-        assert "The `title` parameter is required for `st.dialog`" in e.value.args[0]
 
     def test_dialog_decorator_must_be_called_like_a_function_with_a_title(self):
         """Test that the decorator must be called like a function."""
@@ -2375,9 +2379,8 @@ class DialogTest(DeltaGeneratorTestCase):
         def level1_dialog():
             level2_dialog()
 
-        with pytest.raises(FragmentHandledException) as e:
+        with pytest.raises(FragmentHandledException):
             level1_dialog()
-        assert str(e.value) == "Dialogs may not be nested inside other dialogs."
 
     def test_only_one_dialog_can_be_opened_at_same_time(self):
         @st.dialog("Dialog1")
@@ -2388,13 +2391,9 @@ class DialogTest(DeltaGeneratorTestCase):
         def dialog2():
             st.empty()
 
-        with pytest.raises(StreamlitAPIException) as e:
+        with pytest.raises(StreamlitInvalidLayoutContextError):
             dialog1()
             dialog2()
-
-        assert e.value.args[0].startswith(
-            "Only one dialog is allowed to be opened at the same time."
-        )
 
     def test_dialog_deltagenerator_dismissible_false(self):
         """Test that the delta-generator dialog properly handles dismissible=False"""

--- a/lib/tests/streamlit/elements/layouts_test.py
+++ b/lib/tests/streamlit/elements/layouts_test.py
@@ -1795,13 +1795,13 @@ class TabsTest(DeltaGeneratorTestCase):
         """Test that only strings are allowed as tab labels."""
         with pytest.raises(
             StreamlitInvalidParameterTypeError,
-            match="Each tab label must be a string",
+            match="a string for each tab label",
         ):
             st.tabs(["tab1", True])
 
         with pytest.raises(
             StreamlitInvalidParameterTypeError,
-            match="Each tab label must be a string",
+            match="a string for each tab label",
         ):
             st.tabs(["tab1", 10])
 

--- a/lib/tests/streamlit/elements/lib/layout_utils_test.py
+++ b/lib/tests/streamlit/elements/lib/layout_utils_test.py
@@ -33,12 +33,9 @@ from streamlit.elements.lib.layout_utils import (
     validate_width,
 )
 from streamlit.errors import (
-    StreamlitInvalidColumnGapError,
     StreamlitInvalidHeightError,
-    StreamlitInvalidHorizontalAlignmentError,
-    StreamlitInvalidSizeError,
-    StreamlitInvalidVerticalAlignmentError,
     StreamlitInvalidWidthError,
+    StreamlitValueError,
 )
 from streamlit.proto.Block_pb2 import Block
 from streamlit.proto.GapSize_pb2 import GapSize
@@ -217,7 +214,7 @@ class LayoutUtilsTest(unittest.TestCase):
     def test_get_gap_config_string(self, gap: str | None, expected: GapSize.ValueType):
         """get_gap_config sets gap_size for string / None inputs."""
 
-        config = get_gap_config(gap, "st.columns")
+        config = get_gap_config(gap)
         assert config.WhichOneof("gap_spec") == "gap_size"
         assert config.gap_size == expected
 
@@ -232,28 +229,28 @@ class LayoutUtilsTest(unittest.TestCase):
     def test_get_gap_config_int(self, gap: int):
         """get_gap_config sets pixel_gap for non-negative integer inputs."""
 
-        config = get_gap_config(gap, "st.columns")
+        config = get_gap_config(gap)
         assert config.WhichOneof("gap_spec") == "pixel_gap"
         assert config.pixel_gap == gap
 
     def test_get_gap_config_negative_int_raises(self):
         """get_gap_config raises for negative integer inputs."""
 
-        with pytest.raises(StreamlitInvalidColumnGapError):
-            get_gap_config(-1, "st.columns")
+        with pytest.raises(StreamlitValueError, match=r"`gap`"):
+            get_gap_config(-1)
 
     @parameterized.expand([(True,), (False,)])
     def test_get_gap_config_bool_raises(self, gap: bool):
         """get_gap_config rejects boolean inputs even though ``bool`` is a subclass of ``int``."""
 
-        with pytest.raises(StreamlitInvalidColumnGapError):
-            get_gap_config(gap, "st.columns")  # type: ignore[arg-type]
+        with pytest.raises(StreamlitValueError, match=r"`gap`"):
+            get_gap_config(gap)  # type: ignore[arg-type]
 
     def test_get_gap_config_invalid_string_raises(self):
         """get_gap_config raises for unknown gap strings."""
 
-        with pytest.raises(StreamlitInvalidColumnGapError):
-            get_gap_config("tiny", "st.columns")  # type: ignore[arg-type]
+        with pytest.raises(StreamlitValueError, match=r"`gap`"):
+            get_gap_config("tiny")  # type: ignore[arg-type]
 
     @parameterized.expand(
         [
@@ -271,7 +268,7 @@ class LayoutUtilsTest(unittest.TestCase):
     def test_validate_horizontal_alignment_invalid(self):
         """validate_horizontal_alignment raises for unknown values."""
 
-        with pytest.raises(StreamlitInvalidHorizontalAlignmentError):
+        with pytest.raises(StreamlitValueError, match=r"`horizontal_alignment`"):
             validate_horizontal_alignment("middle")  # type: ignore[arg-type]
 
     @parameterized.expand(
@@ -290,7 +287,7 @@ class LayoutUtilsTest(unittest.TestCase):
     def test_validate_vertical_alignment_invalid(self):
         """validate_vertical_alignment raises for unknown values."""
 
-        with pytest.raises(StreamlitInvalidVerticalAlignmentError):
+        with pytest.raises(StreamlitValueError, match=r"`vertical_alignment`"):
             validate_vertical_alignment("middle")  # type: ignore[arg-type]
 
     @parameterized.expand(
@@ -355,7 +352,7 @@ class LayoutUtilsTest(unittest.TestCase):
     def test_validate_size_invalid(self, size: any):
         """validate_size raises for invalid size values."""
 
-        with pytest.raises(StreamlitInvalidSizeError):
+        with pytest.raises(StreamlitValueError, match=r"`size`"):
             validate_space_size(size)  # type: ignore[arg-type]
 
     @parameterized.expand(

--- a/lib/tests/streamlit/elements/lib/options_selector_utils_test.py
+++ b/lib/tests/streamlit/elements/lib/options_selector_utils_test.py
@@ -38,6 +38,7 @@ from streamlit.elements.lib.options_selector_utils import (
 )
 from streamlit.errors import (
     StreamlitDefaultNotInOptionsError,
+    StreamlitIncompatibleParametersError,
     StreamlitValueError,
 )
 from streamlit.proto.SelectWidgetFilterMode_pb2 import (
@@ -108,39 +109,32 @@ class TestTransformOptions:
 
 class TestValidateSelectWidgetFilterMode:
     @pytest.mark.parametrize(
-        ("mode", "command", "expected"),
+        ("mode", "expected"),
         [
             (
                 "fuzzy",
-                "st.selectbox",
                 ProtoSelectWidgetFilterMode.FILTER_MODE_FUZZY,
             ),
             (
                 "contains",
-                "st.selectbox",
                 ProtoSelectWidgetFilterMode.FILTER_MODE_CONTAINS,
             ),
             (
                 "prefix",
-                "st.multiselect",
                 ProtoSelectWidgetFilterMode.FILTER_MODE_PREFIX,
             ),
             (
                 None,
-                "st.multiselect",
                 ProtoSelectWidgetFilterMode.FILTER_MODE_NONE,
             ),
         ],
     )
-    def test_validates_known_modes(
-        self, mode: str | None, command: str, expected: int
-    ) -> None:
+    def test_validates_known_modes(self, mode: str | None, expected: int) -> None:
         """Test that known filter modes map to the expected protobuf values."""
         assert (
             validate_select_widget_filter_mode(
                 mode,
                 accept_new_options=False,
-                command=command,
             )
             == expected
         )
@@ -150,7 +144,14 @@ class TestValidateSelectWidgetFilterMode:
             validate_select_widget_filter_mode(
                 cast("Any", []),
                 accept_new_options=False,
-                command="st.selectbox",
+            )
+
+    def test_rejects_none_with_accept_new_options(self) -> None:
+        """filter_mode=None cannot be combined with accept_new_options=True."""
+        with pytest.raises(StreamlitIncompatibleParametersError):
+            validate_select_widget_filter_mode(
+                None,
+                accept_new_options=True,
             )
 
 

--- a/lib/tests/streamlit/elements/lib/options_selector_utils_test.py
+++ b/lib/tests/streamlit/elements/lib/options_selector_utils_test.py
@@ -148,7 +148,10 @@ class TestValidateSelectWidgetFilterMode:
 
     def test_rejects_none_with_accept_new_options(self) -> None:
         """filter_mode=None cannot be combined with accept_new_options=True."""
-        with pytest.raises(StreamlitIncompatibleParametersError):
+        with pytest.raises(
+            StreamlitIncompatibleParametersError,
+            match=r"`filter_mode=None` and `accept_new_options=True`",
+        ):
             validate_select_widget_filter_mode(
                 None,
                 accept_new_options=True,

--- a/lib/tests/streamlit/elements/multiselect_test.py
+++ b/lib/tests/streamlit/elements/multiselect_test.py
@@ -31,6 +31,7 @@ from streamlit.elements.widgets.multiselect import (
 from streamlit.errors import (
     StreamlitAPIException,
     StreamlitDuplicateElementId,
+    StreamlitIncompatibleParametersError,
     StreamlitInvalidMaxError,
     StreamlitInvalidWidthError,
     StreamlitSelectionCountExceedsMaxError,
@@ -247,10 +248,7 @@ class Multiselectbox(DeltaGeneratorTestCase):
 
     def test_filter_mode_none_with_accept_new_options_raises_exception(self):
         """Test that filter_mode=None is incompatible with accept_new_options=True."""
-        with pytest.raises(
-            StreamlitAPIException,
-            match=r"cannot be None when `accept_new_options=True`",
-        ):
+        with pytest.raises(StreamlitIncompatibleParametersError):
             st.multiselect(
                 "the label", ("m", "f"), filter_mode=None, accept_new_options=True
             )

--- a/lib/tests/streamlit/elements/selectbox_test.py
+++ b/lib/tests/streamlit/elements/selectbox_test.py
@@ -27,6 +27,7 @@ from streamlit.elements.lib.options_selector_utils import create_mappings
 from streamlit.elements.widgets.selectbox import SelectboxSerde
 from streamlit.errors import (
     StreamlitAPIException,
+    StreamlitIncompatibleParametersError,
     StreamlitInvalidParameterTypeError,
     StreamlitInvalidWidthError,
     StreamlitValueError,
@@ -176,10 +177,7 @@ class SelectboxTest(DeltaGeneratorTestCase):
 
     def test_filter_mode_none_with_accept_new_options_raises_exception(self):
         """Test that filter_mode=None is incompatible with accept_new_options=True."""
-        with pytest.raises(
-            StreamlitAPIException,
-            match=r"cannot be None when `accept_new_options=True`",
-        ):
+        with pytest.raises(StreamlitIncompatibleParametersError):
             st.selectbox(
                 "the label", ("m", "f"), filter_mode=None, accept_new_options=True
             )

--- a/lib/tests/streamlit/elements/space_test.py
+++ b/lib/tests/streamlit/elements/space_test.py
@@ -16,7 +16,7 @@ import pytest
 from parameterized import parameterized
 
 import streamlit as st
-from streamlit.errors import StreamlitInvalidSizeError
+from streamlit.errors import StreamlitValueError
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 
 
@@ -87,5 +87,5 @@ class SpaceTest(DeltaGeneratorTestCase):
     )
     def test_space_invalid_sizes(self, invalid_size):
         """Test that invalid size values raise an exception."""
-        with pytest.raises(StreamlitInvalidSizeError):
+        with pytest.raises(StreamlitValueError, match=r"`size`"):
             st.space(invalid_size)

--- a/lib/tests/streamlit/elements/text_input_test.py
+++ b/lib/tests/streamlit/elements/text_input_test.py
@@ -25,6 +25,7 @@ import streamlit as st
 from streamlit.elements.lib.utils import compute_and_register_element_id
 from streamlit.errors import (
     StreamlitAPIException,
+    StreamlitIncompatibleParametersError,
     StreamlitInvalidWidthError,
     StreamlitValueError,
 )
@@ -746,15 +747,16 @@ class TextInputTest(DeltaGeneratorTestCase):
 
     def test_bind_query_params_with_password_raises_exception(self) -> None:
         """Test that bind='query-params' with type='password' raises an exception."""
-        with pytest.raises(StreamlitAPIException) as exc:
+        with pytest.raises(
+            StreamlitIncompatibleParametersError,
+            match=r"Password values must not appear in URLs",
+        ):
             st.text_input(
                 "the label",
                 key="my_text",
                 bind="query-params",
                 type="password",
             )
-
-        assert "password" in str(exc.value).lower()
 
 
 class TextInputOnChangeModeTest(DeltaGeneratorTestCase):

--- a/lib/tests/streamlit/errors_test.py
+++ b/lib/tests/streamlit/errors_test.py
@@ -302,6 +302,7 @@ def test_incompatible_parameters_error_formats_uses() -> None:
     assert str(exc) == (
         "`wrap=False` and `unsafe_allow_html=True` cannot be used together."
     )
+    assert exc.exec_kwargs["uses"] == ["wrap=False", "unsafe_allow_html=True"]
     assert "parameter" not in exc.exec_kwargs
 
 

--- a/lib/tests/streamlit/errors_test.py
+++ b/lib/tests/streamlit/errors_test.py
@@ -164,7 +164,39 @@ def test_invalid_parameter_type_error_message() -> None:
         "parameter": "index",
         "expected_types": "int, None",
         "provided_type": "str",
+        "detail": None,
     }
+
+
+def test_invalid_parameter_type_error_with_detail() -> None:
+    """Optional detail is appended and is not used as the telemetry parameter."""
+    exc = errors.StreamlitInvalidParameterTypeError(
+        "tabs",
+        "bool",
+        ["str"],
+        detail="Each tab label must be a string.",
+    )
+    assert str(exc) == (
+        "Invalid `tabs` type. Expected one of: str. Provided type: bool. "
+        "Each tab label must be a string."
+    )
+    assert exc.exec_kwargs["parameter"] == "tabs"
+    assert exc.exec_kwargs["detail"] == "Each tab label must be a string."
+
+
+def test_value_error_with_detail() -> None:
+    """Optional detail is appended and is not used as the telemetry parameter."""
+    exc = errors.StreamlitValueError(
+        "scope",
+        ["'global'", "'session'"],
+        detail="Connection class Foo has an invalid scope.",
+    )
+    assert str(exc) == (
+        "Invalid `scope` value. Supported values: 'global', 'session'. "
+        "Connection class Foo has an invalid scope."
+    )
+    assert exc.exec_kwargs["parameter"] == "scope"
+    assert exc.exec_kwargs["detail"] == "Connection class Foo has an invalid scope."
 
 
 def test_widget_already_instantiated_error_message() -> None:
@@ -238,32 +270,83 @@ def test_invalid_max_error_with_corrective_action() -> None:
 
 
 def test_missing_required_parameter_error_message() -> None:
-    """Default message includes command and parameter."""
-    exc = errors.StreamlitMissingRequiredParameterError("st.expander", "label")
-    assert str(exc) == "The `label` parameter is required for `st.expander`."
+    """Default message includes the parameter."""
+    exc = errors.StreamlitMissingRequiredParameterError("label")
+    assert str(exc) == "The `label` parameter is required."
+    assert exc.exec_kwargs["parameter"] == "label"
 
 
 def test_missing_required_parameter_error_with_detail() -> None:
     """Optional detail is appended to the default message."""
     exc = errors.StreamlitMissingRequiredParameterError(
-        "st.toast",
         "body",
         detail="It cannot be blank.",
     )
-    assert str(exc) == (
-        "The `body` parameter is required for `st.toast`. It cannot be blank."
-    )
+    assert str(exc) == ("The `body` parameter is required. It cannot be blank.")
 
 
 def test_missing_required_parameter_error_detail_with_braces() -> None:
     """Detail text with braces does not break message formatting."""
     exc = errors.StreamlitMissingRequiredParameterError(
-        "st.dialog",
         "title",
         detail="Example: use {value}.",
     )
+    assert str(exc) == ("The `title` parameter is required. Example: use {value}.")
+
+
+def test_incompatible_parameters_error_formats_uses() -> None:
+    """Uses are joined into the user-facing message."""
+    exc = errors.StreamlitIncompatibleParametersError(
+        "wrap=False", "unsafe_allow_html=True"
+    )
     assert str(exc) == (
-        "The `title` parameter is required for `st.dialog`. Example: use {value}."
+        "`wrap=False` and `unsafe_allow_html=True` cannot be used together."
+    )
+    assert "parameter" not in exc.exec_kwargs
+
+
+def test_incompatible_parameters_error_formats_three_uses() -> None:
+    """Three uses are joined with an Oxford comma."""
+    exc = errors.StreamlitIncompatibleParametersError(
+        "refresh_mode='background'", "ttl", "persist='disk'"
+    )
+    assert str(exc) == (
+        "`refresh_mode='background'`, `ttl`, and `persist='disk'` "
+        "cannot be used together."
+    )
+
+
+def test_incompatible_parameters_error_requires_two_uses() -> None:
+    """Fewer than two uses is a constructor contract violation."""
+    with pytest.raises(ValueError, match="at least two parameter uses"):
+        errors.StreamlitIncompatibleParametersError()
+    with pytest.raises(ValueError, match="at least two parameter uses"):
+        errors.StreamlitIncompatibleParametersError("ttl")
+
+
+def test_incompatible_parameters_error_with_explanation() -> None:
+    """Optional explanation is appended to the generic message."""
+    exc = errors.StreamlitIncompatibleParametersError(
+        "bind='query-params'",
+        "type='password'",
+        explanation="Password values must not appear in URLs.",
+    )
+    assert str(exc) == (
+        "`bind='query-params'` and `type='password'` cannot be used together. "
+        "Password values must not appear in URLs."
+    )
+
+
+def test_incompatible_parameters_error_explanation_with_braces() -> None:
+    """Explanation text with braces does not break message formatting."""
+    exc = errors.StreamlitIncompatibleParametersError(
+        "refresh_mode='background'",
+        "ttl=None",
+        explanation="Example: use {value}.",
+    )
+    assert str(exc) == (
+        "`refresh_mode='background'` and `ttl=None` cannot be used together. "
+        "Example: use {value}."
     )
 
 

--- a/lib/tests/streamlit/errors_test.py
+++ b/lib/tests/streamlit/errors_test.py
@@ -319,10 +319,10 @@ def test_incompatible_parameters_error_formats_three_uses() -> None:
 
 def test_incompatible_parameters_error_requires_two_uses() -> None:
     """Fewer than two uses is a constructor contract violation."""
-    with pytest.raises(ValueError, match="at least two parameter uses"):
-        errors.StreamlitIncompatibleParametersError()
-    with pytest.raises(ValueError, match="at least two parameter uses"):
-        errors.StreamlitIncompatibleParametersError("ttl")
+    with pytest.raises(TypeError, match="first_use"):
+        errors.StreamlitIncompatibleParametersError()  # type: ignore[call-arg]
+    with pytest.raises(TypeError, match="second_use"):
+        errors.StreamlitIncompatibleParametersError("ttl")  # type: ignore[call-arg]
 
 
 def test_incompatible_parameters_error_with_explanation() -> None:

--- a/lib/tests/streamlit/errors_test.py
+++ b/lib/tests/streamlit/errors_test.py
@@ -357,6 +357,10 @@ def test_incompatible_parameters_error_explanation_with_braces() -> None:
         ("StreamlitInvalidTextAlignmentError", "StreamlitValueError"),
         ("StreamlitInvalidBindValueError", "StreamlitValueError"),
         ("StreamlitInvalidPersistStateError", "StreamlitValueError"),
+        ("StreamlitInvalidSizeError", "StreamlitValueError"),
+        ("StreamlitInvalidVerticalAlignmentError", "StreamlitValueError"),
+        ("StreamlitInvalidColumnGapError", "StreamlitValueError"),
+        ("StreamlitInvalidHorizontalAlignmentError", "StreamlitValueError"),
         ("StreamlitMissingPageLabelError", "StreamlitMissingRequiredParameterError"),
     ],
 )

--- a/lib/tests/streamlit/runtime/caching/cache_data_api_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_data_api_test.py
@@ -30,7 +30,11 @@ from parameterized import parameterized
 
 import streamlit as st
 from streamlit import file_util
-from streamlit.errors import StreamlitAPIException, StreamlitValueError
+from streamlit.errors import (
+    StreamlitIncompatibleParametersError,
+    StreamlitMissingRequiredParameterError,
+    StreamlitValueError,
+)
 from streamlit.proto.Text_pb2 import Text as TextProto
 from streamlit.runtime import Runtime
 from streamlit.runtime.caching import cached_message_replay
@@ -885,44 +889,40 @@ class CacheDataBackgroundRefreshTest(unittest.TestCase):
         st.cache_data.clear()
 
     def test_background_without_ttl_raises(self) -> None:
-        """refresh_mode="background" without a ttl raises a StreamlitAPIException."""
-        with pytest.raises(StreamlitAPIException) as exc:
+        """refresh_mode="background" without a ttl requires a positive ttl."""
+        with pytest.raises(
+            StreamlitMissingRequiredParameterError,
+            match=r'Set a positive `ttl` \(for example `ttl="1h"`\)',
+        ):
 
             @st.cache_data(refresh_mode="background")
             def foo() -> int:
                 return 1
 
-        assert "requires a 'ttl' value" in str(exc.value)
-
     def test_background_with_zero_ttl_raises(self) -> None:
-        """A non-positive ttl is treated as no ttl for background refresh."""
-        with pytest.raises(StreamlitAPIException) as exc:
+        """A non-positive ttl is an invalid value for background refresh."""
+        with pytest.raises(
+            StreamlitValueError,
+            match=r"Background refresh requires a positive `ttl`",
+        ):
 
             @st.cache_data(ttl=0, refresh_mode="background")
             def foo() -> int:
                 return 1
 
-        assert "requires a 'ttl' value" in str(exc.value)
+    @parameterized.expand(
+        [
+            ("disk", "disk"),
+            ("true", True),
+        ]
+    )
+    def test_background_with_persist_raises(self, _: str, persist: str | bool) -> None:
+        """refresh_mode="background" with persist raises an incompatibility error."""
+        with pytest.raises(StreamlitIncompatibleParametersError):
 
-    def test_background_with_persist_disk_raises(self) -> None:
-        """refresh_mode="background" with persist="disk" raises a StreamlitAPIException."""
-        with pytest.raises(StreamlitAPIException) as exc:
-
-            @st.cache_data(ttl="1h", persist="disk", refresh_mode="background")
+            @st.cache_data(ttl="1h", persist=persist, refresh_mode="background")
             def foo() -> int:
                 return 1
-
-        assert "not compatible with 'persist'" in str(exc.value)
-
-    def test_background_with_persist_true_raises(self) -> None:
-        """refresh_mode="background" with persist=True raises a StreamlitAPIException."""
-        with pytest.raises(StreamlitAPIException) as exc:
-
-            @st.cache_data(ttl="1h", persist=True, refresh_mode="background")
-            def foo() -> int:
-                return 1
-
-        assert "not compatible with 'persist'" in str(exc.value)
 
     def test_invalid_refresh_mode_raises(self) -> None:
         """An unknown refresh_mode value raises a StreamlitValueError."""

--- a/lib/tests/streamlit/runtime/caching/cache_data_api_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_data_api_test.py
@@ -912,13 +912,16 @@ class CacheDataBackgroundRefreshTest(unittest.TestCase):
 
     @parameterized.expand(
         [
-            ("disk", "disk"),
-            ("true", True),
+            ("disk",),
+            (True,),
         ]
     )
-    def test_background_with_persist_raises(self, _: str, persist: str | bool) -> None:
+    def test_background_with_persist_raises(self, persist: str | bool) -> None:
         """refresh_mode="background" with persist raises an incompatibility error."""
-        with pytest.raises(StreamlitIncompatibleParametersError):
+        with pytest.raises(
+            StreamlitIncompatibleParametersError,
+            match=rf"persist={persist!r}",
+        ):
 
             @st.cache_data(ttl="1h", persist=persist, refresh_mode="background")
             def foo() -> int:

--- a/lib/tests/streamlit/runtime/caching/cache_resource_api_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_resource_api_test.py
@@ -24,7 +24,10 @@ import pytest
 from parameterized import parameterized
 
 import streamlit as st
-from streamlit.errors import StreamlitAPIException, StreamlitValueError
+from streamlit.errors import (
+    StreamlitMissingRequiredParameterError,
+    StreamlitValueError,
+)
 from streamlit.runtime.caching import (
     cache_background_refresh,
     cache_resource_api,
@@ -596,14 +599,15 @@ class CacheResourceBackgroundRefreshTest(unittest.TestCase):
         )
 
     def test_background_without_ttl_raises(self) -> None:
-        """refresh_mode="background" without a ttl raises a StreamlitAPIException."""
-        with pytest.raises(StreamlitAPIException) as exc:
+        """refresh_mode="background" without a ttl requires a positive ttl."""
+        with pytest.raises(
+            StreamlitMissingRequiredParameterError,
+            match=r'Set a positive `ttl` \(for example `ttl="1h"`\)',
+        ):
 
             @st.cache_resource(refresh_mode="background")
             def foo() -> int:
                 return 1
-
-        assert "requires a 'ttl' value" in str(exc.value)
 
     def test_invalid_refresh_mode_raises(self) -> None:
         """An unknown refresh_mode value raises a StreamlitValueError."""

--- a/lib/tests/streamlit/runtime/metrics_util_test.py
+++ b/lib/tests/streamlit/runtime/metrics_util_test.py
@@ -34,6 +34,7 @@ from streamlit import config
 from streamlit.components.v1.custom_component import CustomComponent
 from streamlit.connections import SQLConnection
 from streamlit.errors import (
+    StreamlitIncompatibleParametersError,
     StreamlitInvalidLayoutContextError,
     StreamlitInvalidParameterTypeError,
     StreamlitMissingRequiredParameterError,
@@ -869,12 +870,26 @@ def test_gather_metrics_records_time_when_rerun_exception_raised() -> None:
             "StreamlitValueError:width",
         ),
         (
-            StreamlitMissingRequiredParameterError("st.expander", "label"),
+            StreamlitValueError(
+                "scope",
+                ["'global'", "'session'"],
+                detail="Connection class Foo has an invalid scope.",
+            ),
+            "StreamlitValueError:scope",
+        ),
+        (
+            StreamlitMissingRequiredParameterError("label"),
             "StreamlitMissingRequiredParameterError:label",
         ),
         (
             StreamlitInvalidParameterTypeError("spec", "str", ["int", "list"]),
             "StreamlitInvalidParameterTypeError:spec",
+        ),
+        (
+            StreamlitIncompatibleParametersError(
+                "wrap=False", "unsafe_allow_html=True"
+            ),
+            "StreamlitIncompatibleParametersError",
         ),
         (
             StreamlitInvalidLayoutContextError(
@@ -946,8 +961,10 @@ def test_gather_metrics_records_time_when_rerun_exception_raised() -> None:
         "unsupported-proto-type",
         "unsupported-byteslike",
         "streamlit-value-error",
+        "streamlit-value-error-detail",
         "streamlit-missing-required-parameter",
         "invalid-parameter-type",
+        "incompatible-parameters",
         "invalid-context-no-command-suffix",
         "modulenotfound-message-fallback",
         "import-error-message-fallback",

--- a/lib/tests/streamlit/runtime/state/widgets_test.py
+++ b/lib/tests/streamlit/runtime/state/widgets_test.py
@@ -643,7 +643,7 @@ class RegisterWidgetsTest(DeltaGeneratorTestCase):
         """Test that `register_widget` raises an exception when both `on_change`
         and `callbacks` are provided.
         """
-        with pytest.raises(errors.StreamlitAPIException):
+        with pytest.raises(errors.StreamlitIncompatibleParametersError):
             register_widget(
                 "el_id",
                 deserializer=lambda x: x,

--- a/lib/tests/streamlit/toast_test.py
+++ b/lib/tests/streamlit/toast_test.py
@@ -42,7 +42,9 @@ class ToastTest(DeltaGeneratorTestCase):
 
     def test_no_text(self):
         """Test that an error is raised if no text is provided."""
-        with pytest.raises(StreamlitMissingRequiredParameterError):
+        with pytest.raises(
+            StreamlitMissingRequiredParameterError, match=r"Please provide a message"
+        ):
             st.toast("")
 
     def test_valid_icon(self):

--- a/lib/tests/streamlit/toast_test.py
+++ b/lib/tests/streamlit/toast_test.py
@@ -42,10 +42,8 @@ class ToastTest(DeltaGeneratorTestCase):
 
     def test_no_text(self):
         """Test that an error is raised if no text is provided."""
-        with pytest.raises(StreamlitMissingRequiredParameterError) as e:
+        with pytest.raises(StreamlitMissingRequiredParameterError):
             st.toast("")
-        assert "The `body` parameter is required for `st.toast`" in str(e.value)
-        assert "Please provide a message." in str(e.value)
 
     def test_valid_icon(self):
         """Test that it can be called passing a valid emoji as icon."""


### PR DESCRIPTION
## Describe your changes

Adds and adopts shared public API exception types so page-profile telemetry can group invalid API usage by error type and relevant parameter.

- Simplifies `StreamlitMissingRequiredParameterError` to identify the missing parameter without storing the command name, which is already available from the traceback.
- Adds `StreamlitIncompatibleParametersError` for conflicting parameter combinations.
- Migrates layout, widget, page, and caching validations to the shared missing-parameter, incompatible-parameter, invalid-value, invalid-type, and layout-context errors.
- Documents the exception and telemetry conventions for future public API validation.

This is the first PR in a stack. #16656 completes the remaining migrations. Do not delete the 1.62.0 layout exception names there (`StreamlitInvalidSizeError`, `StreamlitInvalidVerticalAlignmentError`, `StreamlitInvalidColumnGapError`, `StreamlitInvalidHorizontalAlignmentError`): they shipped as distinct classes and are identity-aliased to `StreamlitValueError` here.

**Backwards compatibility:** Identity-aliasing those shipped names (`OldName = StreamlitValueError`) keeps `except StreamlitInvalidSizeError` working for the migrated raises, but that handler also catches every other `StreamlitValueError`, and the old constructors (`StreamlitInvalidSizeError(size)`, and similar) raise `TypeError`. Empty subclasses would not preserve `except OldName` unless call sites still instantiate the subclass.

## GitHub Issue Link (if applicable)

Follow-up to #16422, #16637, and #16508.

## Testing Plan

- [x] Unit Tests (JS and/or Python) — `make check` (2,428 tests passed)
- [x] E2E Tests — updated `e2e_playwright/st_dialog_test.py`; all 41 behavioral assertions passed locally (snapshot baselines are not present in the temporary worktree)
- Manual testing: not required beyond existing coverage

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

Made with [Cursor](https://cursor.com)