### PR TITLE
[refactor] Remove unused SecretErrorMessages hook

### DIFF
--- a/lib/streamlit/errors.py
+++ b/lib/streamlit/errors.py
@@ -579,11 +579,10 @@ class StreamlitBadTimeStringError(LocalizableStreamlitException):
         )
 
 
-class StreamlitSecretNotFoundError(LocalizableStreamlitException, FileNotFoundError):
-    """Exception raised when a secret cannot be found or parsed in the secrets.toml file."""
-
-    def __init__(self, message: str) -> None:
-        super().__init__(message)
+class StreamlitSecretNotFoundError(
+    LocalizableStreamlitException, FileNotFoundError
+):  # pragma: no cover - trivial subclass
+    """Exception raised when a secret cannot be found or a secrets source cannot be parsed."""
 
 
 class StreamlitInvalidWidthError(LocalizableStreamlitException):

--- a/lib/streamlit/runtime/secrets.py
+++ b/lib/streamlit/runtime/secrets.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import os
 import threading
-from collections.abc import Callable, ItemsView, Iterator, KeysView, Mapping, ValuesView
+from collections.abc import ItemsView, Iterator, KeysView, Mapping, ValuesView
 from copy import deepcopy
 from typing import (
     Any,
@@ -84,100 +84,6 @@ def _validate_secrets_value(value: Any, path: str = "") -> None:
         )
 
 
-class SecretErrorMessages:
-    """SecretErrorMessages stores all error messages we use for secrets to allow customization
-    for different environments.
-
-    For example Streamlit Cloud can customize the message to be different than the open source.
-
-    For internal use, may change in future releases without notice.
-    """
-
-    def __init__(self) -> None:
-        self.missing_attr_message: Callable[[str], str] = lambda attr_name: (
-            f'st.secrets has no attribute "{attr_name}". '
-            "Did you forget to add it to secrets.toml, mount it to secret directory, or the app settings "
-            "on Streamlit Cloud? More info: "
-            "https://docs.streamlit.io/deploy/streamlit-community-cloud/deploy-your-app/secrets-management"
-        )
-        self.missing_key_message: Callable[[str], str] = lambda key: (
-            f'st.secrets has no key "{key}". '
-            "Did you forget to add it to secrets.toml, mount it to secret directory, or the app settings "
-            "on Streamlit Cloud? More info: "
-            "https://docs.streamlit.io/deploy/streamlit-community-cloud/deploy-your-app/secrets-management"
-        )
-        self.no_secrets_found: Callable[[list[str]], str] = lambda file_paths: (
-            f"No secrets found. Valid paths for a secrets.toml file or secret directories are: {', '.join(file_paths)}"
-        )
-        self.error_parsing_file_at_path: Callable[[str, Exception], str] = (
-            lambda path, ex: f"Error parsing secrets file at {path}: {ex}"
-        )
-        self.subfolder_path_is_not_a_folder: Callable[[str], str] = (
-            lambda sub_folder_path: (
-                f"{sub_folder_path} is not a folder. "
-                "To use directory based secrets, mount every secret in a subfolder under the secret directory"
-            )
-        )
-        self.invalid_secret_path: Callable[[str], str] = lambda path: (
-            f"Invalid secrets path: {path}: path is not a .toml file or a directory"
-        )
-
-    def set_missing_attr_message(self, message: Callable[[str], str]) -> None:
-        """Set the missing attribute error message."""
-        self.missing_attr_message = message
-
-    def set_missing_key_message(self, message: Callable[[str], str]) -> None:
-        """Set the missing key error message."""
-        self.missing_key_message = message
-
-    def set_no_secrets_found_message(self, message: Callable[[list[str]], str]) -> None:
-        """Set the no secrets found error message."""
-        self.no_secrets_found = message
-
-    def set_error_parsing_file_at_path_message(
-        self, message: Callable[[str, Exception], str]
-    ) -> None:
-        """Set the error parsing file at path error message."""
-        self.error_parsing_file_at_path = message
-
-    def set_subfolder_path_is_not_a_folder_message(
-        self, message: Callable[[str], str]
-    ) -> None:
-        """Set the subfolder path is not a folder error message."""
-        self.subfolder_path_is_not_a_folder = message
-
-    def set_invalid_secret_path_message(self, message: Callable[[str], str]) -> None:
-        """Set the invalid secret path error message."""
-        self.invalid_secret_path = message
-
-    def get_missing_attr_message(self, attr_name: str) -> str:
-        """Get the missing attribute error message."""
-        return self.missing_attr_message(attr_name)
-
-    def get_missing_key_message(self, key: str) -> str:
-        """Get the missing key error message."""
-        return self.missing_key_message(key)
-
-    def get_no_secrets_found_message(self, file_paths: list[str]) -> str:
-        """Get the no secrets found error message."""
-        return self.no_secrets_found(file_paths)
-
-    def get_error_parsing_file_at_path_message(self, path: str, ex: Exception) -> str:
-        """Get the error parsing file at path error message."""
-        return self.error_parsing_file_at_path(path, ex)
-
-    def get_subfolder_path_is_not_a_folder_message(self, sub_folder_path: str) -> str:
-        """Get the subfolder path is not a folder error message."""
-        return self.subfolder_path_is_not_a_folder(sub_folder_path)
-
-    def get_invalid_secret_path_message(self, path: str) -> str:
-        """Get the invalid secret path error message."""
-        return self.invalid_secret_path(path)
-
-
-secret_error_messages_singleton: Final = SecretErrorMessages()
-
-
 def _convert_to_dict(obj: Mapping[str, Any] | AttrDict) -> dict[str, Any]:
     """Convert Mapping or AttrDict objects to dictionaries."""
     if isinstance(obj, AttrDict):
@@ -185,12 +91,19 @@ def _convert_to_dict(obj: Mapping[str, Any] | AttrDict) -> dict[str, Any]:
     return {k: v.to_dict() if isinstance(v, AttrDict) else v for k, v in obj.items()}
 
 
+_MISSING_ENTRY_HINT: Final = (
+    "Did you forget to add it to secrets.toml, mount it to secret directory, or the app settings "
+    "on Streamlit Cloud? More info: "
+    "https://docs.streamlit.io/deploy/streamlit-community-cloud/deploy-your-app/secrets-management"
+)
+
+
 def _missing_attr_error_message(attr_name: str) -> str:
-    return secret_error_messages_singleton.get_missing_attr_message(attr_name)
+    return f'st.secrets has no attribute "{attr_name}". {_MISSING_ENTRY_HINT}'
 
 
 def _missing_key_error_message(key: str) -> str:
-    return secret_error_messages_singleton.get_missing_key_message(key)
+    return f'st.secrets has no key "{key}". {_MISSING_ENTRY_HINT}'
 
 
 class AttrDict(Mapping[str, Any]):
@@ -275,13 +188,6 @@ class Secrets(Mapping[str, Any]):
             # No secrets.toml files exist. That's fine.
             return False
 
-    def set_suppress_print_error_on_exception(
-        self, suppress_print_error_on_exception: bool
-    ) -> None:
-        """Left in place for compatibility with integrations until integration
-        code can be updated.
-        """
-
     def _reset(self) -> None:
         """Clear the secrets dictionary and remove any secrets that were
         added to os.environ.
@@ -315,12 +221,11 @@ class Secrets(Mapping[str, Any]):
         try:
             secrets.update(toml.loads(secrets_file_str))
         except (TypeError, toml.TomlDecodeError) as ex:
-            msg = (
-                secret_error_messages_singleton.get_error_parsing_file_at_path_message(
-                    path, ex
-                )
-            )
-            raise StreamlitSecretNotFoundError(msg) from ex
+            raise StreamlitSecretNotFoundError(
+                "Error parsing secrets file at {path}: {error}",
+                path=path,
+                error=str(ex),
+            ) from ex
 
         return secrets, found_secrets_file
 
@@ -345,10 +250,11 @@ class Secrets(Mapping[str, Any]):
         for dirname in os.listdir(path):
             sub_folder_path = os.path.join(path, dirname)
             if not os.path.isdir(sub_folder_path):
-                error_msg = secret_error_messages_singleton.get_subfolder_path_is_not_a_folder_message(
-                    sub_folder_path
+                raise StreamlitSecretNotFoundError(
+                    "{sub_folder_path} is not a folder. "
+                    "To use directory based secrets, mount every secret in a subfolder under the secret directory",
+                    sub_folder_path=sub_folder_path,
                 )
-                raise StreamlitSecretNotFoundError(error_msg)
             sub_secrets = {}
 
             for filename in os.listdir(sub_folder_path):
@@ -377,10 +283,10 @@ class Secrets(Mapping[str, Any]):
         if os.path.isdir(path):
             return self._parse_directory(path)
 
-        error_msg = secret_error_messages_singleton.get_invalid_secret_path_message(
-            path
+        raise StreamlitSecretNotFoundError(
+            "Invalid secrets path: {path}: path is not a .toml file or a directory",
+            path=path,
         )
-        raise StreamlitSecretNotFoundError(error_msg)
 
     def _parse(self) -> Mapping[str, Any]:
         """Parse our secrets.toml files if they're not already parsed.
@@ -412,12 +318,10 @@ class Secrets(Mapping[str, Any]):
                 secrets.update(path_secrets)
 
             if not found_secrets_file:
-                error_msg = (
-                    secret_error_messages_singleton.get_no_secrets_found_message(
-                        file_paths
-                    )
+                raise StreamlitSecretNotFoundError(
+                    "No secrets found. Valid paths for a secrets.toml file or secret directories are: {file_paths}",
+                    file_paths=", ".join(file_paths),
                 )
-                raise StreamlitSecretNotFoundError(error_msg)
 
             for k, v in secrets.items():
                 self._maybe_set_environment_variable(k, v)
@@ -599,7 +503,6 @@ class Secrets(Mapping[str, Any]):
             "_secrets",
             "_lock",
             "_file_watchers_installed",
-            "_suppress_print_error_on_exception",
             "_programmatic_secrets",
             "file_change_listener",
             "load_if_toml_exists",

--- a/lib/tests/streamlit/runtime/secrets_test.py
+++ b/lib/tests/streamlit/runtime/secrets_test.py
@@ -23,7 +23,7 @@ import os
 import tempfile
 import threading
 import unittest
-from collections.abc import Iterator, Mapping, MutableMapping
+from collections.abc import Callable, Iterator, Mapping, MutableMapping
 from collections.abc import Mapping as MappingABC
 from collections.abc import MutableMapping as MutableMappingABC
 from typing import TYPE_CHECKING, Any
@@ -37,10 +37,12 @@ import streamlit as st
 from streamlit import config
 from streamlit.errors import StreamlitSecretNotFoundError
 from streamlit.runtime.secrets import (
+    _MISSING_ENTRY_HINT,
     AttrDict,
-    SecretErrorMessages,
     Secrets,
     _convert_to_dict,
+    _missing_attr_error_message,
+    _missing_key_error_message,
 )
 from streamlit.signal_util import Signal
 from tests import testutil
@@ -61,74 +63,6 @@ email="eng@streamlit.io"
 """
 
 MOCK_SECRETS_FILE_LOC = "/mock/secrets.toml"
-
-
-class TestSecretErrorMessages(unittest.TestCase):
-    def test_changing_message(self):
-        messages = SecretErrorMessages()
-        assert (
-            messages.get_missing_attr_message("attr")
-            == 'st.secrets has no attribute "attr". Did you forget to add it to secrets.toml, '
-            "mount it to secret directory, or the app settings on Streamlit Cloud? More info: "
-            "https://docs.streamlit.io/deploy/streamlit-community-cloud/deploy-your-app/secrets-management"
-        )
-
-        messages.set_missing_attr_message(
-            lambda attr: "Missing attribute message",
-        )
-
-        assert messages.get_missing_attr_message([""]) == "Missing attribute message"
-
-    def test_set_and_get_missing_key_message(self) -> None:
-        """Verify set_missing_key_message and get_missing_key_message work correctly."""
-        messages = SecretErrorMessages()
-        messages.set_missing_key_message(lambda key: f"Custom missing key: {key}")
-        assert (
-            messages.get_missing_key_message("my_key") == "Custom missing key: my_key"
-        )
-
-    def test_set_and_get_no_secrets_found_message(self) -> None:
-        """Verify set_no_secrets_found_message and get_no_secrets_found_message work correctly."""
-        messages = SecretErrorMessages()
-        messages.set_no_secrets_found_message(
-            lambda paths: f"No secrets at: {', '.join(paths)}"
-        )
-        assert (
-            messages.get_no_secrets_found_message(["/path/a", "/path/b"])
-            == "No secrets at: /path/a, /path/b"
-        )
-
-    def test_set_and_get_error_parsing_file_at_path_message(self) -> None:
-        """Verify set_error_parsing_file_at_path_message works correctly."""
-        messages = SecretErrorMessages()
-        messages.set_error_parsing_file_at_path_message(
-            lambda path, ex: f"Parse error at {path}: {ex}"
-        )
-        exc = ValueError("invalid toml")
-        assert (
-            messages.get_error_parsing_file_at_path_message("/secrets.toml", exc)
-            == "Parse error at /secrets.toml: invalid toml"
-        )
-
-    def test_set_and_get_subfolder_path_is_not_a_folder_message(self) -> None:
-        """Verify set_subfolder_path_is_not_a_folder_message works correctly."""
-        messages = SecretErrorMessages()
-        messages.set_subfolder_path_is_not_a_folder_message(
-            lambda path: f"Not a folder: {path}"
-        )
-        assert (
-            messages.get_subfolder_path_is_not_a_folder_message("/some/path")
-            == "Not a folder: /some/path"
-        )
-
-    def test_set_and_get_invalid_secret_path_message(self) -> None:
-        """Verify set_invalid_secret_path_message works correctly."""
-        messages = SecretErrorMessages()
-        messages.set_invalid_secret_path_message(lambda path: f"Invalid path: {path}")
-        assert (
-            messages.get_invalid_secret_path_message("/bad/path")
-            == "Invalid path: /bad/path"
-        )
 
 
 class SecretsTest(unittest.TestCase):
@@ -210,24 +144,29 @@ class SecretsTest(unittest.TestCase):
         with patch("builtins.open", mock_open()) as mock_file:
             mock_file.side_effect = FileNotFoundError()
 
-            with pytest.raises(StreamlitSecretNotFoundError):
+            with pytest.raises(StreamlitSecretNotFoundError, match="No secrets found"):
                 self.secrets.get("no_such_secret", None)
 
     @patch("builtins.open", new_callable=mock_open, read_data="invalid_toml")
     @patch("streamlit.config.get_option", return_value=[MOCK_SECRETS_FILE_LOC])
     def test_malformed_toml_error(self, mock_get_option, _):
         """Secrets access raises an error if secrets.toml is malformed."""
-        with pytest.raises(StreamlitSecretNotFoundError):
+        with pytest.raises(
+            StreamlitSecretNotFoundError, match="Error parsing secrets file"
+        ) as excinfo:
             self.secrets.get("no_such_secret", None)
+        assert MOCK_SECRETS_FILE_LOC in str(excinfo.value)
+        assert excinfo.value.exec_kwargs["path"] == MOCK_SECRETS_FILE_LOC
+        assert isinstance(excinfo.value.exec_kwargs["error"], str)
 
     @patch("streamlit.watcher.path_watcher.watch_file")
     @patch("builtins.open", new_callable=mock_open, read_data=MOCK_TOML)
     def test_getattr_nonexistent(self, *mocks):
         """Verify that access to missing attribute raises  AttributeError."""
-        with pytest.raises(AttributeError):
+        with pytest.raises(AttributeError, match="has no attribute"):
             self.secrets.nonexistent_secret  # noqa: B018
 
-        with pytest.raises(AttributeError):
+        with pytest.raises(AttributeError, match="has no attribute"):
             self.secrets.subsection.nonexistent_secret  # noqa: B018
 
     @patch("streamlit.watcher.path_watcher.watch_file")
@@ -244,10 +183,10 @@ class SecretsTest(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data=MOCK_TOML)
     def test_getitem_nonexistent(self, *mocks):
         """Verify that access to missing key via dict notation raises KeyError."""
-        with pytest.raises(KeyError):
+        with pytest.raises(KeyError, match="has no key"):
             self.secrets["nonexistent_secret"]
 
-        with pytest.raises(KeyError):
+        with pytest.raises(KeyError, match="has no key"):
             self.secrets["subsection"]["nonexistent_secret"]
 
     @patch("streamlit.watcher.path_watcher.watch_file")
@@ -308,9 +247,6 @@ class SecretsTest(unittest.TestCase):
         self.secrets._file_watchers_installed = True
         assert self.secrets._file_watchers_installed
 
-        self.secrets._suppress_print_error_on_exception = True
-        assert self.secrets._suppress_print_error_on_exception
-
         self.secrets.file_change_listener = Signal()
         assert isinstance(self.secrets.file_change_listener, Signal)
 
@@ -365,7 +301,7 @@ class MultipleSecretsFilesTest(unittest.TestCase):
         with patch("streamlit.config.get_option", new=mock_get_option):
             secrets = Secrets()
 
-            with pytest.raises(StreamlitSecretNotFoundError):
+            with pytest.raises(StreamlitSecretNotFoundError, match="No secrets found"):
                 secrets.get("no_such_secret", None)
 
     @patch("streamlit.runtime.secrets._LOGGER")
@@ -715,6 +651,23 @@ def test_attr_dict_repr() -> None:
     attr_dict = AttrDict(data)
     assert repr(attr_dict) == repr(data)
     assert len(attr_dict) == 2
+
+
+@pytest.mark.parametrize(
+    ("message_fn", "kind"),
+    [
+        (_missing_attr_error_message, "attribute"),
+        (_missing_key_error_message, "key"),
+    ],
+    ids=["attribute", "key"],
+)
+def test_missing_entry_error_messages_include_hint(
+    message_fn: Callable[[str], str], kind: str
+) -> None:
+    """Missing key and attribute messages include the shared docs hint."""
+    message = message_fn("foo")
+    assert f'st.secrets has no {kind} "foo".' in message
+    assert _MISSING_ENTRY_HINT in message
 
 
 # --- Tests for _validate_secrets_value ---

--- a/lib/tests/streamlit/runtime/secrets_test.py
+++ b/lib/tests/streamlit/runtime/secrets_test.py
@@ -155,9 +155,25 @@ class SecretsTest(unittest.TestCase):
             StreamlitSecretNotFoundError, match="Error parsing secrets file"
         ) as excinfo:
             self.secrets.get("no_such_secret", None)
-        assert MOCK_SECRETS_FILE_LOC in str(excinfo.value)
+        message = str(excinfo.value)
+        error = excinfo.value.exec_kwargs["error"]
+        assert MOCK_SECRETS_FILE_LOC in message
         assert excinfo.value.exec_kwargs["path"] == MOCK_SECRETS_FILE_LOC
-        assert isinstance(excinfo.value.exec_kwargs["error"], str)
+        assert error
+        assert error in message
+
+    @patch("builtins.open", new_callable=mock_open, read_data="key = {invalid")
+    @patch("streamlit.config.get_option", return_value=["/mock/{secrets}.toml"])
+    def test_malformed_toml_error_with_braces_in_path(self, mock_get_option, _):
+        """Brace characters in the secrets path still raise StreamlitSecretNotFoundError."""
+        with pytest.raises(StreamlitSecretNotFoundError) as excinfo:
+            self.secrets.get("no_such_secret", None)
+        message = str(excinfo.value)
+        error = excinfo.value.exec_kwargs["error"]
+        assert "/mock/{secrets}.toml" in message
+        assert excinfo.value.exec_kwargs["path"] == "/mock/{secrets}.toml"
+        assert error
+        assert error in message
 
     @patch("streamlit.watcher.path_watcher.watch_file")
     @patch("builtins.open", new_callable=mock_open, read_data=MOCK_TOML)
@@ -665,9 +681,7 @@ def test_missing_entry_error_messages_include_hint(
     message_fn: Callable[[str], str], kind: str
 ) -> None:
     """Missing key and attribute messages include the shared docs hint."""
-    message = message_fn("foo")
-    assert f'st.secrets has no {kind} "foo".' in message
-    assert _MISSING_ENTRY_HINT in message
+    assert message_fn("foo") == f'st.secrets has no {kind} "foo". {_MISSING_ENTRY_HINT}'
 
 
 # --- Tests for _validate_secrets_value ---


### PR DESCRIPTION
## Describe your changes

Removes the unused internal `SecretErrorMessages` hook so secret errors use the same localizable format-string pattern as other Streamlit API exceptions.

- Secret parse and missing-file errors now pass format templates and kwargs into `StreamlitSecretNotFoundError` (for localization via `exec_kwargs`).
- Drops the no-op `Secrets.set_suppress_print_error_on_exception` compatibility shim (dead since #9078).
- Fixes a latent bug: the previous code passed an already-interpolated f-string through `LocalizableStreamlitException`'s `message.format()`, so a secrets path or TOML error containing `{` or `}` raised `KeyError` instead of `StreamlitSecretNotFoundError`.

Existing secret-error templates are unchanged; paths or parser diagnostics containing braces now produce the intended `StreamlitSecretNotFoundError`.

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- [x] Unit Tests (JS and/or Python)
  - `lib/tests/streamlit/runtime/secrets_test.py` — missing key/attribute messages, TOML parse errors, brace-in-path parse errors, and no-secrets paths
- [ ] E2E Tests — no frontend or user-visible behavior change
- [ ] Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

Made with [Cursor](https://cursor.com)