### PR TITLE
[chore] Make three unit tests pass on Windows

### DIFF
--- a/lib/tests/streamlit/components/v2/test_component_registry.py
+++ b/lib/tests/streamlit/components/v2/test_component_registry.py
@@ -796,7 +796,7 @@ def test_resolve_glob_pattern_direct() -> None:
 
         # Test successful resolution
         resolved = ComponentPathUtils.resolve_glob_pattern("test-*.js", package_root)
-        assert str(resolved.resolve()) == Path(test_file).resolve().as_posix()
+        assert resolved.resolve() == Path(test_file).resolve()
 
         # Test no matches
         with pytest.raises(StreamlitComponentRegistryError) as exc_info:

--- a/lib/tests/streamlit/elements/download_button_test.py
+++ b/lib/tests/streamlit/elements/download_button_test.py
@@ -15,8 +15,10 @@
 """download_button unit test."""
 
 import io
+import mimetypes
 import os
 import tempfile
+from unittest.mock import patch
 
 from parameterized import parameterized
 
@@ -28,6 +30,28 @@ from tests.delta_generator_test_case import DeltaGeneratorTestCase
 
 class DownloadButtonTest(DeltaGeneratorTestCase):
     """Test ability to marshall download_button protos."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        # Bind `mimetypes.types_map` to the dict `guess_type` actually reads, so
+        # the pin in setUp takes effect. A lookup initializes the registry only
+        # if it is not initialized yet; calling `init()` instead would rebuild
+        # it and drop any `add_type()` registrations made earlier in the process.
+        mimetypes.guess_type("pin.csv")
+
+    def setUp(self) -> None:
+        super().setUp()
+        # Pin the extensions these tests infer so the assertions cover
+        # Streamlit's inference, not the host's. On Windows `mimetypes` reads the
+        # registry, where an installed app can claim an extension (Excel maps
+        # .csv to application/vnd.ms-excel).
+        patcher = patch.dict(
+            mimetypes.types_map,
+            {".csv": "text/csv", ".json": "application/json", ".png": "image/png"},
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
 
     @parameterized.expand([("hello world",), (b"byteshere",)])
     def test_just_label(self, data):

--- a/lib/tests/streamlit/elements/video_test.py
+++ b/lib/tests/streamlit/elements/video_test.py
@@ -16,7 +16,7 @@
 
 from io import BytesIO
 from pathlib import Path
-from tempfile import NamedTemporaryFile
+from tempfile import TemporaryDirectory
 
 import numpy as np
 import pytest
@@ -188,12 +188,13 @@ class VideoTest(DeltaGeneratorTestCase):
         fake_video_data = b"\x11\x22\x33\x44\x55\x66"
         fake_sub_content = b"WEBVTT\n\n\n1\n00:01:47.250 --> 00:01:50.500\n`hello."
 
-        with NamedTemporaryFile(suffix=".vtt", mode="wb") as tmp_file:
-            p = Path(tmp_file.name)
-            tmp_file.write(fake_sub_content)
-            tmp_file.flush()
+        # Write the subtitle to a closed file before st.video: subtitle handling
+        # reopens the path, and Windows refuses to reopen a still-open temp file.
+        with TemporaryDirectory() as tmp_dir:
+            subtitle_path = Path(tmp_dir) / "subtitles.vtt"
+            subtitle_path.write_bytes(fake_sub_content)
 
-            st.video(fake_video_data, subtitles=p)
+            st.video(fake_video_data, subtitles=subtitle_path)
 
         expected_english_subtitle_url = _calculate_file_id(
             fake_sub_content,


### PR DESCRIPTION
## Describe your changes

Make three Python unit tests host-independent so they pass on native Windows.

- `test_resolve_glob_pattern_direct` compared a native-separator string to an `as_posix()` string. That assertion is wrong on every platform and passed on POSIX only because the two forms coincide there; it now compares `Path` objects.
- `test_st_video_subtitles_path` called `st.video()` while its `NamedTemporaryFile` was still open, and subtitle handling reopens that path — Windows creates the file with exclusive access, so the reopen raised `PermissionError`. Now uses `TemporaryDirectory`, so nothing is reopened while open.
- `download_button_test` asserted inferred mime types that come from `mimetypes`, which reads the registry on Windows — where an installed app can claim an extension (Excel maps `.csv` to `application/vnd.ms-excel`). `setUp` now pins `.csv`, `.json`, and `.png`, so the assertions cover Streamlit's inference rather than the host. A lookup in `setUpClass` binds `types_map` to the dict `guess_type` reads, without the `add_type()` registrations that `init()` would discard.

No Windows CI job is added. The "Windows" section of `CONTRIBUTING.md` states the development setup is Mac- and Linux-centric and directs Windows contributors to the devcontainer, WSL, or a VM, and the issue lists such a job as optional. Other Windows-only failures remain out of scope; #16674 tracks the `is_mem_address_str` cluster affecting `st.write` and `st.help`.

## GitHub Issue Link (if applicable)

Fixes #16679

## Testing Plan

- Unit Tests (Python): the changed tests are the coverage. None of them weakens what it asserts — each still fails if inference doesn't run or resolves the wrong path.
- E2E Tests: none. Test-only change with no library code.
- Any manual testing needed? No. Verified without a Windows machine by reproducing each failure mode locally: `PureWindowsPath` shows the old path assertion evaluates to `False` under Windows separators, and installing the Windows registry mappings in-process reproduces the exact reported failures (`assert 'application/vnd.ms-excel' == 'text/csv'`, `assert 'image/pjpeg' == 'image/png'`), which the pin resolves.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production code; risk is limited to test maintenance and does not affect runtime behavior.
> 
> **Overview**
> Fixes three unit tests that failed on native Windows due to host-specific path, file locking, and MIME registry behavior. **No library code changes.**
> 
> **Glob path assertion** in `test_resolve_glob_pattern_direct` now compares resolved `Path` objects instead of a native-path string against an `as_posix()` string, which only matched on POSIX.
> 
> **Download button MIME tests** pin `mimetypes.types_map` for `.csv`, `.json`, and `.png` in `setUp` (with `setUpClass` priming `guess_type` so the patch applies), so assertions test Streamlit’s inference rather than Windows registry overrides (e.g. Excel mapping `.csv` to `application/vnd.ms-excel`).
> 
> **Video subtitle path test** writes the VTT under `TemporaryDirectory` and closes the file before `st.video`, avoiding `PermissionError` when subtitle handling reopens the path while a `NamedTemporaryFile` is still open on Windows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 229eaf3f1a5c5073f77acb9134a00e47830f5de6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->