### PR TITLE
[fix] Keep evicted fragments from lingering on screen

### DIFF
--- a/e2e_playwright/st_fragment_run_every.py
+++ b/e2e_playwright/st_fragment_run_every.py
@@ -49,5 +49,10 @@ def outer_nested_demo():
 
         middle()
 
+    # Deliberately after the conditional: this makes the nested fragment a
+    # non-final child, so clearing it would be observable if it ever shifted
+    # this sibling's delta path.
+    st.write("after nested auto fragment")
+
 
 outer_nested_demo()

--- a/e2e_playwright/st_fragment_run_every_test.py
+++ b/e2e_playwright/st_fragment_run_every_test.py
@@ -56,6 +56,10 @@ def test_nested_fragment_run_every_can_hide_without_crash(app: Page):
 
     expect(app.get_by_test_id("stException")).to_have_count(0)
 
+    # The sibling written after the nested fragment must still be there exactly
+    # once: clearing the nested fragment must not shift or duplicate it.
+    expect(app.get_by_text("after nested auto fragment")).to_have_count(1)
+
     # Standalone auto fragment keeps ticking; no frontend exception across ticks.
     for _ in range(3):
         expect(standalone_fragment.get_by_test_id("stMarkdown").first).not_to_have_text(

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -4092,7 +4092,9 @@ describe("App", () => {
       expect(idsAfterStop).not.toContain("fragmentA")
       expect(idsAfterStop.every(id => id === "fragmentB")).toBe(true)
     })
+  })
 
+  describe("App.handleStopAutoRerun", () => {
     it("drops the evicted fragment's elements on a stopAutoRerun message", async () => {
       renderApp(getProps())
       act(() => {

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -4092,6 +4092,55 @@ describe("App", () => {
       expect(idsAfterStop).not.toContain("fragmentA")
       expect(idsAfterStop.every(id => id === "fragmentB")).toBe(true)
     })
+
+    it("drops the evicted fragment's elements on a stopAutoRerun message", async () => {
+      renderApp(getProps())
+      act(() => {
+        getMockConnectionManagerProp("connectionStateChanged")(
+          ConnectionState.CONNECTED
+        )
+      })
+
+      const sendFragmentText = (
+        fragmentId: string,
+        body: string,
+        deltaPath: number[]
+      ): void => {
+        sendForwardMessage(
+          "delta",
+          {
+            type: "newElement",
+            fragmentId,
+            newElement: { type: "text", text: { body, help: "" } },
+          },
+          { deltaPath, activeScriptHash: "hash1" }
+        )
+      }
+
+      act(() => {
+        sendFragmentText("fragmentA", "from evicted fragment", [0, 0])
+        sendFragmentText("fragmentB", "from surviving fragment", [0, 1])
+      })
+
+      await waitFor(() => {
+        expect(screen.getByText("from evicted fragment")).toBeInTheDocument()
+      })
+      expect(screen.getByText("from surviving fragment")).toBeInTheDocument()
+
+      // The server evicts fragmentA. Its elements must go even though no
+      // successful run follows to trigger the usual stale-node cleanup.
+      act(() => {
+        sendForwardMessage("stopAutoRerun", { fragmentIds: ["fragmentA"] })
+      })
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText("from evicted fragment")
+        ).not.toBeInTheDocument()
+      })
+      // An unrelated fragment's elements must survive.
+      expect(screen.getByText("from surviving fragment")).toBeInTheDocument()
+    })
   })
 
   describe("App.requestFileURLs", () => {

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -4101,31 +4101,61 @@ describe("App", () => {
         )
       })
 
-      const sendFragmentText = (
+      // Text elements make the removal observable in the DOM; widget elements
+      // carry ids, which is what `removeInactiveWidgetState` acts on. The "$$ID"
+      // prefix is required by `isValidElementId`
+      // (GENERATED_ELEMENT_ID_PREFIX in ~lib/util/utils).
+      const evictedWidgetId = "$$ID-evicted-widget"
+      const survivingWidgetId = "$$ID-surviving-widget"
+
+      const sendFragmentDelta = (
         fragmentId: string,
-        body: string,
+        newElement: Record<string, unknown>,
         deltaPath: number[]
       ): void => {
         sendForwardMessage(
           "delta",
-          {
-            type: "newElement",
-            fragmentId,
-            newElement: { type: "text", text: { body, help: "" } },
-          },
+          { type: "newElement", fragmentId, newElement },
           { deltaPath, activeScriptHash: "hash1" }
         )
       }
 
       act(() => {
-        sendFragmentText("fragmentA", "from evicted fragment", [0, 0])
-        sendFragmentText("fragmentB", "from surviving fragment", [0, 1])
+        sendFragmentDelta(
+          "fragmentA",
+          { type: "text", text: { body: "from evicted fragment", help: "" } },
+          [0, 0]
+        )
+        sendFragmentDelta(
+          "fragmentA",
+          {
+            type: "textInput",
+            textInput: { id: evictedWidgetId, label: "evicted widget" },
+          },
+          [0, 1]
+        )
+        sendFragmentDelta(
+          "fragmentB",
+          {
+            type: "text",
+            text: { body: "from surviving fragment", help: "" },
+          },
+          [0, 2]
+        )
+        sendFragmentDelta(
+          "fragmentB",
+          {
+            type: "textInput",
+            textInput: { id: survivingWidgetId, label: "surviving widget" },
+          },
+          [0, 3]
+        )
       })
 
       await waitFor(() => {
-        expect(screen.getByText("from evicted fragment")).toBeInTheDocument()
+        expect(screen.getByText("from evicted fragment")).toBeVisible()
       })
-      expect(screen.getByText("from surviving fragment")).toBeInTheDocument()
+      expect(screen.getByText("from surviving fragment")).toBeVisible()
 
       // Pruning must be paired with widget-state cleanup, as it is on every
       // other pruning path. Otherwise an evicted fragment's widget values keep
@@ -4145,8 +4175,14 @@ describe("App", () => {
         ).not.toBeInTheDocument()
       })
       // An unrelated fragment's elements must survive.
-      expect(screen.getByText("from surviving fragment")).toBeInTheDocument()
+      expect(screen.getByText("from surviving fragment")).toBeVisible()
+
+      // Assert the active-id set itself, not just that cleanup ran: a call made
+      // with the pre-prune set would still have removed nothing.
       expect(removeInactive).toHaveBeenCalled()
+      const activeIds = removeInactive.mock.calls.at(-1)?.[0] as Set<string>
+      expect(activeIds.has(evictedWidgetId)).toBe(false)
+      expect(activeIds.has(survivingWidgetId)).toBe(true)
     })
   })
 

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -4127,6 +4127,12 @@ describe("App", () => {
       })
       expect(screen.getByText("from surviving fragment")).toBeInTheDocument()
 
+      // Pruning must be paired with widget-state cleanup, as it is on every
+      // other pruning path. Otherwise an evicted fragment's widget values keep
+      // being sent, and a fragment that returns reuses the retained value.
+      const widgetMgr = getStoredValue<WidgetStateManager>(WidgetStateManager)
+      const removeInactive = vi.spyOn(widgetMgr, "removeInactive")
+
       // The server evicts fragmentA. Its elements must go even though no
       // successful run follows to trigger the usual stale-node cleanup.
       act(() => {
@@ -4140,6 +4146,7 @@ describe("App", () => {
       })
       // An unrelated fragment's elements must survive.
       expect(screen.getByText("from surviving fragment")).toBeInTheDocument()
+      expect(removeInactive).toHaveBeenCalled()
     })
   })
 

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1363,10 +1363,19 @@ export class App extends PureComponent<Props, State> {
     })
 
     const evictedFragmentIds = new Set(stopAutoRerun.fragmentIds)
-    this.setState(prevState => ({
-      elements:
-        prevState.elements.clearEvictedFragmentNodes(evictedFragmentIds),
-    }))
+    this.setState(
+      prevState => ({
+        elements:
+          prevState.elements.clearEvictedFragmentNodes(evictedFragmentIds),
+      }),
+      () => {
+        // Drop widget state for the removed nodes, as every other pruning path
+        // does. Without this, an evicted fragment's widget values keep being
+        // sent on later reruns, and a fragment that comes back initializes its
+        // widgets from the retained value instead of its default.
+        this.removeInactiveWidgetState()
+      }
+    )
   }
 
   /**

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1359,17 +1359,29 @@ export class App extends PureComponent<Props, State> {
     })
 
     const evictedFragmentIds = new Set(stopAutoRerun.fragmentIds)
+
+    // The updater form is required here: ForwardMsgs are dispatched in batches,
+    // so reading `this.state.elements` directly could apply the prune to a stale
+    // tree and clobber deltas from the same batch. Returning null when nothing
+    // matched skips both the re-render and the widget scan below, which matters
+    // because this handler fires once per evicting fragment run - about once a
+    // second under `run_every`.
+    let didPrune = false
     this.setState(
-      prevState => ({
-        elements:
-          prevState.elements.clearEvictedFragmentNodes(evictedFragmentIds),
-      }),
+      prevState => {
+        const nextElements =
+          prevState.elements.clearEvictedFragmentNodes(evictedFragmentIds)
+        didPrune = nextElements !== prevState.elements
+        return didPrune ? { elements: nextElements } : null
+      },
       () => {
-        // Drop widget state for the removed nodes, as every other pruning path
+        // Drop widget state for the cleared nodes, as every other pruning path
         // does. Without this, an evicted fragment's widget values keep being
         // sent on later reruns, and a fragment that comes back initializes its
         // widgets from the retained value instead of its default.
-        this.removeInactiveWidgetState()
+        if (didPrune) {
+          this.removeInactiveWidgetState()
+        }
       }
     )
   }

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1347,12 +1347,26 @@ export class App extends PureComponent<Props, State> {
   /**
    * Handler for ForwardMsg.stopAutoRerun messages. The server sends this when
    * it evicts fragments (e.g. a nested ``run_every`` fragment whose ancestor
-   * stopped rendering it), so we cancel their pending auto-rerun timers.
+   * stopped rendering it), so we cancel their pending auto-rerun timers and
+   * drop any of their nodes still in the element tree.
+   *
+   * Dropping the nodes here is what keeps an evicted fragment from lingering on
+   * screen. The end-of-run `clearStaleNodes` is skipped when a run finishes as
+   * `FINISHED_EARLY_FOR_RERUN`, and the runs that follow are scoped to other
+   * fragments, so the evicted subtree is never revisited. Since its auto-rerun
+   * is cancelled just above, those nodes would otherwise stay frozen on screen
+   * showing stale content until a full rerun.
    */
   handleStopAutoRerun = (stopAutoRerun: StopAutoRerun): void => {
     stopAutoRerun.fragmentIds.forEach(fragmentId => {
       this.clearAutoRerunInterval(fragmentId)
     })
+
+    const evictedFragmentIds = new Set(stopAutoRerun.fragmentIds)
+    this.setState(prevState => ({
+      elements:
+        prevState.elements.clearEvictedFragmentNodes(evictedFragmentIds),
+    }))
   }
 
   /**

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1345,17 +1345,13 @@ export class App extends PureComponent<Props, State> {
   }
 
   /**
-   * Handler for ForwardMsg.stopAutoRerun messages. The server sends this when
-   * it evicts fragments (e.g. a nested ``run_every`` fragment whose ancestor
-   * stopped rendering it), so we cancel their pending auto-rerun timers and
-   * drop any of their nodes still in the element tree.
+   * Handle server eviction of fragments by cancelling their timers and pruning
+   * their nodes.
    *
-   * Dropping the nodes here is what keeps an evicted fragment from lingering on
-   * screen. The end-of-run `clearStaleNodes` is skipped when a run finishes as
-   * `FINISHED_EARLY_FOR_RERUN`, and the runs that follow are scoped to other
-   * fragments, so the evicted subtree is never revisited. Since its auto-rerun
-   * is cancelled just above, those nodes would otherwise stay frozen on screen
-   * showing stale content until a full rerun.
+   * Dropping the nodes keeps an evicted fragment from lingering on screen; its
+   * timer is cancelled here too, so without this the nodes would sit frozen
+   * showing stale content. See `ClearEvictedFragmentNodesVisitor` for why
+   * end-of-run `clearStaleNodes` cannot reach them.
    */
   handleStopAutoRerun = (stopAutoRerun: StopAutoRerun): void => {
     stopAutoRerun.fragmentIds.forEach(fragmentId => {

--- a/frontend/lib/src/render-tree/AppRoot.test.ts
+++ b/frontend/lib/src/render-tree/AppRoot.test.ts
@@ -221,6 +221,85 @@ describe("AppRoot", () => {
     })
   })
 
+  describe("AppRoot.clearEvictedFragmentNodes", () => {
+    const RUN = "run_1"
+
+    function fragmentTextDelta(body: string, fragmentId: string): DeltaProto {
+      return makeProto(DeltaProto, {
+        newElement: { text: { body } },
+        fragmentId,
+      })
+    }
+
+    it("returns the same instance when nothing is evicted", () => {
+      const root = AppRoot.empty(FAKE_SCRIPT_HASH, false).applyDelta(
+        RUN,
+        fragmentTextDelta("kept", "fragB"),
+        forwardMsgMetadata([0, 0])
+      )
+
+      expect(root.clearEvictedFragmentNodes(new Set(["absent"]))).toBe(root)
+    })
+
+    it("returns the same instance for an empty eviction set", () => {
+      const root = AppRoot.empty(FAKE_SCRIPT_HASH, false)
+
+      expect(root.clearEvictedFragmentNodes(new Set())).toBe(root)
+    })
+
+    it("keeps a later delta addressing a surviving sibling's original path", () => {
+      // The reason evicted nodes are replaced rather than removed. Removing
+      // would compact `children`, so this second delta would append a duplicate
+      // instead of overwriting the survivor.
+      let root = AppRoot.empty(FAKE_SCRIPT_HASH, false)
+      root = root.applyDelta(
+        RUN,
+        fragmentTextDelta("evicted", "fragA"),
+        forwardMsgMetadata([0, 0])
+      )
+      root = root.applyDelta(
+        RUN,
+        fragmentTextDelta("live", "fragB"),
+        forwardMsgMetadata([0, 1])
+      )
+
+      root = root.clearEvictedFragmentNodes(new Set(["fragA"]))
+
+      // fragB reruns on its own and rewrites its original absolute path.
+      root = root.applyDelta(
+        RUN,
+        fragmentTextDelta("live v2", "fragB"),
+        forwardMsgMetadata([0, 1])
+      )
+
+      expect(root.main.children).toHaveLength(2)
+      expect(root.main.children[1]).toBeTextNode("live v2")
+      // The survivor must not have been duplicated by an index shift.
+      const bodies = root.main.children.map(child =>
+        child instanceof ElementNode ? child.element.text?.body : "<block>"
+      )
+      expect(bodies).toEqual(["<block>", "live v2"])
+    })
+
+    it("preserves the app logo", () => {
+      const logo = makeProto(LogoProto, { image: "https://example.com/l.png" })
+      const root = AppRoot.empty(FAKE_SCRIPT_HASH, false)
+        .appRootWithLogo(logo, {
+          activeScriptHash: FAKE_SCRIPT_HASH,
+          scriptRunId: RUN,
+        })
+        .applyDelta(
+          RUN,
+          fragmentTextDelta("evicted", "fragA"),
+          forwardMsgMetadata([0, 0])
+        )
+
+      const cleared = root.clearEvictedFragmentNodes(new Set(["fragA"]))
+
+      expect(cleared.logo).toEqual(logo)
+    })
+  })
+
   describe("AppRoot.applyDelta", () => {
     it("handles 'newElement' deltas", () => {
       const delta = makeProto(DeltaProto, {

--- a/frontend/lib/src/render-tree/AppRoot.ts
+++ b/frontend/lib/src/render-tree/AppRoot.ts
@@ -388,11 +388,12 @@ export class AppRoot {
   }
 
   /**
-   * Remove nodes belonging to fragments the server has evicted.
+   * Clear nodes belonging to fragments the server has evicted, replacing them
+   * with empty blocks so sibling indices stay valid.
    *
-   * Enforces the invariant that an evicted fragment owns no nodes in the element
-   * tree; see `ClearEvictedFragmentNodesVisitor` for why `clearStaleNodes`
-   * cannot guarantee this.
+   * Enforces the invariant that an evicted fragment renders nothing; see
+   * `ClearEvictedFragmentNodesVisitor` for why `clearStaleNodes` cannot
+   * guarantee this and why the nodes are substituted rather than removed.
    */
   public clearEvictedFragmentNodes(
     evictedFragmentIds: ReadonlySet<string>

--- a/frontend/lib/src/render-tree/AppRoot.ts
+++ b/frontend/lib/src/render-tree/AppRoot.ts
@@ -35,6 +35,7 @@ import { AppNode, NO_SCRIPT_RUN_ID } from "./AppNode.interface"
 import { BlockNode } from "./BlockNode"
 import { ElementNode } from "./ElementNode"
 import { TransientNode } from "./TransientNode"
+import { ClearEvictedFragmentNodesVisitor } from "./visitors/ClearEvictedFragmentNodesVisitor"
 import { ClearStaleNodeVisitor } from "./visitors/ClearStaleNodeVisitor"
 import { ClearTransientNodesVisitor } from "./visitors/ClearTransientNodesVisitor"
 import { DebugVisitor } from "./visitors/DebugVisitor"
@@ -370,6 +371,39 @@ export class AppRoot {
 
   public clearTransientNodes(fragmentIdsThisRun?: Array<string>): AppRoot {
     const visitor = new ClearTransientNodesVisitor(fragmentIdsThisRun)
+    const newChildren = this.root.children.map(node =>
+      this.ensureBlockNode(node.accept(visitor))
+    )
+
+    return new AppRoot(
+      this.mainScriptHash,
+      new BlockNode(
+        this.mainScriptHash,
+        newChildren,
+        new BlockProto({ allowEmpty: true }),
+        this.main.scriptRunId
+      ),
+      this.appLogo
+    )
+  }
+
+  /**
+   * Remove nodes belonging to fragments the server has evicted.
+   *
+   * Upholds the invariant that an evicted fragment owns no nodes in the element
+   * tree, which `clearStaleNodes` cannot guarantee on its own: a fragment rerun
+   * that ends as `FINISHED_EARLY_FOR_RERUN` skips stale-node cleanup, and later
+   * runs are scoped to other fragments, so the evicted subtree is never
+   * revisited.
+   */
+  public clearEvictedFragmentNodes(
+    evictedFragmentIds: ReadonlySet<string>
+  ): AppRoot {
+    if (evictedFragmentIds.size === 0) {
+      return this
+    }
+
+    const visitor = new ClearEvictedFragmentNodesVisitor(evictedFragmentIds)
     const newChildren = this.root.children.map(node =>
       this.ensureBlockNode(node.accept(visitor))
     )

--- a/frontend/lib/src/render-tree/AppRoot.ts
+++ b/frontend/lib/src/render-tree/AppRoot.ts
@@ -390,11 +390,9 @@ export class AppRoot {
   /**
    * Remove nodes belonging to fragments the server has evicted.
    *
-   * Upholds the invariant that an evicted fragment owns no nodes in the element
-   * tree, which `clearStaleNodes` cannot guarantee on its own: a fragment rerun
-   * that ends as `FINISHED_EARLY_FOR_RERUN` skips stale-node cleanup, and later
-   * runs are scoped to other fragments, so the evicted subtree is never
-   * revisited.
+   * Enforces the invariant that an evicted fragment owns no nodes in the element
+   * tree; see `ClearEvictedFragmentNodesVisitor` for why `clearStaleNodes`
+   * cannot guarantee this.
    */
   public clearEvictedFragmentNodes(
     evictedFragmentIds: ReadonlySet<string>
@@ -407,6 +405,12 @@ export class AppRoot {
     const newChildren = this.root.children.map(node =>
       this.ensureBlockNode(node.accept(visitor))
     )
+
+    // No matching fragment was in the tree. Returning the same AppRoot keeps
+    // `state.elements` referentially stable so `App` does not re-render.
+    if (newChildren.every((child, i) => child === this.root.children[i])) {
+      return this
+    }
 
     return new AppRoot(
       this.mainScriptHash,

--- a/frontend/lib/src/render-tree/visitors/ClearEvictedFragmentNodesVisitor.test.ts
+++ b/frontend/lib/src/render-tree/visitors/ClearEvictedFragmentNodesVisitor.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Block as BlockProto,
+  Element,
+  ForwardMsgMetadata,
+} from "@streamlit/protobuf"
+
+import { BlockNode } from "~lib/render-tree/BlockNode"
+import { ElementNode } from "~lib/render-tree/ElementNode"
+import { FAKE_SCRIPT_HASH } from "~lib/render-tree/test-utils"
+
+import { ClearEvictedFragmentNodesVisitor } from "./ClearEvictedFragmentNodesVisitor"
+
+const SCRIPT_RUN_ID = "run_1"
+
+function elementNode(body: string, fragmentId?: string): ElementNode {
+  return new ElementNode(
+    new Element({ text: { body } }),
+    ForwardMsgMetadata.create(),
+    SCRIPT_RUN_ID,
+    FAKE_SCRIPT_HASH,
+    fragmentId
+  )
+}
+
+function blockNode(
+  children: (BlockNode | ElementNode)[],
+  fragmentId?: string
+): BlockNode {
+  return new BlockNode(
+    FAKE_SCRIPT_HASH,
+    children,
+    new BlockProto({ allowEmpty: true }),
+    SCRIPT_RUN_ID,
+    fragmentId
+  )
+}
+
+describe("ClearEvictedFragmentNodesVisitor", () => {
+  it("removes an element node belonging to an evicted fragment", () => {
+    const visitor = new ClearEvictedFragmentNodesVisitor(new Set(["nested"]))
+
+    expect(elementNode("gone", "nested").accept(visitor)).toBeUndefined()
+  })
+
+  it("keeps element nodes of other fragments and of no fragment", () => {
+    const visitor = new ClearEvictedFragmentNodesVisitor(new Set(["nested"]))
+
+    const otherFragment = elementNode("kept", "outer")
+    const noFragment = elementNode("kept")
+
+    expect(otherFragment.accept(visitor)).toBe(otherFragment)
+    expect(noFragment.accept(visitor)).toBe(noFragment)
+  })
+
+  it("removes a block belonging to an evicted fragment, with its subtree", () => {
+    const visitor = new ClearEvictedFragmentNodesVisitor(new Set(["nested"]))
+    const nestedBlock = blockNode([elementNode("inner")], "nested")
+
+    expect(nestedBlock.accept(visitor)).toBeUndefined()
+  })
+
+  it("removes an evicted child from a surviving parent block", () => {
+    const visitor = new ClearEvictedFragmentNodesVisitor(new Set(["nested"]))
+    const kept = elementNode("kept", "outer")
+    const parent = blockNode(
+      [kept, blockNode([elementNode("inner", "nested")], "nested")],
+      "outer"
+    )
+
+    const result = parent.accept(visitor) as BlockNode
+
+    expect(result).not.toBe(parent)
+    expect(result.children).toHaveLength(1)
+    expect(result.children[0]).toBe(kept)
+    // Identity of the surviving parent's own metadata is preserved.
+    expect(result.fragmentId).toBe("outer")
+    expect(result.scriptRunId).toBe(SCRIPT_RUN_ID)
+  })
+
+  it("returns the identical node when nothing is evicted", () => {
+    const visitor = new ClearEvictedFragmentNodesVisitor(new Set(["absent"]))
+    const parent = blockNode([elementNode("kept", "outer")], "outer")
+
+    // Referential stability matters: a new node would re-render the subtree.
+    expect(parent.accept(visitor)).toBe(parent)
+  })
+
+  it("removes nodes nested several blocks deep", () => {
+    const visitor = new ClearEvictedFragmentNodesVisitor(new Set(["nested"]))
+    const parent = blockNode([
+      blockNode([blockNode([elementNode("deep", "nested")], "nested")]),
+    ])
+
+    const result = parent.accept(visitor) as BlockNode
+
+    expect(result.children).toHaveLength(1)
+    expect((result.children[0] as BlockNode).children).toHaveLength(0)
+  })
+})

--- a/frontend/lib/src/render-tree/visitors/ClearEvictedFragmentNodesVisitor.test.ts
+++ b/frontend/lib/src/render-tree/visitors/ClearEvictedFragmentNodesVisitor.test.ts
@@ -39,6 +39,16 @@ function elementNode(body: string, fragmentId?: string): ElementNode {
   )
 }
 
+function toastNode(fragmentId?: string): ElementNode {
+  return new ElementNode(
+    new Element({ toast: { body: "Toast survives eviction" } }),
+    ForwardMsgMetadata.create(),
+    SCRIPT_RUN_ID,
+    FAKE_SCRIPT_HASH,
+    fragmentId
+  )
+}
+
 function blockNode(
   children: (BlockNode | ElementNode)[],
   fragmentId?: string
@@ -52,11 +62,24 @@ function blockNode(
   )
 }
 
+/** True for the index-preserving stand-in the visitor substitutes. */
+function isPlaceholder(node: unknown): boolean {
+  return (
+    node instanceof BlockNode &&
+    node.children.length === 0 &&
+    !node.deltaBlock.allowEmpty
+  )
+}
+
 describe("ClearEvictedFragmentNodesVisitor", () => {
-  it("removes an element node belonging to an evicted fragment", () => {
+  it("replaces an evicted fragment's element with a placeholder", () => {
     const visitor = new ClearEvictedFragmentNodesVisitor(new Set(["nested"]))
 
-    expect(elementNode("gone", "nested").accept(visitor)).toBeUndefined()
+    const result = elementNode("gone", "nested").accept(visitor)
+
+    // An empty block with allowEmpty unset renders nothing, so the stale content
+    // disappears while the index survives.
+    expect(isPlaceholder(result)).toBe(true)
   })
 
   it("keeps element nodes of other fragments and of no fragment", () => {
@@ -70,58 +93,50 @@ describe("ClearEvictedFragmentNodesVisitor", () => {
   })
 
   it("preserves a toast emitted by an evicted fragment (issue #7740)", () => {
-    // A fragment's toast carries that fragment's id. If the eviction lands in
-    // the same batch as the toast delta, pruning the node here would drop the
-    // notification before the Toast component registers it with the queue.
+    // A fragment's toast carries that fragment's id. Replacing the node here
+    // would drop the notification before the Toast component registers it with
+    // the queue.
     const visitor = new ClearEvictedFragmentNodesVisitor(new Set(["nested"]))
-    const toast = new ElementNode(
-      new Element({ toast: { body: "Toast survives eviction" } }),
-      ForwardMsgMetadata.create(),
-      SCRIPT_RUN_ID,
-      FAKE_SCRIPT_HASH,
-      "nested"
-    )
+    const toast = toastNode("nested")
 
     expect(toast.accept(visitor)).toBe(toast)
   })
 
-  it("keeps an evicted fragment's toast while removing its other elements", () => {
+  it("keeps an evicted fragment's toast while replacing its other elements", () => {
     const visitor = new ClearEvictedFragmentNodesVisitor(new Set(["nested"]))
-    const toast = new ElementNode(
-      new Element({ toast: { body: "Toast survives eviction" } }),
-      ForwardMsgMetadata.create(),
-      SCRIPT_RUN_ID,
-      FAKE_SCRIPT_HASH,
-      "nested"
-    )
+    const toast = toastNode("nested")
     const parent = blockNode([toast, elementNode("gone", "nested")], "outer")
 
     const result = parent.accept(visitor) as BlockNode
 
-    expect(result.children).toEqual([toast])
+    expect(result.children[0]).toBe(toast)
+    expect(isPlaceholder(result.children[1])).toBe(true)
   })
 
-  it("removes a block belonging to an evicted fragment, with its subtree", () => {
+  it("replaces a block of an evicted fragment, dropping its subtree", () => {
     const visitor = new ClearEvictedFragmentNodesVisitor(new Set(["nested"]))
     const nestedBlock = blockNode([elementNode("inner")], "nested")
 
-    expect(nestedBlock.accept(visitor)).toBeUndefined()
+    expect(isPlaceholder(nestedBlock.accept(visitor))).toBe(true)
   })
 
-  it("removes an evicted child from a surviving parent block", () => {
+  it("preserves sibling indices when replacing an evicted child", () => {
+    // The point of substituting rather than removing: deltas address nodes by
+    // absolute path, and `addBlock` inherits children instead of resetting them,
+    // so compacting would leave every later sibling permanently shifted.
     const visitor = new ClearEvictedFragmentNodesVisitor(new Set(["nested"]))
     const kept = elementNode("kept", "outer")
     const parent = blockNode(
-      [kept, blockNode([elementNode("inner", "nested")], "nested")],
+      [blockNode([elementNode("inner", "nested")], "nested"), kept],
       "outer"
     )
 
     const result = parent.accept(visitor) as BlockNode
 
-    expect(result).not.toBe(parent)
-    expect(result.children).toHaveLength(1)
-    expect(result.children[0]).toBe(kept)
-    // The surviving parent keeps its fragmentId and scriptRunId.
+    expect(result.children).toHaveLength(2)
+    expect(isPlaceholder(result.children[0])).toBe(true)
+    // Still at index 1, not shifted down to 0.
+    expect(result.children[1]).toBe(kept)
     expect(result.fragmentId).toBe("outer")
     expect(result.scriptRunId).toBe(SCRIPT_RUN_ID)
   })
@@ -134,16 +149,28 @@ describe("ClearEvictedFragmentNodesVisitor", () => {
     expect(parent.accept(visitor)).toBe(parent)
   })
 
+  it("replaces nodes nested several blocks deep", () => {
+    const visitor = new ClearEvictedFragmentNodesVisitor(new Set(["nested"]))
+    const parent = blockNode([
+      blockNode([blockNode([elementNode("deep", "nested")], "nested")]),
+    ])
+
+    const result = parent.accept(visitor) as BlockNode
+    const middle = result.children[0] as BlockNode
+
+    expect(middle.children).toHaveLength(1)
+    expect(isPlaceholder(middle.children[0])).toBe(true)
+  })
+
   describe("transient nodes", () => {
     it("returns the identical node when nothing in its subtree is evicted", () => {
       const visitor = new ClearEvictedFragmentNodesVisitor(new Set(["absent"]))
       const transient = new TransientNode(
         SCRIPT_RUN_ID,
         elementNode("anchor", "outer"),
-        [elementNode("toast", "outer")]
+        [elementNode("transient", "outer")]
       )
 
-      // Referential stability: reconstructing would re-render this subtree.
       expect(transient.accept(visitor)).toBe(transient)
     })
 
@@ -151,33 +178,48 @@ describe("ClearEvictedFragmentNodesVisitor", () => {
       const visitor = new ClearEvictedFragmentNodesVisitor(new Set(["nested"]))
       const anchor = elementNode("anchor", "outer")
       const transient = new TransientNode(SCRIPT_RUN_ID, anchor, [
-        elementNode("toast", "nested"),
+        elementNode("transient", "nested"),
       ])
 
       expect(transient.accept(visitor)).toBe(anchor)
     })
 
-    it("removes the whole node when anchor and transients are evicted", () => {
+    it("replaces the node when it has no anchor and all transients are evicted", () => {
+      // `addTransient` places a TransientNode at an absolute delta path with no
+      // anchor, so removing it here would compact the parent and shift every
+      // later sibling.
+      const visitor = new ClearEvictedFragmentNodesVisitor(new Set(["nested"]))
+      const transient = new TransientNode(SCRIPT_RUN_ID, undefined, [
+        elementNode("transient", "nested"),
+      ])
+
+      expect(isPlaceholder(transient.accept(visitor))).toBe(true)
+    })
+
+    it("replaces an evicted anchor rather than dropping it", () => {
       const visitor = new ClearEvictedFragmentNodesVisitor(new Set(["nested"]))
       const transient = new TransientNode(
         SCRIPT_RUN_ID,
         elementNode("anchor", "nested"),
-        [elementNode("toast", "nested")]
+        [elementNode("transient", "outer")]
       )
 
-      expect(transient.accept(visitor)).toBeUndefined()
+      const result = transient.accept(visitor) as TransientNode
+
+      expect(result).toBeInstanceOf(TransientNode)
+      expect(isPlaceholder(result.anchor)).toBe(true)
     })
-  })
 
-  it("removes nodes nested several blocks deep", () => {
-    const visitor = new ClearEvictedFragmentNodesVisitor(new Set(["nested"]))
-    const parent = blockNode([
-      blockNode([blockNode([elementNode("deep", "nested")], "nested")]),
-    ])
+    it("keeps a transient toast belonging to an evicted fragment", () => {
+      const visitor = new ClearEvictedFragmentNodesVisitor(new Set(["nested"]))
+      const toast = toastNode("nested")
+      const transient = new TransientNode(
+        SCRIPT_RUN_ID,
+        elementNode("anchor", "outer"),
+        [toast]
+      )
 
-    const result = parent.accept(visitor) as BlockNode
-
-    expect(result.children).toHaveLength(1)
-    expect((result.children[0] as BlockNode).children).toHaveLength(0)
+      expect(transient.accept(visitor)).toBe(transient)
+    })
   })
 })

--- a/frontend/lib/src/render-tree/visitors/ClearEvictedFragmentNodesVisitor.test.ts
+++ b/frontend/lib/src/render-tree/visitors/ClearEvictedFragmentNodesVisitor.test.ts
@@ -23,6 +23,7 @@ import {
 import { BlockNode } from "~lib/render-tree/BlockNode"
 import { ElementNode } from "~lib/render-tree/ElementNode"
 import { FAKE_SCRIPT_HASH } from "~lib/render-tree/test-utils"
+import { TransientNode } from "~lib/render-tree/TransientNode"
 
 import { ClearEvictedFragmentNodesVisitor } from "./ClearEvictedFragmentNodesVisitor"
 
@@ -99,6 +100,41 @@ describe("ClearEvictedFragmentNodesVisitor", () => {
 
     // Referential stability matters: a new node would re-render the subtree.
     expect(parent.accept(visitor)).toBe(parent)
+  })
+
+  describe("transient nodes", () => {
+    it("returns the identical node when nothing in its subtree is evicted", () => {
+      const visitor = new ClearEvictedFragmentNodesVisitor(new Set(["absent"]))
+      const transient = new TransientNode(
+        SCRIPT_RUN_ID,
+        elementNode("anchor", "outer"),
+        [elementNode("toast", "outer")]
+      )
+
+      // Referential stability: reconstructing would re-render this subtree.
+      expect(transient.accept(visitor)).toBe(transient)
+    })
+
+    it("drops an evicted transient element but keeps the anchor", () => {
+      const visitor = new ClearEvictedFragmentNodesVisitor(new Set(["nested"]))
+      const anchor = elementNode("anchor", "outer")
+      const transient = new TransientNode(SCRIPT_RUN_ID, anchor, [
+        elementNode("toast", "nested"),
+      ])
+
+      expect(transient.accept(visitor)).toBe(anchor)
+    })
+
+    it("removes the whole node when anchor and transients are evicted", () => {
+      const visitor = new ClearEvictedFragmentNodesVisitor(new Set(["nested"]))
+      const transient = new TransientNode(
+        SCRIPT_RUN_ID,
+        elementNode("anchor", "nested"),
+        [elementNode("toast", "nested")]
+      )
+
+      expect(transient.accept(visitor)).toBeUndefined()
+    })
   })
 
   it("removes nodes nested several blocks deep", () => {

--- a/frontend/lib/src/render-tree/visitors/ClearEvictedFragmentNodesVisitor.test.ts
+++ b/frontend/lib/src/render-tree/visitors/ClearEvictedFragmentNodesVisitor.test.ts
@@ -69,6 +69,38 @@ describe("ClearEvictedFragmentNodesVisitor", () => {
     expect(noFragment.accept(visitor)).toBe(noFragment)
   })
 
+  it("preserves a toast emitted by an evicted fragment (issue #7740)", () => {
+    // A fragment's toast carries that fragment's id. If the eviction lands in
+    // the same batch as the toast delta, pruning the node here would drop the
+    // notification before the Toast component registers it with the queue.
+    const visitor = new ClearEvictedFragmentNodesVisitor(new Set(["nested"]))
+    const toast = new ElementNode(
+      new Element({ toast: { body: "Toast survives eviction" } }),
+      ForwardMsgMetadata.create(),
+      SCRIPT_RUN_ID,
+      FAKE_SCRIPT_HASH,
+      "nested"
+    )
+
+    expect(toast.accept(visitor)).toBe(toast)
+  })
+
+  it("keeps an evicted fragment's toast while removing its other elements", () => {
+    const visitor = new ClearEvictedFragmentNodesVisitor(new Set(["nested"]))
+    const toast = new ElementNode(
+      new Element({ toast: { body: "Toast survives eviction" } }),
+      ForwardMsgMetadata.create(),
+      SCRIPT_RUN_ID,
+      FAKE_SCRIPT_HASH,
+      "nested"
+    )
+    const parent = blockNode([toast, elementNode("gone", "nested")], "outer")
+
+    const result = parent.accept(visitor) as BlockNode
+
+    expect(result.children).toEqual([toast])
+  })
+
   it("removes a block belonging to an evicted fragment, with its subtree", () => {
     const visitor = new ClearEvictedFragmentNodesVisitor(new Set(["nested"]))
     const nestedBlock = blockNode([elementNode("inner")], "nested")
@@ -89,7 +121,7 @@ describe("ClearEvictedFragmentNodesVisitor", () => {
     expect(result).not.toBe(parent)
     expect(result.children).toHaveLength(1)
     expect(result.children[0]).toBe(kept)
-    // Identity of the surviving parent's own metadata is preserved.
+    // The surviving parent keeps its fragmentId and scriptRunId.
     expect(result.fragmentId).toBe("outer")
     expect(result.scriptRunId).toBe(SCRIPT_RUN_ID)
   })

--- a/frontend/lib/src/render-tree/visitors/ClearEvictedFragmentNodesVisitor.ts
+++ b/frontend/lib/src/render-tree/visitors/ClearEvictedFragmentNodesVisitor.ts
@@ -99,6 +99,19 @@ export class ClearEvictedFragmentNodesVisitor implements AppNodeVisitor<
       element => element.accept(this) as ElementNode | undefined
     )
 
+    // Performance optimization: nothing in this subtree was evicted, so keep
+    // the same node. `updateTransientNodes` always allocates a fresh array, so
+    // this has to compare contents rather than the array reference. Checked
+    // before the collapse cases below, which would otherwise replace an
+    // untouched TransientNode with its anchor.
+    if (
+      anchorNode === node.anchor &&
+      transientNodes.length === node.transientNodes.length &&
+      transientNodes.every((element, i) => element === node.transientNodes[i])
+    ) {
+      return node
+    }
+
     if (!anchorNode && transientNodes.length === 0) {
       return undefined
     }

--- a/frontend/lib/src/render-tree/visitors/ClearEvictedFragmentNodesVisitor.ts
+++ b/frontend/lib/src/render-tree/visitors/ClearEvictedFragmentNodesVisitor.ts
@@ -19,28 +19,13 @@ import { AppNode, BlockNode, ElementNode, TransientNode } from "~lib/AppNode"
 import { AppNodeVisitor } from "./AppNodeVisitor.interface"
 
 /**
- * Visitor that removes nodes belonging to fragments the server has evicted.
+ * Removes nodes whose `fragmentId` the server has evicted.
  *
- * Enforces the invariant that a fragment the server has dropped owns no nodes
- * in the element tree. The server reports evicted fragments explicitly (see
- * `clear_stale_descendants`, which reports every evicted fragment and not only
- * those with a `run_every` timer), so this does not depend on inferring
- * staleness from script run ids.
- *
- * `ClearStaleNodeVisitor` cannot be relied on for this: it prunes a nested
- * fragment only during a run that both writes the ancestor's subtree and
- * completes successfully. A fragment rerun that ends as
- * `FINISHED_EARLY_FOR_RERUN` skips that cleanup entirely, and the runs that
- * follow are scoped to other fragments, so nothing revisits the evicted
- * fragment's subtree. Its auto-rerun is cancelled at the same time, leaving the
- * nodes frozen on screen showing stale content until a full rerun.
- *
- * Usage:
- * ```typescript
- * const visitor = new ClearEvictedFragmentNodesVisitor(evictedFragmentIds)
- * const newNode = node.accept(visitor)
- * // newNode will be undefined if the node should be filtered out
- * ```
+ * Evicted ids arrive in `stopAutoRerun` (every evicted fragment, not only those
+ * with a `run_every` timer). `ClearStaleNodeVisitor` cannot cover this: it only
+ * prunes during a successful ancestor run, and `FINISHED_EARLY_FOR_RERUN` skips
+ * that cleanup. Later runs are scoped to other fragments, so the evicted
+ * subtree would stay on screen until a full rerun.
  */
 export class ClearEvictedFragmentNodesVisitor implements AppNodeVisitor<
   AppNode | undefined
@@ -56,6 +41,8 @@ export class ClearEvictedFragmentNodesVisitor implements AppNodeVisitor<
   }
 
   visitBlockNode(node: BlockNode): AppNode | undefined {
+    // Drop the subtree: descendants belong to this fragment, or to nested
+    // fragments the server also reports as evicted.
     if (this.isEvicted(node.fragmentId)) {
       return undefined
     }
@@ -90,6 +77,17 @@ export class ClearEvictedFragmentNodesVisitor implements AppNodeVisitor<
   }
 
   visitElementNode(node: ElementNode): AppNode | undefined {
+    // Toasts are fire-and-forget: the frontend toast queue owns their lifetime,
+    // not the element tree. A toast emitted from a fragment carries that
+    // fragment's id, so an eviction applied in the same batch as the toast delta
+    // would remove the node before the Toast component registers it with the
+    // queue, silently dropping the notification (issue #7740). The node renders
+    // nothing on its own, so keeping it is safe. `ClearStaleNodeVisitor` makes
+    // the same exception.
+    if (node.element.type === "toast") {
+      return node
+    }
+
     return this.isEvicted(node.fragmentId) ? undefined : node
   }
 
@@ -99,15 +97,14 @@ export class ClearEvictedFragmentNodesVisitor implements AppNodeVisitor<
       element => element.accept(this) as ElementNode | undefined
     )
 
-    // Performance optimization: nothing in this subtree was evicted, so keep
-    // the same node. `updateTransientNodes` always allocates a fresh array, so
-    // this has to compare contents rather than the array reference. Checked
-    // before the collapse cases below, which would otherwise replace an
-    // untouched TransientNode with its anchor.
+    // Keep the same node when nothing in this subtree was evicted; a fresh node
+    // would re-render it. `updateTransientNodes` either keeps an element
+    // identically or drops it, so an unchanged length means nothing was
+    // removed. This must precede the collapse cases below, which would
+    // otherwise swap an untouched node for its anchor.
     if (
       anchorNode === node.anchor &&
-      transientNodes.length === node.transientNodes.length &&
-      transientNodes.every((element, i) => element === node.transientNodes[i])
+      transientNodes.length === node.transientNodes.length
     ) {
       return node
     }

--- a/frontend/lib/src/render-tree/visitors/ClearEvictedFragmentNodesVisitor.ts
+++ b/frontend/lib/src/render-tree/visitors/ClearEvictedFragmentNodesVisitor.ts
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { AppNode, BlockNode, ElementNode, TransientNode } from "~lib/AppNode"
+
+import { AppNodeVisitor } from "./AppNodeVisitor.interface"
+
+/**
+ * Visitor that removes nodes belonging to fragments the server has evicted.
+ *
+ * Enforces the invariant that a fragment the server has dropped owns no nodes
+ * in the element tree. The server reports evicted fragments explicitly (see
+ * `clear_stale_descendants`, which reports every evicted fragment and not only
+ * those with a `run_every` timer), so this does not depend on inferring
+ * staleness from script run ids.
+ *
+ * `ClearStaleNodeVisitor` cannot be relied on for this: it prunes a nested
+ * fragment only during a run that both writes the ancestor's subtree and
+ * completes successfully. A fragment rerun that ends as
+ * `FINISHED_EARLY_FOR_RERUN` skips that cleanup entirely, and the runs that
+ * follow are scoped to other fragments, so nothing revisits the evicted
+ * fragment's subtree. Its auto-rerun is cancelled at the same time, leaving the
+ * nodes frozen on screen showing stale content until a full rerun.
+ *
+ * Usage:
+ * ```typescript
+ * const visitor = new ClearEvictedFragmentNodesVisitor(evictedFragmentIds)
+ * const newNode = node.accept(visitor)
+ * // newNode will be undefined if the node should be filtered out
+ * ```
+ */
+export class ClearEvictedFragmentNodesVisitor implements AppNodeVisitor<
+  AppNode | undefined
+> {
+  private readonly evictedFragmentIds: ReadonlySet<string>
+
+  constructor(evictedFragmentIds: ReadonlySet<string>) {
+    this.evictedFragmentIds = evictedFragmentIds
+  }
+
+  private isEvicted(fragmentId: string | undefined): boolean {
+    return !!fragmentId && this.evictedFragmentIds.has(fragmentId)
+  }
+
+  visitBlockNode(node: BlockNode): AppNode | undefined {
+    if (this.isEvicted(node.fragmentId)) {
+      return undefined
+    }
+
+    const newChildren: AppNode[] = []
+    let childrenChanged = false
+
+    node.children.forEach(child => {
+      const filteredChild = child.accept(this)
+      if (filteredChild !== child) {
+        childrenChanged = true
+      }
+      if (filteredChild !== undefined) {
+        newChildren.push(filteredChild)
+      }
+    })
+
+    // Performance optimization: if nothing was removed, keep the same node so
+    // React does not re-render this subtree.
+    if (!childrenChanged) {
+      return node
+    }
+
+    return new BlockNode(
+      node.activeScriptHash,
+      newChildren,
+      node.deltaBlock,
+      node.scriptRunId,
+      node.fragmentId,
+      node.deltaMsgReceivedAt
+    )
+  }
+
+  visitElementNode(node: ElementNode): AppNode | undefined {
+    return this.isEvicted(node.fragmentId) ? undefined : node
+  }
+
+  visitTransientNode(node: TransientNode): AppNode | undefined {
+    const anchorNode = node.anchor?.accept(this)
+    const transientNodes = node.updateTransientNodes(
+      element => element.accept(this) as ElementNode | undefined
+    )
+
+    if (!anchorNode && transientNodes.length === 0) {
+      return undefined
+    }
+
+    if (transientNodes.length === 0) {
+      return anchorNode
+    }
+
+    return new TransientNode(
+      node.scriptRunId,
+      anchorNode,
+      transientNodes,
+      node.deltaMsgReceivedAt
+    )
+  }
+}

--- a/frontend/lib/src/render-tree/visitors/ClearEvictedFragmentNodesVisitor.ts
+++ b/frontend/lib/src/render-tree/visitors/ClearEvictedFragmentNodesVisitor.ts
@@ -14,18 +14,29 @@
  * limitations under the License.
  */
 
+import { Block as BlockProto } from "@streamlit/protobuf"
+
 import { AppNode, BlockNode, ElementNode, TransientNode } from "~lib/AppNode"
 
 import { AppNodeVisitor } from "./AppNodeVisitor.interface"
 
 /**
- * Removes nodes whose `fragmentId` the server has evicted.
+ * Replaces nodes of server-evicted fragments with empty blocks that render
+ * nothing.
  *
- * Evicted ids arrive in `stopAutoRerun` (every evicted fragment, not only those
- * with a `run_every` timer). `ClearStaleNodeVisitor` cannot cover this: it only
- * prunes during a successful ancestor run, and `FINISHED_EARLY_FOR_RERUN` skips
- * that cleanup. Later runs are scoped to other fragments, so the evicted
- * subtree would stay on screen until a full rerun.
+ * - Evicted ids arrive in `stopAutoRerun` — every evicted fragment, not only
+ *   those with a `run_every` timer.
+ * - `ClearStaleNodeVisitor` cannot cover this: it prunes only during a
+ *   successful ancestor run, and `FINISHED_EARLY_FOR_RERUN` skips that cleanup.
+ *   Later runs are scoped to other fragments, so the subtree would linger.
+ * - Replace, never remove: deltas address nodes by absolute path. Removing
+ *   compacts the parent's `children`, and `addBlock` inherits children rather
+ *   than resetting them, so every later sibling keeps a shifted index and a
+ *   fragment that reruns writes to the wrong slot.
+ * - Placeholders don't accumulate: they carry no `fragmentId`, so a repeat
+ *   eviction matches nothing and the tree is returned unchanged. A returning
+ *   fragment overwrites the slot, and a later full run prunes them via their
+ *   stale `scriptRunId`.
  */
 export class ClearEvictedFragmentNodesVisitor implements AppNodeVisitor<
   AppNode | undefined
@@ -40,28 +51,58 @@ export class ClearEvictedFragmentNodesVisitor implements AppNodeVisitor<
     return !!fragmentId && this.evictedFragmentIds.has(fragmentId)
   }
 
+  /**
+   * Whether this element should be replaced.
+   *
+   * Toasts are fire-and-forget: the frontend toast queue owns their lifetime,
+   * not the element tree. Replacing a toast node before the `Toast` component
+   * registers it silently drops the notification (issue #7740); keeping it is
+   * safe because the node renders nothing itself.
+   * `ClearStaleNodeVisitor.visitElementNode` makes the same exception. Note
+   * `st.toast` always writes to the event container, so a toast is never inside
+   * a fragment-owned block that `visitBlockNode` replaces wholesale.
+   */
+  private shouldReplace(node: ElementNode): boolean {
+    return node.element.type !== "toast" && this.isEvicted(node.fragmentId)
+  }
+
+  /**
+   * An index-preserving stand-in that renders nothing.
+   *
+   * Deliberately omits `fragmentId`, so a repeat eviction leaves the tree
+   * untouched, and leaves `deltaBlock.type` unset, so `AppRoot.addBlock` does
+   * not treat a returning block as the same type and inherit these (empty)
+   * children.
+   */
+  private makePlaceholder(
+    activeScriptHash: string,
+    scriptRunId: string
+  ): BlockNode {
+    return new BlockNode(activeScriptHash, [], new BlockProto({}), scriptRunId)
+  }
+
   visitBlockNode(node: BlockNode): AppNode | undefined {
-    // Drop the subtree: descendants belong to this fragment, or to nested
-    // fragments the server also reports as evicted.
+    // Replace the whole subtree: its descendants belong to this fragment, or to
+    // nested fragments the server also reports as evicted.
     if (this.isEvicted(node.fragmentId)) {
-      return undefined
+      return this.makePlaceholder(node.activeScriptHash, node.scriptRunId)
     }
 
     const newChildren: AppNode[] = []
     let childrenChanged = false
 
     node.children.forEach(child => {
-      const filteredChild = child.accept(this)
-      if (filteredChild !== child) {
+      const newChild = child.accept(this)
+      if (newChild !== child) {
         childrenChanged = true
       }
-      if (filteredChild !== undefined) {
-        newChildren.push(filteredChild)
+      if (newChild !== undefined) {
+        newChildren.push(newChild)
       }
     })
 
-    // Performance optimization: if nothing was removed, keep the same node so
-    // React does not re-render this subtree.
+    // Performance optimization: if nothing changed, keep the same node so React
+    // does not re-render this subtree.
     if (!childrenChanged) {
       return node
     }
@@ -77,31 +118,26 @@ export class ClearEvictedFragmentNodesVisitor implements AppNodeVisitor<
   }
 
   visitElementNode(node: ElementNode): AppNode | undefined {
-    // Toasts are fire-and-forget: the frontend toast queue owns their lifetime,
-    // not the element tree. A toast emitted from a fragment carries that
-    // fragment's id, so an eviction applied in the same batch as the toast delta
-    // would remove the node before the Toast component registers it with the
-    // queue, silently dropping the notification (issue #7740). The node renders
-    // nothing on its own, so keeping it is safe. `ClearStaleNodeVisitor` makes
-    // the same exception.
-    if (node.element.type === "toast") {
-      return node
-    }
-
-    return this.isEvicted(node.fragmentId) ? undefined : node
+    return this.shouldReplace(node)
+      ? this.makePlaceholder(node.activeScriptHash, node.scriptRunId)
+      : node
   }
 
   visitTransientNode(node: TransientNode): AppNode | undefined {
     const anchorNode = node.anchor?.accept(this)
-    const transientNodes = node.updateTransientNodes(
-      element => element.accept(this) as ElementNode | undefined
+    // Transient *elements* are dropped rather than replaced: they are addressed
+    // as a set within this node, not by their own absolute path. The node
+    // itself does occupy an absolute path, so it is replaced below rather than
+    // removed.
+    const transientNodes = node.updateTransientNodes(element =>
+      this.shouldReplace(element) ? undefined : element
     )
 
     // Keep the same node when nothing in this subtree was evicted; a fresh node
     // would re-render it. `updateTransientNodes` either keeps an element
     // identically or drops it, so an unchanged length means nothing was
-    // removed. This must precede the collapse cases below, which would
-    // otherwise swap an untouched node for its anchor.
+    // removed. This must precede the cases below, which would otherwise swap an
+    // untouched node for its anchor.
     if (
       anchorNode === node.anchor &&
       transientNodes.length === node.transientNodes.length
@@ -109,8 +145,17 @@ export class ClearEvictedFragmentNodesVisitor implements AppNodeVisitor<
       return node
     }
 
+    // Everything here was evicted. `addTransient` places this node at an
+    // absolute delta path (often with no anchor yet), so returning `undefined`
+    // would compact the parent and shift every later sibling.
     if (!anchorNode && transientNodes.length === 0) {
-      return undefined
+      // Reaching here means the identity check above did not fire, so at least
+      // one transient element existed and was dropped; take its script hash.
+      const [firstTransient] = node.transientNodes
+      return this.makePlaceholder(
+        firstTransient.activeScriptHash,
+        node.scriptRunId
+      )
     }
 
     if (transientNodes.length === 0) {


### PR DESCRIPTION
## Describe your changes

Hiding a nested `run_every` fragment can leave its container on screen, frozen with stale content, until the *enclosing* fragment next completes a run. The enclosing fragment has no timer of its own, so in practice that means the next time the user interacts with it — the element the user just hid stays visible, showing stale data, until then.

When the server evicts a fragment it reports the id in `stop_auto_rerun`. The client cancelled that fragment's auto-rerun timer but left its nodes in the element tree, which is why the leftover container is *frozen* rather than still ticking. `handleStopAutoRerun` now clears those nodes too, and drops their widget state as every other pruning path does.

**Evicted nodes are replaced in place with an empty block, not removed.** This is the load-bearing design decision. Deltas address nodes by absolute path, and `AppRoot.addBlock` inherits an existing block's children rather than resetting them, so removing a node compacts its parent's `children` and every later sibling keeps the shifted index permanently. A fragment sibling that reruns on its own then writes to the wrong slot: reproduced as a silent duplication (`["live"]` → later delta at its original path `[0, 1]` → `["live", "live v2"]`), and `SetNodeByDeltaPathVisitor` can escalate the same shift to a `Bad delta path index` throw. An empty block with `allowEmpty` unset renders nothing (`Block.tsx`), so the stale content disappears while the index survives and a returning fragment overwrites the placeholder at its original path. `ClearStaleNodeVisitor` can compact safely only because it runs at the end of a successful run, where the next run rewrites every slot from index 0.

Why the existing cleanup doesn't reach these nodes: `clearStaleNodes` collects a fragment's stale descendants only on a run that writes the enclosing subtree. In the traced failure the enclosing fragment's run received no `clearStaleNodes` call at all — the only run in the window that didn't — and every run after it was scoped to a different fragment.

Found while investigating why `st_fragment_run_every_test.py::test_nested_fragment_run_every_can_hide_without_crash` keeps flaking (2 reruns in 4 days, webkit). The test was catching a real bug: its CI failure was `nested_auto_fragment` still attached after being hidden.

## GitHub Issue Link (if applicable)

Follow-up to #15130 / #15084, which fixed the crash in this area. This is not a regression of that fix.

## Testing Plan

- `AppRoot.clearEvictedFragmentNodes` tests covering the reason the design exists: apply deltas → evict → re-apply at a surviving sibling's original absolute path → assert one occurrence, not two. Plus the empty-set and no-match short circuits and logo preservation.
- `ClearEvictedFragmentNodesVisitor` tests: index preservation with a non-final evicted sibling, referential stability when nothing is evicted, toast preservation (#7740), and the `TransientNode` paths including the no-anchor case (`addTransient` places transients at an absolute path, so that branch must substitute rather than remove).
- `App.test.tsx`: `drops the evicted fragment's elements on a stopAutoRerun message`, confirmed to **fail without the fix**. Asserts an unrelated fragment survives, and asserts the `removeInactive` active-id set excludes the evicted widget id while including the surviving one.
- `st_fragment_run_every.py` now writes a sibling *after* the conditional nested fragment, so the existing e2e test can observe a sibling shift; the test asserts that sibling appears exactly once after hiding.
- Reproduced the original bug with a scripted toggle sweep across the 1.0s `run_every` period under CPU load, hitting roughly once every 4-6 runs. After the fix: 270 toggles under the same load, zero orphans.
- Fragment and toast e2e suites pass: `run_every` 2, `basics` 33 (+1 skipped), `nested` 5, `parallel` 15, `toast` 12.

## Note for reviewers

Ranked by how much they might affect your read:

1. **Eviction also fires for fragments that are coming back, and this is unresolved.** `clear_stale_descendants` runs in a `finally` that also covers `RerunException`/`StopException`, and says so outright: *"Children that the fragment did not get a chance to re-register will be dropped here and re-created on the next rerun."* So a parent calling `st.rerun()` before rendering a nested child evicts a child the next run recreates. Previously that only cancelled a timer; now it also blanks the slot and drops widget state — losing a user's typed value, plus keyed-container `elementStates` (expander open/closed, dataframe sort, column widths), which cuts against `specs/2026-02-26-layout-container-state-persistence/tech-spec.md:167-170`. Gating on `FINISHED_EARLY_FOR_RERUN` is the obvious fix but may disable the fix for the bug above, since I could not confirm which status the orphan-producing run ends with. This likely needs the server to distinguish "evicted" from "deferred re-creation" rather than overloading one signal, so I would value a maintainer's call before I take it further.
2. Scoped to the eviction invariant rather than reworking stale-node cleanup, on the grounds that an explicit server signal is a more reliable basis than comparing script run ids. If you would rather see one cleanup mechanism here than two, say so and I will rework it.
3. The class name still says `Clear…` while the behaviour is now "replace with an empty block", kept for symmetry with `ClearStaleNodeVisitor`. Happy to rename if you prefer accuracy over symmetry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core render-tree pruning and widget cleanup on server eviction; the PR notes eviction may also run when a nested fragment is only deferred for the next rerun, which could clear widget/layout state prematurely.
> 
> **Overview**
> When the server evicts a fragment (e.g. a nested `run_every` block stops rendering), **`stopAutoRerun` now removes that fragment’s stale UI from the element tree and prunes its widget state**, not only cancelling its auto-rerun timer. That fixes frozen leftover containers and wrong values if the fragment returns later.
> 
> Evicted nodes are **replaced with empty placeholder blocks** (via `ClearEvictedFragmentNodesVisitor` / `AppRoot.clearEvictedFragmentNodes`) so **sibling delta paths stay fixed**—removing nodes would shift indices and duplicate or break later deltas. Toasts from evicted fragments are left alone (#7740). Pruning uses a functional `setState` update and skips re-renders when nothing matched; **`removeInactiveWidgetState` runs after a successful prune**, same as other cleanup paths.
> 
> Tests cover the visitor, `AppRoot` sibling-path behavior, `App.handleStopAutoRerun`, and an e2e sibling line after a hideable nested `run_every` fragment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9062963b8abecca0a4bccc5c57a26ffca77078d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->