### PR TITLE
[fix] Accept typed exception handlers in st.App

### DIFF
--- a/e2e_playwright/st_app_advanced.py
+++ b/e2e_playwright/st_app_advanced.py
@@ -128,7 +128,7 @@ app = st.App(
     ],
     middleware=[Middleware(CustomHeaderMiddleware)],
     lifespan=lifespan,
-    exception_handlers={CustomAPIError: custom_api_error_handler},  # type: ignore[dict-item] # ty: ignore[invalid-argument-type]
+    exception_handlers={CustomAPIError: custom_api_error_handler},
     on_script_error=handle_script_error,
     secrets={
         "api_key": "test-api-key-12345",

--- a/lib/streamlit/web/server/starlette/starlette_app.py
+++ b/lib/streamlit/web/server/starlette/starlette_app.py
@@ -74,12 +74,6 @@ if TYPE_CHECKING:
     from starlette.routing import BaseRoute
     from starlette.types import Receive, Scope, Send
 
-    # Starlette types ExceptionHandler as Callable[[Request, Exception], Response].
-    # Callable parameters are contravariant, so a handler annotated with a
-    # specific exception subclass — the usual user pattern — is rejected.
-    # Ellipsis parameters accept those handlers while still requiring a callable.
-    ExceptionHandler: TypeAlias = Callable[..., Any]
-
     from streamlit.runtime import Runtime
     from streamlit.runtime.media_file_manager import MediaFileManager
     from streamlit.runtime.memory_media_file_storage import MemoryMediaFileStorage
@@ -88,6 +82,13 @@ if TYPE_CHECKING:
         OnScriptErrorHandler,
     )
     from streamlit.runtime.secrets import SecretsValue
+
+    # Accept handlers typed with a specific exception subclass (the usual user
+    # pattern). Starlette's ExceptionHandler uses Callable[[Request, Exception],
+    # Response]; because Callable parameters are contravariant, those handlers
+    # are rejected. Two Any parameters accept them while still requiring a
+    # two-argument callable.
+    ExceptionHandler: TypeAlias = Callable[[Any, Any], Any]
 
 # Reserved route prefixes that users cannot override.
 _RESERVED_ROUTE_PREFIXES: Final[tuple[str, ...]] = (

--- a/lib/streamlit/web/server/starlette/starlette_app.py
+++ b/lib/streamlit/web/server/starlette/starlette_app.py
@@ -67,11 +67,18 @@ if TYPE_CHECKING:
     import asyncio
     from collections.abc import AsyncIterator, Callable, Mapping, Sequence
     from contextlib import AbstractAsyncContextManager
+    from typing import TypeAlias
 
     from starlette.applications import Starlette
     from starlette.middleware import Middleware
     from starlette.routing import BaseRoute
-    from starlette.types import ExceptionHandler, Receive, Scope, Send
+    from starlette.types import Receive, Scope, Send
+
+    # Starlette types ExceptionHandler as Callable[[Request, Exception], Response].
+    # Callable parameters are contravariant, so a handler annotated with a
+    # specific exception subclass — the usual user pattern — is rejected.
+    # Ellipsis parameters accept those handlers while still requiring a callable.
+    ExceptionHandler: TypeAlias = Callable[..., Any]
 
     from streamlit.runtime import Runtime
     from streamlit.runtime.media_file_manager import MediaFileManager
@@ -339,9 +346,10 @@ class App:
         A mapping of either integer status codes, or exception class types onto
         callables which handle the exceptions. Exception handler callables should
         be of the form ``handler(request, exc) -> response`` and may be either
-        standard functions, or async functions. This is only for exception handling
-        on the network layer. Use ``on_script_error`` for customized handling of
-        uncaught exceptions from the app script.
+        standard functions, or async functions. The ``exc`` argument may be
+        annotated with a specific exception subclass. This is only for exception
+        handling on the network layer. Use ``on_script_error`` for customized
+        handling of uncaught exceptions from the app script.
     debug : bool
         Enable debug mode for the underlying Starlette application.
 

--- a/lib/tests/streamlit/typing/app_types.py
+++ b/lib/tests/streamlit/typing/app_types.py
@@ -33,6 +33,8 @@ if TYPE_CHECKING:
     from starlette.types import Receive, Scope, Send
     from starlette.websockets import WebSocket
 
+    # NOTE: st.App is a module-level re-export, so we must import streamlit as
+    # st here rather than only importing App from streamlit.starlette.
     import streamlit as st
     from streamlit.starlette import App
 
@@ -135,10 +137,7 @@ if TYPE_CHECKING:
     assert_type(App("main.py", on_script_error=maybe_suppress_error), App)
 
     # =====================================================================
-    # exception_handlers: handlers may be typed with a specific exception
-    # subclass. Starlette's ExceptionHandler uses Callable[[Request, Exception],
-    # Response], which rejects that pattern because Callable parameters are
-    # contravariant.
+    # exception_handlers: subclass-typed exc must be accepted (see starlette_app.py).
     # =====================================================================
 
     assert_type(App("main.py", exception_handlers=None), App)
@@ -154,7 +153,7 @@ if TYPE_CHECKING:
         App("main.py", exception_handlers={Exception: handle_any_exception}),
         App,
     )
-    assert_type(App("main.py", exception_handlers={429: handle_quota}), App)
+    assert_type(App("main.py", exception_handlers={429: handle_any_exception}), App)
     assert_type(
         App("main.py", exception_handlers={Exception: handle_websocket}),
         App,
@@ -246,10 +245,17 @@ if TYPE_CHECKING:
 
     App("main.py", on_script_error=bad_error_handler)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
 
-    # exception_handlers values must be callables
+    # exception_handlers values must be two-argument callables
     App(
         "main.py",
         exception_handlers={ValueError: "not a handler"},  # type: ignore[dict-item]  # ty: ignore[invalid-argument-type]
+    )
+
+    def wrong_arity_handler(exc: Exception) -> JSONResponse: ...
+
+    App(
+        "main.py",
+        exception_handlers={ValueError: wrong_arity_handler},  # type: ignore[dict-item]  # ty: ignore[invalid-argument-type]
     )
 
     # debug must be bool

--- a/lib/tests/streamlit/typing/app_types.py
+++ b/lib/tests/streamlit/typing/app_types.py
@@ -1,0 +1,261 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from typing_extensions import assert_type
+
+# Perform type checking tests for st.App. These are checked by mypy and ty,
+# never executed at runtime.
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Callable
+    from contextlib import AbstractAsyncContextManager, asynccontextmanager
+    from pathlib import Path
+    from typing import Any
+
+    from starlette.middleware import Middleware
+    from starlette.requests import Request
+    from starlette.responses import JSONResponse
+    from starlette.routing import Mount, Route
+    from starlette.types import Receive, Scope, Send
+    from starlette.websockets import WebSocket
+
+    import streamlit as st
+    from streamlit.starlette import App
+
+    class QuotaExceeded(Exception):
+        """Typed exception used by a user exception handler."""
+
+    class HeaderMiddleware:
+        def __init__(self, app: object) -> None: ...
+
+        async def __call__(
+            self, scope: object, receive: object, send: object
+        ) -> None: ...
+
+    async def health(request: Request) -> JSONResponse: ...
+
+    async def handle_quota(request: Request, exc: QuotaExceeded) -> JSONResponse: ...
+
+    def handle_quota_sync(request: Request, exc: QuotaExceeded) -> JSONResponse: ...
+
+    async def handle_any_exception(
+        request: Request, exc: Exception
+    ) -> JSONResponse: ...
+
+    async def handle_websocket(websocket: WebSocket, exc: Exception) -> None: ...
+
+    def suppress_error(exc: Exception) -> bool: ...
+
+    def show_error(exc: Exception) -> None: ...
+
+    def maybe_suppress_error(exc: Exception) -> bool | None: ...
+
+    @asynccontextmanager
+    async def lifespan_with_state(app: App) -> AsyncIterator[dict[str, Any]]:
+        yield {"ready": True}
+
+    @asynccontextmanager
+    async def lifespan_none(app: App) -> AsyncIterator[None]:
+        yield None
+
+    # =====================================================================
+    # script_path
+    # =====================================================================
+
+    assert_type(App("main.py"), App)
+    assert_type(App(Path("main.py")), App)
+    assert_type(st.App("main.py"), App)
+
+    # =====================================================================
+    # secrets
+    # =====================================================================
+
+    assert_type(App("main.py", secrets=None), App)
+    assert_type(App("main.py", secrets={"api_key": "secret"}), App)
+    assert_type(App("main.py", secrets={"port": 5432}), App)
+    assert_type(App("main.py", secrets={"ratio": 1.5}), App)
+    assert_type(App("main.py", secrets={"enabled": True}), App)
+    assert_type(App("main.py", secrets={"tags": ["a", "b"]}), App)
+    assert_type(
+        App("main.py", secrets={"db": {"host": "localhost", "port": 5432}}),
+        App,
+    )
+
+    # =====================================================================
+    # lifespan
+    # =====================================================================
+
+    assert_type(App("main.py", lifespan=None), App)
+    assert_type(App("main.py", lifespan=lifespan_with_state), App)
+    assert_type(App("main.py", lifespan=lifespan_none), App)
+
+    # =====================================================================
+    # routes
+    # =====================================================================
+
+    assert_type(App("main.py", routes=None), App)
+    assert_type(App("main.py", routes=[]), App)
+    assert_type(App("main.py", routes=[Route("/health", health)]), App)
+    assert_type(
+        App(
+            "main.py", routes=[Route("/health", health), Mount("/static", App("x.py"))]
+        ),
+        App,
+    )
+
+    # =====================================================================
+    # middleware
+    # =====================================================================
+
+    assert_type(App("main.py", middleware=None), App)
+    assert_type(App("main.py", middleware=[]), App)
+    assert_type(App("main.py", middleware=[Middleware(HeaderMiddleware)]), App)
+
+    # =====================================================================
+    # on_script_error
+    # =====================================================================
+
+    assert_type(App("main.py", on_script_error=None), App)
+    assert_type(App("main.py", on_script_error=suppress_error), App)
+    assert_type(App("main.py", on_script_error=show_error), App)
+    assert_type(App("main.py", on_script_error=maybe_suppress_error), App)
+
+    # =====================================================================
+    # exception_handlers: handlers may be typed with a specific exception
+    # subclass. Starlette's ExceptionHandler uses Callable[[Request, Exception],
+    # Response], which rejects that pattern because Callable parameters are
+    # contravariant.
+    # =====================================================================
+
+    assert_type(App("main.py", exception_handlers=None), App)
+    assert_type(
+        App("main.py", exception_handlers={QuotaExceeded: handle_quota}),
+        App,
+    )
+    assert_type(
+        App("main.py", exception_handlers={QuotaExceeded: handle_quota_sync}),
+        App,
+    )
+    assert_type(
+        App("main.py", exception_handlers={Exception: handle_any_exception}),
+        App,
+    )
+    assert_type(App("main.py", exception_handlers={429: handle_quota}), App)
+    assert_type(
+        App("main.py", exception_handlers={Exception: handle_websocket}),
+        App,
+    )
+
+    # =====================================================================
+    # debug
+    # =====================================================================
+
+    assert_type(App("main.py", debug=True), App)
+    assert_type(App("main.py", debug=False), App)
+
+    # =====================================================================
+    # All constructor parameters combined
+    # =====================================================================
+
+    assert_type(
+        App(
+            Path("main.py"),
+            secrets={"api_key": "secret", "db": {"host": "localhost"}},
+            lifespan=lifespan_with_state,
+            routes=[Route("/health", health)],
+            middleware=[Middleware(HeaderMiddleware)],
+            on_script_error=suppress_error,
+            exception_handlers={QuotaExceeded: handle_quota},
+            debug=True,
+        ),
+        App,
+    )
+
+    # =====================================================================
+    # Public properties and methods
+    # =====================================================================
+
+    app = App("main.py")
+    assert_type(app.script_path, Path)
+    assert_type(app.state, dict[str, Any])
+    assert_type(app.run(), None)
+    assert_type(app.run(config=None), None)
+    assert_type(app.run(config={"server.port": 8502}), None)
+    assert_type(
+        app.lifespan(),
+        Callable[[Any], AbstractAsyncContextManager[None]],
+    )
+
+    async def asgi(scope: Scope, receive: Receive, send: Send) -> None:
+        await app(scope, receive, send)
+
+    # =====================================================================
+    # Invalid usages - should NOT type check
+    # =====================================================================
+
+    # script_path is required
+    App()  # type: ignore[call-arg]  # ty: ignore[missing-argument]
+
+    # script_path must be str or Path
+    App(None)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+    App(123)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+
+    # Remaining constructor parameters are keyword-only
+    App("main.py", None)  # type: ignore[call-arg]  # ty: ignore[too-many-positional-arguments]
+
+    # secrets must be a mapping of supported value types
+    App("main.py", secrets="not-a-mapping")  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+    App("main.py", secrets={1: "x"})  # type: ignore[dict-item]  # ty: ignore[invalid-argument-type]
+    App("main.py", secrets={"x": None})  # type: ignore[dict-item]  # ty: ignore[invalid-argument-type]
+
+    # lifespan must be an async context manager factory
+    App("main.py", lifespan="startup")  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+
+    def not_a_lifespan(app: App) -> dict[str, Any]:
+        return {}
+
+    App("main.py", lifespan=not_a_lifespan)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+
+    # routes must be a sequence of BaseRoute
+    App("main.py", routes="/health")  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+    App("main.py", routes=["/health"])  # type: ignore[list-item]  # ty: ignore[invalid-argument-type]
+
+    # middleware must be a sequence of Middleware
+    App("main.py", middleware=HeaderMiddleware)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+    App("main.py", middleware=[HeaderMiddleware])  # type: ignore[list-item]  # ty: ignore[invalid-argument-type]
+
+    # on_script_error must be Callable[[Exception], bool | None]
+    App("main.py", on_script_error="sentry")  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+
+    def bad_error_handler(exc: Exception) -> str:
+        return "no"
+
+    App("main.py", on_script_error=bad_error_handler)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+
+    # exception_handlers values must be callables
+    App(
+        "main.py",
+        exception_handlers={ValueError: "not a handler"},  # type: ignore[dict-item]  # ty: ignore[invalid-argument-type]
+    )
+
+    # debug must be bool
+    App("main.py", debug=None)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+    App("main.py", debug="yes")  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+
+    # run() config is keyword-only and must be a mapping
+    app.run("server.port")  # type: ignore[call-arg, arg-type]  # ty: ignore[too-many-positional-arguments]
+    app.run(config=["server.port"])  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]


### PR DESCRIPTION
## Describe your changes

`st.App(exception_handlers=...)` now type-checks handlers whose `exc` parameter
is a specific exception subclass — the usual Starlette pattern. Type checkers
previously rejected that because Starlette types `exc` as the base `Exception`.

Types-only; runtime behavior is unchanged.

Also adds `lib/tests/streamlit/typing/app_types.py`, covering the full `st.App`
constructor surface and public methods, and removes the now-unnecessary
type-checker suppressions in `e2e_playwright/st_app_advanced.py`.

## GitHub Issue Link (if applicable)

## Testing Plan

- [x] Type checks (mypy and ty): `lib/tests/streamlit/typing/app_types.py`

## Contribution License Agreement

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.