### PR TITLE
[fix] Flaky FIPS smoke test timeouts

### DIFF
--- a/lib/tests/streamlit/fips_test.py
+++ b/lib/tests/streamlit/fips_test.py
@@ -28,6 +28,8 @@ import urllib.request
 from typing import TYPE_CHECKING, Any, NoReturn
 
 import pytest
+from typing_extensions import Self
+from websockets.exceptions import InvalidHandshake
 from websockets.sync.client import connect
 
 from streamlit import util
@@ -43,8 +45,9 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 _STREAMLIT_SERVER_STARTUP_TIMEOUT_SECS = 30
-# Deadline for the WebSocket smoke session (rerun request to script finish),
-# kept separate from the server-startup timeout so each reads independently.
+# Budget for opening the smoke WebSocket and, separately, for the session
+# from rerun request to script finish. Kept independent of the server-startup
+# timeout so each phase reads independently.
 _FIPS_SMOKE_SESSION_TIMEOUT_SECS = 30
 # Number of times to retry starting the server on a fresh port, guarding against
 # the small window where the chosen port is claimed between selection and bind.
@@ -165,12 +168,10 @@ def test_internal_hashing_uses_non_security_hashes(
 def test_wait_for_streamlit_health_retries_socket_timeout(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """Retry when urllib raises a raw ``TimeoutError`` instead of ``URLError``.
+    """Retry health polling when urllib raises a raw socket timeout.
 
-    A 1s socket timeout during ``getresponse()``/``read()`` is
-    ``TimeoutError("timed out")`` and is not wrapped in ``URLError``. That is
-    the failure this smoke test flakes with under CI load if the health poll
-    does not catch it.
+    urllib does not wrap a socket read timeout in ``URLError``, so
+    ``_wait_for_streamlit_health`` must catch ``TimeoutError`` too.
     """
 
     class _AliveProcess:
@@ -178,7 +179,7 @@ def test_wait_for_streamlit_health_retries_socket_timeout(
             return None
 
     class _OkResponse:
-        def __enter__(self):
+        def __enter__(self) -> Self:
             return self
 
         def __exit__(self, *_args: object) -> None:
@@ -187,11 +188,12 @@ def test_wait_for_streamlit_health_retries_socket_timeout(
         def read(self) -> bytes:
             return b"ok"
 
-    calls = {"n": 0}
+    call_count = 0
 
     def fake_open(_url: str, timeout: float = 1) -> _OkResponse:
-        calls["n"] += 1
-        if calls["n"] < 3:
+        nonlocal call_count
+        call_count += 1
+        if call_count < 3:
             raise TimeoutError("timed out")
         return _OkResponse()
 
@@ -207,7 +209,7 @@ def test_wait_for_streamlit_health_retries_socket_timeout(
     log_path.write_text("", encoding="utf-8")
     process: Any = _AliveProcess()
     assert _wait_for_streamlit_health(process, 12345, log_path) is True
-    assert calls["n"] == 3
+    assert call_count == 3
 
 
 @pytest.mark.parametrize("reject_blake2_digest_size", [False, True])
@@ -310,33 +312,37 @@ def _run_streamlit_websocket_session(port: int, log_path: Path) -> None:
     """
     websocket_url = f"ws://127.0.0.1:{port}/_stcore/stream"
     rerun_request = BackMsg(rerun_script=ClientState()).SerializeToString()
-    deadline = time.monotonic() + _FIPS_SMOKE_SESSION_TIMEOUT_SECS
+    connect_params = inspect.signature(connect).parameters
     connect_kwargs: dict[str, Any] = {
         "subprotocols": ["streamlit"],
         # Generous close timeout so teardown cannot fail a completed session
         # when the server is still flushing under FIPS hash-fallback load.
         "close_timeout": 10,
+    }
+    # ping_interval and proxy only exist on the sync client in websockets 15+.
+    # 12.x rejects unknown kwargs; 13-14 forward them to create_connection.
+    if "ping_interval" in connect_params:
         # This is a short smoke test; disable client pings so keepalive
         # timeouts cannot surface as a raw ``TimeoutError: timed out``.
-        "ping_interval": None,
-    }
-    # websockets>=13 honors HTTP_PROXY by default. Force direct loopback,
-    # matching the health check's ProxyHandler({}). websockets 12 (min-deps)
-    # has no proxy argument and forwards unknown kwargs to create_connection.
-    if "proxy" in inspect.signature(connect).parameters:
+        connect_kwargs["ping_interval"] = None
+    # websockets>=15 honors HTTP_PROXY by default. Force direct loopback,
+    # matching the health check's ProxyHandler({}). Older releases have no
+    # proxy argument, and 12.x rejects unknown kwargs outright.
+    if "proxy" in connect_params:
         connect_kwargs["proxy"] = None
 
     websocket = None
     last_connect_error: BaseException | None = None
-    while time.monotonic() < deadline:
+    connect_deadline = time.monotonic() + _FIPS_SMOKE_SESSION_TIMEOUT_SECS
+    while time.monotonic() < connect_deadline:
         try:
             websocket = connect(
                 websocket_url,
-                open_timeout=max(0.1, deadline - time.monotonic()),
+                open_timeout=min(5, max(0.1, connect_deadline - time.monotonic())),
                 **connect_kwargs,
             )
             break
-        except (TimeoutError, OSError, ConnectionError) as ex:
+        except (OSError, InvalidHandshake) as ex:
             last_connect_error = ex
             time.sleep(0.2)
 
@@ -348,6 +354,9 @@ def _run_streamlit_websocket_session(port: int, log_path: Path) -> None:
         )
 
     saw_smoke_marker = False
+    # Start the session budget after the socket is open so a slow handshake
+    # cannot starve the rerun round-trip or misreport "did not finish".
+    deadline = time.monotonic() + _FIPS_SMOKE_SESSION_TIMEOUT_SECS
     try:
         websocket.send(rerun_request)
         while time.monotonic() < deadline:

--- a/lib/tests/streamlit/fips_test.py
+++ b/lib/tests/streamlit/fips_test.py
@@ -25,11 +25,12 @@ import subprocess
 import sys
 import time
 import urllib.request
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, NoReturn
 
 import pytest
 from typing_extensions import Self
-from websockets.exceptions import InvalidHandshake
+from websockets.exceptions import ConnectionClosed, InvalidHandshake
 from websockets.sync.client import connect
 
 from streamlit import util
@@ -197,11 +198,10 @@ def test_wait_for_streamlit_health_retries_socket_timeout(
             raise TimeoutError("timed out")
         return _OkResponse()
 
-    class _FakeOpener:
-        open = staticmethod(fake_open)
-
     monkeypatch.setattr(
-        urllib.request, "build_opener", lambda *_args, **_kwargs: _FakeOpener()
+        urllib.request,
+        "build_opener",
+        lambda *_args, **_kwargs: SimpleNamespace(open=fake_open),
     )
     monkeypatch.setattr(time, "sleep", lambda _seconds: None)
 
@@ -315,9 +315,9 @@ def _run_streamlit_websocket_session(port: int, log_path: Path) -> None:
     connect_params = inspect.signature(connect).parameters
     connect_kwargs: dict[str, Any] = {
         "subprotocols": ["streamlit"],
-        # Generous close timeout so teardown cannot fail a completed session
-        # when the server is still flushing under FIPS hash-fallback load.
-        "close_timeout": 10,
+        # Keep teardown snappy if the server is wedged. Close failures are
+        # already suppressed below, so a long close_timeout only adds wait.
+        "close_timeout": 2,
     }
     # ping_interval and proxy only exist on the sync client in websockets 15+.
     # 12.x rejects unknown kwargs; 13-14 forward them to create_connection.
@@ -358,32 +358,44 @@ def _run_streamlit_websocket_session(port: int, log_path: Path) -> None:
     # cannot starve the rerun round-trip or misreport "did not finish".
     deadline = time.monotonic() + _FIPS_SMOKE_SESSION_TIMEOUT_SECS
     try:
-        websocket.send(rerun_request)
-        while time.monotonic() < deadline:
-            try:
-                payload = websocket.recv(timeout=max(0.1, deadline - time.monotonic()))
-            except TimeoutError:
+        try:
+            websocket.send(rerun_request)
+            while time.monotonic() < deadline:
+                try:
+                    payload = websocket.recv(
+                        timeout=max(0.1, deadline - time.monotonic())
+                    )
+                except TimeoutError:
+                    _fail_with_server_log(
+                        log_path,
+                        "Timed out waiting for the FIPS smoke app's messages",
+                    )
+                assert isinstance(payload, bytes)
+
+                forward_msg = ForwardMsg.FromString(payload)
+                if (
+                    forward_msg.HasField("delta")
+                    and forward_msg.delta.HasField("new_element")
+                    and forward_msg.delta.new_element.HasField("markdown")
+                    and forward_msg.delta.new_element.markdown.body
+                    == _FIPS_SMOKE_MARKER
+                ):
+                    saw_smoke_marker = True
+
+                if forward_msg.WhichOneof("type") == "script_finished":
+                    assert (
+                        forward_msg.script_finished == ForwardMsg.FINISHED_SUCCESSFULLY
+                    )
+                    break
+            else:
                 _fail_with_server_log(
-                    log_path,
-                    "Timed out waiting for the FIPS smoke app's messages",
+                    log_path, "Streamlit did not finish the FIPS smoke app"
                 )
-            assert isinstance(payload, bytes)
-
-            forward_msg = ForwardMsg.FromString(payload)
-            if (
-                forward_msg.HasField("delta")
-                and forward_msg.delta.HasField("new_element")
-                and forward_msg.delta.new_element.HasField("markdown")
-                and forward_msg.delta.new_element.markdown.body == _FIPS_SMOKE_MARKER
-            ):
-                saw_smoke_marker = True
-
-            if forward_msg.WhichOneof("type") == "script_finished":
-                assert forward_msg.script_finished == ForwardMsg.FINISHED_SUCCESSFULLY
-                break
-        else:
+        except ConnectionClosed as ex:
             _fail_with_server_log(
-                log_path, "Streamlit did not finish the FIPS smoke app"
+                log_path,
+                "FIPS smoke WebSocket closed before the session finished. "
+                f"Last error: {ex!r}",
             )
     finally:
         # Close is best-effort: a close-handshake timeout must not replace a

--- a/lib/tests/streamlit/fips_test.py
+++ b/lib/tests/streamlit/fips_test.py
@@ -18,14 +18,14 @@ from __future__ import annotations
 
 import contextlib
 import hashlib
+import inspect
 import os
 import socket
 import subprocess
 import sys
 import time
 import urllib.request
-from typing import TYPE_CHECKING, Any
-from urllib.error import URLError
+from typing import TYPE_CHECKING, Any, NoReturn
 
 import pytest
 from websockets.sync.client import connect
@@ -162,6 +162,54 @@ def test_internal_hashing_uses_non_security_hashes(
         assert md5_call_count > 0  # BLAKE2b was rejected, so we fell back to MD5.
 
 
+def test_wait_for_streamlit_health_retries_socket_timeout(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Retry when urllib raises a raw ``TimeoutError`` instead of ``URLError``.
+
+    A 1s socket timeout during ``getresponse()``/``read()`` is
+    ``TimeoutError("timed out")`` and is not wrapped in ``URLError``. That is
+    the failure this smoke test flakes with under CI load if the health poll
+    does not catch it.
+    """
+
+    class _AliveProcess:
+        def poll(self) -> None:
+            return None
+
+    class _OkResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return b"ok"
+
+    calls = {"n": 0}
+
+    def fake_open(_url: str, timeout: float = 1) -> _OkResponse:
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise TimeoutError("timed out")
+        return _OkResponse()
+
+    class _FakeOpener:
+        open = staticmethod(fake_open)
+
+    monkeypatch.setattr(
+        urllib.request, "build_opener", lambda *_args, **_kwargs: _FakeOpener()
+    )
+    monkeypatch.setattr(time, "sleep", lambda _seconds: None)
+
+    log_path = tmp_path / "streamlit_server.log"
+    log_path.write_text("", encoding="utf-8")
+    process: Any = _AliveProcess()
+    assert _wait_for_streamlit_health(process, 12345, log_path) is True
+    assert calls["n"] == 3
+
+
 @pytest.mark.parametrize("reject_blake2_digest_size", [False, True])
 def test_streamlit_run_serves_app_when_fips_rejects_security_hashes(
     reject_blake2_digest_size: bool, tmp_path: Path
@@ -209,7 +257,7 @@ st.write("{_FIPS_SMOKE_MARKER}")
     log_path = tmp_path / "streamlit_server.log"
     process, port = _start_streamlit_server(app_path, env, log_path)
     try:
-        _run_streamlit_websocket_session(port)
+        _run_streamlit_websocket_session(port, log_path)
     finally:
         _terminate(process)
 
@@ -254,7 +302,7 @@ def _start_streamlit_server(
     )
 
 
-def _run_streamlit_websocket_session(port: int) -> None:
+def _run_streamlit_websocket_session(port: int, log_path: Path) -> None:
     """Drive a rerun over the WebSocket and assert the smoke session succeeds.
 
     Sends a ``BackMsg`` rerun request, then asserts that the app emits the
@@ -262,22 +310,54 @@ def _run_streamlit_websocket_session(port: int) -> None:
     """
     websocket_url = f"ws://127.0.0.1:{port}/_stcore/stream"
     rerun_request = BackMsg(rerun_script=ClientState()).SerializeToString()
+    deadline = time.monotonic() + _FIPS_SMOKE_SESSION_TIMEOUT_SECS
+    connect_kwargs: dict[str, Any] = {
+        "subprotocols": ["streamlit"],
+        # Generous close timeout so teardown cannot fail a completed session
+        # when the server is still flushing under FIPS hash-fallback load.
+        "close_timeout": 10,
+        # This is a short smoke test; disable client pings so keepalive
+        # timeouts cannot surface as a raw ``TimeoutError: timed out``.
+        "ping_interval": None,
+    }
+    # websockets>=13 honors HTTP_PROXY by default. Force direct loopback,
+    # matching the health check's ProxyHandler({}). websockets 12 (min-deps)
+    # has no proxy argument and forwards unknown kwargs to create_connection.
+    if "proxy" in inspect.signature(connect).parameters:
+        connect_kwargs["proxy"] = None
+
+    websocket = None
+    last_connect_error: BaseException | None = None
+    while time.monotonic() < deadline:
+        try:
+            websocket = connect(
+                websocket_url,
+                open_timeout=max(0.1, deadline - time.monotonic()),
+                **connect_kwargs,
+            )
+            break
+        except (TimeoutError, OSError, ConnectionError) as ex:
+            last_connect_error = ex
+            time.sleep(0.2)
+
+    if websocket is None:
+        _fail_with_server_log(
+            log_path,
+            f"Timed out opening the FIPS smoke WebSocket at {websocket_url}. "
+            f"Last error: {last_connect_error!r}",
+        )
+
     saw_smoke_marker = False
-
-    with connect(
-        websocket_url,
-        subprotocols=["streamlit"],
-        open_timeout=5,
-        close_timeout=2,
-    ) as websocket:
+    try:
         websocket.send(rerun_request)
-
-        deadline = time.monotonic() + _FIPS_SMOKE_SESSION_TIMEOUT_SECS
         while time.monotonic() < deadline:
             try:
                 payload = websocket.recv(timeout=max(0.1, deadline - time.monotonic()))
             except TimeoutError:
-                pytest.fail("Timed out waiting for the FIPS smoke app's messages")
+                _fail_with_server_log(
+                    log_path,
+                    "Timed out waiting for the FIPS smoke app's messages",
+                )
             assert isinstance(payload, bytes)
 
             forward_msg = ForwardMsg.FromString(payload)
@@ -293,9 +373,17 @@ def _run_streamlit_websocket_session(port: int) -> None:
                 assert forward_msg.script_finished == ForwardMsg.FINISHED_SUCCESSFULLY
                 break
         else:
-            pytest.fail("Streamlit did not finish the FIPS smoke app")
+            _fail_with_server_log(
+                log_path, "Streamlit did not finish the FIPS smoke app"
+            )
+    finally:
+        # Close is best-effort: a close-handshake timeout must not replace a
+        # real session failure (or fail a session that already succeeded).
+        with contextlib.suppress(Exception):
+            websocket.close()
 
-    assert saw_smoke_marker, "The FIPS runtime canaries did not complete"
+    if not saw_smoke_marker:
+        _fail_with_server_log(log_path, "The FIPS runtime canaries did not complete")
 
 
 def _wait_for_streamlit_health(
@@ -320,7 +408,12 @@ def _wait_for_streamlit_health(
             with opener.open(health_url, timeout=1) as response:
                 if response.read().decode("utf-8") == "ok":
                     return True
-        except URLError as ex:
+        except OSError as ex:
+            # urllib wraps connect/send failures in URLError (an OSError). A
+            # 1s socket timeout during getresponse()/read() can also raise
+            # TimeoutError("timed out") directly. Catch both so a slow
+            # response retries until the startup deadline instead of failing
+            # the test with an uncaught TimeoutError.
             last_error = ex
 
         time.sleep(0.2)
@@ -335,6 +428,12 @@ def _wait_for_streamlit_health(
         f"Last error: {last_error!r}\n"
         f"Output:\n{output}"
     )
+
+
+def _fail_with_server_log(log_path: Path, message: str) -> NoReturn:
+    """Fail the test, appending the Streamlit server log for diagnostics."""
+    output = log_path.read_text(encoding="utf-8", errors="replace")
+    pytest.fail(f"{message}\nOutput:\n{output}")
 
 
 def _terminate(process: subprocess.Popen[str]) -> None:


### PR DESCRIPTION
## Describe your changes

- Health polling now retries on raw socket `TimeoutError("timed out")`. urllib does not wrap read timeouts in `URLError`, which is what aborted `test_streamlit_run_serves_app_when_fips_rejects_security_hashes[True]` under CI load.
- The WebSocket smoke session uses the 30s deadline, retries connect, skips HTTP proxies on loopback, and includes the server log on failure.

## GitHub Issue Link (if applicable)

## Testing Plan

- `lib/tests/streamlit/fips_test.py` — health-poll TimeoutError retry plus the FIPS `streamlit run` WebSocket smoke cases

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

Made with [Cursor](https://cursor.com)