### PR TITLE
[chore] Honor PR-body product approval in reviews

### DIFF
--- a/.claude/agents/reviewing-local-changes.md
+++ b/.claude/agents/reviewing-local-changes.md
@@ -131,9 +131,10 @@ Review this branch's changes and ensure the changes are bug-free, backwards comp
 3. Read and analyze the changed files to understand the full context.
 4. Important: Read the relevant sub-directory `AGENTS.md` files based on changed files (see checklist above).
 5. Classify whether the PR has user-facing product impact. If it does, read
-   the PR body for explicit product-approval context, read `specs/AGENTS.md`, inspect comparable
-   existing Streamlit surfaces, and perform the product alignment assessment from the checklist.
-   If it does not, mark the Product Alignment section as not applicable and explain why briefly.
+   `specs/AGENTS.md`, inspect comparable existing Streamlit surfaces, read the PR body for explicit
+   product-approval context if a PR exists, and perform the product alignment assessment from the
+   checklist. If it does not, mark the Product Alignment section as not applicable and explain why
+   briefly.
 6. Assess performance impact, including the backend and frontend hot paths.
 7. Run an explicit external-test risk assessment using `/assessing-external-test-risk` and determine whether this branch should include `@pytest.mark.external_test` coverage.
 8. Evaluate readability: run the `/reviewing-readability` skill on the changed code (comments, docstrings, naming) and the `/reviewing-pr-description` skill on the PR title/description if a PR exists, and include their findings and proposed rewrites in your review.

--- a/.claude/agents/reviewing-local-changes.md
+++ b/.claude/agents/reviewing-local-changes.md
@@ -75,14 +75,20 @@ Review this branch's changes and ensure the changes are bug-free, backwards comp
     aligned; do not relitigate them. Instead, verify that the implementation follows the spec
     and separately assess any user-facing behavior that the merged spec does not cover. A new
     or modified spec in the current PR is not already approved by this rule.
+  - Read the PR body for explicit product-approval context. If it states that specific
+    product-related decisions were explicitly approved, treat only those decisions as approved
+    and aligned; do not relitigate them. Verify that the implementation matches the approved
+    decisions and separately assess any user-facing behavior outside their stated scope. Do not
+    infer approval from vague wording or the mere presence of product discussion.
   - A new user-facing feature or significant public API change requires a product spec
-    already merged into the base branch. If none exists, call this out as a merge-blocking
-    Product Alignment issue: merge the product spec first, then the implementation (see
-    `specs/README.md` and `specs/AGENTS.md`). A spec that exists only on this implementation
-    PR is not sufficient. Bug fixes, DevOps work, and small non-controversial enhancements
-    do not need a spec.
-  - If no merged spec covers a product decision, that absence is not approval.
-    Request changes for material product/API alignment issues.
+    already merged into the base branch unless the PR body explicitly documents approval of
+    both the product change and proceeding without a merged spec. If neither condition is met,
+    call this out as a merge-blocking Product Alignment issue: merge the product spec first,
+    then the implementation (see `specs/README.md` and `specs/AGENTS.md`). A spec that exists
+    only on this implementation PR is not sufficient. Bug fixes, DevOps work, and small
+    non-controversial enhancements do not need a spec.
+  - If neither a merged spec nor explicit PR-body approval covers a product decision, that
+    absence is not approval. Request changes for material product/API alignment issues.
   - Inspect analogous Streamlit APIs, configs, and behaviors. Check that the proposed surface
     uses established names, defaults, interaction patterns, return types, and error behavior.
     For public APIs, follow the "Docstrings for Public API" best practices in
@@ -125,9 +131,9 @@ Review this branch's changes and ensure the changes are bug-free, backwards comp
 3. Read and analyze the changed files to understand the full context.
 4. Important: Read the relevant sub-directory `AGENTS.md` files based on changed files (see checklist above).
 5. Classify whether the PR has user-facing product impact. If it does, read
-   `specs/AGENTS.md`, inspect comparable existing Streamlit surfaces, and perform the product
-   alignment assessment from the checklist. If it does not, mark the Product Alignment section as not
-   applicable and explain why briefly.
+   the PR body for explicit product-approval context, read `specs/AGENTS.md`, inspect comparable
+   existing Streamlit surfaces, and perform the product alignment assessment from the checklist.
+   If it does not, mark the Product Alignment section as not applicable and explain why briefly.
 6. Assess performance impact, including the backend and frontend hot paths.
 7. Run an explicit external-test risk assessment using `/assessing-external-test-risk` and determine whether this branch should include `@pytest.mark.external_test` coverage.
 8. Evaluate readability: run the `/reviewing-readability` skill on the changed code (comments, docstrings, naming) and the `/reviewing-pr-description` skill on the PR title/description if a PR exists, and include their findings and proposed rewrites in your review.
@@ -147,12 +153,14 @@ Write your review using valid GitHub Flavored Markdown in the following structur
 
 [State whether the PR has user-facing product impact. If yes, identify any relevant product
 spec already merged into the base branch, treat its documented product decisions as approved,
-and assess whether the implementation follows it. If this is a new user-facing feature or
-significant public API change with no merged product spec, request that the spec be merged
-before this implementation PR. For user-facing aspects not covered by an approved spec,
-assess the user value and complexity tradeoff, consistency with analogous Streamlit surfaces,
-and alignment with the principles in `specs/AGENTS.md`; clearly identify material issues that
-warrant requested changes. If no, state why this section is not applicable.]
+and assess whether the implementation follows it. Also identify any specific product-related
+decisions that the PR body says were explicitly approved and assess whether the implementation
+matches them. If this is a new user-facing feature or significant public API change with neither
+a merged product spec nor explicit PR-body approval to proceed without one, request that the spec
+be merged before this implementation PR. For user-facing aspects not covered by either form of
+approval, assess the user value and complexity tradeoff, consistency with analogous Streamlit
+surfaces, and alignment with the principles in `specs/AGENTS.md`; clearly identify material
+issues that warrant requested changes. If no, state why this section is not applicable.]
 
 ## Code Quality
 
@@ -201,7 +209,7 @@ meaningful performance impact, say why briefly.]
 
 Verdict criteria:
 - **APPROVED**: If there are no critical/merge-blocking issues. Minor suggestions or optional improvements should not block approval — those can be addressed in follow-up PRs.
-- **CHANGES REQUESTED**: Only use this for merge-blocking issues such as: bugs, security vulnerabilities, material performance regressions, breaking changes, missing required tests, a new user-facing feature or significant public API change without a product spec already merged into the base branch, or clear material violations of documented Streamlit product/API principles and patterns. Optional improvements, style preferences, and "nice to have" suggestions should NOT result in CHANGES REQUESTED.
+- **CHANGES REQUESTED**: Only use this for merge-blocking issues such as: bugs, security vulnerabilities, material performance regressions, breaking changes, missing required tests, a new user-facing feature or significant public API change without a product spec already merged into the base branch or explicit PR-body approval to proceed without one, or clear material violations of documented Streamlit product/API principles and patterns. Optional improvements, style preferences, and "nice to have" suggestions should NOT result in CHANGES REQUESTED.
 
 ---
 *This is an automated AI review. Please verify the feedback and use your judgment.*
@@ -214,10 +222,12 @@ Verdict criteria:
 - Focus on the root cause of issues, not cascading failures.
 - Be specific with file references and line numbers when noting issues.
 - Product feedback must cite concrete changed behavior and the relevant documented principle or
-  established Streamlit pattern. A new user-facing feature or significant public API change
-  without a product spec already merged into the base branch is merge-blocking: request that
-  the spec land first. For smaller changes that do not require a spec, a missing merged spec
-  is expected; still request changes for material alignment issues. Product questions and
-  optional refinements are non-blocking; request changes when a mismatch would create
-  material user harm or lasting, unjustified complexity in the public surface.
+  established Streamlit pattern. Do not raise product feedback for a decision explicitly approved
+  in the PR body unless the implementation deviates from that decision or introduces behavior
+  outside its stated scope. A new user-facing feature or significant public API change without a
+  product spec already merged into the base branch or explicit PR-body approval to proceed without
+  one is merge-blocking: request that the spec land first. For smaller changes that do not require
+  a spec, a missing merged spec is expected; still request changes for material alignment issues.
+  Product questions and optional refinements are non-blocking; request changes when a mismatch
+  would create material user harm or lasting, unjustified complexity in the public surface.
 - Findings that are covered by inline comments should NOT be repeated in the PR-level review body. The PR-level review covers high-level and cross-cutting concerns only. Inline comments handle line-specific findings.

--- a/scripts/assets/code-review-instructions.md
+++ b/scripts/assets/code-review-instructions.md
@@ -19,14 +19,20 @@
     aligned; do not relitigate them. Instead, verify that the implementation follows the spec
     and separately assess any user-facing behavior that the merged spec does not cover. A new
     or modified spec in the current PR is not already approved by this rule.
+  - Read the PR body for explicit product-approval context. If it states that specific
+    product-related decisions were explicitly approved, treat only those decisions as approved
+    and aligned; do not relitigate them. Verify that the implementation matches the approved
+    decisions and separately assess any user-facing behavior outside their stated scope. Do not
+    infer approval from vague wording or the mere presence of product discussion.
   - A new user-facing feature or significant public API change requires a product spec
-    already merged into the base branch. If none exists, call this out as a merge-blocking
-    Product Alignment issue: merge the product spec first, then the implementation (see
-    `specs/README.md` and `specs/AGENTS.md`). A spec that exists only on this implementation
-    PR is not sufficient. Bug fixes, DevOps work, and small non-controversial enhancements
-    do not need a spec.
-  - If no merged spec covers a product decision, that absence is not approval.
-    Request changes for material product/API alignment issues.
+    already merged into the base branch unless the PR body explicitly documents approval of
+    both the product change and proceeding without a merged spec. If neither condition is met,
+    call this out as a merge-blocking Product Alignment issue: merge the product spec first,
+    then the implementation (see `specs/README.md` and `specs/AGENTS.md`). A spec that exists
+    only on this implementation PR is not sufficient. Bug fixes, DevOps work, and small
+    non-controversial enhancements do not need a spec.
+  - If neither a merged spec nor explicit PR-body approval covers a product decision, that
+    absence is not approval. Request changes for material product/API alignment issues.
   - Inspect analogous Streamlit APIs, configs, and behaviors. Check that the proposed surface
     uses established names, defaults, interaction patterns, return types, and error behavior.
     For public APIs, follow the "Docstrings for Public API" best practices in
@@ -69,9 +75,9 @@
 3. Read and analyze the changed files to understand the full context.
 4. Important: Read the relevant sub-directory `AGENTS.md` files based on changed files (see checklist above).
 5. Classify whether the PR has user-facing product impact. If it does, read
-   `specs/AGENTS.md`, inspect comparable existing Streamlit surfaces, and perform the product
-   alignment assessment from the checklist. If it does not, mark the Product Alignment section as not
-   applicable and explain why briefly.
+   the PR body for explicit product-approval context, read `specs/AGENTS.md`, inspect comparable
+   existing Streamlit surfaces, and perform the product alignment assessment from the checklist.
+   If it does not, mark the Product Alignment section as not applicable and explain why briefly.
 6. Assess performance impact, including the backend and frontend hot paths.
 7. Run an explicit external-test risk assessment using `/assessing-external-test-risk` and determine whether this branch should include `@pytest.mark.external_test` coverage.
 8. Evaluate readability: run the `/reviewing-readability` skill on the changed code (comments, docstrings, naming) and the `/reviewing-pr-description` skill on the PR title/description if a PR exists, and include their findings and proposed rewrites in your review.
@@ -91,12 +97,14 @@ Write your review using valid GitHub Flavored Markdown in the following structur
 
 [State whether the PR has user-facing product impact. If yes, identify any relevant product
 spec already merged into the base branch, treat its documented product decisions as approved,
-and assess whether the implementation follows it. If this is a new user-facing feature or
-significant public API change with no merged product spec, request that the spec be merged
-before this implementation PR. For user-facing aspects not covered by an approved spec,
-assess the user value and complexity tradeoff, consistency with analogous Streamlit surfaces,
-and alignment with the principles in `specs/AGENTS.md`; clearly identify material issues that
-warrant requested changes. If no, state why this section is not applicable.]
+and assess whether the implementation follows it. Also identify any specific product-related
+decisions that the PR body says were explicitly approved and assess whether the implementation
+matches them. If this is a new user-facing feature or significant public API change with neither
+a merged product spec nor explicit PR-body approval to proceed without one, request that the spec
+be merged before this implementation PR. For user-facing aspects not covered by either form of
+approval, assess the user value and complexity tradeoff, consistency with analogous Streamlit
+surfaces, and alignment with the principles in `specs/AGENTS.md`; clearly identify material
+issues that warrant requested changes. If no, state why this section is not applicable.]
 
 ## Code Quality
 
@@ -145,7 +153,7 @@ meaningful performance impact, say why briefly.]
 
 Verdict criteria:
 - **APPROVED**: If there are no critical/merge-blocking issues. Minor suggestions or optional improvements should not block approval — those can be addressed in follow-up PRs.
-- **CHANGES REQUESTED**: Only use this for merge-blocking issues such as: bugs, security vulnerabilities, material performance regressions, breaking changes, missing required tests, a new user-facing feature or significant public API change without a product spec already merged into the base branch, or clear material violations of documented Streamlit product/API principles and patterns. Optional improvements, style preferences, and "nice to have" suggestions should NOT result in CHANGES REQUESTED.
+- **CHANGES REQUESTED**: Only use this for merge-blocking issues such as: bugs, security vulnerabilities, material performance regressions, breaking changes, missing required tests, a new user-facing feature or significant public API change without a product spec already merged into the base branch or explicit PR-body approval to proceed without one, or clear material violations of documented Streamlit product/API principles and patterns. Optional improvements, style preferences, and "nice to have" suggestions should NOT result in CHANGES REQUESTED.
 
 ---
 *This is an automated AI review. Please verify the feedback and use your judgment.*
@@ -158,10 +166,12 @@ Verdict criteria:
 - Focus on the root cause of issues, not cascading failures.
 - Be specific with file references and line numbers when noting issues.
 - Product feedback must cite concrete changed behavior and the relevant documented principle or
-  established Streamlit pattern. A new user-facing feature or significant public API change
-  without a product spec already merged into the base branch is merge-blocking: request that
-  the spec land first. For smaller changes that do not require a spec, a missing merged spec
-  is expected; still request changes for material alignment issues. Product questions and
-  optional refinements are non-blocking; request changes when a mismatch would create
-  material user harm or lasting, unjustified complexity in the public surface.
+  established Streamlit pattern. Do not raise product feedback for a decision explicitly approved
+  in the PR body unless the implementation deviates from that decision or introduces behavior
+  outside its stated scope. A new user-facing feature or significant public API change without a
+  product spec already merged into the base branch or explicit PR-body approval to proceed without
+  one is merge-blocking: request that the spec land first. For smaller changes that do not require
+  a spec, a missing merged spec is expected; still request changes for material alignment issues.
+  Product questions and optional refinements are non-blocking; request changes when a mismatch
+  would create material user harm or lasting, unjustified complexity in the public surface.
 - Findings that are covered by inline comments should NOT be repeated in the PR-level review body. The PR-level review covers high-level and cross-cutting concerns only. Inline comments handle line-specific findings.

--- a/scripts/assets/code-review-instructions.md
+++ b/scripts/assets/code-review-instructions.md
@@ -75,9 +75,10 @@
 3. Read and analyze the changed files to understand the full context.
 4. Important: Read the relevant sub-directory `AGENTS.md` files based on changed files (see checklist above).
 5. Classify whether the PR has user-facing product impact. If it does, read
-   the PR body for explicit product-approval context, read `specs/AGENTS.md`, inspect comparable
-   existing Streamlit surfaces, and perform the product alignment assessment from the checklist.
-   If it does not, mark the Product Alignment section as not applicable and explain why briefly.
+   `specs/AGENTS.md`, inspect comparable existing Streamlit surfaces, read the PR body for explicit
+   product-approval context if a PR exists, and perform the product alignment assessment from the
+   checklist. If it does not, mark the Product Alignment section as not applicable and explain why
+   briefly.
 6. Assess performance impact, including the backend and frontend hot paths.
 7. Run an explicit external-test risk assessment using `/assessing-external-test-risk` and determine whether this branch should include `@pytest.mark.external_test` coverage.
 8. Evaluate readability: run the `/reviewing-readability` skill on the changed code (comments, docstrings, naming) and the `/reviewing-pr-description` skill on the PR title/description if a PR exists, and include their findings and proposed rewrites in your review.


### PR DESCRIPTION
## Describe your changes

Treat explicit product decisions documented in a PR body as approved during AI review, so a missing merged spec is not merge-blocking when that approval is stated.

- Only explicit, scoped approvals count; vague product discussion is not treated as approval
- New user-facing features and significant public API changes still need a merged spec unless the PR body also documents approval to proceed without one

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

Documentation-only change to AI review instructions. No runtime behavior or tests to update.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

Made with [Cursor](https://cursor.com)