### PR TITLE
[chore] Fix false positive in sidebar flicker e2e test

### DIFF
--- a/e2e_playwright/st_sidebar_flicker_test.py
+++ b/e2e_playwright/st_sidebar_flicker_test.py
@@ -48,27 +48,32 @@ def verify_sidebar_state(page: Page, expected_state: str) -> None:
 def create_sidebar_monitor_script() -> str:
     """Create JavaScript to monitor sidebar state changes during page load.
 
-    Exposes two globals to the test:
+    Exposes to the test:
 
     - ``window.__sidebarStates``: the log of observed ``aria-expanded`` changes.
-    - ``window.__resetSidebarStates()``: empties that log.
+    - ``window.__lastSidebarState``: the last observed value, tracked outside
+      the log.
+    - ``window.__resetSidebarStates()``: empties the log and restarts the
+      timestamp baseline, deliberately keeping ``window.__lastSidebarState``.
 
-    The last observed value is tracked in ``window.__lastSidebarState``, which
-    deliberately lives outside the log: resetting the log must not make the next
-    observation of an unchanged sidebar look like a fresh state change.
+    Keeping the last observed value across a reset is what stops an unrelated
+    DOM mutation after the reset from looking like a fresh state change.
     """
     return """
     window.__sidebarStates = [];
     window.__monitorStarted = Date.now();
     window.__lastSidebarState = null;
 
+    // Must NOT reset window.__lastSidebarState: dropping the baseline is
+    // exactly what made an unrelated DOM mutation after the reset look like a
+    // sidebar state change.
     window.__resetSidebarStates = function() {
         window.__sidebarStates = [];
         window.__monitorStarted = Date.now();
     };
 
-    // Record a state only when it differs from the last observed one, so that
-    // repeated observations of an unchanged sidebar are not logged as changes.
+    // Skip unchanged aria-expanded values so unrelated DOM mutations are not
+    // logged as sidebar state changes.
     const recordState = (ariaExpanded, method) => {
         if (window.__lastSidebarState === ariaExpanded) {
             return;
@@ -328,10 +333,21 @@ def test_sidebar_stability_after_initial_load(page: Page, app_base_url: str):
     # Verify initial state
     verify_sidebar_state(page, "collapsed")
 
-    # Clear previous state tracking and monitor for additional changes
+    # Clear the event log and monitor for additional changes.
     page.evaluate("window.__resetSidebarStates()")
 
-    # Wait a bit more and verify state hasn't changed
+    # An unrelated DOM change must not be recorded as a sidebar state change.
+    # Asserting it explicitly keeps that regression covered: the wait below
+    # observes no mutation at all on a quiet page, so on its own it would not
+    # exercise this path.
+    page.evaluate("document.body.appendChild(document.createElement('div'))")
+    assert page.evaluate("window.__sidebarStates") == [], (
+        "an unrelated DOM mutation was recorded as a sidebar state change"
+    )
+
+    # Wait a bit more and verify state hasn't changed. A fixed wait is
+    # intentional here: the assertion is that nothing happens during a window,
+    # which `expect` cannot express.
     page.wait_for_timeout(1000)
     verify_sidebar_state(page, "collapsed")
 

--- a/e2e_playwright/st_sidebar_flicker_test.py
+++ b/e2e_playwright/st_sidebar_flicker_test.py
@@ -64,9 +64,8 @@ def create_sidebar_monitor_script() -> str:
     window.__monitorStarted = Date.now();
     window.__lastSidebarState = null;
 
-    // Must NOT reset window.__lastSidebarState: dropping the baseline is
-    // exactly what made an unrelated DOM mutation after the reset look like a
-    // sidebar state change.
+    // Do not clear window.__lastSidebarState. Reset only empties the log, so
+    // that an unchanged sidebar is not treated as a new state change.
     window.__resetSidebarStates = function() {
         window.__sidebarStates = [];
         window.__monitorStarted = Date.now();
@@ -368,3 +367,17 @@ def test_sidebar_stability_after_initial_load(page: Page, app_base_url: str):
     sidebar = page.get_by_test_id("stSidebar")
     expect(sidebar).to_be_attached()
     expect(sidebar).to_have_attribute("aria-expanded", "false")
+
+    # Last: prove the monitor is not blind after a reset. A monitor that logged
+    # nothing would satisfy every assertion above, so assert that a real change
+    # still gets recorded. Mutating the sidebar is safe here because the checks
+    # above have already run.
+    page.evaluate(
+        "document.querySelector('[data-testid=\"stSidebar\"]')"
+        ".setAttribute('aria-expanded', 'true')"
+    )
+    recorded = page.evaluate("window.__sidebarStates")
+    assert recorded, "a real sidebar state change was not recorded at all"
+    assert recorded[-1]["ariaExpanded"] == "true", (
+        f"a real sidebar state change was not recorded: {recorded}"
+    )

--- a/e2e_playwright/st_sidebar_flicker_test.py
+++ b/e2e_playwright/st_sidebar_flicker_test.py
@@ -46,38 +46,59 @@ def verify_sidebar_state(page: Page, expected_state: str) -> None:
 
 
 def create_sidebar_monitor_script() -> str:
-    """Create JavaScript to monitor sidebar state changes during page load."""
+    """Create JavaScript to monitor sidebar state changes during page load.
+
+    Exposes two globals to the test:
+
+    - ``window.__sidebarStates``: the log of observed ``aria-expanded`` changes.
+    - ``window.__resetSidebarStates()``: empties that log.
+
+    The last observed value is tracked in ``window.__lastSidebarState``, which
+    deliberately lives outside the log: resetting the log must not make the next
+    observation of an unchanged sidebar look like a fresh state change.
+    """
     return """
     window.__sidebarStates = [];
     window.__monitorStarted = Date.now();
+    window.__lastSidebarState = null;
 
-    // Override setAttribute to catch aria-expanded changes
+    window.__resetSidebarStates = function() {
+        window.__sidebarStates = [];
+        window.__monitorStarted = Date.now();
+    };
+
+    // Record a state only when it differs from the last observed one, so that
+    // repeated observations of an unchanged sidebar are not logged as changes.
+    const recordState = (ariaExpanded, method) => {
+        if (window.__lastSidebarState === ariaExpanded) {
+            return;
+        }
+        window.__lastSidebarState = ariaExpanded;
+        window.__sidebarStates.push({
+            timestamp: Date.now() - window.__monitorStarted,
+            ariaExpanded: ariaExpanded,
+            method: method
+        });
+    };
+
+    // Override setAttribute to catch a value that is set and then reverted
+    // within a single task, which the MutationObserver below would coalesce
+    // into a single callback and therefore miss.
     const originalSetAttribute = Element.prototype.setAttribute;
     Element.prototype.setAttribute = function(name, value) {
         if (this.dataset && this.dataset.testid === 'stSidebar' && name === 'aria-expanded') {
-            window.__sidebarStates.push({
-                timestamp: Date.now() - window.__monitorStarted,
-                ariaExpanded: value,
-                method: 'setAttribute'
-            });
+            recordState(value, 'setAttribute');
         }
         return originalSetAttribute.call(this, name, value);
     };
 
-    // Monitor DOM mutations
+    // Monitor DOM mutations. `childList` is needed to observe the sidebar's
+    // state as soon as it is added to the DOM, which also means this callback
+    // fires on unrelated DOM changes; recordState filters those out.
     const observer = new MutationObserver(() => {
         const sidebar = document.querySelector('[data-testid="stSidebar"]');
         if (sidebar) {
-            const ariaExpanded = sidebar.getAttribute('aria-expanded');
-            const lastState = window.__sidebarStates[window.__sidebarStates.length - 1];
-
-            if (!lastState || lastState.ariaExpanded !== ariaExpanded) {
-                window.__sidebarStates.push({
-                    timestamp: Date.now() - window.__monitorStarted,
-                    ariaExpanded: ariaExpanded,
-                    method: 'mutation'
-                });
-            }
+            recordState(sidebar.getAttribute('aria-expanded'), 'mutation');
         }
     });
 
@@ -308,7 +329,7 @@ def test_sidebar_stability_after_initial_load(page: Page, app_base_url: str):
     verify_sidebar_state(page, "collapsed")
 
     # Clear previous state tracking and monitor for additional changes
-    page.evaluate("window.__sidebarStates = []; window.__monitorStarted = Date.now();")
+    page.evaluate("window.__resetSidebarStates()")
 
     # Wait a bit more and verify state hasn't changed
     page.wait_for_timeout(1000)


### PR DESCRIPTION
## Describe your changes

Keeps the last observed sidebar `aria-expanded` value in `window.__lastSidebarState`, outside the resettable log, so clearing the log can't manufacture a state change.

`test_sidebar_stability_after_initial_load` was the most-rerun e2e test over the last four days (5 reruns, Firefox). The monitor deduplicated observations against the last entry *in the log*. The test clears that log after load, so the next `MutationObserver` callback — often an unrelated `childList` mutation while CI is still settling — found an empty log and recorded the still-collapsed value as a change. The failure message was self-inflicted: it reported `aria-expanded=false` while `false` was exactly the state being asserted.

- `__resetSidebarStates()` clears the log and restarts timestamps without resetting the last observed value.
- Both the `setAttribute` override and the observer now record through one `recordState` helper, so they share a single baseline.
- A genuine post-load `false → true` change is still recorded and still fails the test.

## Testing Plan

- `test_sidebar_stability_after_initial_load` now appends an unrelated DOM node after the reset and asserts the log stays empty, so the false-positive path is exercised deterministically rather than depending on CI being noisy. Locally there are **0** observer callbacks in that 1s window, which is why this only ever failed in CI.
- `st_sidebar_flicker_test.py` passed 15/15 consecutive full-file runs on Firefox before review changes, and 6/6 after.
- Verified separately that the previous monitor records a bogus entry after the log is cleared plus one unrelated DOM mutation, that the new monitor records nothing in that case, and that the new monitor still records a real `false → true` change.
- No manual testing needed: test-harness logic only, no production code paths.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> E2E test harness JavaScript only; no production sidebar or app behavior changes.
> 
> **Overview**
> Fixes flaky **`test_sidebar_stability_after_initial_load`** by changing how the injected sidebar monitor deduplicates `aria-expanded` events after the test clears its log.
> 
> The monitor now keeps **`window.__lastSidebarState`** across **`__resetSidebarStates()`** (log + timestamp only) and routes both the `setAttribute` hook and `MutationObserver` through **`recordState`**, so an unrelated `childList` mutation in CI no longer logs the same collapsed value as a new change when the log was empty.
> 
> **`test_sidebar_stability_after_initial_load`** uses the reset helper, **deterministically** appends a dummy DOM node and asserts the log stays empty, then **mutates** `aria-expanded` to prove the monitor still records a real post-reset change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d505d415ef74991dea9c2566461cc3884988eec2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->