### PR TITLE
[fix] Error message bullets and uppercase-hex object reprs

### DIFF
--- a/frontend/lib/src/components/elements/ExceptionElement/ExceptionElement.test.tsx
+++ b/frontend/lib/src/components/elements/ExceptionElement/ExceptionElement.test.tsx
@@ -73,6 +73,28 @@ describe("ExceptionElement Element", () => {
     expect(screen.getByTestId("stMarkdownContainer")).toBeInTheDocument()
   })
 
+  it("renders a markdown message's bullets as a real list", () => {
+    // A Streamlit exception message is Markdown, so a bullet list in it must
+    // render as list markup rather than as literal asterisks in the prose.
+    render(
+      <ExceptionElement
+        {...getProps({
+          messageIsMarkdown: true,
+          message: "Pick one of:\n\n* the first option\n* the second option",
+        })}
+      />
+    )
+
+    expect(screen.getByRole("list")).toBeVisible()
+    const bullets = screen.getAllByRole("listitem")
+    expect(bullets).toHaveLength(2)
+    expect(bullets[0]).toHaveTextContent("the first option")
+    expect(bullets[1]).toHaveTextContent("the second option")
+
+    // No asterisk survives in the prose.
+    expect(screen.queryByText(/of:\s*\*/)).not.toBeInTheDocument()
+  })
+
   it("should render if there's no message", () => {
     render(<ExceptionElement {...getProps({ message: "" })} />)
 

--- a/lib/streamlit/errors.py
+++ b/lib/streamlit/errors.py
@@ -545,8 +545,8 @@ class StreamlitInvalidColorError(LocalizableStreamlitException):
     ) -> None:
         super().__init__(
             "This does not look like a valid color: {color}.\n\n"
-            "Colors must be in one of the following formats:"
-            "* Hex string with 3, 4, 6, or 8 digits. Example: `'#00ff00'`"
+            "Colors must be in one of the following formats:\n\n"
+            "* Hex string with 3, 4, 6, or 8 digits. Example: `'#00ff00'`\n"
             "* List or tuple with 3 or 4 components. Example: `[1.0, 0.5, 0, 0.2]`",
             color=repr(color),
         )
@@ -557,7 +557,7 @@ class StreamlitBadTimeStringError(LocalizableStreamlitException):
 
     def __init__(self, time_string: str) -> None:
         super().__init__(
-            "Time string doesn't look right. It should be formatted as"
+            "Time string doesn't look right. It should be formatted as "
             "`'1d2h34m'` or `2 days`, for example. Got: {time_string}",
             time_string=time_string,
         )

--- a/lib/streamlit/string_util.py
+++ b/lib/streamlit/string_util.py
@@ -247,8 +247,11 @@ def simplify_number(num: int) -> str:
     )
 
 
+# Match both hex casings: CPython formats the address with the platform C
+# runtime's "%p" (glibc lowercase, MSVC uppercase). Use a character class
+# rather than re.IGNORECASE so " AT 0X" still fails to match.
 _OBJ_MEM_ADDRESS: Final = re.compile(
-    r"^\<[a-zA-Z_]+[a-zA-Z0-9<>._ ]* at 0x[0-9a-f]+\>$"
+    r"^\<[a-zA-Z_]+[a-zA-Z0-9<>._ ]* at 0x[0-9a-fA-F]+\>$"
 )
 
 

--- a/lib/tests/streamlit/errors_test.py
+++ b/lib/tests/streamlit/errors_test.py
@@ -349,3 +349,39 @@ def test_incompatible_parameters_error_explanation_with_braces() -> None:
         "`refresh_mode='background'` and `ttl=None` cannot be used together. "
         "Example: use {value}."
     )
+
+
+# StreamlitInvalidColorError tests
+
+
+def test_invalid_color_error_bullets_start_their_own_lines() -> None:
+    """Bullets each start a line, so the Markdown-rendered message shows a list
+    rather than literal asterisks mid-sentence."""
+    exc = errors.StreamlitInvalidColorError("red")
+    assert str(exc) == (
+        "This does not look like a valid color: 'red'.\n\n"
+        "Colors must be in one of the following formats:\n\n"
+        "* Hex string with 3, 4, 6, or 8 digits. Example: `'#00ff00'`\n"
+        "* List or tuple with 3 or 4 components. Example: `[1.0, 0.5, 0, 0.2]`"
+    )
+
+
+def test_invalid_color_error_reprs_non_string_color() -> None:
+    """A sequence color is shown as its repr rather than as a bare string."""
+    exc = errors.StreamlitInvalidColorError([1.0, 0.5, 0, 0.2, 9])
+    assert str(exc).startswith(
+        "This does not look like a valid color: [1.0, 0.5, 0, 0.2, 9]."
+    )
+
+
+# StreamlitBadTimeStringError tests
+
+
+def test_bad_time_string_error_message_reads_as_one_sentence() -> None:
+    """The message keeps a space between "as" and the example, so it reads as
+    one sentence."""
+    exc = errors.StreamlitBadTimeStringError("nonsense")
+    assert str(exc) == (
+        "Time string doesn't look right. It should be formatted as "
+        "`'1d2h34m'` or `2 days`, for example. Got: nonsense"
+    )

--- a/lib/tests/streamlit/string_util_test.py
+++ b/lib/tests/streamlit/string_util_test.py
@@ -283,6 +283,30 @@ class StringUtilTest(unittest.TestCase):
         """Test that is_binary_string correctly identifies binary vs text data."""
         assert string_util.is_binary_string(inp) == expected
 
+    @parameterized.expand(
+        [
+            ("<foo blarg at 0x15ee6f9a0>", True),  # glibc: lowercase hex
+            ("<__main__.Foo object at 0x0000027B0C1B1550>", True),  # MSVC instance
+            ("<property object at 0x000002500A1F3240>", True),  # MSVC property
+            # The "at" and "0x" literals stay case-sensitive: CPython normalizes
+            # the prefix to a lowercase "0x" no matter how the C runtime cased
+            # the digits.
+            ("<foo blarg AT 0X15EE6F9A0>", False),
+            ("<module 'os' from '/usr/lib/os.py'>", False),  # Repr with no address
+            ("<foo blarg at 0xdeadbeefg>", False),  # Non-hex character
+            ("<foo blarg at 15ee6f9a0>", False),  # Missing the 0x prefix
+            ("", False),
+        ]
+    )
+    def test_is_mem_address_str(self, string: str, expected: bool) -> None:
+        """``is_mem_address_str`` matches default object reprs in either hex casing."""
+        assert string_util.is_mem_address_str(string) == expected
+
+    def test_is_mem_address_str_matches_this_host(self) -> None:
+        """This host's default object repr matches, whatever hex casing its C
+        runtime emits."""
+        assert string_util.is_mem_address_str(repr(object()))
+
     def test_from_number_with_invalid_item_method(self):
         """Test from_number with object that has item() but returns non-numeric."""
 

--- a/lib/tests/streamlit/write_test.py
+++ b/lib/tests/streamlit/write_test.py
@@ -376,6 +376,24 @@ class StreamlitWriteTest(unittest.TestCase):
 
             p.assert_called_once_with(my_instance)
 
+    def test_obj_instance_with_uppercase_hex_repr(self):
+        """An address repr reaches the help view whatever hex casing it uses.
+
+        Windows CPython formats addresses with uppercase digits, so this pins
+        the routing on hosts whose own reprs are lowercase.
+        """
+
+        class SomeClass:
+            def __repr__(self) -> str:
+                return "<__main__.SomeClass object at 0x0000027B0C1B1550>"
+
+        my_instance = SomeClass()
+
+        with patch("streamlit.delta_generator.DeltaGenerator.help") as p:
+            st.write(my_instance)
+
+            p.assert_called_once_with(my_instance)
+
     def test_dataclass_instance(self):
         """Test st.write with a dataclass instance."""
 
@@ -390,8 +408,8 @@ class StreamlitWriteTest(unittest.TestCase):
 
             p.assert_called_once_with(my_instance)
 
-    # We use "looks like a memory address" as a test inside st.write, so here we're
-    # checking that that logic isn't broken.
+    # A string argument takes st.write's string branch, so an address-looking
+    # string must render as markdown rather than reaching the help view.
     def test_str_looking_like_mem_address(self):
         """Test calling st.write on a string that looks like a memory address."""
 


### PR DESCRIPTION
## Describe your changes

`StreamlitInvalidColorError` now renders the valid formats as a Markdown list, and `StreamlitBadTimeStringError` includes the missing space before its format example. Exception messages are rendered as Markdown in the app, so the colour error's bullets previously showed as literal asterisks mid-sentence.

`is_mem_address_str()` now matches uppercase hex, so Windows object reprs take the same `st.write` / `st.help` path as on Linux. CPython formats the address with the platform C runtime's `%p`, and MSVC yields `0x0000027B0C1B1550` — which made `st.write()` print a raw address instead of the object-help view, and `st.help()` render `<property object at 0x...>` as a member value while dropping that member's docstring. Uses a character class rather than `re.IGNORECASE`, which would also let `" AT 0X"` match; a negative test pins that.

Patches for both were posted by @rajarshidattapy, who cannot open PRs against this repo.

## GitHub Issue Link (if applicable)

Fixes #16677
Fixes #16674

## Testing Plan

- Unit Tests (Python): `is_mem_address_str()` had no direct coverage at all; added a parameterized test over both hex casings, non-address reprs, and the `re.IGNORECASE` regression, plus a live-repr case so a change in how this host formats reprs fails locally. Exact-message assertions for both exceptions.
- Unit Tests (JS): `ExceptionElement` now asserts a Markdown message's bullets render as a real list (`role="list"` with two `listitem`s), which is what the Python assertion alone cannot prove. Verified it fails on a run-on string.
- E2E Tests: none. CI runs Playwright on Linux only, where reprs are already lowercase, so the address fix is not observable there — `st_write_objects.py` and `st_help.py` already cover both branches. No snapshot changes.
- Any manual testing needed? Verified the rendered error text and the `st.write` / `st.help` routing locally.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing copy and a narrow regex tweak in display routing, with broad unit/JS test coverage and no auth or data-path changes.
> 
> **Overview**
> Fixes **Markdown exception text** and **object repr detection on Windows** so users see proper lists and consistent `st.write` / `st.help` behavior.
> 
> **Exception messages:** `StreamlitInvalidColorError` now inserts blank lines and line breaks so valid-format bullets render as a list in the app (not inline `*`). `StreamlitBadTimeStringError` adds the missing space after “formatted as” so the sentence reads correctly. A frontend test on `ExceptionElement` asserts markdown bullets become real `list` / `listitem` nodes.
> 
> **Windows reprs:** `is_mem_address_str()` accepts **uppercase** hex in `0x…` addresses (MSVC `%p`), so default object reprs like `<Foo object at 0x0000027B…>` route to the help view in `st.write` and `st.help` instead of being treated as plain strings. Matching uses a hex digit character class—not `re.IGNORECASE`—so malformed strings like `AT 0X` still do not match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33627a38621b6f39f5e7fa60027c6d33aafc6941. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->