### PR TITLE
[refactor] Add error_id to StreamlitAPIException

### DIFF
--- a/.cursor/rules/python_lib.mdc
+++ b/.cursor/rules/python_lib.mdc
@@ -217,7 +217,10 @@ generic `StreamlitAPIException` with a one-off message.
 
 Reserve bare `StreamlitAPIException` for one-off cases that no shared type
 covers and that users are expected to hit uncommonly (serialization failures
-and similar). Always pass `error_id` at those remaining sites.
+and similar). Always pass `error_id` at those remaining sites. Do not tag
+sites in `_UNTAGGED_STREAMLIT_API_EXCEPTION_SITES` in
+`lib/tests/streamlit/errors_test.py`; those await a specialized-type
+migration — update the allowlist when migrating them.
 
 ## Theming and Layout
 

--- a/.cursor/rules/python_lib.mdc
+++ b/.cursor/rules/python_lib.mdc
@@ -147,7 +147,12 @@ User-facing API errors raised from `st.*` commands belong in
 generic `StreamlitAPIException` with a one-off message.
 
 - `StreamlitAPIException`: base for malformed user interaction with the Streamlit
-  API. Prefer a more specific subclass when one fits.
+  API. Prefer a more specific subclass when one fits. When a bare
+  `StreamlitAPIException` is still the right type, pass a unique kebab-case
+  `error_id` (for example `failed-loading-secrets-file`). It is stored on the
+  exception and appended in uncaught-exception telemetry
+  (`StreamlitAPIException:<error_id>`). Do not put widget keys, file paths, or
+  free-text values in `error_id`.
 - `StreamlitValueError(parameter, valid_values, *, detail=None)`: use when a
   parameter receives an invalid value from a known set of options, or a short
   open-ended constraint (for example `"a positive duration"`). For a closed
@@ -211,7 +216,7 @@ generic `StreamlitAPIException` with a one-off message.
 
 Reserve bare `StreamlitAPIException` for one-off cases that no shared type
 covers and that users are expected to hit uncommonly (serialization failures
-and similar).
+and similar). Always pass `error_id` at those remaining sites.
 
 ## Theming and Layout
 

--- a/.cursor/rules/python_lib.mdc
+++ b/.cursor/rules/python_lib.mdc
@@ -148,11 +148,12 @@ generic `StreamlitAPIException` with a one-off message.
 
 - `StreamlitAPIException`: base for malformed user interaction with the Streamlit
   API. Prefer a more specific subclass when one fits. When a bare
-  `StreamlitAPIException` is still the right type, pass a unique kebab-case
-  `error_id` (for example `failed-loading-secrets-file`). It is stored on the
-  exception and appended in uncaught-exception telemetry
-  (`StreamlitAPIException:<error_id>`). Do not put widget keys, file paths, or
-  free-text values in `error_id`.
+  `StreamlitAPIException` is still the right type, pass a stable kebab-case
+  `error_id` that is unique per distinct error (reuse the same id when the same
+  error is raised from multiple sites; for example
+  `failed-loading-secrets-file`). It is stored on the exception and appended in
+  uncaught-exception telemetry (`StreamlitAPIException:<error_id>`). Do not put
+  widget keys, file paths, or free-text values in `error_id`.
 - `StreamlitValueError(parameter, valid_values, *, detail=None)`: use when a
   parameter receives an invalid value from a known set of options, or a short
   open-ended constraint (for example `"a positive duration"`). For a closed

--- a/.github/instructions/python_lib.instructions.md
+++ b/.github/instructions/python_lib.instructions.md
@@ -145,7 +145,12 @@ User-facing API errors raised from `st.*` commands belong in
 generic `StreamlitAPIException` with a one-off message.
 
 - `StreamlitAPIException`: base for malformed user interaction with the Streamlit
-  API. Prefer a more specific subclass when one fits.
+  API. Prefer a more specific subclass when one fits. When a bare
+  `StreamlitAPIException` is still the right type, pass a unique kebab-case
+  `error_id` (for example `failed-loading-secrets-file`). It is stored on the
+  exception and appended in uncaught-exception telemetry
+  (`StreamlitAPIException:<error_id>`). Do not put widget keys, file paths, or
+  free-text values in `error_id`.
 - `StreamlitValueError(parameter, valid_values, *, detail=None)`: use when a
   parameter receives an invalid value from a known set of options, or a short
   open-ended constraint (for example `"a positive duration"`). For a closed
@@ -209,7 +214,7 @@ generic `StreamlitAPIException` with a one-off message.
 
 Reserve bare `StreamlitAPIException` for one-off cases that no shared type
 covers and that users are expected to hit uncommonly (serialization failures
-and similar).
+and similar). Always pass `error_id` at those remaining sites.
 
 ## Theming and Layout
 

--- a/.github/instructions/python_lib.instructions.md
+++ b/.github/instructions/python_lib.instructions.md
@@ -146,11 +146,12 @@ generic `StreamlitAPIException` with a one-off message.
 
 - `StreamlitAPIException`: base for malformed user interaction with the Streamlit
   API. Prefer a more specific subclass when one fits. When a bare
-  `StreamlitAPIException` is still the right type, pass a unique kebab-case
-  `error_id` (for example `failed-loading-secrets-file`). It is stored on the
-  exception and appended in uncaught-exception telemetry
-  (`StreamlitAPIException:<error_id>`). Do not put widget keys, file paths, or
-  free-text values in `error_id`.
+  `StreamlitAPIException` is still the right type, pass a stable kebab-case
+  `error_id` that is unique per distinct error (reuse the same id when the same
+  error is raised from multiple sites; for example
+  `failed-loading-secrets-file`). It is stored on the exception and appended in
+  uncaught-exception telemetry (`StreamlitAPIException:<error_id>`). Do not put
+  widget keys, file paths, or free-text values in `error_id`.
 - `StreamlitValueError(parameter, valid_values, *, detail=None)`: use when a
   parameter receives an invalid value from a known set of options, or a short
   open-ended constraint (for example `"a positive duration"`). For a closed

--- a/.github/instructions/python_lib.instructions.md
+++ b/.github/instructions/python_lib.instructions.md
@@ -215,7 +215,10 @@ generic `StreamlitAPIException` with a one-off message.
 
 Reserve bare `StreamlitAPIException` for one-off cases that no shared type
 covers and that users are expected to hit uncommonly (serialization failures
-and similar). Always pass `error_id` at those remaining sites.
+and similar). Always pass `error_id` at those remaining sites. Do not tag
+sites in `_UNTAGGED_STREAMLIT_API_EXCEPTION_SITES` in
+`lib/tests/streamlit/errors_test.py`; those await a specialized-type
+migration — update the allowlist when migrating them.
 
 ## Theming and Layout
 

--- a/lib/streamlit/AGENTS.md
+++ b/lib/streamlit/AGENTS.md
@@ -140,11 +140,12 @@ generic `StreamlitAPIException` with a one-off message.
 
 - `StreamlitAPIException`: base for malformed user interaction with the Streamlit
   API. Prefer a more specific subclass when one fits. When a bare
-  `StreamlitAPIException` is still the right type, pass a unique kebab-case
-  `error_id` (for example `failed-loading-secrets-file`). It is stored on the
-  exception and appended in uncaught-exception telemetry
-  (`StreamlitAPIException:<error_id>`). Do not put widget keys, file paths, or
-  free-text values in `error_id`.
+  `StreamlitAPIException` is still the right type, pass a stable kebab-case
+  `error_id` that is unique per distinct error (reuse the same id when the same
+  error is raised from multiple sites; for example
+  `failed-loading-secrets-file`). It is stored on the exception and appended in
+  uncaught-exception telemetry (`StreamlitAPIException:<error_id>`). Do not put
+  widget keys, file paths, or free-text values in `error_id`.
 - `StreamlitValueError(parameter, valid_values, *, detail=None)`: use when a
   parameter receives an invalid value from a known set of options, or a short
   open-ended constraint (for example `"a positive duration"`). For a closed

--- a/lib/streamlit/AGENTS.md
+++ b/lib/streamlit/AGENTS.md
@@ -139,7 +139,12 @@ User-facing API errors raised from `st.*` commands belong in
 generic `StreamlitAPIException` with a one-off message.
 
 - `StreamlitAPIException`: base for malformed user interaction with the Streamlit
-  API. Prefer a more specific subclass when one fits.
+  API. Prefer a more specific subclass when one fits. When a bare
+  `StreamlitAPIException` is still the right type, pass a unique kebab-case
+  `error_id` (for example `failed-loading-secrets-file`). It is stored on the
+  exception and appended in uncaught-exception telemetry
+  (`StreamlitAPIException:<error_id>`). Do not put widget keys, file paths, or
+  free-text values in `error_id`.
 - `StreamlitValueError(parameter, valid_values, *, detail=None)`: use when a
   parameter receives an invalid value from a known set of options, or a short
   open-ended constraint (for example `"a positive duration"`). For a closed
@@ -203,7 +208,7 @@ generic `StreamlitAPIException` with a one-off message.
 
 Reserve bare `StreamlitAPIException` for one-off cases that no shared type
 covers and that users are expected to hit uncommonly (serialization failures
-and similar).
+and similar). Always pass `error_id` at those remaining sites.
 
 ## Theming and Layout
 

--- a/lib/streamlit/AGENTS.md
+++ b/lib/streamlit/AGENTS.md
@@ -209,7 +209,10 @@ generic `StreamlitAPIException` with a one-off message.
 
 Reserve bare `StreamlitAPIException` for one-off cases that no shared type
 covers and that users are expected to hit uncommonly (serialization failures
-and similar). Always pass `error_id` at those remaining sites.
+and similar). Always pass `error_id` at those remaining sites. Do not tag
+sites in `_UNTAGGED_STREAMLIT_API_EXCEPTION_SITES` in
+`lib/tests/streamlit/errors_test.py`; those await a specialized-type
+migration — update the allowlist when migrating them.
 
 ## Theming and Layout
 

--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -308,7 +308,8 @@ def switch_page(  # type: ignore[misc]
         if page.is_external:
             raise StreamlitAPIException(
                 "Cannot use st.switch_page with external URL pages. "
-                "Use st.page_link instead to create a link to external pages."
+                "Use st.page_link instead to create a link to external pages.",
+                error_id="switch-page-external-url-not-supported",
             )
         _validate_registered_page(page)
         page_script_hash = page._script_hash

--- a/lib/streamlit/commands/logo.py
+++ b/lib/streamlit/commands/logo.py
@@ -214,7 +214,10 @@ def logo(
         fwd_msg.logo.image = image_value
         fwd_msg.logo.image_type = image_type
     except Exception as ex:
-        raise StreamlitAPIException(_invalid_logo_text("image")) from ex
+        raise StreamlitAPIException(
+            _invalid_logo_text("image"),
+            error_id="logo-invalid-image",
+        ) from ex
 
     if link:
         # Handle external links:
@@ -231,7 +234,10 @@ def logo(
             fwd_msg.logo.icon_image = icon_image_value
             fwd_msg.logo.icon_image_type = icon_image_type
         except Exception as ex:
-            raise StreamlitAPIException(_invalid_logo_text("icon_image")) from ex
+            raise StreamlitAPIException(
+                _invalid_logo_text("icon_image"),
+                error_id="logo-invalid-icon-image",
+            ) from ex
 
     def validate_size(size: str) -> str:
         if isinstance(size, str):

--- a/lib/streamlit/commands/navigation.py
+++ b/lib/streamlit/commands/navigation.py
@@ -363,7 +363,8 @@ def _navigation(
                 if default_page is not None:
                     raise StreamlitAPIException(
                         "Multiple Pages specified with `default=True`. "
-                        "At most one Page can be set to default."
+                        "At most one Page can be set to default.",
+                        error_id="navigation-multiple-default-pages",
                     )
                 default_page = page
 
@@ -372,7 +373,8 @@ def _navigation(
         if not non_external_pages:
             raise StreamlitAPIException(
                 "At least one non-external page is required. "
-                "External URL pages cannot be the default page."
+                "External URL pages cannot be the default page.",
+                error_id="navigation-external-only-pages",
             )
         default_page = non_external_pages[0]
         default_page._default = True
@@ -396,7 +398,8 @@ def _navigation(
                 raise StreamlitAPIException(
                     f"Multiple Pages specified with URL pathname {page.url_path}. "
                     "URL pathnames must be unique. The url pathname may be "
-                    "inferred from the filename, callable name, or title."
+                    "inferred from the filename, callable name, or title.",
+                    error_id="navigation-duplicate-url-pathname",
                 )
 
             pagehash_to_pageinfo[script_hash] = {

--- a/lib/streamlit/components/lib/local_component_registry.py
+++ b/lib/streamlit/components/lib/local_component_registry.py
@@ -49,7 +49,10 @@ class LocalComponentRegistry(BaseComponentRegistry):
         # Validate the component's path
         abspath = component.abspath
         if abspath is not None and not os.path.isdir(abspath):
-            raise StreamlitAPIException(f"No such component directory: '{abspath}'")
+            raise StreamlitAPIException(
+                f"No such component directory: '{abspath}'",
+                error_id="custom-component-directory-not-found",
+            )
 
         with self._lock:
             existing = self._components.get(component.name)

--- a/lib/streamlit/components/types/base_custom_component.py
+++ b/lib/streamlit/components/types/base_custom_component.py
@@ -40,7 +40,10 @@ class BaseCustomComponent(ABC):
         module_name: str | None = None,
     ) -> None:
         if path is None and url is None:
-            raise StreamlitAPIException("Either 'path' or 'url' must be set.")
+            raise StreamlitAPIException(
+                "Either 'path' or 'url' must be set.",
+                error_id="custom-component-path-or-url-required",
+            )
 
         self._name = name
         self._path = path

--- a/lib/streamlit/components/v1/custom_component.py
+++ b/lib/streamlit/components/v1/custom_component.py
@@ -135,7 +135,8 @@ PyArrow. To do so locally:
 
 `pip install pyarrow`
 
-And if you're using Streamlit Cloud, add "pyarrow" to your requirements.txt."""
+And if you're using Streamlit Cloud, add "pyarrow" to your requirements.txt.""",
+                error_id="custom-component-missing-pyarrow",
             )
 
         check_cache_replay_rules()

--- a/lib/streamlit/components/v2/component_definition_resolver.py
+++ b/lib/streamlit/components/v2/component_definition_resolver.py
@@ -106,7 +106,8 @@ def build_definition_with_validation(
         if asset_root is None:
             raise StreamlitAPIException(
                 f"Component '{component_key}' must be declared in pyproject.toml with asset_dir "
-                f"to use file-backed {kind}."
+                f"to use file-backed {kind}.",
+                error_id="component-missing-asset-dir",
             )
 
         value_str = value

--- a/lib/streamlit/components/v2/presentation.py
+++ b/lib/streamlit/components/v2/presentation.py
@@ -74,7 +74,8 @@ def make_bidi_component_presenter(
                 ):
                     raise StreamlitAPIException(
                         f"`st.session_state.{user_key}.{k}` cannot be modified after the component"
-                        f" with key `{user_key}` is instantiated."
+                        f" with key `{user_key}` is instantiated.",
+                        error_id="bidi-component-state-cannot-be-modified",
                     )
 
         # Base state must be a flat mapping; otherwise, present as-is.

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -188,7 +188,10 @@ def set_user_option(key: str, value: Any) -> None:
     try:
         opt = _config_options_template[key]
     except KeyError as ke:
-        raise StreamlitAPIException(f"Unrecognized config option: {key}") from ke
+        raise StreamlitAPIException(
+            f"Unrecognized config option: {key}",
+            error_id="unrecognized-config-option",
+        ) from ke
     # Allow e2e tests to set any option
     if opt.scriptable:
         set_option(key, value)
@@ -196,7 +199,8 @@ def set_user_option(key: str, value: Any) -> None:
 
     raise StreamlitAPIException(
         f"{key} cannot be set on the fly. Set as command line option, e.g. "
-        f"streamlit run script.py --{key}, or in config.toml instead."
+        f"streamlit run script.py --{key}, or in config.toml instead.",
+        error_id="config-option-not-scriptable",
     )
 
 

--- a/lib/streamlit/connections/snowflake_connection.py
+++ b/lib/streamlit/connections/snowflake_connection.py
@@ -682,7 +682,8 @@ class SnowflakeConnection(BaseSnowflakeConnection):
                     "or as kwargs to `st.connection`? "
                     "See the [SnowflakeConnection configuration documentation]"
                     "(https://docs.streamlit.io/st.connections.snowflakeconnection-configuration) "
-                    "for more details and examples."
+                    "for more details and examples.",
+                    error_id="snowflake-missing-connection-config",
                 )
             raise
 
@@ -745,7 +746,8 @@ class SnowflakeCallersRightsConnection(SnowflakeConnection):
             if value is None:
                 raise StreamlitAPIException(
                     f"Environment variable `{env_var_name}` not found. Is this app "
-                    "running in a Snowflake container environment?"
+                    "running in a Snowflake container environment?",
+                    error_id="snowflake-env-var-not-found",
                 )
             params[param_name] = value
 
@@ -753,7 +755,8 @@ class SnowflakeCallersRightsConnection(SnowflakeConnection):
         if not os.path.exists(SNOWPARK_CONNECTION_TOKEN_FILE):
             raise StreamlitAPIException(
                 f"Token file `{SNOWPARK_CONNECTION_TOKEN_FILE}` not found. Is this app "
-                "running in a Snowflake container environment?"
+                "running in a Snowflake container environment?",
+                error_id="snowflake-token-file-not-found",
             )
         login_token = cls._read_token_file()
 
@@ -762,7 +765,8 @@ class SnowflakeCallersRightsConnection(SnowflakeConnection):
             raise StreamlitAPIException(
                 "Token header not found. Is this app running with caller's "
                 "rights enabled, and is this connection being created in an app "
-                "execution thread?"
+                "execution thread?",
+                error_id="snowflake-token-header-not-found",
             )
         user_token = st_context.headers[SNOWPARK_USER_TOKEN_HEADER_NAME]
 

--- a/lib/streamlit/dataframe/lazy_df_source.py
+++ b/lib/streamlit/dataframe/lazy_df_source.py
@@ -353,7 +353,8 @@ def _get_native_row_count(source: DataframeSource, lazy: bool | None) -> int | N
         if lazy is True:
             raise StreamlitAPIException(
                 "`lazy=True` is not supported for this object because Streamlit "
-                "could not determine its row count for lazy loading."
+                "could not determine its row count for lazy loading.",
+                error_id="lazy-could-not-determine-row-count",
             ) from ex
         _LOGGER.info(
             "Could not determine row count for native lazy dataframe source; "
@@ -365,7 +366,8 @@ def _get_native_row_count(source: DataframeSource, lazy: bool | None) -> int | N
     if row_count is None and lazy is True:
         raise StreamlitAPIException(
             "`lazy=True` is not supported for this object because the first "
-            "lazy dataframe version requires a known row count."
+            "lazy dataframe version requires a known row count.",
+            error_id="lazy-requires-known-row-count",
         )
     return row_count
 
@@ -493,7 +495,8 @@ def resolve_lazy_source(
                 "`lazy=True` is not supported for this object because no lazy "
                 "adapter is available for it yet. Remove `lazy=True` to use the "
                 "default preview behavior, or convert it to a pandas/Polars "
-                "dataframe first."
+                "dataframe first.",
+                error_id="lazy-no-adapter-available",
             )
         return None
 

--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -401,16 +401,19 @@ class DeltaGenerator(
                         f"Method `{name}()` does not exist for "
                         f"`st.sidebar`. Did you mean `st.{name}()`?"
                     )
+                    error_id = "sidebar-method-does-not-exist"
                 else:
                     message = (
                         f"Method `{name}()` does not exist for "
                         "`DeltaGenerator` objects. Did you mean "
                         f"`st.{name}()`?"
                     )
+                    error_id = "delta-generator-method-does-not-exist"
             else:
                 message = f"`{name}()` is not a valid Streamlit command."
+                error_id = "invalid-streamlit-command"
 
-            raise StreamlitAPIException(message)
+            raise StreamlitAPIException(message, error_id=error_id)
 
         return wrapper
 

--- a/lib/streamlit/delta_generator.py
+++ b/lib/streamlit/delta_generator.py
@@ -397,23 +397,21 @@ class DeltaGenerator(
         def wrapper(*args: Any, **kwargs: Any) -> NoReturn:
             if name in streamlit_methods:
                 if self._root_container == RootContainer.SIDEBAR:
-                    message = (
+                    raise StreamlitAPIException(
                         f"Method `{name}()` does not exist for "
-                        f"`st.sidebar`. Did you mean `st.{name}()`?"
+                        f"`st.sidebar`. Did you mean `st.{name}()`?",
+                        error_id="sidebar-method-does-not-exist",
                     )
-                    error_id = "sidebar-method-does-not-exist"
-                else:
-                    message = (
-                        f"Method `{name}()` does not exist for "
-                        "`DeltaGenerator` objects. Did you mean "
-                        f"`st.{name}()`?"
-                    )
-                    error_id = "delta-generator-method-does-not-exist"
-            else:
-                message = f"`{name}()` is not a valid Streamlit command."
-                error_id = "invalid-streamlit-command"
-
-            raise StreamlitAPIException(message, error_id=error_id)
+                raise StreamlitAPIException(
+                    f"Method `{name}()` does not exist for "
+                    "`DeltaGenerator` objects. Did you mean "
+                    f"`st.{name}()`?",
+                    error_id="delta-generator-method-does-not-exist",
+                )
+            raise StreamlitAPIException(
+                f"`{name}()` is not a valid Streamlit command.",
+                error_id="invalid-streamlit-command",
+            )
 
         return wrapper
 

--- a/lib/streamlit/elements/arrow.py
+++ b/lib/streamlit/elements/arrow.py
@@ -478,7 +478,8 @@ def _validate_selection_state(
     if not isinstance(value, dict) or not isinstance(value.get("selection"), dict):
         raise StreamlitAPIException(
             "Selection state must be a dictionary with a 'selection' key "
-            "containing 'rows', 'columns', and 'cells' arrays."
+            "containing 'rows', 'columns', and 'cells' arrays.",
+            error_id="dataframe-invalid-selection-state",
         )
 
     selection = value["selection"]
@@ -1362,7 +1363,8 @@ def marshall(
         # and `None` otherwise.
         if not isinstance(default_uuid, str):
             raise StreamlitAPIException(
-                "Default UUID must be a string for Styler data."
+                "Default UUID must be a string for Styler data.",
+                error_id="styler-default-uuid-must-be-string",
             )
         marshall_styler(proto, data, default_uuid)
 

--- a/lib/streamlit/elements/iframe.py
+++ b/lib/streamlit/elements/iframe.py
@@ -455,7 +455,8 @@ class IframeMixin:
                 UnicodeDecodeError,
             ) as e:
                 raise StreamlitAPIException(
-                    f"Unable to read file '{file_path}': {e}"
+                    f"Unable to read file '{file_path}': {e}",
+                    error_id="iframe-unable-to-read-html-file",
                 ) from e
             return True
         # Non-HTML files: upload to media storage
@@ -464,7 +465,8 @@ class IframeMixin:
                 file_data = f.read()
         except (FileNotFoundError, PermissionError, OSError) as e:
             raise StreamlitAPIException(
-                f"Unable to read file '{file_path}': {e}"
+                f"Unable to read file '{file_path}': {e}",
+                error_id="iframe-unable-to-read-file",
             ) from e
 
         mimetype, _ = mimetypes.guess_type(file_path)

--- a/lib/streamlit/elements/image.py
+++ b/lib/streamlit/elements/image.py
@@ -199,7 +199,8 @@ class ImageMixin:
             if len(image_list_proto.imgs) > 1:
                 raise StreamlitAPIException(
                     "The `link` parameter is only supported when displaying a single image. "
-                    f"You passed {len(image_list_proto.imgs)} images."
+                    f"You passed {len(image_list_proto.imgs)} images.",
+                    error_id="image-link-requires-single-image",
                 )
             image_list_proto.link = link
 

--- a/lib/streamlit/elements/lib/built_in_chart_utils.py
+++ b/lib/streamlit/elements/lib/built_in_chart_utils.py
@@ -576,7 +576,8 @@ def _melt_data(
     ):
         raise StreamlitAPIException(
             "The columns used for rendering the chart contain too many values with "
-            "mixed types. Please select the columns manually via the y parameter."
+            "mixed types. Please select the columns manually via the y parameter.",
+            error_id="chart-mixed-type-columns",
         )
 
     # Arrow has problems with object types after melting two different dtypes

--- a/lib/streamlit/elements/lib/column_config_utils.py
+++ b/lib/streamlit/elements/lib/column_config_utils.py
@@ -499,14 +499,16 @@ class ButtonClickSerde:
             or not isinstance(parsed.get("label"), str)
         ):
             raise StreamlitAPIException(
-                "Invalid button click state: expected {row: int, label: str}."
+                "Invalid button click state: expected {row: int, label: str}.",
+                error_id="button-column-invalid-click-state",
             )
 
         # Validate row is non-negative (bounds check - row < num_rows is
         # checked downstream when accessing the data)
         if parsed["row"] < 0:
             raise StreamlitAPIException(
-                f"Invalid button click row index: {parsed['row']}. Row must be >= 0."
+                f"Invalid button click row index: {parsed['row']}. Row must be >= 0.",
+                error_id="button-column-invalid-click-row",
             )
 
         return ButtonColumnClickState(parsed)
@@ -696,7 +698,8 @@ def _convert_column_config_to_json(column_config_mapping: ColumnConfigMapping) -
         )
     except ValueError as ex:
         raise StreamlitAPIException(
-            f"The provided column config cannot be serialized into JSON: {ex}"
+            f"The provided column config cannot be serialized into JSON: {ex}",
+            error_id="column-config-json-serialize-failed",
         ) from ex
 
 

--- a/lib/streamlit/elements/lib/file_uploader_utils.py
+++ b/lib/streamlit/elements/lib/file_uploader_utils.py
@@ -132,7 +132,10 @@ def enforce_filename_restriction(filename: str, allowed_types: Sequence[str]) ->
     # Ensure that there isn't a null byte in a filename
     # since this could be a workaround to bypass the file type check.
     if "\0" in filename:
-        raise StreamlitAPIException("Filename cannot contain null bytes.")
+        raise StreamlitAPIException(
+            "Filename cannot contain null bytes.",
+            error_id="filename-contains-null-bytes",
+        )
 
     # Check if any MIME types are present (contain "/")
     has_mime_types = any("/" in t for t in allowed_types)
@@ -153,5 +156,6 @@ def enforce_filename_restriction(filename: str, allowed_types: Sequence[str]) ->
         normalized_filename.endswith(allowed_type) for allowed_type in extension_types
     ):
         raise StreamlitAPIException(
-            f"Invalid file extension: `{extension}`. Allowed: {extension_types}"
+            f"Invalid file extension: `{extension}`. Allowed: {extension_types}",
+            error_id="file-uploader-invalid-extension",
         )

--- a/lib/streamlit/elements/lib/image_utils.py
+++ b/lib/streamlit/elements/lib/image_utils.py
@@ -165,7 +165,8 @@ def _verify_np_shape(array: npt.NDArray[Any]) -> npt.NDArray[Any]:
         )
     if len(shape) == 3 and shape[-1] not in {1, 3, 4}:
         raise StreamlitAPIException(
-            f"Channel can only be 1, 3, or 4 got {shape[-1]}. Shape is {shape}"
+            f"Channel can only be 1, 3, or 4 got {shape[-1]}. Shape is {shape}",
+            error_id="image-invalid-channel-count",
         )
 
     # If there's only one channel, convert is to x, y
@@ -334,7 +335,8 @@ def image_to_url(
             else:
                 raise StreamlitAPIException(
                     'When using `channels="BGR"`, the input image should '
-                    "have exactly 3 color channels"
+                    "have exactly 3 color channels",
+                    error_id="image-bgr-requires-three-channels",
                 )
 
         image_data = _np_array_to_bytes(array=image, output_format=output_format)
@@ -430,7 +432,8 @@ def marshall_images(
 
     if len(captions) != len(images):
         raise StreamlitAPIException(
-            f"Cannot pair {len(captions)} captions with {len(images)} images."
+            f"Cannot pair {len(captions)} captions with {len(images)} images.",
+            error_id="image-caption-count-mismatch",
         )
 
     # Each image in an image list needs to be kept track of at its own coordinates.

--- a/lib/streamlit/elements/lib/pandas_styler_utils.py
+++ b/lib/streamlit/elements/lib/pandas_styler_utils.py
@@ -54,7 +54,8 @@ def marshall_styler(proto: ArrowDataProto, styler: Styler, default_uuid: str) ->
             "of cells allowed to be rendered by Pandas Styler is configured to "
             f"`{pd.options.styler.render.max_elements}`. To allow more cells to be "
             'styled, you can change the `"styler.render.max_elements"` config. For example: '
-            f'`pd.set_option("styler.render.max_elements", {styler_data_df.size})`'
+            f'`pd.set_option("styler.render.max_elements", {styler_data_df.size})`',
+            error_id="styler-exceeds-max-elements",
         )
 
     # pandas.Styler uuid should be set before _compute is called.

--- a/lib/streamlit/elements/lib/shortcut_utils.py
+++ b/lib/streamlit/elements/lib/shortcut_utils.py
@@ -114,7 +114,8 @@ def _normalize_key_token(lower_token: str) -> str:
 
     raise StreamlitAPIException(
         "shortcut must include a single character or one of the supported keys "
-        "(e.g. Enter, Space, Tab, Escape)."
+        "(e.g. Enter, Space, Tab, Escape).",
+        error_id="shortcut-missing-character-or-key",
     )
 
 
@@ -150,7 +151,8 @@ def normalize_shortcut(shortcut: str) -> str:
     tokens = [token.strip() for token in shortcut.split("+") if token.strip()]
     if not tokens:
         raise StreamlitAPIException(
-            "The `shortcut` must contain at least one key or modifier."
+            "The `shortcut` must contain at least one key or modifier.",
+            error_id="shortcut-empty",
         )
 
     modifiers: list[str] = []
@@ -166,20 +168,23 @@ def normalize_shortcut(shortcut: str) -> str:
 
         if key is not None:
             raise StreamlitAPIException(
-                "The `shortcut` may only specify a single non-modifier key."
+                "The `shortcut` may only specify a single non-modifier key.",
+                error_id="shortcut-multiple-non-modifier-keys",
             )
 
         normalized_key = _normalize_key_token(lower_token)
         if normalized_key in _RESERVED_KEYS:
             raise StreamlitAPIException(
-                "The `shortcut` cannot use the keys 'C' or 'R', with or without modifiers."
+                "The `shortcut` cannot use the keys 'C' or 'R', with or without modifiers.",
+                error_id="shortcut-reserved-key",
             )
 
         key = normalized_key
 
     if key is None:
         raise StreamlitAPIException(
-            "The `shortcut` must include a non-modifier key such as 'K' or 'Ctrl+K'."
+            "The `shortcut` must include a non-modifier key such as 'K' or 'Ctrl+K'.",
+            error_id="shortcut-missing-non-modifier-key",
         )
 
     normalized_tokens: list[str] = [

--- a/lib/streamlit/elements/map.py
+++ b/lib/streamlit/elements/map.py
@@ -376,7 +376,8 @@ def _get_lat_or_lon_col_name(
 
             raise StreamlitAPIException(
                 f"Map data must contain a {human_readable_name} column named: "
-                f"{formatted_allowed_col_name}. Existing columns: {formmated_col_names}"
+                f"{formatted_allowed_col_name}. Existing columns: {formmated_col_names}",
+                error_id="map-missing-lat-lon-column",
             )
         col_name = candidate_col_name
 
@@ -389,7 +390,8 @@ def _get_lat_or_lon_col_name(
     if any(data[col_name].isna().array):
         raise StreamlitAPIException(
             f"Column {col_name} is not allowed to contain null values, such "
-            "as NaN, NaT, or None."
+            "as NaN, NaT, or None.",
+            error_id="map-column-contains-nulls",
         )
 
     return col_name
@@ -450,7 +452,8 @@ def _convert_color_arg_or_column(
             data[color_col_name] = data[color_col_name].map(to_int_color_tuple)
         else:
             raise StreamlitAPIException(
-                f'Column "{color_col_name}" does not appear to contain valid colors.'
+                f'Column "{color_col_name}" does not appear to contain valid colors.',
+                error_id="map-invalid-color-column",
             )
 
         color_arg_out = color_arg

--- a/lib/streamlit/elements/media.py
+++ b/lib/streamlit/elements/media.py
@@ -571,7 +571,10 @@ def marshall_video(
     """
 
     if start_time < 0 or (end_time is not None and end_time <= start_time):
-        raise StreamlitAPIException("Invalid start_time and end_time combination.")
+        raise StreamlitAPIException(
+            "Invalid start_time and end_time combination.",
+            error_id="media-invalid-start-end-time",
+        )
 
     proto.start_time = start_time
     proto.muted = muted
@@ -648,7 +651,8 @@ def marshall_video(
                 )
             except (TypeError, ValueError) as original_err:
                 raise StreamlitAPIException(
-                    f"Failed to process the provided subtitle: {label}"
+                    f"Failed to process the provided subtitle: {label}",
+                    error_id="video-failed-processing-subtitle",
                 ) from original_err
 
     if autoplay:
@@ -684,7 +688,9 @@ def _parse_start_time_end_time(
         error_msg = TIMEDELTA_PARSE_ERROR_MESSAGE.format(
             param_name="start_time", param_value=start_time
         )
-        raise StreamlitAPIException(error_msg) from None
+        raise StreamlitAPIException(
+            error_msg, error_id="media-invalid-start-time"
+        ) from None
 
     try:
         end_time = time_to_seconds(end_time, coerce_none_to_inf=False)
@@ -694,7 +700,9 @@ def _parse_start_time_end_time(
         error_msg = TIMEDELTA_PARSE_ERROR_MESSAGE.format(
             param_name="end_time", param_value=end_time
         )
-        raise StreamlitAPIException(error_msg) from None
+        raise StreamlitAPIException(
+            error_msg, error_id="media-invalid-end-time"
+        ) from None
 
     return start_time, end_time
 
@@ -733,7 +741,10 @@ def _validate_and_normalize(data: npt.NDArray[Any]) -> tuple[bytes, int]:
         nchan = transformed_data.shape[0]
         transformed_data = transformed_data.T.ravel()
     else:
-        raise StreamlitAPIException("Numpy array audio input must be a 1D or 2D array.")
+        raise StreamlitAPIException(
+            "Numpy array audio input must be a 1D or 2D array.",
+            error_id="audio-numpy-invalid-rank",
+        )
 
     if transformed_data.size == 0:
         return transformed_data.astype(np.int16).tobytes(), nchan

--- a/lib/streamlit/elements/metric.py
+++ b/lib/streamlit/elements/metric.py
@@ -442,7 +442,8 @@ class MetricMixin:
                     raise StreamlitAPIException(
                         "Only numeric values are supported for chart data sequence. The "
                         f"value '{val}' is of type {type(val)} and "
-                        "cannot be converted to float."
+                        "cannot be converted to float.",
+                        error_id="metric-chart-data-not-numeric",
                     ) from ex
             if len(prepared_data) > 0:
                 metric_proto.chart_data.extend(prepared_data)

--- a/lib/streamlit/elements/pdf.py
+++ b/lib/streamlit/elements/pdf.py
@@ -145,7 +145,8 @@ class PdfMixin:
                         file_param = file.read()
                 except (FileNotFoundError, PermissionError) as e:
                     raise StreamlitAPIException(
-                        f"Unable to read file '{data_str}': {e}"
+                        f"Unable to read file '{data_str}': {e}",
+                        error_id="pdf-unable-to-read-file",
                     )
 
         elif isinstance(data, bytes):
@@ -186,8 +187,9 @@ class PdfMixin:
             "The PDF viewer requires the `streamlit-pdf` component to be installed.\n\n"
             "Please run `pip install streamlit[pdf]` to install it.\n\n"
             "For more information, see the Streamlit PDF documentation at "
-            "https://docs.streamlit.io/develop/api-reference/media/st.pdf."
+            "https://docs.streamlit.io/develop/api-reference/media/st.pdf.",
             # TODO: Update this URL when docs are updated
+            error_id="pdf-component-not-installed",
         )
 
     @property

--- a/lib/streamlit/elements/pdf.py
+++ b/lib/streamlit/elements/pdf.py
@@ -187,8 +187,8 @@ class PdfMixin:
             "The PDF viewer requires the `streamlit-pdf` component to be installed.\n\n"
             "Please run `pip install streamlit[pdf]` to install it.\n\n"
             "For more information, see the Streamlit PDF documentation at "
-            "https://docs.streamlit.io/develop/api-reference/media/st.pdf.",
             # TODO: Update this URL when docs are updated
+            "https://docs.streamlit.io/develop/api-reference/media/st.pdf.",
             error_id="pdf-component-not-installed",
         )
 

--- a/lib/streamlit/elements/table.py
+++ b/lib/streamlit/elements/table.py
@@ -66,7 +66,8 @@ def marshall_table(
         # and `None` otherwise.
         if not isinstance(default_uuid, str):
             raise StreamlitAPIException(
-                "Default UUID must be a string for Styler data."
+                "Default UUID must be a string for Styler data.",
+                error_id="styler-default-uuid-must-be-string",
             )
         marshall_styler(proto, data, default_uuid)
 

--- a/lib/streamlit/elements/vega_charts.py
+++ b/lib/streamlit/elements/vega_charts.py
@@ -1486,7 +1486,8 @@ class VegaChartsMixin:
         if type_util.is_altair_version_less_than("5.0.0") and stack is False:
             raise StreamlitAPIException(
                 "Streamlit does not support non-stacked (grouped) bar charts with "
-                "Altair 4.x. Please upgrade to Version 5."
+                "Altair 4.x. Please upgrade to Version 5.",
+                error_id="altair4-grouped-bar-not-supported",
             )
 
         bar_chart_type = (
@@ -2255,7 +2256,8 @@ class VegaChartsMixin:
                 "Streamlit does not support selections with Altair 4.x. Please upgrade "
                 "to Version 5. "
                 "If you would like to use Altair 4.x with selections, please upvote "
-                "this [Github issue](https://github.com/streamlit/streamlit/issues/8516)."
+                "this [Github issue](https://github.com/streamlit/streamlit/issues/8516).",
+                error_id="altair4-selections-not-supported",
             )
 
         vega_lite_spec = _convert_altair_to_vega_lite_spec(altair_chart)

--- a/lib/streamlit/elements/widgets/button.py
+++ b/lib/streamlit/elements/widgets/button.py
@@ -1874,7 +1874,8 @@ def marshall_file(
     data_as_bytes, inferred_mime_type = convert_data_to_bytes_and_infer_mime(
         data,
         unsupported_error=StreamlitAPIException(
-            f"Invalid binary data format: {type(data)}"
+            f"Invalid binary data format: {type(data)}",
+            error_id="download-button-invalid-binary-data-format",
         ),
     )
     if mimetype is None:

--- a/lib/streamlit/elements/widgets/chat.py
+++ b/lib/streamlit/elements/widgets/chat.py
@@ -267,7 +267,8 @@ def _process_avatar_input(
         )
     except Exception as ex:
         raise StreamlitAPIException(
-            "Failed to load the provided avatar value as an image."
+            "Failed to load the provided avatar value as an image.",
+            error_id="chat-failed-loading-avatar-image",
         ) from ex
 
 
@@ -359,14 +360,16 @@ def _pop_audio_file(
     if not uploaded_file.name.lower().endswith(_ACCEPTED_AUDIO_EXTENSION):
         raise StreamlitAPIException(
             f"Invalid file extension for audio input: `{uploaded_file.name}`. "
-            f"Only WAV files ({_ACCEPTED_AUDIO_EXTENSION}) are accepted."
+            f"Only WAV files ({_ACCEPTED_AUDIO_EXTENSION}) are accepted.",
+            error_id="audio-input-invalid-file-extension",
         )
 
     # Validate MIME type (browsers may send different variations of WAV MIME types)
     if uploaded_file.type not in _ACCEPTED_AUDIO_MIME_TYPES:
         raise StreamlitAPIException(
             f"Invalid MIME type for audio input: `{uploaded_file.type}`. "
-            f"Expected one of {_ACCEPTED_AUDIO_MIME_TYPES}."
+            f"Expected one of {_ACCEPTED_AUDIO_MIME_TYPES}.",
+            error_id="audio-input-invalid-mime-type",
         )
 
     # Remove the file from the manager after creating the UploadedFile object.

--- a/lib/streamlit/elements/widgets/data_editor.py
+++ b/lib/streamlit/elements/widgets/data_editor.py
@@ -661,7 +661,8 @@ def _check_column_names(data_df: pd.DataFrame) -> None:
         raise StreamlitAPIException(
             f"All column names are required to be unique for usage with data editor. "
             f"The following column names are duplicated: {list(duplicated_columns)}. "
-            f"Please rename the duplicated columns in the provided data."
+            f"Please rename the duplicated columns in the provided data.",
+            error_id="data-editor-duplicate-column-names",
         )
 
     # Check if the column names are not named "_index" and raise an exception if so.
@@ -669,7 +670,8 @@ def _check_column_names(data_df: pd.DataFrame) -> None:
         raise StreamlitAPIException(
             f"The column name '{INDEX_IDENTIFIER}' is reserved for the index column "
             f"and can't be used for data columns. Please rename the column in the "
-            f"provided data."
+            f"provided data.",
+            error_id="data-editor-reserved-index-column-name",
         )
 
 
@@ -732,7 +734,8 @@ def _check_type_compatibilities(
                     f"`{column_name}` is not compatible for editing the underlying "
                     f"data type `{column_data_kind}`.\n\nYou have following options to "
                     f"fix this: 1) choose a compatible type 2) disable the column "
-                    f"3) convert the column into a compatible data type."
+                    f"3) convert the column into a compatible data type.",
+                    error_id="data-editor-incompatible-column-type",
                 )
 
 
@@ -1221,7 +1224,8 @@ class DataEditorMixin:
         if not _is_supported_index(data_df.index):
             raise StreamlitAPIException(
                 f"The type of the dataframe index - {type(data_df.index).__name__} - is not "
-                "yet supported by the data editor."
+                "yet supported by the data editor.",
+                error_id="data-editor-unsupported-index-type",
             )
 
         # Check if the column names are valid and unique.

--- a/lib/streamlit/elements/widgets/menu_button.py
+++ b/lib/streamlit/elements/widgets/menu_button.py
@@ -376,7 +376,8 @@ class MenuButtonMixin:
         if len(formatted_options) != len(formatted_option_to_option_index):
             raise StreamlitAPIException(
                 "The `format_func` produced duplicate labels for the menu button "
-                "options. Each formatted option label must be unique."
+                "options. Each formatted option label must be unique.",
+                error_id="menu-button-duplicate-format-labels",
             )
 
         element_id = compute_and_register_element_id(

--- a/lib/streamlit/elements/write.py
+++ b/lib/streamlit/elements/write.py
@@ -209,7 +209,8 @@ class WriteMixin:
         except TypeError as exc:
             raise StreamlitAPIException(
                 f"The provided input (type: {type(stream)}) cannot be iterated. "
-                "Please make sure that it is a generator, generator function or iterable."
+                "Please make sure that it is a generator, generator function or iterable.",
+                error_id="write-stream-not-iterable",
             ) from exc
 
         # Iterate through the generator and write each chunk to the app
@@ -230,7 +231,8 @@ class WriteMixin:
                         "The most likely cause is a change of the chunk object structure "
                         "due to a recent OpenAI update. You might be able to fix this "
                         "by downgrading the OpenAI library or upgrading Streamlit. Also, "
-                        "please report this issue to: https://github.com/streamlit/streamlit/issues."
+                        "please report this issue to: https://github.com/streamlit/streamlit/issues.",
+                        error_id="write-stream-openai-chat-parse-failed",
                     ) from err
 
             elif type_util.is_openai_response_event(chunk):
@@ -246,7 +248,8 @@ class WriteMixin:
                         "The most likely cause is a change of the event object structure "
                         "due to a recent OpenAI update. You might be able to fix this "
                         "by downgrading the OpenAI library or upgrading Streamlit. Also, "
-                        "please report this issue to: https://github.com/streamlit/streamlit/issues."
+                        "please report this issue to: https://github.com/streamlit/streamlit/issues.",
+                        error_id="write-stream-openai-response-parse-failed",
                     ) from err
 
             if type_util.is_type(chunk, "langchain_core.messages.ai.AIMessageChunk"):
@@ -259,7 +262,8 @@ class WriteMixin:
                         "The most likely cause is a change of the chunk object structure "
                         "due to a recent LangChain update. You might be able to fix this "
                         "by downgrading the LangChain library or upgrading Streamlit. Also, "
-                        "please report this issue to: https://github.com/streamlit/streamlit/issues."
+                        "please report this issue to: https://github.com/streamlit/streamlit/issues.",
+                        error_id="write-stream-langchain-parse-failed",
                     ) from err
 
             if isinstance(chunk, str):
@@ -451,7 +455,8 @@ class WriteMixin:
                 "Cannot replace a single element with multiple elements.\n\n"
                 "The `write()` method only supports multiple elements when "
                 "inserting elements rather than replacing. That is, only "
-                "when called as `st.write()` or `st.sidebar.write()`."
+                "when called as `st.write()` or `st.sidebar.write()`.",
+                error_id="write-cannot-replace-with-multiple-elements",
             )
 
         def flush_buffer() -> None:

--- a/lib/streamlit/errors.py
+++ b/lib/streamlit/errors.py
@@ -84,7 +84,15 @@ class StreamlitAPIException(MarkdownFormattedException):
     entries from the stack trace so that the user doesn't see a bunch of
     noise related to Streamlit internals.
 
+    Prefer a more specific subclass when one fits. When this base type is
+    still right, pass a kebab-case ``error_id`` so uncaught-exception
+    telemetry can distinguish raise sites (``StreamlitAPIException:<error_id>``).
+    Do not put widget keys, file paths, or free-text values in ``error_id``.
     """
+
+    def __init__(self, *args: Any, error_id: str | None = None) -> None:
+        super().__init__(*args)
+        self.error_id = error_id
 
     def __repr__(self) -> str:
         return util.repr_(self)
@@ -173,11 +181,15 @@ class LocalizableStreamlitException(StreamlitAPIException):
 
     Users can localize the message from ``exec_kwargs``, for example in an
     ``on_script_error`` handler on ``st.App``. Kwargs are used for telemetry
-    only in a few specific cases (for example ``parameter``).
+    only in a few specific cases (for example ``parameter``). ``error_id`` is
+    reserved for telemetry and is not interpolated into the message.
     """
 
     def __init__(self, message: str, **kwargs: Any) -> None:
-        super().__init__((message).format(**kwargs))
+        # Pop ``error_id`` so telemetry can store it without interpolating it
+        # into the message.
+        error_id = kwargs.pop("error_id", None)
+        super().__init__((message).format(**kwargs), error_id=error_id)
         self._exec_kwargs = kwargs
 
     @property

--- a/lib/streamlit/errors.py
+++ b/lib/streamlit/errors.py
@@ -186,8 +186,9 @@ class LocalizableStreamlitException(StreamlitAPIException):
     """
 
     def __init__(self, message: str, **kwargs: Any) -> None:
-        # Pop ``error_id`` so telemetry can store it without interpolating it
-        # into the message.
+        # Treat error_id as a telemetry slug, not a message placeholder:
+        # extract it before formatting so it is not interpolated or stored
+        # in exec_kwargs.
         error_id = kwargs.pop("error_id", None)
         super().__init__((message).format(**kwargs), error_id=error_id)
         self._exec_kwargs = kwargs

--- a/lib/streamlit/errors.py
+++ b/lib/streamlit/errors.py
@@ -84,13 +84,15 @@ class StreamlitAPIException(MarkdownFormattedException):
     entries from the stack trace so that the user doesn't see a bunch of
     noise related to Streamlit internals.
 
-    Prefer a more specific subclass when one fits. When this base type is
-    still right, pass a kebab-case ``error_id`` so uncaught-exception
-    telemetry can distinguish raise sites (``StreamlitAPIException:<error_id>``).
-    Do not put widget keys, file paths, or free-text values in ``error_id``.
+    Prefer a more specific subclass when one fits. ``error_id`` is an optional
+    stable telemetry identifier. When this base type is still right, pass a
+    kebab-case ``error_id`` so uncaught-exception telemetry can distinguish
+    error categories (``StreamlitAPIException:<error_id>``). Reuse the same id
+    when the same error is raised from multiple sites.
     """
 
     def __init__(self, *args: Any, error_id: str | None = None) -> None:
+        # Do not put widget keys, file paths, or free-text values in error_id.
         super().__init__(*args)
         self.error_id = error_id
 

--- a/lib/streamlit/navigation/page.py
+++ b/lib/streamlit/navigation/page.py
@@ -303,7 +303,8 @@ class Page:
                 )
             if "/" in self._url_path:
                 raise StreamlitAPIException(
-                    "The URL path cannot contain a nested path (e.g. foo/bar)."
+                    "The URL path cannot contain a nested path (e.g. foo/bar).",
+                    error_id="page-nested-url-path",
                 )
 
             self._can_be_called: bool = False
@@ -313,7 +314,8 @@ class Page:
             page_path = str(page)
             if "\x00" in page_path:
                 raise StreamlitAPIException(
-                    "Unable to create Page. Page paths must not contain null bytes."
+                    "Unable to create Page. Page paths must not contain null bytes.",
+                    error_id="page-path-contains-null-bytes",
                 )
 
             # Reject UNC paths before resolve/is_file can initiate an SMB connection
@@ -322,7 +324,8 @@ class Page:
             # passing an absolute page path is part of the public st.Page contract.
             if env_util.IS_WINDOWS and is_windows_unc_path(page_path):
                 raise StreamlitAPIException(
-                    "Unable to create Page. Network paths are not supported."
+                    "Unable to create Page. Network paths are not supported.",
+                    error_id="page-network-path-not-supported",
                 )
 
         main_path = ctx.pages_manager.main_script_parent
@@ -378,7 +381,8 @@ class Page:
             self._url_path = stripped_url_path
             if "/" in self._url_path:
                 raise StreamlitAPIException(
-                    "The URL path cannot contain a nested path (e.g. foo/bar)."
+                    "The URL path cannot contain a nested path (e.g. foo/bar).",
+                    error_id="page-nested-url-path",
                 )
 
         if self._icon:
@@ -467,7 +471,8 @@ class Page:
         """
         if not self._can_be_called:
             raise StreamlitAPIException(
-                "This page cannot be called directly. Only the page returned from st.navigation can be called once."
+                "This page cannot be called directly. Only the page returned from st.navigation can be called once.",
+                error_id="page-cannot-be-called-directly",
             )
 
         self._can_be_called = False
@@ -545,7 +550,8 @@ def _validate_registered_page(page: Page) -> None:
                 f"registered with `st.navigation` for URL pathname "
                 f"`/{page.url_path}` (`{registered_source}`). Pass the page "
                 "object returned by `st.navigation` or re-create the page "
-                "with the matching source."
+                "with the matching source.",
+                error_id="page-source-mismatch-file",
             )
     elif callable(page._page) and registered_script_path:
         raise StreamlitAPIException(
@@ -553,7 +559,8 @@ def _validate_registered_page(page: Page) -> None:
             f"(`{registered_script_path}`) is registered with `st.navigation` "
             f"for URL pathname `/{page.url_path}`. Pass the page object "
             "returned by `st.navigation` or re-create the page with the "
-            "matching source."
+            "matching source.",
+            error_id="page-source-mismatch-callable",
         )
     # Callable-vs-callable collisions fall through intentionally: PageInfo
     # only stores an empty script_path for callables, so we have no identity

--- a/lib/streamlit/runtime/caching/cache_utils.py
+++ b/lib/streamlit/runtime/caching/cache_utils.py
@@ -266,7 +266,8 @@ def get_session_id_or_throw() -> str:
         raise StreamlitAPIException(
             "A session-scoped cache was accessed outside of the app execution thread. "
             "Make sure all session-scoped caches are read during rendering and not "
-            "read in background threads."
+            "read in background threads.",
+            error_id="session-scoped-cache-outside-app-thread",
         )
     return ctx.session_id
 

--- a/lib/streamlit/runtime/connection_factory.py
+++ b/lib/streamlit/runtime/connection_factory.py
@@ -125,14 +125,18 @@ def _create_connection(
 
 def _get_first_party_connection(connection_class: str) -> type[BaseConnection[Any]]:
     if connection_class == _SNOWPARK_CONNECTION_TYPE:
-        raise StreamlitAPIException(_SNOWPARK_CONNECTION_REMOVED_ERROR)
+        raise StreamlitAPIException(
+            _SNOWPARK_CONNECTION_REMOVED_ERROR,
+            error_id="snowpark-connection-removed",
+        )
 
     if connection_class in _FIRST_PARTY_CONNECTIONS:
         return _FIRST_PARTY_CONNECTIONS[connection_class]
 
     raise StreamlitAPIException(
         f"Invalid connection '{connection_class}'. "
-        f"Supported connection classes: {_FIRST_PARTY_CONNECTIONS}"
+        f"Supported connection classes: {_FIRST_PARTY_CONNECTIONS}",
+        error_id="invalid-first-party-connection",
     )
 
 
@@ -431,7 +435,10 @@ def connection_factory(  # type: ignore
         # through to the secrets.toml lookup and raise a confusing "no secrets" error
         # instead of the actionable removal message.
         if name == _SNOWPARK_CONNECTION_TYPE:
-            raise StreamlitAPIException(_SNOWPARK_CONNECTION_REMOVED_ERROR)
+            raise StreamlitAPIException(
+                _SNOWPARK_CONNECTION_REMOVED_ERROR,
+                error_id="snowpark-connection-removed",
+            )
 
         if name in _FIRST_PARTY_CONNECTIONS:
             # We allow users to simply write `st.connection("sql")` instead of

--- a/lib/streamlit/runtime/metrics_util.py
+++ b/lib/streamlit/runtime/metrics_util.py
@@ -27,7 +27,7 @@ from functools import lru_cache, wraps
 from typing import Any, Final, TypeVar, cast, overload
 
 from streamlit import config, file_util, type_util, util
-from streamlit.errors import LocalizableStreamlitException
+from streamlit.errors import LocalizableStreamlitException, StreamlitAPIException
 from streamlit.logger import get_logger
 from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
 from streamlit.proto.PageProfile_pb2 import Argument, Command
@@ -557,6 +557,8 @@ def format_uncaught_exception(exc: BaseException) -> str:
     - missing top-level ``streamlit`` attributes → ``"AttributeError:<attribute>"``
     - ``LocalizableStreamlitException`` with a ``parameter`` kwarg
       → ``"<Type>:<parameter>"``
+    - ``StreamlitAPIException`` with ``error_id`` (when there is no
+      ``parameter``) → ``"<Type>:<error_id>"``
 
     Does not append user values such as widget keys or file paths.
     Enrichment failures are swallowed so telemetry cannot interrupt script
@@ -597,10 +599,14 @@ def format_uncaught_exception(exc: BaseException) -> str:
                 match = _STREAMLIT_ATTRIBUTE_RE.fullmatch(str(exc))
                 if match:
                     return f"{name}:{match.group(1)}"
-        elif isinstance(exc, LocalizableStreamlitException):
-            parameter = exc.exec_kwargs.get("parameter")
-            if isinstance(parameter, str) and parameter:
-                return f"{name}:{parameter}"
+        elif isinstance(exc, StreamlitAPIException):
+            if isinstance(exc, LocalizableStreamlitException):
+                parameter = exc.exec_kwargs.get("parameter")
+                if isinstance(parameter, str) and parameter:
+                    return f"{name}:{parameter}"
+            error_id = exc.error_id
+            if isinstance(error_id, str) and error_id:
+                return f"{name}:{error_id}"
     return name
 
 

--- a/lib/streamlit/runtime/secrets.py
+++ b/lib/streamlit/runtime/secrets.py
@@ -225,6 +225,7 @@ class Secrets(Mapping[str, Any]):
                 "Error parsing secrets file at {path}: {error}",
                 path=path,
                 error=str(ex),
+                error_id="failed-parsing-secrets-file",
             ) from ex
 
         return secrets, found_secrets_file
@@ -254,6 +255,7 @@ class Secrets(Mapping[str, Any]):
                     "{sub_folder_path} is not a folder. "
                     "To use directory based secrets, mount every secret in a subfolder under the secret directory",
                     sub_folder_path=sub_folder_path,
+                    error_id="secrets-directory-entry-not-folder",
                 )
             sub_secrets = {}
 
@@ -286,6 +288,7 @@ class Secrets(Mapping[str, Any]):
         raise StreamlitSecretNotFoundError(
             "Invalid secrets path: {path}: path is not a .toml file or a directory",
             path=path,
+            error_id="invalid-secrets-path",
         )
 
     def _parse(self) -> Mapping[str, Any]:
@@ -321,6 +324,7 @@ class Secrets(Mapping[str, Any]):
                 raise StreamlitSecretNotFoundError(
                     "No secrets found. Valid paths for a secrets.toml file or secret directories are: {file_paths}",
                     file_paths=", ".join(file_paths),
+                    error_id="no-secrets-found",
                 )
 
             for k, v in secrets.items():

--- a/lib/streamlit/runtime/state/common.py
+++ b/lib/streamlit/runtime/state/common.py
@@ -294,7 +294,8 @@ def require_valid_user_key(key: str) -> None:
         )
     if is_element_id(key):
         raise StreamlitAPIException(
-            f"Keys beginning with {GENERATED_ELEMENT_ID_PREFIX} are reserved."
+            f"Keys beginning with {GENERATED_ELEMENT_ID_PREFIX} are reserved.",
+            error_id="reserved-generated-element-id-prefix",
         )
 
 

--- a/lib/streamlit/runtime/state/query_params.py
+++ b/lib/streamlit/runtime/state/query_params.py
@@ -364,7 +364,8 @@ class QueryParams(MutableMapping[str, str]):
         if self.is_bound(key):
             raise StreamlitAPIException(
                 f"Cannot directly set query parameter '{key}' - "
-                f"it is bound to a widget. Modify the widget value instead."
+                f"it is bound to a widget. Modify the widget value instead.",
+                error_id="query-param-bound-cannot-set",
             )
         self._set_item_internal(key, value)
         self._send_query_param_msg()
@@ -379,7 +380,8 @@ class QueryParams(MutableMapping[str, str]):
         if self.is_bound(key):
             raise StreamlitAPIException(
                 f"Cannot directly delete query parameter '{key}' - "
-                f"it is bound to a widget. Modify the widget value instead."
+                f"it is bound to a widget. Modify the widget value instead.",
+                error_id="query-param-bound-cannot-delete",
             )
         try:
             del self._query_params[key]
@@ -418,7 +420,8 @@ class QueryParams(MutableMapping[str, str]):
             if self.is_bound(key):
                 raise StreamlitAPIException(
                     f"Cannot directly set query parameter '{key}' - "
-                    f"it is bound to a widget. Modify the widget value instead."
+                    f"it is bound to a widget. Modify the widget value instead.",
+                    error_id="query-param-bound-cannot-set",
                 )
 
         # Now apply the updates
@@ -465,7 +468,8 @@ class QueryParams(MutableMapping[str, str]):
             raise StreamlitAPIException(
                 f"Cannot clear query parameters - the following are bound to widgets: "
                 f"{', '.join(repr(k) for k in bound_params)}. "
-                f"Modify the widget values instead, or remove the bind parameter."
+                f"Modify the widget values instead, or remove the bind parameter.",
+                error_id="query-param-bound-cannot-clear",
             )
         self.clear_with_no_forward_msg(preserve_embed=True)
         self._send_query_param_msg()
@@ -535,7 +539,8 @@ class QueryParams(MutableMapping[str, str]):
             raise StreamlitAPIException(
                 f"Cannot bind to reserved query parameter '{param_key}'. "
                 f"'{EMBED_QUERY_PARAM}' and '{EMBED_OPTIONS_QUERY_PARAM}' are "
-                f"used internally for Streamlit's embed functionality."
+                f"used internally for Streamlit's embed functionality.",
+                error_id="query-param-reserved-cannot-bind",
             )
 
         # Clean up old binding if a different widget was bound to this param
@@ -883,7 +888,8 @@ def _set_item_in_dict(
 
     if key.lower() in EMBED_QUERY_PARAMS_KEYS:
         raise StreamlitAPIException(
-            "Query param embed and embed_options (case-insensitive) cannot be set programmatically."
+            "Query param embed and embed_options (case-insensitive) cannot be set programmatically.",
+            error_id="query-param-embed-cannot-set",
         )
     # Type checking users should handle the string serialization themselves
     # We will accept any type for the list and serialize to str just in case

--- a/lib/streamlit/string_util.py
+++ b/lib/streamlit/string_util.py
@@ -99,7 +99,8 @@ def validate_emoji(maybe_emoji: str | None) -> str:
         return maybe_emoji
     raise StreamlitAPIException(
         f'The value "{maybe_emoji}" is not a valid emoji. Shortcodes are not allowed, '
-        "please use a single character instead."
+        "please use a single character instead.",
+        error_id="invalid-emoji",
     )
 
 
@@ -126,7 +127,8 @@ def validate_material_icon(maybe_material_icon: str | None) -> str:
         raise StreamlitAPIException(
             f'The value `"{maybe_material_icon.replace("/", invisible_white_space + "/")}"` is '
             "not a valid Material icon. Please use a Material icon shortcode like "
-            f"**`:material{invisible_white_space}/thumb_up:`**"
+            f"**`:material{invisible_white_space}/thumb_up:`**",
+            error_id="invalid-material-icon",
         )
 
     pack_name, icon_name = icon_match.groups()
@@ -139,7 +141,8 @@ def validate_material_icon(maybe_material_icon: str | None) -> str:
         raise StreamlitAPIException(
             f'The value `"{maybe_material_icon.replace("/", invisible_white_space + "/")}"` is not a '
             "valid Material icon. Please use a Material icon shortcode like "
-            f"**`:material{invisible_white_space}/thumb_up:`**."
+            f"**`:material{invisible_white_space}/thumb_up:`**.",
+            error_id="invalid-material-icon",
         )
 
     return f":{pack_name}/{icon_name}:"

--- a/lib/streamlit/time_util.py
+++ b/lib/streamlit/time_util.py
@@ -42,7 +42,8 @@ def adjust_years(input_date: date, years: int) -> date:
 
         raise StreamlitAPIException(  # pragma: no cover - defensive
             f"Date {input_date} does not exist in the target year {target_year}. "
-            "This should never happen. Please report this bug."
+            "This should never happen. Please report this bug.",
+            error_id="date-does-not-exist-in-year",
         ) from err
 
 

--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -452,7 +452,8 @@ def check_python_comparable(seq: Sequence[Any]) -> None:
             "Invalid option type provided. Options must be comparable, returning a "
             f"boolean when used with *==*. \n\nGot **{type(seq[0]).__name__}**, "
             "which cannot be compared. Refactor your code to use elements of "
-            "comparable types as options, e.g. use indices instead."
+            "comparable types as options, e.g. use indices instead.",
+            error_id="incomparable-select-options",
         )
 
 

--- a/lib/streamlit/user_info.py
+++ b/lib/streamlit/user_info.py
@@ -504,10 +504,16 @@ class TokensProxy(Mapping[str, str]):
         if name.startswith("_"):
             super().__setattr__(name, value)
         else:
-            raise StreamlitAPIException("st.user.tokens cannot be modified")
+            raise StreamlitAPIException(
+                "st.user.tokens cannot be modified",
+                error_id="user-tokens-cannot-be-modified",
+            )
 
     def __setitem__(self, name: str, value: Any) -> None:
-        raise StreamlitAPIException("st.user.tokens cannot be modified")
+        raise StreamlitAPIException(
+            "st.user.tokens cannot be modified",
+            error_id="user-tokens-cannot-be-modified",
+        )
 
     def __iter__(self) -> Iterator[str]:
         return iter(self._tokens)
@@ -665,10 +671,16 @@ class UserInfoProxy(Mapping[str, str | bool | TokensProxy | None]):
             raise AttributeError(f'st.user has no attribute "{key}".')
 
     def __setattr__(self, name: str, value: str | None) -> NoReturn:
-        raise StreamlitAPIException("st.user cannot be modified")
+        raise StreamlitAPIException(
+            "st.user cannot be modified",
+            error_id="user-cannot-be-modified",
+        )
 
     def __setitem__(self, name: str, value: str | None) -> NoReturn:
-        raise StreamlitAPIException("st.user cannot be modified")
+        raise StreamlitAPIException(
+            "st.user cannot be modified",
+            error_id="user-cannot-be-modified",
+        )
 
     def __iter__(self) -> Iterator[str]:
         return iter(_get_user_info())

--- a/lib/streamlit/web/server/starlette/starlette_app.py
+++ b/lib/streamlit/web/server/starlette/starlette_app.py
@@ -107,13 +107,17 @@ def _validate_run_config(
     for config_key in validated_config:
         config_option = config._config_options_template.get(config_key)
         if config_option is None:
-            raise StreamlitAPIException(f"Unrecognized config option: {config_key!r}")
+            raise StreamlitAPIException(
+                f"Unrecognized config option: {config_key!r}",
+                error_id="app-run-unrecognized-config-option",
+            )
 
         if config_option.sensitive:
             raise StreamlitAPIException(
                 f"Setting {config_key!r} option using App.run(config=...) is not "
                 "allowed. Set this option in the configuration file or environment "
-                f"variable: {config_option.env_var!r}"
+                f"variable: {config_option.env_var!r}",
+                error_id="app-run-sensitive-config-option",
             )
 
     return validated_config
@@ -575,7 +579,8 @@ class App:
             raise StreamlitAPIException(
                 "A Streamlit server is already running in this process; call "
                 "App.run() only once, and not when the app is also served via "
-                "streamlit run, uvicorn, or mounted on another framework."
+                "streamlit run, uvicorn, or mounted on another framework.",
+                error_id="app-already-running",
             )
 
         # Guard on `sys.argv[0]` representing a script path, not just on

--- a/lib/tests/streamlit/errors_test.py
+++ b/lib/tests/streamlit/errors_test.py
@@ -16,9 +16,82 @@
 
 from __future__ import annotations
 
+import ast
+import re
+from collections import Counter
+from pathlib import Path
+
 import pytest
 
 from streamlit import errors
+
+_KEBAB_CASE_ERROR_ID = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+
+# Bare ``StreamlitAPIException`` constructions without ``error_id`` are pending
+# migration to a specialized type in ``errors.py``. Do not tag them with
+# ``error_id``; migrate them in a follow-up instead.
+_UNTAGGED_STREAMLIT_API_EXCEPTION_SITES: dict[str, int] = {
+    "components/v2/__init__.py": 1,
+    "connections/sql_connection.py": 2,
+    "dataframe/lazy_df_source.py": 3,
+    "elements/arrow.py": 3,
+    "elements/deck_gl_json_chart.py": 2,
+    "elements/lib/built_in_chart_utils.py": 2,
+    "elements/markdown.py": 1,
+    "elements/pdf.py": 1,
+    "elements/pyplot.py": 1,
+    "elements/vega_charts.py": 3,
+    "elements/widgets/button_group.py": 1,
+    "elements/widgets/color_picker.py": 2,
+    "elements/widgets/pagination.py": 2,
+    "elements/widgets/slider.py": 1,
+    "elements/write.py": 1,
+    "runtime/connection_factory.py": 1,
+    "runtime/fragment.py": 1,
+    "runtime/theme_util.py": 2,
+    "web/server/starlette/starlette_app.py": 1,
+}
+
+
+def _is_streamlit_api_exception_call(func: ast.expr) -> bool:
+    if isinstance(func, ast.Name):
+        return func.id == "StreamlitAPIException"
+    return isinstance(func, ast.Attribute) and func.attr == "StreamlitAPIException"
+
+
+def _iter_streamlit_api_exception_calls() -> list[tuple[str, ast.Call]]:
+    """Return production ``StreamlitAPIException(...)`` calls as (relative path, node)."""
+    lib_root = Path(errors.__file__).parent
+    calls: list[tuple[str, ast.Call]] = []
+    for path in lib_root.rglob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and _is_streamlit_api_exception_call(
+                node.func
+            ):
+                calls.append((str(path.relative_to(lib_root)), node))
+    return calls
+
+
+# StreamlitAPIException tests
+
+
+def test_api_exception_error_id_defaults_to_none() -> None:
+    """Bare constructions keep ``error_id`` unset so existing callers stay valid."""
+    exc = errors.StreamlitAPIException("oh no")
+    assert str(exc) == "oh no"
+    assert exc.error_id is None
+
+
+def test_api_exception_stores_error_id() -> None:
+    """``error_id`` is stored on the exception and does not change the message."""
+    exc = errors.StreamlitAPIException(
+        "Failed to load secrets",
+        error_id="failed-loading-secrets-file",
+    )
+    assert str(exc) == "Failed to load secrets"
+    assert exc.error_id == "failed-loading-secrets-file"
+
 
 # LocalizableStreamlitException tests
 
@@ -47,6 +120,53 @@ def test_localizable_exception_exec_kwargs_empty() -> None:
     """Test exec_kwargs is empty when no kwargs provided."""
     exc = errors.LocalizableStreamlitException("Simple message")
     assert exc.exec_kwargs == {}
+
+
+def test_localizable_exception_error_id_is_reserved() -> None:
+    """``error_id`` is stored on the exception and omitted from ``exec_kwargs``."""
+    exc = errors.LocalizableStreamlitException(
+        "Error parsing secrets file at {path}",
+        path="secrets.toml",
+        error_id="failed-parsing-secrets-file",
+    )
+    assert str(exc) == "Error parsing secrets file at secrets.toml"
+    assert exc.error_id == "failed-parsing-secrets-file"
+    assert exc.exec_kwargs == {"path": "secrets.toml"}
+
+
+def test_streamlit_api_exception_error_ids_are_kebab_case() -> None:
+    """Literal ``error_id`` values must be kebab-case slugs.
+
+    ``ast.Name`` is allowed for computed category slugs (for example
+    ``delta_generator``). Interpolated or call-built values are not.
+    """
+    invalid: list[str] = []
+    for rel, node in _iter_streamlit_api_exception_calls():
+        error_id_kw = next((kw for kw in node.keywords if kw.arg == "error_id"), None)
+        if error_id_kw is None:
+            continue
+        value = error_id_kw.value
+        if isinstance(value, ast.Name):
+            continue
+        if isinstance(value, ast.Constant) and isinstance(value.value, str):
+            if not _KEBAB_CASE_ERROR_ID.fullmatch(value.value):
+                invalid.append(f"{rel}:{node.lineno}:{value.value}")
+            continue
+        invalid.append(f"{rel}:{node.lineno}:{type(value).__name__}")
+    assert invalid == [], "error_id values must be kebab-case:\n" + "\n".join(invalid)
+
+
+def test_untagged_api_exceptions_are_pending_specialized_types() -> None:
+    """Untagged ``StreamlitAPIException`` sites must stay on the specialized-type follow-up list.
+
+    New one-off raises should pass ``error_id``. Sites in the allowlist should be
+    migrated to a specialized type in ``errors.py`` rather than tagged.
+    """
+    untagged: Counter[str] = Counter()
+    for rel, node in _iter_streamlit_api_exception_calls():
+        if not any(kw.arg == "error_id" for kw in node.keywords):
+            untagged[rel] += 1
+    assert dict(untagged) == _UNTAGGED_STREAMLIT_API_EXCEPTION_SITES
 
 
 # StreamlitAPIWarning tests

--- a/lib/tests/streamlit/errors_test.py
+++ b/lib/tests/streamlit/errors_test.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import ast
 import re
 from collections import Counter
+from functools import cache
 from pathlib import Path
 
 import pytest
@@ -59,18 +60,46 @@ def _is_streamlit_api_exception_call(func: ast.expr) -> bool:
     return isinstance(func, ast.Attribute) and func.attr == "StreamlitAPIException"
 
 
+@cache
+def _parsed_streamlit_modules() -> tuple[tuple[str, ast.Module], ...]:
+    """Parse ``lib/streamlit`` once for the inventory tests."""
+    lib_root = Path(errors.__file__).parent
+    parsed: list[tuple[str, ast.Module]] = []
+    for path in lib_root.rglob("*.py"):
+        parsed.append(
+            (
+                path.relative_to(lib_root).as_posix(),
+                ast.parse(path.read_text(encoding="utf-8"), filename=str(path)),
+            )
+        )
+    return tuple(parsed)
+
+
 def _iter_streamlit_api_exception_calls() -> list[tuple[str, ast.Call]]:
     """Return production ``StreamlitAPIException(...)`` calls as (relative path, node)."""
-    lib_root = Path(errors.__file__).parent
     calls: list[tuple[str, ast.Call]] = []
-    for path in lib_root.rglob("*.py"):
-        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    for rel, tree in _parsed_streamlit_modules():
         for node in ast.walk(tree):
             if isinstance(node, ast.Call) and _is_streamlit_api_exception_call(
                 node.func
             ):
-                calls.append((str(path.relative_to(lib_root)), node))
+                calls.append((rel, node))
     return calls
+
+
+def _iter_error_id_kwargs() -> list[tuple[str, ast.Call, ast.expr]]:
+    """Return ``error_id=`` kwargs on production constructors, including subclasses."""
+    kwargs: list[tuple[str, ast.Call, ast.expr]] = []
+    for rel, tree in _parsed_streamlit_modules():
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            error_id_kw = next(
+                (kw for kw in node.keywords if kw.arg == "error_id"), None
+            )
+            if error_id_kw is not None:
+                kwargs.append((rel, node, error_id_kw.value))
+    return kwargs
 
 
 # StreamlitAPIException tests
@@ -137,16 +166,14 @@ def test_localizable_exception_error_id_is_reserved() -> None:
 def test_streamlit_api_exception_error_ids_are_kebab_case() -> None:
     """Literal ``error_id`` values must be kebab-case slugs.
 
-    ``ast.Name`` is allowed for computed category slugs (for example
-    ``delta_generator``). Interpolated or call-built values are not.
+    Interpolated or call-built values are not allowed so widget keys, paths,
+    and free text cannot reach telemetry labels. ``error_id=error_id``
+    pass-throughs on constructors are ignored.
     """
     invalid: list[str] = []
-    for rel, node in _iter_streamlit_api_exception_calls():
-        error_id_kw = next((kw for kw in node.keywords if kw.arg == "error_id"), None)
-        if error_id_kw is None:
-            continue
-        value = error_id_kw.value
-        if isinstance(value, ast.Name):
+    for rel, node, value in _iter_error_id_kwargs():
+        if isinstance(value, ast.Name) and value.id == "error_id":
+            # Constructor pass-through such as ``error_id=error_id``.
             continue
         if isinstance(value, ast.Constant) and isinstance(value.value, str):
             if not _KEBAB_CASE_ERROR_ID.fullmatch(value.value):
@@ -166,7 +193,12 @@ def test_untagged_api_exceptions_are_pending_specialized_types() -> None:
     for rel, node in _iter_streamlit_api_exception_calls():
         if not any(kw.arg == "error_id" for kw in node.keywords):
             untagged[rel] += 1
-    assert dict(untagged) == _UNTAGGED_STREAMLIT_API_EXCEPTION_SITES
+    assert dict(untagged) == _UNTAGGED_STREAMLIT_API_EXCEPTION_SITES, (
+        "Untagged StreamlitAPIException sites changed. Pass error_id on one-off "
+        "raises, or add the site to _UNTAGGED_STREAMLIT_API_EXCEPTION_SITES if it "
+        "should become a specialized type in errors.py. "
+        f"Found: {dict(untagged)}"
+    )
 
 
 # StreamlitAPIWarning tests

--- a/lib/tests/streamlit/errors_test.py
+++ b/lib/tests/streamlit/errors_test.py
@@ -54,10 +54,24 @@ _UNTAGGED_STREAMLIT_API_EXCEPTION_SITES: dict[str, int] = {
 }
 
 
-def _is_streamlit_api_exception_call(func: ast.expr) -> bool:
+def _constructor_name(func: ast.expr) -> str | None:
     if isinstance(func, ast.Name):
-        return func.id == "StreamlitAPIException"
-    return isinstance(func, ast.Attribute) and func.attr == "StreamlitAPIException"
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+def _is_streamlit_api_exception_call(func: ast.expr) -> bool:
+    return _constructor_name(func) == "StreamlitAPIException"
+
+
+def _is_streamlit_exception_constructor(func: ast.expr) -> bool:
+    """Match Streamlit API exception constructors that may take ``error_id``."""
+    name = _constructor_name(func)
+    if name in {"StreamlitAPIException", "LocalizableStreamlitException"}:
+        return True
+    return bool(name) and name.startswith("Streamlit") and name.endswith("Error")
 
 
 @cache
@@ -88,11 +102,13 @@ def _iter_streamlit_api_exception_calls() -> list[tuple[str, ast.Call]]:
 
 
 def _iter_error_id_kwargs() -> list[tuple[str, ast.Call, ast.expr]]:
-    """Return ``error_id=`` kwargs on production constructors, including subclasses."""
+    """Return ``error_id=`` kwargs on Streamlit exception constructors."""
     kwargs: list[tuple[str, ast.Call, ast.expr]] = []
     for rel, tree in _parsed_streamlit_modules():
         for node in ast.walk(tree):
-            if not isinstance(node, ast.Call):
+            if not isinstance(
+                node, ast.Call
+            ) or not _is_streamlit_exception_constructor(node.func):
                 continue
             error_id_kw = next(
                 (kw for kw in node.keywords if kw.arg == "error_id"), None

--- a/lib/tests/streamlit/runtime/metrics_util_test.py
+++ b/lib/tests/streamlit/runtime/metrics_util_test.py
@@ -923,9 +923,9 @@ def test_gather_metrics_records_time_when_rerun_exception_raised() -> None:
         (
             StreamlitInvalidLayoutContextError(
                 "Forms cannot be nested in other forms.",
-                error_id="nested-dialogs-not-allowed",
+                error_id="nested-forms-not-allowed",
             ),
-            "StreamlitInvalidLayoutContextError:nested-dialogs-not-allowed",
+            "StreamlitInvalidLayoutContextError:nested-forms-not-allowed",
         ),
         (
             LocalizableStreamlitException(

--- a/lib/tests/streamlit/runtime/metrics_util_test.py
+++ b/lib/tests/streamlit/runtime/metrics_util_test.py
@@ -34,6 +34,8 @@ from streamlit import config
 from streamlit.components.v1.custom_component import CustomComponent
 from streamlit.connections import SQLConnection
 from streamlit.errors import (
+    LocalizableStreamlitException,
+    StreamlitAPIException,
     StreamlitIncompatibleParametersError,
     StreamlitInvalidLayoutContextError,
     StreamlitInvalidMinMaxError,
@@ -908,6 +910,40 @@ def test_gather_metrics_records_time_when_rerun_exception_raised() -> None:
             "StreamlitInvalidLayoutContextError",
         ),
         (
+            StreamlitAPIException("Failed to load secrets"),
+            "StreamlitAPIException",
+        ),
+        (
+            StreamlitAPIException(
+                "Failed to load secrets",
+                error_id="failed-loading-secrets-file",
+            ),
+            "StreamlitAPIException:failed-loading-secrets-file",
+        ),
+        (
+            StreamlitInvalidLayoutContextError(
+                "Forms cannot be nested in other forms.",
+                error_id="nested-dialogs-not-allowed",
+            ),
+            "StreamlitInvalidLayoutContextError:nested-dialogs-not-allowed",
+        ),
+        (
+            LocalizableStreamlitException(
+                "Error parsing secrets file at {path}",
+                path="secrets.toml",
+                error_id="failed-parsing-secrets-file",
+            ),
+            "LocalizableStreamlitException:failed-parsing-secrets-file",
+        ),
+        (
+            LocalizableStreamlitException(
+                "Invalid {parameter}",
+                parameter="width",
+                error_id="should-not-appear",
+            ),
+            "LocalizableStreamlitException:width",
+        ),
+        (
             ModuleNotFoundError("No module named 'pyarrow'"),
             "ModuleNotFoundError:pyarrow",
         ),
@@ -978,6 +1014,11 @@ def test_gather_metrics_records_time_when_rerun_exception_raised() -> None:
         "value-out-of-range",
         "incompatible-parameters",
         "invalid-context-no-command-suffix",
+        "streamlit-api-exception-plain",
+        "streamlit-api-exception-error-id",
+        "streamlit-api-exception-subclass-error-id",
+        "localizable-error-id-without-parameter",
+        "localizable-parameter-takes-precedence-over-error-id",
         "modulenotfound-message-fallback",
         "import-error-message-fallback",
         "modulenotfound-private-module",


### PR DESCRIPTION
## Describe your changes

Adds optional kebab-case `error_id` on remaining one-off `StreamlitAPIException` sites so uncaught-exception telemetry can distinguish them (`StreamlitAPIException:<error_id>`).

- Sites that already match a specialized type in `errors.py` stay untagged for a follow-up migration
- On `LocalizableStreamlitException`, `parameter` still wins over `error_id` when both are set
- `error_id` is reserved on localizable exceptions so it is not interpolated into the message
- No user-facing error message text changes; every touched site only gains the `error_id` keyword argument

## GitHub Issue Link (if applicable)

## Testing Plan

- [x] Unit Tests (JS and/or Python)
  - `lib/tests/streamlit/errors_test.py` — stores `error_id`, kebab-case literals, untagged-site allowlist
  - `lib/tests/streamlit/runtime/metrics_util_test.py` — `format_uncaught_exception` suffixes and `parameter` precedence
- [ ] E2E Tests — no user-visible behavior change

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.