### PR TITLE
[refactor] Split range errors into min/max vs interval

### DIFF
--- a/.cursor/rules/python_lib.mdc
+++ b/.cursor/rules/python_lib.mdc
@@ -149,13 +149,19 @@ generic `StreamlitAPIException` with a one-off message.
 - `StreamlitAPIException`: base for malformed user interaction with the Streamlit
   API. Prefer a more specific subclass when one fits.
 - `StreamlitValueError(parameter, valid_values, *, detail=None)`: use when a
-  parameter receives an invalid value from a known set of options or an
-  accepted range. `valid_values` is the user-facing list of supported values:
-  Literal / enum-like options, or a short range description (for example
-  `"a positive duration"`). `parameter` is appended in uncaught-exception
-  telemetry (`StreamlitValueError:<parameter>`); optional `detail` appears in
-  the error message only. Example:
+  parameter receives an invalid value from a known set of options, or a short
+  open-ended constraint (for example `"a positive duration"`). For a closed
+  `[min, max]` interval, use `StreamlitValueOutOfRangeError` instead.
+  `valid_values` is the user-facing list of supported values. `parameter` is
+  appended in uncaught-exception telemetry (`StreamlitValueError:<parameter>`);
+  optional `detail` appears in the error message only. Example:
   `raise StreamlitValueError("type", ["'primary'", "'secondary'", "'tertiary'"])`.
+- `StreamlitValueOutOfRangeError(parameter, value, min_value, max_value, *, detail=None)`:
+  use when a parameter is outside a closed `[min, max]` interval, including a
+  dynamic max such as `len(options) - 1`. `parameter` is appended in
+  uncaught-exception telemetry (`StreamlitValueOutOfRangeError:<parameter>`);
+  optional `detail` appears in the error message only. Example:
+  `raise StreamlitValueOutOfRangeError("index", index, 0, len(options) - 1)`.
 - `StreamlitMissingRequiredParameterError(parameter, *, detail=None)`:
   use when a required parameter is missing, `None`, or empty, including an
   empty sequence. `parameter` is appended in uncaught-exception telemetry
@@ -180,11 +186,12 @@ generic `StreamlitAPIException` with a one-off message.
   - `StreamlitInvalidWidthError` / `StreamlitInvalidHeightError`
     (layout sizing helpers)
   - `StreamlitInvalidColorError`
-  - `StreamlitValueBelowMinError` / `StreamlitValueAboveMaxError` (numeric /
-    date/time bounds)
-  - `StreamlitInvalidRangeError` (`min_value` cannot be greater than `max_value`.
-    `st.slider` also rejects equal bounds; `st.date_input` /
-    `st.datetime_input` allow a single-day / single-instant range)
+  - `StreamlitValueBelowMinError` / `StreamlitValueAboveMaxError` (widget
+    `value` vs user-configured `min_value` / `max_value`)
+  - `StreamlitInvalidMinMaxError` (`min_value` cannot be greater than
+    `max_value`; `st.slider` also rejects equal bounds, while
+    `st.date_input` / `st.datetime_input` allow a single-day /
+    single-instant range)
   - `StreamlitInvalidURLError(url, protocols)` (`st.logo(link=)`, page-config
     menu items). Pass the allowed schemes, for example `["http", "https"]`.
     `protocols` defaults to `("http", "https", "mailto")`.

--- a/.github/instructions/python_lib.instructions.md
+++ b/.github/instructions/python_lib.instructions.md
@@ -147,13 +147,19 @@ generic `StreamlitAPIException` with a one-off message.
 - `StreamlitAPIException`: base for malformed user interaction with the Streamlit
   API. Prefer a more specific subclass when one fits.
 - `StreamlitValueError(parameter, valid_values, *, detail=None)`: use when a
-  parameter receives an invalid value from a known set of options or an
-  accepted range. `valid_values` is the user-facing list of supported values:
-  Literal / enum-like options, or a short range description (for example
-  `"a positive duration"`). `parameter` is appended in uncaught-exception
-  telemetry (`StreamlitValueError:<parameter>`); optional `detail` appears in
-  the error message only. Example:
+  parameter receives an invalid value from a known set of options, or a short
+  open-ended constraint (for example `"a positive duration"`). For a closed
+  `[min, max]` interval, use `StreamlitValueOutOfRangeError` instead.
+  `valid_values` is the user-facing list of supported values. `parameter` is
+  appended in uncaught-exception telemetry (`StreamlitValueError:<parameter>`);
+  optional `detail` appears in the error message only. Example:
   `raise StreamlitValueError("type", ["'primary'", "'secondary'", "'tertiary'"])`.
+- `StreamlitValueOutOfRangeError(parameter, value, min_value, max_value, *, detail=None)`:
+  use when a parameter is outside a closed `[min, max]` interval, including a
+  dynamic max such as `len(options) - 1`. `parameter` is appended in
+  uncaught-exception telemetry (`StreamlitValueOutOfRangeError:<parameter>`);
+  optional `detail` appears in the error message only. Example:
+  `raise StreamlitValueOutOfRangeError("index", index, 0, len(options) - 1)`.
 - `StreamlitMissingRequiredParameterError(parameter, *, detail=None)`:
   use when a required parameter is missing, `None`, or empty, including an
   empty sequence. `parameter` is appended in uncaught-exception telemetry
@@ -178,11 +184,12 @@ generic `StreamlitAPIException` with a one-off message.
   - `StreamlitInvalidWidthError` / `StreamlitInvalidHeightError`
     (layout sizing helpers)
   - `StreamlitInvalidColorError`
-  - `StreamlitValueBelowMinError` / `StreamlitValueAboveMaxError` (numeric /
-    date/time bounds)
-  - `StreamlitInvalidRangeError` (`min_value` cannot be greater than `max_value`.
-    `st.slider` also rejects equal bounds; `st.date_input` /
-    `st.datetime_input` allow a single-day / single-instant range)
+  - `StreamlitValueBelowMinError` / `StreamlitValueAboveMaxError` (widget
+    `value` vs user-configured `min_value` / `max_value`)
+  - `StreamlitInvalidMinMaxError` (`min_value` cannot be greater than
+    `max_value`; `st.slider` also rejects equal bounds, while
+    `st.date_input` / `st.datetime_input` allow a single-day /
+    single-instant range)
   - `StreamlitInvalidURLError(url, protocols)` (`st.logo(link=)`, page-config
     menu items). Pass the allowed schemes, for example `["http", "https"]`.
     `protocols` defaults to `("http", "https", "mailto")`.

--- a/lib/streamlit/AGENTS.md
+++ b/lib/streamlit/AGENTS.md
@@ -141,13 +141,19 @@ generic `StreamlitAPIException` with a one-off message.
 - `StreamlitAPIException`: base for malformed user interaction with the Streamlit
   API. Prefer a more specific subclass when one fits.
 - `StreamlitValueError(parameter, valid_values, *, detail=None)`: use when a
-  parameter receives an invalid value from a known set of options or an
-  accepted range. `valid_values` is the user-facing list of supported values:
-  Literal / enum-like options, or a short range description (for example
-  `"a positive duration"`). `parameter` is appended in uncaught-exception
-  telemetry (`StreamlitValueError:<parameter>`); optional `detail` appears in
-  the error message only. Example:
+  parameter receives an invalid value from a known set of options, or a short
+  open-ended constraint (for example `"a positive duration"`). For a closed
+  `[min, max]` interval, use `StreamlitValueOutOfRangeError` instead.
+  `valid_values` is the user-facing list of supported values. `parameter` is
+  appended in uncaught-exception telemetry (`StreamlitValueError:<parameter>`);
+  optional `detail` appears in the error message only. Example:
   `raise StreamlitValueError("type", ["'primary'", "'secondary'", "'tertiary'"])`.
+- `StreamlitValueOutOfRangeError(parameter, value, min_value, max_value, *, detail=None)`:
+  use when a parameter is outside a closed `[min, max]` interval, including a
+  dynamic max such as `len(options) - 1`. `parameter` is appended in
+  uncaught-exception telemetry (`StreamlitValueOutOfRangeError:<parameter>`);
+  optional `detail` appears in the error message only. Example:
+  `raise StreamlitValueOutOfRangeError("index", index, 0, len(options) - 1)`.
 - `StreamlitMissingRequiredParameterError(parameter, *, detail=None)`:
   use when a required parameter is missing, `None`, or empty, including an
   empty sequence. `parameter` is appended in uncaught-exception telemetry
@@ -172,11 +178,12 @@ generic `StreamlitAPIException` with a one-off message.
   - `StreamlitInvalidWidthError` / `StreamlitInvalidHeightError`
     (layout sizing helpers)
   - `StreamlitInvalidColorError`
-  - `StreamlitValueBelowMinError` / `StreamlitValueAboveMaxError` (numeric /
-    date/time bounds)
-  - `StreamlitInvalidRangeError` (`min_value` cannot be greater than `max_value`.
-    `st.slider` also rejects equal bounds; `st.date_input` /
-    `st.datetime_input` allow a single-day / single-instant range)
+  - `StreamlitValueBelowMinError` / `StreamlitValueAboveMaxError` (widget
+    `value` vs user-configured `min_value` / `max_value`)
+  - `StreamlitInvalidMinMaxError` (`min_value` cannot be greater than
+    `max_value`; `st.slider` also rejects equal bounds, while
+    `st.date_input` / `st.datetime_input` allow a single-day /
+    single-instant range)
   - `StreamlitInvalidURLError(url, protocols)` (`st.logo(link=)`, page-config
     menu items). Pass the allowed schemes, for example `["http", "https"]`.
     `protocols` defaults to `("http", "https", "mailto")`.

--- a/lib/streamlit/elements/progress.py
+++ b/lib/streamlit/elements/progress.py
@@ -18,7 +18,10 @@ import math
 from typing import TYPE_CHECKING, TypeAlias, cast
 
 from streamlit.elements.lib.layout_utils import create_layout_config
-from streamlit.errors import StreamlitAPIException, StreamlitInvalidParameterTypeError
+from streamlit.errors import (
+    StreamlitInvalidParameterTypeError,
+    StreamlitValueOutOfRangeError,
+)
 from streamlit.proto.Progress_pb2 import Progress as ProgressProto
 from streamlit.string_util import clean_text
 
@@ -60,18 +63,14 @@ def _check_float_between(value: float, low: float = 0.0, high: float = 1.0) -> b
 
 def _get_value(value: FloatOrInt) -> int:
     if isinstance(value, int):
-        if 0 <= value <= 100:
-            return value
-        raise StreamlitAPIException(
-            f"Progress Value has invalid value [0, 100]: {value}"
-        )
+        if not 0 <= value <= 100:
+            raise StreamlitValueOutOfRangeError("value", value, 0, 100)
+        return value
 
     if isinstance(value, float):
-        if _check_float_between(value, low=0.0, high=1.0):
-            return int(value * 100)
-        raise StreamlitAPIException(
-            f"Progress Value has invalid value [0.0, 1.0]: {value}"
-        )
+        if not _check_float_between(value, low=0.0, high=1.0):
+            raise StreamlitValueOutOfRangeError("value", value, 0.0, 1.0)
+        return int(value * 100)
     raise StreamlitInvalidParameterTypeError(
         "value",
         type(value).__name__,

--- a/lib/streamlit/elements/widgets/feedback.py
+++ b/lib/streamlit/elements/widgets/feedback.py
@@ -34,7 +34,7 @@ from streamlit.elements.lib.utils import (
     save_for_app_testing,
     to_key,
 )
-from streamlit.errors import StreamlitAPIException, StreamlitValueError
+from streamlit.errors import StreamlitValueError, StreamlitValueOutOfRangeError
 from streamlit.proto.Feedback_pb2 import Feedback as FeedbackProto
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner_utils.script_run_context import get_script_run_ctx
@@ -265,11 +265,8 @@ class FeedbackMixin:
 
         num_options = _get_num_options(options)
 
-        if default is not None and (default < 0 or default >= num_options):
-            raise StreamlitAPIException(
-                f"The default value in '{options}' must be a number between 0 and {num_options - 1}."
-                f" The passed default value is {default}"
-            )
+        if default is not None and not (0 <= default < num_options):
+            raise StreamlitValueOutOfRangeError("default", default, 0, num_options - 1)
 
         key = to_key(key)
         layout_config = create_layout_config(width=width, allow_content_width=True)

--- a/lib/streamlit/elements/widgets/pagination.py
+++ b/lib/streamlit/elements/widgets/pagination.py
@@ -26,7 +26,11 @@ from streamlit.elements.lib.utils import (
     save_for_app_testing,
     to_key,
 )
-from streamlit.errors import StreamlitAPIException
+from streamlit.errors import (
+    StreamlitAPIException,
+    StreamlitInvalidParameterTypeError,
+    StreamlitValueOutOfRangeError,
+)
 from streamlit.proto.Pagination_pb2 import Pagination as PaginationProto
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner_utils.script_run_context import get_script_run_ctx
@@ -262,17 +266,15 @@ class PaginationMixin:
                 f"`num_pages` must be an integer of at least 1. Got {num_pages}."
             )
 
-        # Validate default
-        if (
-            not isinstance(default, int)
-            or isinstance(default, bool)
-            or default < 1
-            or default > num_pages
-        ):
-            raise StreamlitAPIException(
-                f"`default` must be between 1 and `num_pages` ({num_pages}). "
-                f"Got {default}."
+        # bool is a subclass of int, so True would otherwise be treated as page 1.
+        if isinstance(default, bool) or not isinstance(default, int):
+            raise StreamlitInvalidParameterTypeError(
+                "default",
+                type(default).__name__,
+                ["int"],
             )
+        if not 1 <= default <= num_pages:
+            raise StreamlitValueOutOfRangeError("default", default, 1, num_pages)
 
         # Validate max_visible_pages
         if max_visible_pages is not None and (

--- a/lib/streamlit/elements/widgets/radio.py
+++ b/lib/streamlit/elements/widgets/radio.py
@@ -42,8 +42,8 @@ from streamlit.elements.lib.utils import (
     to_key,
 )
 from streamlit.errors import (
-    StreamlitAPIException,
     StreamlitInvalidParameterTypeError,
+    StreamlitValueOutOfRangeError,
 )
 from streamlit.proto.Radio_pb2 import Radio as RadioProto
 from streamlit.runtime.metrics_util import gather_metrics
@@ -500,9 +500,7 @@ class RadioMixin:
             )
 
         if index is not None and len(opt) > 0 and not 0 <= index < len(opt):
-            raise StreamlitAPIException(
-                "Radio index must be between 0 and length of options"
-            )
+            raise StreamlitValueOutOfRangeError("index", index, 0, len(opt) - 1)
 
         def handle_captions(caption: str | None) -> str:
             if caption is None:

--- a/lib/streamlit/elements/widgets/selectbox.py
+++ b/lib/streamlit/elements/widgets/selectbox.py
@@ -50,7 +50,10 @@ from streamlit.elements.lib.utils import (
     save_for_app_testing,
     to_key,
 )
-from streamlit.errors import StreamlitAPIException, StreamlitInvalidParameterTypeError
+from streamlit.errors import (
+    StreamlitInvalidParameterTypeError,
+    StreamlitValueOutOfRangeError,
+)
 from streamlit.proto.Selectbox_pb2 import Selectbox as SelectboxProto
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
@@ -662,10 +665,7 @@ class SelectboxMixin:
             )
 
         if index is not None and len(opt) > 0 and not 0 <= index < len(opt):
-            raise StreamlitAPIException(
-                "Selectbox index must be greater than or equal to 0 "
-                "and less than the length of options."
-            )
+            raise StreamlitValueOutOfRangeError("index", index, 0, len(opt) - 1)
 
         # Convert empty string to single space to distinguish from None:
         # - None (default) → "" → Frontend shows contextual placeholders

--- a/lib/streamlit/elements/widgets/slider.py
+++ b/lib/streamlit/elements/widgets/slider.py
@@ -46,8 +46,8 @@ from streamlit.elements.lib.utils import (
 )
 from streamlit.errors import (
     StreamlitAPIException,
+    StreamlitInvalidMinMaxError,
     StreamlitInvalidParameterTypeError,
-    StreamlitInvalidRangeError,
     StreamlitJSNumberBoundsError,
     StreamlitValueAboveMaxError,
     StreamlitValueBelowMinError,
@@ -1154,7 +1154,7 @@ class SliderMixin:
         # The frontend will error if the values are equal, so checking here
         # lets us produce a nicer python error message and stack trace.
         if min_value == max_value:
-            raise StreamlitInvalidRangeError(min_value, max_value)
+            raise StreamlitInvalidMinMaxError(min_value, max_value)
 
         # Now, convert to microseconds (so we can serialize datetime to a long)
         if data_type in TIMELIKE_TYPES:

--- a/lib/streamlit/elements/widgets/time_widgets.py
+++ b/lib/streamlit/elements/widgets/time_widgets.py
@@ -44,12 +44,12 @@ from streamlit.elements.lib.utils import (
     to_key,
 )
 from streamlit.errors import (
-    StreamlitAPIException,
+    StreamlitInvalidMinMaxError,
     StreamlitInvalidParameterTypeError,
-    StreamlitInvalidRangeError,
     StreamlitValueAboveMaxError,
     StreamlitValueBelowMinError,
     StreamlitValueError,
+    StreamlitValueOutOfRangeError,
 )
 from streamlit.proto.DateInput_pb2 import DateInput as DateInputProto
 from streamlit.proto.DateTimeInput_pb2 import DateTimeInput as DateTimeInputProto
@@ -418,7 +418,7 @@ class _DateTimeInputValues:
 
     def __post_init__(self) -> None:
         if self.min > self.max:
-            raise StreamlitInvalidRangeError(self.min, self.max)
+            raise StreamlitInvalidMinMaxError(self.min, self.max)
 
         if self.value is not None:
             if self.value < self.min:
@@ -467,7 +467,7 @@ class _DateInputValues:
 
     def __post_init__(self) -> None:
         if self.min > self.max:
-            raise StreamlitInvalidRangeError(self.min, self.max)
+            raise StreamlitInvalidMinMaxError(self.min, self.max)
 
         if self.value:
             start_value = self.value[0]
@@ -1080,9 +1080,14 @@ class TimeWidgetsMixin:
             )
         if isinstance(step, timedelta):
             step = int(step.total_seconds())
-        if step < 1 or step > timedelta(hours=23).seconds:
-            raise StreamlitAPIException(
-                f"`step` must be between 1 second and 23 hours but is currently set to {step} seconds."
+        if not 1 <= step <= timedelta(hours=23).seconds:
+            # Use unit labels so the message reads [1 second, 23 hours]
+            # rather than [1, 82800].
+            raise StreamlitValueOutOfRangeError(
+                "step",
+                value=f"{step} seconds",
+                min_value="1 second",
+                max_value="23 hours",
             )
 
         serde = TimeInputSerde(parsed_time, step=step)
@@ -1501,9 +1506,14 @@ class TimeWidgetsMixin:
         step_seconds = (
             int(step.total_seconds()) if isinstance(step, timedelta) else step
         )
-        if step_seconds < 60 or step_seconds > timedelta(hours=23).seconds:
-            raise StreamlitAPIException(
-                f"`step` must be between 60 seconds and 23 hours but is currently set to {step_seconds} seconds."
+        if not 60 <= step_seconds <= timedelta(hours=23).seconds:
+            # Use unit labels so the message reads [60 seconds, 23 hours]
+            # rather than [60, 82800].
+            raise StreamlitValueOutOfRangeError(
+                "step",
+                value=f"{step_seconds} seconds",
+                min_value="60 seconds",
+                max_value="23 hours",
             )
 
         session_state = get_session_state().filtered_state

--- a/lib/streamlit/errors.py
+++ b/lib/streamlit/errors.py
@@ -320,19 +320,62 @@ class StreamlitValueAboveMaxError(LocalizableStreamlitException):
         )
 
 
-class StreamlitInvalidRangeError(LocalizableStreamlitException):
+class StreamlitInvalidMinMaxError(LocalizableStreamlitException):
     """Raised when ``min_value`` is greater than ``max_value``.
 
-    ``st.slider`` also raises this for equal bounds; ``st.date_input`` and
-    ``st.datetime_input`` treat equal bounds as a valid single-day range.
+    ``st.slider`` also raises this for equal bounds. ``st.date_input`` and
+    ``st.datetime_input`` treat equal bounds as a valid single-day /
+    single-instant range.
     """
 
     def __init__(self, min_value: object, max_value: object) -> None:
+        if min_value == max_value:
+            message = (
+                "The `min_value` and `max_value` parameters are both set to "
+                "{min_value}. They must not be equal."
+            )
+        else:
+            message = (
+                "The `min_value`, set to {min_value}, cannot be greater than "
+                "the `max_value`, set to {max_value}."
+            )
         super().__init__(
-            "The `min_value`, set to {min_value}, cannot be greater than "
-            "the `max_value`, set to {max_value}.",
+            message,
             min_value=min_value,
             max_value=max_value,
+        )
+
+
+class StreamlitValueOutOfRangeError(LocalizableStreamlitException):
+    """Raised when a parameter is outside a closed ``[min, max]`` interval.
+
+    Uncaught-exception telemetry appends the parameter name, for example
+    ``StreamlitValueOutOfRangeError:index``. Optional ``detail`` appears in
+    the error message only.
+    """
+
+    def __init__(
+        self,
+        parameter: str,
+        value: object,
+        min_value: object,
+        max_value: object,
+        *,
+        detail: str | None = None,
+    ) -> None:
+        message = (
+            "The `{parameter}` parameter, set to {value}, is outside the "
+            "required range [{min_value}, {max_value}]."
+        )
+        if detail:
+            message += " {detail}"
+        super().__init__(
+            message,
+            parameter=parameter,
+            value=value,
+            min_value=min_value,
+            max_value=max_value,
+            detail=detail,
         )
 
 
@@ -617,13 +660,14 @@ class StreamlitInvalidHeightError(LocalizableStreamlitException):
 
 
 class StreamlitValueError(LocalizableStreamlitException):
-    """Raised when a parameter receives a value outside a known set or range.
+    """Raised when a parameter receives a value outside a known set of options.
 
     ``valid_values`` is the user-facing list of supported values: Literal /
-    enum-like options, or a short description of an accepted range (for
-    example ``a positive duration``). Uncaught-exception telemetry appends
-    the parameter name, for example ``StreamlitValueError:width``. Optional
-    ``detail`` appears in the error message only.
+    enum-like options, or a short description of an open-ended constraint (for
+    example ``a positive duration``). For a closed ``[min, max]`` interval,
+    use ``StreamlitValueOutOfRangeError``. Uncaught-exception telemetry
+    appends the parameter name, for example ``StreamlitValueError:width``.
+    Optional ``detail`` appears in the error message only.
     """
 
     def __init__(

--- a/lib/tests/streamlit/elements/date_input_test.py
+++ b/lib/tests/streamlit/elements/date_input_test.py
@@ -24,8 +24,8 @@ import streamlit as st
 from streamlit.elements.widgets.time_widgets import DateInputSerde, _DateInputValues
 from streamlit.errors import (
     StreamlitAPIException,
+    StreamlitInvalidMinMaxError,
     StreamlitInvalidParameterTypeError,
-    StreamlitInvalidRangeError,
     StreamlitInvalidWidthError,
     StreamlitValueAboveMaxError,
     StreamlitValueBelowMinError,
@@ -222,8 +222,8 @@ class DateInputTest(DeltaGeneratorTestCase):
         # No need to assert anything. Testing if not throwing an error.
 
     def test_min_max_exception(self):
-        """min_value after max_value raises StreamlitInvalidRangeError."""
-        with pytest.raises(StreamlitInvalidRangeError, match="cannot be greater than"):
+        """min_value after max_value raises StreamlitInvalidMinMaxError."""
+        with pytest.raises(StreamlitInvalidMinMaxError, match="cannot be greater than"):
             st.date_input(
                 "the label",
                 min_value=date(2022, 1, 1),

--- a/lib/tests/streamlit/elements/datetime_input_test.py
+++ b/lib/tests/streamlit/elements/datetime_input_test.py
@@ -26,12 +26,13 @@ import streamlit as st
 from streamlit.elements.widgets.time_widgets import DateTimeInputSerde
 from streamlit.errors import (
     StreamlitAPIException,
+    StreamlitInvalidMinMaxError,
     StreamlitInvalidParameterTypeError,
-    StreamlitInvalidRangeError,
     StreamlitInvalidWidthError,
     StreamlitValueAboveMaxError,
     StreamlitValueBelowMinError,
     StreamlitValueError,
+    StreamlitValueOutOfRangeError,
 )
 from streamlit.proto.LabelVisibility_pb2 import LabelVisibility
 from streamlit.testing.v1.app_test import AppTest
@@ -150,9 +151,13 @@ class DateTimeInputTest(DeltaGeneratorTestCase):
             st.datetime_input("The label", step=True)
         with pytest.raises(StreamlitInvalidParameterTypeError):
             st.datetime_input("The label", step=(1, 0))
-        with pytest.raises(StreamlitAPIException):
+        with pytest.raises(
+            StreamlitValueOutOfRangeError, match=r"\[60 seconds, 23 hours\]"
+        ):
             st.datetime_input("The label", step=30)
-        with pytest.raises(StreamlitAPIException):
+        with pytest.raises(
+            StreamlitValueOutOfRangeError, match=r"\[60 seconds, 23 hours\]"
+        ):
             st.datetime_input("The label", step=timedelta(hours=24))
 
     def test_format_validation(self):
@@ -297,10 +302,10 @@ class DateTimeInputTest(DeltaGeneratorTestCase):
             assert proto.max == "2024-01-01T12:00"
 
     def test_min_max_exception(self):
-        """min_value after max_value raises StreamlitInvalidRangeError."""
+        """min_value after max_value raises StreamlitInvalidMinMaxError."""
         min_value = datetime(2030, 1, 1, 12, 0)
         max_value = datetime(2020, 1, 1, 12, 0)
-        with pytest.raises(StreamlitInvalidRangeError, match="cannot be greater than"):
+        with pytest.raises(StreamlitInvalidMinMaxError, match="cannot be greater than"):
             st.datetime_input("Label", min_value=min_value, max_value=max_value)
 
     def test_min_equals_max_is_allowed(self):

--- a/lib/tests/streamlit/elements/feedback_test.py
+++ b/lib/tests/streamlit/elements/feedback_test.py
@@ -24,7 +24,11 @@ from parameterized import parameterized
 
 import streamlit as st
 from streamlit.elements.widgets.feedback import FeedbackSerde
-from streamlit.errors import StreamlitAPIException, StreamlitValueError
+from streamlit.errors import (
+    StreamlitAPIException,
+    StreamlitValueError,
+    StreamlitValueOutOfRangeError,
+)
 from streamlit.proto.Feedback_pb2 import Feedback as FeedbackProto
 from streamlit.runtime.state.session_state import get_script_run_ctx
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
@@ -156,23 +160,23 @@ class TestFeedbackCommand(DeltaGeneratorTestCase):
         val = st.feedback("thumbs")
         assert val is None
 
-    def test_invalid_default_for_thumbs(self):
-        """Test that invalid default for thumbs raises exception."""
-        with pytest.raises(StreamlitAPIException) as e:
-            st.feedback("thumbs", default=2)
-        assert "must be a number between 0 and 1" in str(e.value)
-
-    def test_invalid_default_for_faces(self):
-        """Test that invalid default for faces raises exception."""
-        with pytest.raises(StreamlitAPIException) as e:
-            st.feedback("faces", default=5)
-        assert "must be a number between 0 and 4" in str(e.value)
-
-    def test_invalid_default_for_stars(self):
-        """Test that invalid default for stars raises exception."""
-        with pytest.raises(StreamlitAPIException) as e:
-            st.feedback("stars", default=-1)
-        assert "must be a number between 0 and 4" in str(e.value)
+    @parameterized.expand(
+        [
+            ("thumbs", 2, "[0, 1]"),
+            ("faces", 5, "[0, 4]"),
+            ("stars", -1, "[0, 4]"),
+        ]
+    )
+    def test_invalid_default(
+        self,
+        options: Literal["thumbs", "faces", "stars"],
+        default: int,
+        expected_range: str,
+    ):
+        """Out-of-range default raises StreamlitValueOutOfRangeError."""
+        with pytest.raises(StreamlitValueOutOfRangeError) as e:
+            st.feedback(options, default=default)
+        assert f"required range {expected_range}" in str(e.value)
 
     def test_disabled_state(self):
         """Test that disabled state is set correctly."""

--- a/lib/tests/streamlit/elements/pagination_test.py
+++ b/lib/tests/streamlit/elements/pagination_test.py
@@ -22,7 +22,12 @@ import pytest
 
 import streamlit as st
 from streamlit.elements.widgets.pagination import PaginationSerde
-from streamlit.errors import StreamlitAPIException, StreamlitValueError
+from streamlit.errors import (
+    StreamlitAPIException,
+    StreamlitInvalidParameterTypeError,
+    StreamlitValueError,
+    StreamlitValueOutOfRangeError,
+)
 from streamlit.runtime.state.session_state import get_script_run_ctx
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 from tests.streamlit.elements.layout_test_utils import WidthConfigFields
@@ -127,14 +132,27 @@ class TestPaginationValidation(DeltaGeneratorTestCase):
         assert "`num_pages` must be an integer of at least 1" in str(e.value)
 
     def test_default_must_be_in_range(self):
-        """Test that default must be between 1 and num_pages."""
-        with pytest.raises(StreamlitAPIException) as e:
+        """Values outside [1, num_pages] raise StreamlitValueOutOfRangeError."""
+        with pytest.raises(StreamlitValueOutOfRangeError) as e:
             st.pagination(10, default=0)
-        assert "`default` must be between 1 and `num_pages`" in str(e.value)
+        assert "required range [1, 10]" in str(e.value)
 
-        with pytest.raises(StreamlitAPIException) as e:
+        with pytest.raises(StreamlitValueOutOfRangeError) as e:
             st.pagination(10, default=11)
-        assert "`default` must be between 1 and `num_pages`" in str(e.value)
+        assert "required range [1, 10]" in str(e.value)
+
+    def test_default_must_be_int(self):
+        """Non-int values raise StreamlitInvalidParameterTypeError.
+
+        True is a subclass of int and would otherwise be treated as page 1.
+        """
+        with pytest.raises(StreamlitInvalidParameterTypeError) as e:
+            st.pagination(10, default=True)
+        assert e.value.exec_kwargs["parameter"] == "default"
+
+        with pytest.raises(StreamlitInvalidParameterTypeError) as e:
+            st.pagination(10, default="1")
+        assert e.value.exec_kwargs["parameter"] == "default"
 
     def test_max_visible_pages_negative(self):
         """Test that negative max_visible_pages raises exception."""

--- a/lib/tests/streamlit/elements/progress_test.py
+++ b/lib/tests/streamlit/elements/progress_test.py
@@ -16,7 +16,11 @@ import pytest
 from parameterized import parameterized
 
 import streamlit as st
-from streamlit.errors import StreamlitAPIException, StreamlitInvalidParameterTypeError
+from streamlit.errors import (
+    StreamlitAPIException,
+    StreamlitInvalidParameterTypeError,
+    StreamlitValueOutOfRangeError,
+)
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 from tests.streamlit.elements.layout_test_utils import WidthConfigFields
 
@@ -42,13 +46,16 @@ class DeltaGeneratorProgressTest(DeltaGeneratorTestCase):
             element = self.get_delta_from_queue().new_element
             assert int(value * 100) == element.progress.value
 
-    def test_progress_bad_values(self):
-        """Test Progress with bad values."""
-        values = [-1, 101, -0.01, 1.01]
-        for value in values:
-            with pytest.raises(StreamlitAPIException):
-                st.progress(value)
+    @parameterized.expand([-1, 101, -0.01, 1.01])
+    def test_progress_out_of_range(self, value: float):
+        """Out-of-range values raise StreamlitValueOutOfRangeError."""
+        with pytest.raises(StreamlitValueOutOfRangeError) as exc_info:
+            st.progress(value)
+        expected_range = "[0, 100]" if isinstance(value, int) else "[0.0, 1.0]"
+        assert expected_range in str(exc_info.value)
 
+    def test_progress_invalid_type(self):
+        """Non-numeric values raise StreamlitInvalidParameterTypeError."""
         with pytest.raises(StreamlitInvalidParameterTypeError) as exc_info:
             st.progress("some string")
         assert exc_info.value.exec_kwargs["parameter"] == "value"

--- a/lib/tests/streamlit/elements/radio_test.py
+++ b/lib/tests/streamlit/elements/radio_test.py
@@ -29,6 +29,7 @@ from streamlit.errors import (
     StreamlitAPIException,
     StreamlitInvalidParameterTypeError,
     StreamlitValueError,
+    StreamlitValueOutOfRangeError,
 )
 from streamlit.proto.LabelVisibility_pb2 import LabelVisibility
 from streamlit.testing.v1.app_test import AppTest
@@ -160,10 +161,13 @@ class RadioTest(DeltaGeneratorTestCase):
         with pytest.raises(StreamlitInvalidParameterTypeError):
             st.radio("the label", ("m", "f"), "1")
 
-    def test_invalid_value_range(self):
-        """Test that value must be within the length of the options."""
-        with pytest.raises(StreamlitAPIException):
+    def test_index_out_of_range(self):
+        """Out-of-range index names the closed interval in StreamlitValueOutOfRangeError."""
+        with pytest.raises(StreamlitValueOutOfRangeError) as ex:
             st.radio("the label", ("m", "f"), 2)
+        assert str(ex.value) == (
+            "The `index` parameter, set to 2, is outside the required range [0, 1]."
+        )
 
     def test_outside_form(self):
         """Test that form id is marshalled correctly outside of a form."""

--- a/lib/tests/streamlit/elements/selectbox_test.py
+++ b/lib/tests/streamlit/elements/selectbox_test.py
@@ -31,6 +31,7 @@ from streamlit.errors import (
     StreamlitInvalidParameterTypeError,
     StreamlitInvalidWidthError,
     StreamlitValueError,
+    StreamlitValueOutOfRangeError,
 )
 from streamlit.proto.LabelVisibility_pb2 import LabelVisibility
 from streamlit.proto.SelectWidgetFilterMode_pb2 import (
@@ -192,17 +193,16 @@ class SelectboxTest(DeltaGeneratorTestCase):
 
     def test_invalid_value_range(self):
         """Test that value must be within the length of the options."""
-        with pytest.raises(StreamlitAPIException):
+        with pytest.raises(StreamlitValueOutOfRangeError):
             st.selectbox("the label", ("m", "f"), 2)
 
-    def test_raises_exception_of_index_larger_than_options(self):
-        """Test that it raises an exception if index is larger than options."""
-        with pytest.raises(StreamlitAPIException) as ex:
+    def test_index_out_of_range_error_message(self):
+        """Out-of-range index names the closed interval in StreamlitValueOutOfRangeError."""
+        with pytest.raises(StreamlitValueOutOfRangeError) as ex:
             st.selectbox("Test box", ["a"], index=1)
 
-        assert (
-            str(ex.value)
-            == "Selectbox index must be greater than or equal to 0 and less than the length of options."
+        assert str(ex.value) == (
+            "The `index` parameter, set to 1, is outside the required range [0, 0]."
         )
 
     def test_outside_form(self):

--- a/lib/tests/streamlit/elements/slider_test.py
+++ b/lib/tests/streamlit/elements/slider_test.py
@@ -34,8 +34,8 @@ from streamlit.elements.widgets.slider import (
 )
 from streamlit.errors import (
     StreamlitAPIException,
+    StreamlitInvalidMinMaxError,
     StreamlitInvalidParameterTypeError,
-    StreamlitInvalidRangeError,
     StreamlitInvalidWidthError,
     StreamlitJSNumberBoundsError,
     StreamlitValueAboveMaxError,
@@ -222,9 +222,9 @@ class SliderTest(DeltaGeneratorTestCase):
         assert c.max == 101
 
     def test_min_equals_max(self):
-        with pytest.raises(StreamlitInvalidRangeError, match="cannot be greater than"):
+        with pytest.raises(StreamlitInvalidMinMaxError, match="must not be equal"):
             st.slider("oh no", min_value=10, max_value=10)
-        with pytest.raises(StreamlitInvalidRangeError, match="cannot be greater than"):
+        with pytest.raises(StreamlitInvalidMinMaxError, match="must not be equal"):
             date = datetime(2024, 4, 3)
             st.slider("datetime", min_value=date, max_value=date)
 

--- a/lib/tests/streamlit/elements/time_input_test.py
+++ b/lib/tests/streamlit/elements/time_input_test.py
@@ -32,6 +32,7 @@ from streamlit.errors import (
     StreamlitInvalidParameterTypeError,
     StreamlitInvalidWidthError,
     StreamlitValueError,
+    StreamlitValueOutOfRangeError,
 )
 from streamlit.proto.LabelVisibility_pb2 import LabelVisibility
 from streamlit.testing.v1.app_test import AppTest
@@ -152,12 +153,14 @@ class TimeInputTest(DeltaGeneratorTestCase):
             st.time_input("Set an alarm for", value, step=True)
         with pytest.raises(StreamlitInvalidParameterTypeError):
             st.time_input("Set an alarm for", value, step=(90, 0))
-        with pytest.raises(StreamlitAPIException):
+        with pytest.raises(
+            StreamlitValueOutOfRangeError, match=r"\[1 second, 23 hours\]"
+        ):
             st.time_input("Set an alarm for", value, step=0)
-        with pytest.raises(StreamlitAPIException):
+        with pytest.raises(
+            StreamlitValueOutOfRangeError, match=r"\[1 second, 23 hours\]"
+        ):
             st.time_input("Set an alarm for", value, step=timedelta(hours=24))
-        with pytest.raises(StreamlitAPIException):
-            st.time_input("Set an alarm for", value, step=timedelta(days=1))
         # step=1 and step=59 are now valid (sub-minute steps unlocked)
         st.time_input("Set an alarm for", value, step=1)
         st.time_input("Set an alarm for", value, step=59)

--- a/lib/tests/streamlit/elements/time_widgets_test.py
+++ b/lib/tests/streamlit/elements/time_widgets_test.py
@@ -31,8 +31,8 @@ from streamlit.elements.widgets.time_widgets import (
 )
 from streamlit.errors import (
     StreamlitAPIException,
+    StreamlitInvalidMinMaxError,
     StreamlitInvalidParameterTypeError,
-    StreamlitInvalidRangeError,
 )
 
 if TYPE_CHECKING:
@@ -80,8 +80,8 @@ def test_convert_datetimelike_rejects_unparseable_string() -> None:
 
 
 def test_date_input_values_rejects_min_after_max() -> None:
-    """min after max raises StreamlitInvalidRangeError; equal bounds are allowed."""
-    with pytest.raises(StreamlitInvalidRangeError, match="cannot be greater than"):
+    """min after max raises StreamlitInvalidMinMaxError; equal bounds are allowed."""
+    with pytest.raises(StreamlitInvalidMinMaxError, match="cannot be greater than"):
         _DateInputValues(
             value=None,
             is_range=False,

--- a/lib/tests/streamlit/errors_test.py
+++ b/lib/tests/streamlit/errors_test.py
@@ -238,15 +238,52 @@ def test_selection_count_exceeds_max_pluralization(
     assert f"{max_sel} {expected_options_noun}" in msg
 
 
-# StreamlitInvalidRangeError tests
+# StreamlitInvalidMinMaxError tests
 
 
-def test_invalid_range_error_message() -> None:
-    """Range errors name both bounds."""
-    exc = errors.StreamlitInvalidRangeError(10, 5)
+def test_invalid_min_max_error_message() -> None:
+    """Min/max errors name both bounds."""
+    exc = errors.StreamlitInvalidMinMaxError(10, 5)
     assert str(exc) == (
         "The `min_value`, set to 10, cannot be greater than the `max_value`, set to 5."
     )
+
+
+def test_invalid_min_max_error_equal_bounds_message() -> None:
+    """Equal bounds use a dedicated sentence instead of 'cannot be greater than'."""
+    exc = errors.StreamlitInvalidMinMaxError(10, 10)
+    assert str(exc) == (
+        "The `min_value` and `max_value` parameters are both set to 10. "
+        "They must not be equal."
+    )
+
+
+# StreamlitValueOutOfRangeError tests
+
+
+def test_value_out_of_range_error_message() -> None:
+    """Out-of-range errors name the parameter, value, and closed interval."""
+    exc = errors.StreamlitValueOutOfRangeError("index", 5, 0, 2)
+    assert str(exc) == (
+        "The `index` parameter, set to 5, is outside the required range [0, 2]."
+    )
+
+
+def test_value_out_of_range_error_with_detail() -> None:
+    """Optional detail is appended and is not used as the telemetry parameter."""
+    exc = errors.StreamlitValueOutOfRangeError(
+        "index",
+        5,
+        0,
+        2,
+        detail="Choose an index that exists in options.",
+    )
+    assert str(exc) == (
+        "The `index` parameter, set to 5, is outside the required range [0, 2]. "
+        "Choose an index that exists in options."
+    )
+    assert exc.exec_kwargs["parameter"] == "index"
+    assert exc.exec_kwargs["detail"] == "Choose an index that exists in options."
 
 
 # StreamlitInvalidURLError tests

--- a/lib/tests/streamlit/runtime/metrics_util_test.py
+++ b/lib/tests/streamlit/runtime/metrics_util_test.py
@@ -36,10 +36,11 @@ from streamlit.connections import SQLConnection
 from streamlit.errors import (
     StreamlitIncompatibleParametersError,
     StreamlitInvalidLayoutContextError,
+    StreamlitInvalidMinMaxError,
     StreamlitInvalidParameterTypeError,
-    StreamlitInvalidRangeError,
     StreamlitMissingRequiredParameterError,
     StreamlitValueError,
+    StreamlitValueOutOfRangeError,
 )
 from streamlit.navigation.page import _create_page
 from streamlit.runtime import metrics_util
@@ -887,8 +888,12 @@ def test_gather_metrics_records_time_when_rerun_exception_raised() -> None:
             "StreamlitInvalidParameterTypeError:spec",
         ),
         (
-            StreamlitInvalidRangeError(10, 5),
-            "StreamlitInvalidRangeError",
+            StreamlitInvalidMinMaxError(10, 5),
+            "StreamlitInvalidMinMaxError",
+        ),
+        (
+            StreamlitValueOutOfRangeError("index", 5, 0, 2),
+            "StreamlitValueOutOfRangeError:index",
         ),
         (
             StreamlitIncompatibleParametersError(
@@ -969,7 +974,8 @@ def test_gather_metrics_records_time_when_rerun_exception_raised() -> None:
         "streamlit-value-error-detail",
         "streamlit-missing-required-parameter",
         "invalid-parameter-type",
-        "invalid-range",
+        "invalid-min-max",
+        "value-out-of-range",
         "incompatible-parameters",
         "invalid-context-no-command-suffix",
         "modulenotfound-message-fallback",


### PR DESCRIPTION
## Describe your changes

Renames `StreamlitInvalidRangeError` to `StreamlitInvalidMinMaxError` and adds `StreamlitValueOutOfRangeError` for closed `[min, max]` intervals, so widgets share one typed error instead of one-off `StreamlitAPIException` messages.

- `st.progress`, `st.feedback`, `st.pagination`, `st.radio`, `st.selectbox`, and time/datetime `step` now raise `StreamlitValueOutOfRangeError`.
- Pagination `default` type errors (including `True`) raise `StreamlitInvalidParameterTypeError`.
- Slider equal bounds now say the values must not be equal, instead of "cannot be greater than".
- `StreamlitInvalidRangeError` was unreleased; no alias is kept.

## GitHub Issue Link (if applicable)

Not applicable. Continues the typed-exception cleanup from #16690.

## Testing Plan

- [x] Unit Tests (JS and/or Python): `lib/tests/streamlit/errors_test.py` and widget tests for progress, feedback, pagination, radio, selectbox, slider, time/datetime
- [ ] E2E Tests (no e2e files changed; Python exception taxonomy only)
- [ ] Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

Made with [Cursor](https://cursor.com)