### PR TITLE
[fix] Show the correct year in the date picker header

### DIFF
--- a/e2e_playwright/st_date_input.py
+++ b/e2e_playwright/st_date_input.py
@@ -205,3 +205,19 @@ else:
         format="YYYY/MM/DD",
     )
     st.write("Initial date input value:", dval)
+
+# --- Year-crossing bounds (see GitHub issue #16686) ---
+# `max_value`'s month/day precedes `min_value`'s, so the calendar header's year
+# dropdown must still offer the later year.
+st.date_input(
+    "Year-crossing single",
+    value=date(2025, 2, 1),
+    min_value=date(2024, 8, 3),
+    max_value=date(2025, 2, 3),
+)
+st.date_input(
+    "Year-crossing range",
+    value=[date(2025, 2, 1), date(2025, 2, 2)],
+    min_value=date(2024, 8, 3),
+    max_value=date(2025, 2, 3),
+)

--- a/e2e_playwright/st_date_input_test.py
+++ b/e2e_playwright/st_date_input_test.py
@@ -37,7 +37,7 @@ from e2e_playwright.shared.app_utils import (
     type_date,
 )
 
-NUM_DATE_INPUTS = 24
+NUM_DATE_INPUTS = 26
 
 
 def test_date_input_rendering(themed_app: Page, assert_snapshot: ImageCompareFunction):
@@ -884,3 +884,103 @@ def test_year_picker_does_not_revert_month(app: Page):
     calendar.get_by_label(re.compile(r"March 6, 2011")).click()
     wait_for_app_run(app)
     expect_markdown(app, "Value 2: 2011-03-06")
+
+
+def test_calendar_header_with_year_crossing_bounds(app: Page):
+    """Exercises the calendar header when the bounds cross a year boundary.
+
+    With `max_value`'s month/day preceding `min_value`'s:
+
+    - the year dropdown offers both years,
+    - the header year matches the grid,
+    - picking the earlier year clamps into range,
+    - months with no reachable day are neither selectable nor styled as live,
+    - range mode behaves the same.
+
+    Regression test for GitHub issue #16686.
+    """
+    date_field = get_date_input(app, "Year-crossing single").get_by_test_id(
+        "stDateInputField"
+    )
+    date_field.get_by_role("spinbutton").first.click()
+
+    calendar = app.get_by_test_id("stDateInputCalendar")
+    expect(calendar).to_be_visible()
+
+    # The grid opens on February 2025, so the header must agree.
+    expect(calendar.get_by_role("button", name="month", exact=True)).to_have_text(
+        "February"
+    )
+    year_trigger = calendar.get_by_role("button", name="year", exact=True)
+    expect(year_trigger).to_have_text("2025")
+
+    year_trigger.click()
+    year_popover = app.get_by_test_id("stDateInputHeaderPickerPopover")
+    expect(year_popover).to_be_visible()
+    expect(year_popover.get_by_role("option")).to_have_text(["2024", "2025"])
+
+    # 2024 is reachable. February 2024 precedes `min_value`, so the calendar
+    # clamps to the earliest allowed month instead of leaving the valid range.
+    year_popover.get_by_role("option", name="2024").click()
+    expect(year_trigger).to_have_text("2024")
+    expect(calendar.get_by_role("button", name="month", exact=True)).to_have_text(
+        "August"
+    )
+    # --- Months with no reachable day are offered but not selectable ---
+    # Selecting a year closes the picker but leaves the calendar open, now on
+    # August 2024: August is in range, January-July 2024 are not.
+    calendar.get_by_role("button", name="month", exact=True).click()
+    month_popover = app.get_by_test_id("stDateInputHeaderPickerPopover")
+    expect(month_popover).to_be_visible()
+    expect(month_popover.get_by_role("option", name="August")).not_to_have_attribute(
+        "aria-disabled", "true"
+    )
+    expect(month_popover.get_by_role("option", name="January")).to_have_attribute(
+        "aria-disabled", "true"
+    )
+
+    # The state has to be visible, not just announced: an unselectable month
+    # that looks identical to a selectable one reads as a dead click target.
+    # December rather than August is the enabled sample, because August is the
+    # selected month and `data-selected` styling would confound the comparison.
+    expect(month_popover.get_by_role("option", name="January")).to_have_css(
+        "cursor", "not-allowed"
+    )
+    expect(month_popover.get_by_role("option", name="December")).to_have_css(
+        "cursor", "pointer"
+    )
+    reachable_color = month_popover.get_by_role("option", name="December").evaluate(
+        "el => getComputedStyle(el).color"
+    )
+    unreachable_color = month_popover.get_by_role("option", name="January").evaluate(
+        "el => getComputedStyle(el).color"
+    )
+    assert reachable_color != unreachable_color, (
+        f"disabled month is styled identically to an enabled one ({reachable_color})"
+    )
+
+    # Assert each dismissal: if the first Escape missed the picker, the calendar
+    # would stay open and the range half below would match two calendars.
+    app.keyboard.press("Escape")
+    expect(month_popover).not_to_be_attached()
+    expect(calendar).to_be_visible()
+
+    app.keyboard.press("Escape")
+    expect(calendar).not_to_be_attached()
+
+    # --- Range mode reads a different calendar state, so re-check it there ---
+    range_field = get_date_input(app, "Year-crossing range").get_by_test_id(
+        "stDateInputField"
+    )
+    range_field.get_by_role("spinbutton").first.click()
+
+    range_calendar = app.get_by_test_id("stDateInputCalendar")
+    expect(range_calendar).to_be_visible()
+
+    range_year_trigger = range_calendar.get_by_role("button", name="year", exact=True)
+    expect(range_year_trigger).to_have_text("2025")
+
+    range_year_trigger.click()
+    range_year_popover = app.get_by_test_id("stDateInputHeaderPickerPopover")
+    expect(range_year_popover).to_be_visible()
+    expect(range_year_popover.get_by_role("option")).to_have_text(["2024", "2025"])

--- a/e2e_playwright/st_date_input_test.py
+++ b/e2e_playwright/st_date_input_test.py
@@ -894,7 +894,7 @@ def test_calendar_header_with_year_crossing_bounds(app: Page):
     - the year dropdown offers both years,
     - the header year matches the grid,
     - picking the earlier year clamps into range,
-    - months with no reachable day are neither selectable nor styled as live,
+    - disabled month options are visibly distinct from selectable ones,
     - range mode behaves the same.
 
     Regression test for GitHub issue #16686.
@@ -940,23 +940,15 @@ def test_calendar_header_with_year_crossing_bounds(app: Page):
     )
 
     # The state has to be visible, not just announced: an unselectable month
-    # that looks identical to a selectable one reads as a dead click target.
-    # December rather than August is the enabled sample, because August is the
-    # selected month and `data-selected` styling would confound the comparison.
+    # that looks identical to a selectable one reads as a dead click target. The
+    # cursor and the fade come from the same rule, so asserting the cursor is
+    # enough to prove it matched. December rather than August is the enabled
+    # sample, because August is selected and would bring its own styling.
     expect(month_popover.get_by_role("option", name="January")).to_have_css(
         "cursor", "not-allowed"
     )
     expect(month_popover.get_by_role("option", name="December")).to_have_css(
         "cursor", "pointer"
-    )
-    reachable_color = month_popover.get_by_role("option", name="December").evaluate(
-        "el => getComputedStyle(el).color"
-    )
-    unreachable_color = month_popover.get_by_role("option", name="January").evaluate(
-        "el => getComputedStyle(el).color"
-    )
-    assert reachable_color != unreachable_color, (
-        f"disabled month is styled identically to an enabled one ({reachable_color})"
     )
 
     # Assert each dismissal: if the first Escape missed the picker, the calendar

--- a/e2e_playwright/st_datetime_input.py
+++ b/e2e_playwright/st_datetime_input.py
@@ -175,3 +175,13 @@ else:
         max_value=datetime(2030, 12, 31, 23, 59),
     )
     st.write("Initial datetime input value:", dval)
+
+# --- Year-crossing bounds (see GitHub issue #16686) ---
+# `max_value`'s month/day precedes `min_value`'s, so the calendar header's year
+# dropdown must still offer the later year.
+st.datetime_input(
+    "Year-crossing datetime",
+    value=datetime(2025, 2, 1, 10, 0),
+    min_value=datetime(2024, 8, 3, 0, 0),
+    max_value=datetime(2025, 2, 3, 23, 59),
+)

--- a/e2e_playwright/st_datetime_input_test.py
+++ b/e2e_playwright/st_datetime_input_test.py
@@ -35,7 +35,7 @@ from e2e_playwright.shared.app_utils import (
     type_date,
 )
 
-NUM_DATETIME_INPUTS = 19
+NUM_DATETIME_INPUTS = 20
 
 
 def test_datetime_input_widget_rendering(
@@ -374,3 +374,27 @@ def test_datetime_input_query_param_out_of_range_resets(page: Page, app_base_url
 
     expect_prefixed_markdown(page, "Bound minmax datetime:", "2025-11-19 16:45:00")
     expect(page).not_to_have_url(re.compile(r"[?&]bound_minmax_dt="))
+
+
+def test_year_picker_lists_boundary_year_when_bounds_cross_a_year(app: Page):
+    """st.datetime_input shares the calendar header with st.date_input, so the
+    year dropdown must offer the later year here too.
+
+    Regression test for GitHub issue #16686.
+    """
+    datetime_field = get_datetime_input(app, "Year-crossing datetime")
+    datetime_field.get_by_role("spinbutton").first.click()
+
+    calendar = app.get_by_test_id("stDateTimeInputCalendar")
+    expect(calendar).to_be_visible()
+
+    expect(calendar.get_by_role("button", name="month", exact=True)).to_have_text(
+        "February"
+    )
+    year_trigger = calendar.get_by_role("button", name="year", exact=True)
+    expect(year_trigger).to_have_text("2025")
+
+    year_trigger.click()
+    year_popover = app.get_by_test_id("stDateInputHeaderPickerPopover")
+    expect(year_popover).to_be_visible()
+    expect(year_popover.get_by_role("option")).to_have_text(["2024", "2025"])

--- a/frontend/lib/src/components/widgets/DateInput/CalendarPopoverHeader.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/CalendarPopoverHeader.tsx
@@ -15,6 +15,7 @@
  */
 
 import {
+  ContextType,
   KeyboardEvent,
   ReactElement,
   useCallback,
@@ -25,6 +26,14 @@ import {
 
 import { KeyboardArrowDown } from "@emotion-icons/material-outlined"
 import { ArrowBack, ArrowForward } from "@emotion-icons/material-rounded"
+import {
+  CalendarDate,
+  endOfMonth,
+  startOfMonth,
+  toCalendar,
+  toCalendarDate,
+} from "@internationalized/date"
+import { useDateFormatter } from "react-aria"
 import {
   CalendarMonthPicker,
   CalendarStateContext,
@@ -56,7 +65,7 @@ import {
 interface HeaderPickerItem {
   id: number
   formatted: string
-  date?: { year: number; month: number; day: number }
+  isDisabled?: boolean
 }
 
 /** Marks the month/year picker popover so the calendar ignores nested clicks and Escape. */
@@ -67,7 +76,10 @@ export const DATE_INPUT_HEADER_PICKER_POPOVER_CLASS =
 const renderPickerItem = (item: unknown): ReactElement => {
   const pickerItem = item as HeaderPickerItem
   return (
-    <StyledDropdownListBoxItem id={pickerItem.id}>
+    <StyledDropdownListBoxItem
+      id={pickerItem.id}
+      isDisabled={pickerItem.isDisabled}
+    >
       {pickerItem.formatted}
     </StyledDropdownListBoxItem>
   )
@@ -151,6 +163,131 @@ function HeaderPickerSelect({
 }
 
 /**
+ * Number of year options offered at once, matching React Aria's `visibleYears`
+ * default so the dropdown keeps its familiar length.
+ */
+const VISIBLE_YEARS = 20
+
+/**
+ * Calendar state from the single or range calendar context, or null when
+ * neither provider is above this component.
+ */
+type CalendarHeaderState =
+  | ContextType<typeof CalendarStateContext>
+  | ContextType<typeof RangeCalendarStateContext>
+
+/**
+ * Builds the year dropdown's options and selected value, replacing React Aria's,
+ * which gets two things wrong for Streamlit's bounds:
+ *
+ * - Its list steps whole years from `minValue`, so it drops the final year
+ *   whenever `maxValue`'s month/day precedes `minValue`'s (2024-08-03 ->
+ *   2025-02-03 lists only 2024).
+ * - Its `value` is an index that falls back to 0 when the focused year is
+ *   missing, so the trigger names a year the grid isn't on.
+ *
+ * See https://github.com/streamlit/streamlit/issues/16686.
+ *
+ * Keys are year numbers, which is safe only because the bounds are converted
+ * into the focused date's calendar first: the visitor's locale picks the
+ * calendar system, so `minValue`/`maxValue` arrive Gregorian while `focusedDate`
+ * may be Buddhist or Persian. React Aria keys by index to survive era resets in
+ * calendars like the Japanese; that can't reach us, because the locale comes
+ * from `window.navigator.language` (see `LibConfigContext`), which never carries
+ * `-u-ca-japanese`.
+ */
+function useYearPickerItems(state: CalendarHeaderState): {
+  items: HeaderPickerItem[]
+  value: number
+} {
+  const formatter = useDateFormatter({
+    year: "numeric",
+    calendar: state?.focusedDate.calendar.identifier,
+    timeZone: state?.timeZone,
+  })
+
+  if (!state) return { items: [], value: 0 }
+
+  const { focusedDate, timeZone } = state
+  const { calendar } = focusedDate
+  const focusedYear = focusedDate.year
+
+  /** Reads a bound's year in the focused date's calendar system. */
+  const boundYear = (
+    bound: typeof state.minValue,
+    fallback: number
+  ): number =>
+    bound ? toCalendar(toCalendarDate(bound), calendar).year : fallback
+
+  const halfWindow = Math.floor(VISIBLE_YEARS / 2)
+  // The fallbacks are defensive: Streamlit's backend always sends both bounds.
+  const minYear = boundYear(state.minValue, focusedYear - halfWindow)
+  const maxYear = boundYear(state.maxValue, focusedYear + halfWindow)
+
+  // Anchor a VISIBLE_YEARS window on the focused year, then slide it inside
+  // [minYear, maxYear]. React Aria centers the window as
+  // [focused - 10, focused + 9]; mirror that.
+  const anchorEnd = Math.min(
+    focusedYear + Math.ceil(VISIBLE_YEARS / 2) - 1,
+    maxYear
+  )
+  const startYear = Math.max(anchorEnd - VISIBLE_YEARS + 1, minYear)
+  const endYear = Math.min(startYear + VISIBLE_YEARS - 1, maxYear)
+
+  const items: HeaderPickerItem[] = []
+  for (let year = startYear; year <= endYear; year++) {
+    items.push({
+      id: year,
+      formatted: formatter.format(focusedDate.set({ year }).toDate(timeZone)),
+    })
+  }
+
+  // The window always contains the focused year when `focusedDate` is in
+  // bounds. It can fall outside for a single render, while React Aria corrects
+  // a controlled `focusedValue` through `onFocusChange`; clamp so the trigger
+  // shows a year rather than going blank. Clamping rather than widening keeps
+  // the list bounded — a focused year far outside the bounds would otherwise
+  // stretch it to hundreds of options.
+  return {
+    items,
+    value: Math.min(Math.max(focusedYear, startYear), endYear),
+  }
+}
+
+/**
+ * Copies React Aria's month options, disabling the ones that hold no selectable
+ * day. React Aria offers every month in the focused year regardless of the
+ * bounds, and picking an unreachable one relocates the calendar entirely
+ * (`constrainValue` clamps to the nearest bound), so the user asks for January
+ * and lands in August.
+ *
+ * Mapping over React Aria's items rather than rebuilding 1-12 keeps the month
+ * count right in calendars whose year length varies, like the Hebrew.
+ *
+ * Only months where *every* day is out of bounds get disabled. Partly reachable
+ * months stay selectable — with `maxValue` 2025-02-03, February 2025 still
+ * offers the 1st through the 3rd.
+ */
+function markUnavailableMonths(
+  items: readonly { id: number; formatted: string; date: CalendarDate }[],
+  state: NonNullable<CalendarHeaderState>
+): HeaderPickerItem[] {
+  // No calendar conversion needed here: `compare` works on absolute days, so a
+  // Buddhist month start compares correctly against a Gregorian bound. Year
+  // *numbers* do need converting — see useYearPickerItems.
+  const minDate = state.minValue ? toCalendarDate(state.minValue) : null
+  const maxDate = state.maxValue ? toCalendarDate(state.maxValue) : null
+
+  return items.map(({ id, formatted, date }) => ({
+    id,
+    formatted,
+    isDisabled:
+      (maxDate !== null && startOfMonth(date).compare(maxDate) > 0) ||
+      (minDate !== null && endOfMonth(date).compare(minDate) < 0),
+  }))
+}
+
+/**
  * Shared calendar header (prev/next nav + month/year pickers).
  * Must be a child of `Calendar`/`RangeCalendar` to access calendar state.
  * Uses RAC `Select`/`Popover`/`ListBox` (not native `<select>`) for
@@ -160,20 +297,16 @@ export function CalendarPopoverHeader(): ReactElement {
   const calendarState = useContext(CalendarStateContext)
   const rangeCalendarState = useContext(RangeCalendarStateContext)
   const state = calendarState || rangeCalendarState
+  const { items: yearItems, value: yearValue } = useYearPickerItems(state)
 
-  // Workaround for React Aria bug: CalendarYearPicker's items may embed a
-  // stale month when focusedValue is controlled. When the user changes the
-  // month and then picks a year, the library would propagate the old month
-  // from items[key].date. We intercept onChange to use state.focusedDate
-  // (which always reflects the correct month) and only change the year.
+  // Keys are year numbers, so picking one changes only the year and keeps the
+  // focused month. React Aria's own onChange would move the month too: each of
+  // its items carries the window start's month/day — usually minValue's — not
+  // the focused month.
   const handleYearChange = useCallback(
-    (key: Key | null, items: HeaderPickerItem[]): void => {
+    (key: Key | null): void => {
       if (isNullOrUndefined(key) || !state) return
-      const selectedItem = items.find(i => i.id === Number(key))
-      if (!selectedItem) return
-      const selectedYear = selectedItem.date?.year
-      if (isNullOrUndefined(selectedYear)) return
-      state.setFocusedDate(state.focusedDate.set({ year: selectedYear }))
+      state.setFocusedDate(state.focusedDate.set({ year: Number(key) }))
     },
     [state]
   )
@@ -190,17 +323,21 @@ export function CalendarPopoverHeader(): ReactElement {
               ariaLabel={ariaLabel}
               value={value}
               onChange={onChange}
-              items={items}
+              items={state ? markUnavailableMonths(items, state) : items}
             />
           )}
         </CalendarMonthPicker>
+        {/* items/value come from useYearPickerItems, not React Aria.
+            CalendarYearPicker is kept mounted, rather than inlining its label,
+            so this workaround reverts cleanly once the upstream fix lands:
+            https://github.com/adobe/react-spectrum/issues/10531 */}
         <CalendarYearPicker>
-          {({ "aria-label": ariaLabel, value, items }) => (
+          {({ "aria-label": ariaLabel }) => (
             <HeaderPickerSelect
               ariaLabel={ariaLabel}
-              value={value}
-              onChange={key => handleYearChange(key, items)}
-              items={items}
+              value={yearValue}
+              onChange={handleYearChange}
+              items={yearItems}
             />
           )}
         </CalendarYearPicker>

--- a/frontend/lib/src/components/widgets/DateInput/CalendarPopoverHeader.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/CalendarPopoverHeader.tsx
@@ -28,6 +28,7 @@ import { KeyboardArrowDown } from "@emotion-icons/material-outlined"
 import { ArrowBack, ArrowForward } from "@emotion-icons/material-rounded"
 import {
   CalendarDate,
+  DateValue,
   endOfMonth,
   startOfMonth,
   toCalendar,
@@ -188,13 +189,18 @@ type CalendarHeaderState =
  *
  * See https://github.com/streamlit/streamlit/issues/16686.
  *
- * Keys are year numbers, which is safe only because the bounds are converted
- * into the focused date's calendar first: the visitor's locale picks the
- * calendar system, so `minValue`/`maxValue` arrive Gregorian while `focusedDate`
- * may be Buddhist or Persian. React Aria keys by index to survive era resets in
- * calendars like the Japanese; that can't reach us, because the locale comes
- * from `window.navigator.language` (see `LibConfigContext`), which never carries
- * `-u-ca-japanese`.
+ * Keys are year numbers. `minValue`/`maxValue` must therefore be converted into
+ * `focusedDate`'s calendar before their years are read — the visitor's locale
+ * picks the calendar system, so the bounds arrive Gregorian while `focusedDate`
+ * may be Buddhist or Persian.
+ *
+ * React Aria keys by index instead, which also survives Japanese era resets
+ * (Heisei 31 -> Reiwa 1), where converted year numbers stop increasing. Numeric
+ * keys are safe here because Streamlit never selects that calendar: the locale
+ * is `window.navigator.language` (see `LibConfigContext`), and browsers do not
+ * put `-u-ca-japanese` on it. `getSafeLocale` would preserve such an extension
+ * if one ever arrived, so the year window is clamped to a non-empty range below
+ * rather than trusting the bounds to be ordered.
  */
 function useYearPickerItems(state: CalendarHeaderState): {
   items: HeaderPickerItem[]
@@ -214,25 +220,33 @@ function useYearPickerItems(state: CalendarHeaderState): {
 
   /** Reads a bound's year in the focused date's calendar system. */
   const boundYear = (
-    bound: typeof state.minValue,
+    bound: DateValue | null | undefined,
     fallback: number
   ): number =>
     bound ? toCalendar(toCalendarDate(bound), calendar).year : fallback
 
+  // The fallbacks split the window evenly and are defensive — Streamlit's
+  // backend always sends both bounds. The anchor below mirrors React Aria's
+  // off-center window, [focused - 10, focused + 9], hence the different halves.
   const halfWindow = Math.floor(VISIBLE_YEARS / 2)
-  // The fallbacks are defensive: Streamlit's backend always sends both bounds.
   const minYear = boundYear(state.minValue, focusedYear - halfWindow)
   const maxYear = boundYear(state.maxValue, focusedYear + halfWindow)
 
   // Anchor a VISIBLE_YEARS window on the focused year, then slide it inside
-  // [minYear, maxYear]. React Aria centers the window as
-  // [focused - 10, focused + 9]; mirror that.
+  // [minYear, maxYear].
   const anchorEnd = Math.min(
     focusedYear + Math.ceil(VISIBLE_YEARS / 2) - 1,
     maxYear
   )
   const startYear = Math.max(anchorEnd - VISIBLE_YEARS + 1, minYear)
-  const endYear = Math.min(startYear + VISIBLE_YEARS - 1, maxYear)
+  // Never let the range invert: `maxYear < startYear` would emit no options at
+  // all, blanking the trigger — the failure this hook exists to prevent. Only
+  // reachable if the bounds' years stop increasing after conversion, as they do
+  // across a Japanese era reset.
+  const endYear = Math.max(
+    Math.min(startYear + VISIBLE_YEARS - 1, maxYear),
+    startYear
+  )
 
   const items: HeaderPickerItem[] = []
   for (let year = startYear; year <= endYear; year++) {
@@ -242,12 +256,11 @@ function useYearPickerItems(state: CalendarHeaderState): {
     })
   }
 
-  // The window always contains the focused year when `focusedDate` is in
-  // bounds. It can fall outside for a single render, while React Aria corrects
-  // a controlled `focusedValue` through `onFocusChange`; clamp so the trigger
-  // shows a year rather than going blank. Clamping rather than widening keeps
-  // the list bounded — a focused year far outside the bounds would otherwise
-  // stretch it to hundreds of options.
+  // Clamp the selected key into the window so the trigger never goes blank.
+  // `focusedDate` is in bounds once React Aria has applied `onFocusChange`, but
+  // can sit outside it for a single render of a controlled `focusedValue`.
+  // Widening the list to reach that year instead would let a far-out-of-range
+  // focus stretch it to hundreds of options.
   return {
     items,
     value: Math.min(Math.max(focusedYear, startYear), endYear),

--- a/frontend/lib/src/components/widgets/DateInput/CalendarPopoverHeader.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/CalendarPopoverHeader.tsx
@@ -194,13 +194,15 @@ type CalendarHeaderState =
  * picks the calendar system, so the bounds arrive Gregorian while `focusedDate`
  * may be Buddhist or Persian.
  *
- * React Aria keys by index instead, which also survives Japanese era resets
- * (Heisei 31 -> Reiwa 1), where converted year numbers stop increasing. Numeric
- * keys are safe here because Streamlit never selects that calendar: the locale
- * is `window.navigator.language` (see `LibConfigContext`), and browsers do not
- * put `-u-ca-japanese` on it. `getSafeLocale` would preserve such an extension
- * if one ever arrived, so the year window is clamped to a non-empty range below
- * rather than trusting the bounds to be ordered.
+ * React Aria keys by index instead, so its list survives a Japanese era reset
+ * (Heisei 31 -> Reiwa 1), where converted year numbers stop increasing.
+ * Numeric keys cover the calendars Streamlit actually selects:
+ *
+ * - The locale is `window.navigator.language` (see `LibConfigContext`); browsers
+ *   do not put `-u-ca-japanese` on it.
+ * - `getSafeLocale` would preserve an explicit `-u-ca-*` extension if one arrived,
+ *   so the year window below is clamped to a non-empty range rather than assuming
+ *   converted bounds stay ordered.
  */
 function useYearPickerItems(state: CalendarHeaderState): {
   items: HeaderPickerItem[]
@@ -225,9 +227,9 @@ function useYearPickerItems(state: CalendarHeaderState): {
   ): number =>
     bound ? toCalendar(toCalendarDate(bound), calendar).year : fallback
 
-  // The fallbacks split the window evenly and are defensive — Streamlit's
-  // backend always sends both bounds. The anchor below mirrors React Aria's
-  // off-center window, [focused - 10, focused + 9], hence the different halves.
+  // Streamlit's backend always sends both bounds; these fallbacks only apply if
+  // a bound is missing. They are then clipped to React Aria's off-center window,
+  // [focused - 10, focused + 9], below.
   const halfWindow = Math.floor(VISIBLE_YEARS / 2)
   const minYear = boundYear(state.minValue, focusedYear - halfWindow)
   const maxYear = boundYear(state.maxValue, focusedYear + halfWindow)
@@ -239,10 +241,9 @@ function useYearPickerItems(state: CalendarHeaderState): {
     maxYear
   )
   const startYear = Math.max(anchorEnd - VISIBLE_YEARS + 1, minYear)
-  // Never let the range invert: `maxYear < startYear` would emit no options at
-  // all, blanking the trigger — the failure this hook exists to prevent. Only
-  // reachable if the bounds' years stop increasing after conversion, as they do
-  // across a Japanese era reset.
+  // Keep the range non-empty: an inverted range would emit no options and blank
+  // the trigger, the failure this hook exists to prevent. Only reachable if the
+  // converted bounds stop increasing, as they do across a Japanese era reset.
   const endYear = Math.max(
     Math.min(startYear + VISIBLE_YEARS - 1, maxYear),
     startYear

--- a/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
@@ -3110,9 +3110,17 @@ describe("DateInput year picker with a constrained range", () => {
   // The visitor's locale chooses the calendar system, so `focusedDate` may be
   // Buddhist or Persian while the min/max props stay Gregorian. Reading years
   // off both without converting left the trigger blank. See #16686.
-  it.each(["th", "fa-IR"])(
-    "shows the focused year in a non-Gregorian calendar — %s",
-    async locale => {
+  it.each([
+    // Buddhist months align with Gregorian ones, so only January and February
+    // 2568 (= 2025) hold a selectable day, exactly as in the Gregorian case.
+    { locale: "th", enabledMonths: 2 },
+    // Persian months straddle Gregorian ones: the bounds fall inside Solar
+    // Hijri 1403, spanning its months 5-11. A different count from `th` is what
+    // proves the month bounds are evaluated in the visitor's calendar.
+    { locale: "fa-IR", enabledMonths: 7 },
+  ])(
+    "shows the focused year and reachable months in a non-Gregorian calendar — $locale",
+    async ({ locale, enabledMonths }) => {
       const user = userEvent.setup()
       renderWithContexts(
         <DateInput
@@ -3130,11 +3138,9 @@ describe("DateInput year picker with a constrained range", () => {
       // month is the first picker trigger, year the second.
       await user.click(within(region).getAllByRole("spinbutton")[0])
       const calendar = await screen.findByTestId("stDateInputCalendar")
-      const yearTrigger = within(calendar)
+      const [monthTrigger, yearTrigger] = within(calendar)
         .getAllByRole("button")
-        .filter(
-          button => button.getAttribute("aria-haspopup") === "listbox"
-        )[1]
+        .filter(button => button.getAttribute("aria-haspopup") === "listbox")
 
       // Localized year strings vary with browser locale data, so compare the
       // numeric year in the trigger against the grid's accessible name — React
@@ -3146,6 +3152,23 @@ describe("DateInput year picker with a constrained range", () => {
       expect(within(calendar).getByRole("grid")).toHaveAccessibleName(
         new RegExp(String(triggerYear))
       )
+
+      // Month availability is compared on absolute days rather than converted
+      // year numbers, so it needs its own non-Gregorian coverage: a month-off
+      // result would otherwise be silent. Counts rather than localized month
+      // names, which shift with locale data.
+      await user.click(monthTrigger)
+      const monthOptions = await screen.findAllByRole("option")
+      const reachable = monthOptions.filter(
+        option => option.getAttribute("aria-disabled") !== "true"
+      )
+      expect(monthOptions).toHaveLength(12)
+      expect(reachable).toHaveLength(enabledMonths)
+      // The month on screen must be one the user can still choose.
+      expect(reachable.map(option => option.textContent)).toContain(
+        monthTrigger.textContent
+      )
+      await user.keyboard("{Escape}")
 
       await user.click(yearTrigger)
       const options = (await screen.findAllByRole("option")).map(

--- a/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
@@ -3136,10 +3136,10 @@ describe("DateInput year picker with a constrained range", () => {
           button => button.getAttribute("aria-haspopup") === "listbox"
         )[1]
 
-      // Exact localized year strings break with ICU data changes, so compare
-      // digits against the grid's accessible name — React Aria formats that
-      // from `focusedDate` independently of this hook, so it witnesses the year
-      // actually on screen.
+      // Localized year strings vary with browser locale data, so compare the
+      // numeric year in the trigger against the grid's accessible name — React
+      // Aria formats that from `focusedDate` independently of this hook, so it
+      // witnesses the year actually on screen.
       const triggerText = yearTrigger.textContent
       const triggerYear = triggerText?.match(/\p{Nd}+/gu)?.at(-1)
       expect(triggerYear).toBeTruthy()

--- a/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
@@ -3012,6 +3012,269 @@ describe("DateInput month/year picker escape handling", () => {
   })
 })
 
+describe("DateInput year picker with a constrained range", () => {
+  const openCalendarHeader = async (
+    user: ReturnType<typeof userEvent.setup>
+  ): Promise<{ yearTrigger: HTMLElement; monthTrigger: HTMLElement }> => {
+    const region = screen.getByTestId("stDateInput")
+    const { year } = getSingleDateSegments(region)
+    await user.click(year)
+
+    const calendar = await screen.findByTestId("stDateInputCalendar")
+    return {
+      yearTrigger: within(calendar).getByRole("button", { name: "year" }),
+      monthTrigger: within(calendar).getByRole("button", { name: "month" }),
+    }
+  }
+
+  // React Aria builds its year list by stepping whole years from `min`, so it
+  // drops the final year whenever `max`'s month/day precedes `min`'s — leaving
+  // the trigger showing a year the grid isn't on. See #16686.
+  it.each([
+    {
+      name: "max month/day before min's (the reported case)",
+      min: "2024-08-03",
+      max: "2025-02-03",
+      value: "2025-02-01",
+      expectedYear: "2025",
+      expectedOptions: ["2024", "2025"],
+    },
+    {
+      name: "bounds sharing a month/day",
+      min: "2024-08-03",
+      max: "2025-08-03",
+      value: "2025-08-01",
+      expectedYear: "2025",
+      expectedOptions: ["2024", "2025"],
+    },
+    {
+      name: "range within a single year",
+      min: "2024-08-03",
+      max: "2024-11-03",
+      value: "2024-09-01",
+      expectedYear: "2024",
+      expectedOptions: ["2024"],
+    },
+  ])(
+    "lists every in-range year and shows the focused one — $name",
+    async ({ min, max, value, expectedYear, expectedOptions }) => {
+      const user = userEvent.setup()
+      render(<DateInput {...getProps({ min, max, default: [value] })} />)
+
+      const { yearTrigger } = await openCalendarHeader(user)
+
+      // The trigger must agree with the year the calendar grid is showing.
+      expect(yearTrigger).toHaveTextContent(expectedYear)
+      expect(screen.getByRole("grid")).toHaveAccessibleName(
+        new RegExp(expectedYear)
+      )
+
+      await user.click(yearTrigger)
+      const options = await screen.findAllByRole("option")
+      expect(options.map(option => option.textContent)).toEqual(
+        expectedOptions
+      )
+    }
+  )
+
+  // Range mode reads RangeCalendarStateContext instead of CalendarStateContext,
+  // so it needs its own coverage even though the header component is shared.
+  it("lists the boundary year in range mode", async () => {
+    const user = userEvent.setup()
+    render(
+      <DateInput
+        {...getProps({
+          isRange: true,
+          min: "2024-08-03",
+          max: "2025-02-03",
+          default: ["2025-02-01", "2025-02-02"],
+        })}
+      />
+    )
+
+    const region = screen.getByTestId("stDateInput")
+    await user.click(getRangeDateSegments(region, "start").year)
+
+    const calendar = await screen.findByTestId("stDateInputCalendar")
+    const yearTrigger = within(calendar).getByRole("button", { name: "year" })
+    expect(yearTrigger).toHaveTextContent("2025")
+    expect(within(calendar).getByRole("grid")).toHaveAccessibleName(/2025/)
+
+    await user.click(yearTrigger)
+    const years = (await screen.findAllByRole("option")).map(
+      option => option.textContent
+    )
+    expect(years).toEqual(["2024", "2025"])
+  })
+
+  // The visitor's locale chooses the calendar system, so `focusedDate` may be
+  // Buddhist or Persian while the min/max props stay Gregorian. Reading years
+  // off both without converting left the trigger blank. See #16686.
+  it.each(["th", "fa-IR"])(
+    "shows the focused year in a non-Gregorian calendar — %s",
+    async locale => {
+      const user = userEvent.setup()
+      renderWithContexts(
+        <DateInput
+          {...getProps({
+            min: "2024-08-03",
+            max: "2025-02-03",
+            default: ["2025-02-01"],
+          })}
+        />,
+        { libConfigContext: { locale } }
+      )
+
+      const region = screen.getByTestId("stDateInput")
+      // Segment and picker aria-labels are localized, so locate positionally:
+      // month is the first picker trigger, year the second.
+      await user.click(within(region).getAllByRole("spinbutton")[0])
+      const calendar = await screen.findByTestId("stDateInputCalendar")
+      const yearTrigger = within(calendar)
+        .getAllByRole("button")
+        .filter(
+          button => button.getAttribute("aria-haspopup") === "listbox"
+        )[1]
+
+      // Exact localized year strings break with ICU data changes, so compare
+      // digits against the grid's accessible name — React Aria formats that
+      // from `focusedDate` independently of this hook, so it witnesses the year
+      // actually on screen.
+      const triggerText = yearTrigger.textContent
+      const triggerYear = triggerText?.match(/\p{Nd}+/gu)?.at(-1)
+      expect(triggerYear).toBeTruthy()
+      expect(within(calendar).getByRole("grid")).toHaveAccessibleName(
+        new RegExp(String(triggerYear))
+      )
+
+      await user.click(yearTrigger)
+      const options = (await screen.findAllByRole("option")).map(
+        option => option.textContent
+      )
+      expect(options).toContain(triggerText)
+    }
+  )
+
+  it("caps a wide range at the visible-year window around the focused year", async () => {
+    const user = userEvent.setup()
+    render(
+      <DateInput
+        {...getProps({
+          min: "1990-08-03",
+          max: "2025-02-03",
+          default: ["2025-02-01"],
+        })}
+      />
+    )
+
+    const { yearTrigger } = await openCalendarHeader(user)
+    await user.click(yearTrigger)
+
+    const years = (await screen.findAllByRole("option")).map(
+      option => option.textContent
+    )
+    expect(years).toHaveLength(20)
+    expect(years.at(0)).toBe("2006")
+    expect(years.at(-1)).toBe("2025")
+    // The window is clamped to `max`, so later years are never offered.
+    expect(years).not.toContain("2026")
+  })
+
+  it("changes only the year, keeping the focused month", async () => {
+    const user = userEvent.setup()
+    render(
+      <DateInput
+        {...getProps({
+          min: "2020-08-03",
+          max: "2025-02-03",
+          default: ["2025-02-01"],
+        })}
+      />
+    )
+
+    const { yearTrigger, monthTrigger } = await openCalendarHeader(user)
+    // 2025 is the boundary year React Aria's list omits, so an unfixed picker
+    // falls back to the first option (2020) here.
+    expect(yearTrigger).toHaveTextContent("2025")
+    expect(monthTrigger).toHaveTextContent("February")
+
+    await user.click(yearTrigger)
+    await user.click(await screen.findByRole("option", { name: "2022" }))
+
+    expect(yearTrigger).toHaveTextContent("2022")
+    expect(monthTrigger).toHaveTextContent("February")
+    // The grid is formatted independently of the header, so it confirms the
+    // month really did survive the year change.
+    expect(screen.getByRole("grid")).toHaveAccessibleName(/February 2022/)
+  })
+
+  it("disables only the months holding no selectable day", async () => {
+    const user = userEvent.setup()
+    // Focused on December so the clamp target for a disabled month (August, the
+    // nearest bound) differs from where the calendar already is. Focusing a
+    // boundary month instead would make the final assertion unfalsifiable,
+    // because every unreachable month clamps straight back onto it.
+    render(
+      <DateInput
+        {...getProps({
+          min: "2024-08-03",
+          max: "2025-02-03",
+          default: ["2024-12-01"],
+        })}
+      />
+    )
+
+    const { monthTrigger } = await openCalendarHeader(user)
+    await user.click(monthTrigger)
+
+    const options = await screen.findAllByRole("option")
+    const enabled = options
+      .filter(option => option.getAttribute("aria-disabled") !== "true")
+      .map(option => option.textContent)
+
+    // The grid is on 2024, reachable from August onwards. August is partly out
+    // of range (min is the 3rd) but must stay usable.
+    expect(enabled).toEqual([
+      "August",
+      "September",
+      "October",
+      "November",
+      "December",
+    ])
+    expect(options).toHaveLength(12)
+
+    // The attribute alone isn't the point — clicking a disabled month must not
+    // relocate the calendar, which is the behavior the disabling protects.
+    await user.click(screen.getByRole("option", { name: "January" }))
+    expect(monthTrigger).toHaveTextContent("December")
+    // A disabled option isn't selectable, so the picker is still open.
+    expect(screen.getAllByRole("option")).toHaveLength(12)
+  })
+
+  it("clamps into range when the picked year puts the month out of bounds", async () => {
+    const user = userEvent.setup()
+    render(
+      <DateInput
+        {...getProps({
+          min: "2024-08-03",
+          max: "2025-02-03",
+          default: ["2025-02-01"],
+        })}
+      />
+    )
+
+    const { yearTrigger, monthTrigger } = await openCalendarHeader(user)
+    await user.click(yearTrigger)
+    await user.click(await screen.findByRole("option", { name: "2024" }))
+
+    // February 2024 precedes min_value, so the calendar moves to the earliest
+    // allowed month rather than leaving the valid range.
+    expect(yearTrigger).toHaveTextContent("2024")
+    expect(monthTrigger).toHaveTextContent("August")
+    expect(screen.getByRole("grid")).toHaveAccessibleName(/August 2024/)
+  })
+})
+
 describe("DateInput query param binding", () => {
   it("registers query param binding on mount when queryParamKey is set", () => {
     const props = getProps({ queryParamKey: "my_date" })

--- a/frontend/lib/src/components/widgets/DateInput/styled-components.ts
+++ b/frontend/lib/src/components/widgets/DateInput/styled-components.ts
@@ -387,6 +387,15 @@ export const StyledDropdownListBoxItem = styled(ListBoxItem)(({ theme }) => ({
   "&[data-selected]": {
     backgroundColor: theme.colors.darkenedBgMix25,
   },
+  // Mirrors StyledCalendarCell's [data-disabled] rule, so an unselectable month
+  // reads the same in the dropdown as it does in the calendar below. Fading is
+  // allowed here because these options are genuinely inactive — WCAG exempts
+  // inactive controls from the contrast requirement.
+  "&[data-disabled]": {
+    color: theme.colors.fadedText40,
+    cursor: "not-allowed",
+    backgroundColor: "transparent",
+  },
 }))
 
 export const StyledCalendarHeaderSelectTrigger = styled(Button)(

--- a/frontend/lib/src/components/widgets/DateInput/styled-components.ts
+++ b/frontend/lib/src/components/widgets/DateInput/styled-components.ts
@@ -381,10 +381,12 @@ export const StyledDropdownListBoxItem = styled(ListBoxItem)(({ theme }) => ({
   fontSize: theme.fontSizes.sm,
   color: theme.colors.bodyText,
   outline: "none",
-  "&[data-hovered], &[data-focused]": {
+  // Interactive fills exclude disabled items rather than relying on the rule
+  // below coming last, matching how BaseButton gates its own states.
+  "&:is([data-hovered],[data-focused]):not([data-disabled])": {
     backgroundColor: theme.colors.darkenedBgMix15,
   },
-  "&[data-selected]": {
+  "&[data-selected]:not([data-disabled])": {
     backgroundColor: theme.colors.darkenedBgMix25,
   },
   // Mirrors StyledCalendarCell's [data-disabled] rule, so an unselectable month
@@ -394,7 +396,6 @@ export const StyledDropdownListBoxItem = styled(ListBoxItem)(({ theme }) => ({
   "&[data-disabled]": {
     color: theme.colors.fadedText40,
     cursor: "not-allowed",
-    backgroundColor: "transparent",
   },
 }))
 

--- a/frontend/lib/src/components/widgets/DateTimeInput/DateTimeInput.test.tsx
+++ b/frontend/lib/src/components/widgets/DateTimeInput/DateTimeInput.test.tsx
@@ -161,6 +161,33 @@ describe("DateTimeInput widget", () => {
     expect(calendar).toBeVisible()
   })
 
+  // CalendarPopoverHeader is shared with st.date_input, so the year-boundary
+  // regression in #16686 applies here too.
+  it("year picker lists the boundary year when min/max cross a year", async () => {
+    const user = userEvent.setup()
+    render(
+      <DateTimeInput
+        {...getProps({
+          min: "2024-08-03T00:00",
+          max: "2025-02-03T23:59",
+          default: ["2025-02-01T10:00"],
+        })}
+      />
+    )
+
+    await user.click(screen.getAllByRole("spinbutton")[0])
+    const calendar = screen.getByTestId("stDateTimeInputCalendar")
+    const yearTrigger = within(calendar).getByRole("button", { name: "year" })
+    expect(yearTrigger).toHaveTextContent("2025")
+    expect(yearTrigger).not.toHaveTextContent("2024")
+
+    await user.click(yearTrigger)
+    const years = (await screen.findAllByRole("option")).map(
+      option => option.textContent
+    )
+    expect(years).toEqual(["2024", "2025"])
+  })
+
   it("calendar selection stays open and commits on close", async () => {
     const user = userEvent.setup()
     const props = getProps({


### PR DESCRIPTION
## Describe your changes

The date and datetime calendar header now builds its year options from the widget's own bounds, so the header year matches the grid when `min_value` and `max_value` cross a year boundary.

React Aria's `CalendarYearPicker` stepped whole years from `minValue`, dropping the final year whenever `maxValue`'s month/day fell earlier in the year, and its `value` is an index that then silently falls back to the first entry. With `min_value=date(2024, 8, 3)` and `max_value=date(2025, 2, 3)`, the grid showed February 2025 while the header read 2024 and the dropdown offered only 2024.

The dropdown still offers 20 years at a time, matching React Aria's `visibleYears` default, but the window is now anchored on the focused year and slid inside the bounds rather than starting at `min_value`. With default bounds (`value ± 10 years`) the resulting list is unchanged; for wide explicit bounds it shifts which 20 years appear.

Two further defects surfaced while fixing that and are addressed here:

- **Non-Gregorian locales.** The visitor's locale selects the calendar system, so `focusedDate` may be Buddhist or Persian while `minValue`/`maxValue` arrive Gregorian. The bounds are converted before their years are read — otherwise Thai and Persian visitors get a blank year trigger on every `st.date_input`, including with default bounds.
- **Unreachable months.** Every month was offered regardless of the bounds, and picking one relocated the calendar to the nearest bound: ask for January, land in August. Months holding no selectable day are now disabled and faded, matching how the day grid already renders unreachable dates. Partly reachable months stay selectable — with `max_value` 2025-02-03, February still offers the 1st through the 3rd.

`CalendarYearPicker` stays mounted for its localized `aria-label`, so the workaround reverts cleanly once the upstream fix lands.

Affects `st.date_input` (single and range) and `st.datetime_input`, which share the calendar header.

## GitHub Issue Link (if applicable)

Closes https://github.com/streamlit/streamlit/issues/16686

Upstream issue filed for the root cause: https://github.com/adobe/react-spectrum/issues/10531

## Testing Plan

- **Frontend unit tests** — boundary-year listing across bound shapes, non-Gregorian trigger/grid agreement (`th`, `fa-IR`), the visible-year window cap, month availability, clamping when a picked year leaves the range, and range mode's separate calendar state.
- **E2E tests** — `st_date_input_test.py` and `st_datetime_input_test.py`, asserting header text, option lists, and that unreachable months are styled as unreachable rather than only marked `aria-disabled`.
- Verified the new tests fail without the fix: 5 against the pre-fix header, and 2 more that specifically cover the non-Gregorian conversion.
- Manual testing: covered by the unit and E2E cases above, plus an automated QA pass (25 scenarios, including `th`/`fa-IR` locales) against a debug server.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Widget-only frontend calendar UX with extensive tests; no auth, persistence, or API contract changes.
> 
> **Overview**
> Fixes **#16686** by replacing React Aria’s year dropdown logic in `CalendarPopoverHeader` with a bounds-aware list: a 20-year window anchored on the focused year, both boundary years included when `min_value`/`max_value` span a year with “earlier” month/day on the max side, and the header label aligned with the grid instead of falling back to the first option.
> 
> **Also in this change:** convert `min`/`max` years into the visitor’s calendar before building options (fixes blank year triggers for locales like Thai/Persian); mark months with no selectable days as disabled with faded/`not-allowed` styling so choosing them no longer jumps the view to a bound; year selection updates only the year and keeps the focused month.
> 
> Applies to **`st.date_input`** (single and range) and **`st.datetime_input`** via the shared header. Coverage adds unit tests, Playwright scenarios for year-crossing bounds, and e2e demo widgets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8488e47497d94c9e6a2c6dd57d92369207eb1478. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

