### PR TITLE
[fix] Prevent upload hang when middleware reads the body first

### DIFF
--- a/e2e_playwright/mega_tester_app_test.py
+++ b/e2e_playwright/mega_tester_app_test.py
@@ -18,7 +18,7 @@ import re
 from typing import TYPE_CHECKING
 
 import pytest
-from playwright.sync_api import Page, expect
+from playwright.sync_api import FilePayload, Page, expect
 
 from e2e_playwright.conftest import IframedPage, rerun_app, wait_for_app_run, wait_until
 from e2e_playwright.shared.app_utils import (
@@ -199,6 +199,47 @@ def test_mega_tester_app_rendering_performance(app: Page) -> None:
     # Rerun the app 5 times:
     for _ in range(5):
         rerun_app(app)
+
+
+@pytest.mark.external_test
+def test_mega_tester_app_uploads_small_file(app_target: AppTarget) -> None:
+    """A small file uploads end to end and reaches a settled, error-free state.
+
+    This is the only coverage that drives the ``/_stcore/upload_file`` route
+    against a hosted app; the other external tests assert rendering, console
+    errors, and host messaging. Uploads are a separate round trip that hosting
+    can break on its own — via XSRF handling, session affinity, proxy body
+    limits, or path rewriting — without anything else looking wrong.
+
+    The payload is only a few hundred bytes, so a failure points at the upload
+    round trip itself rather than at a hosting body-size limit.
+    """
+    uploader = app_target.locator(".st-key-file_input")
+    uploader.scroll_into_view_if_needed()
+
+    with app_target.page.expect_file_chooser() as file_chooser_info:
+        uploader.get_by_test_id("stFileUploaderDropzone").click()
+
+    file_chooser_info.value.set_files(
+        files=[
+            FilePayload(
+                name="upload_probe.csv",
+                mimeType="text/csv",
+                buffer=b"col_a,col_b\n" + b"1,2\n" * 40,
+            )
+        ]
+    )
+
+    app_target.wait_for_run()
+
+    expect(uploader.get_by_test_id("stFileChipName")).to_have_text(
+        "upload_probe.csv", use_inner_text=True
+    )
+    # The chip name alone renders while the PUT is still in flight, so assert the
+    # terminal state: the spinner exists only during upload, and the alert only on
+    # error. Together these fail a stalled or rejected round trip.
+    expect(uploader.get_by_test_id("stFileChipIconSpinner")).to_have_count(0)
+    expect(uploader.get_by_role("alert")).to_have_count(0)
 
 
 @pytest.mark.external_test(upload_test_assets=True)

--- a/lib/streamlit/web/server/starlette/starlette_routes.py
+++ b/lib/streamlit/web/server/starlette/starlette_routes.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import asyncio
 import os
 import time
+from contextlib import aclosing
 from typing import TYPE_CHECKING, Final
 from urllib.parse import quote
 
@@ -863,11 +864,49 @@ def create_upload_routes(
         max_body_bytes = max_size_bytes + _MAX_UPLOAD_MULTIPART_OVERHEAD_BYTES
         bytes_received = 0
 
-        async def limited_receive() -> Message:
-            nonlocal bytes_received
-            message = await request.receive()
-            if message["type"] == "http.request":
-                bytes_received += len(message.get("body", b""))
+        # Use the original request's stream so a middleware-cached body is
+        # replayed instead of blocking on the drained ASGI channel (a keep-alive
+        # connection sends no disconnect). Create the iterator once so each
+        # `limited_receive` call advances the same stream, and aclose it so
+        # cleanup does not wait for GC. Sentry's StarletteIntegration is the
+        # reported trigger: it reads bodies to attach them to error events.
+        # See #16697.
+        async with aclosing(request.stream()) as body_chunks:
+
+            async def limited_receive() -> Message:
+                nonlocal bytes_received
+                try:
+                    chunk = await anext(body_chunks)
+                except StopAsyncIteration:
+                    # The stream is exhausted, so the body is complete.
+                    return {"type": "http.request", "body": b"", "more_body": False}
+                except RuntimeError as ex:
+                    # Starlette raises RuntimeError("Stream consumed") when a
+                    # middleware streamed the body away without caching it,
+                    # leaving nothing to parse. Any other RuntimeError comes from
+                    # the ASGI channel; let it keep its 500 rather than blaming a
+                    # body that was never consumed.
+                    if "Stream consumed" not in str(ex):
+                        raise
+                    # The client only ever sees the HTTP status, so log the cause
+                    # for whoever has to fix the middleware. Without this a 400
+                    # leaves no server-side signal at all, unlike the 413 below.
+                    _LOGGER.warning(
+                        "Upload rejected: the request body was already consumed "
+                        "before reaching the upload handler. This usually means "
+                        "in-process ASGI middleware read the body without "
+                        "replaying it downstream."
+                    )
+                    raise HTTPException(
+                        status_code=400,
+                        detail=(
+                            "Request body was already consumed before it reached "
+                            "the upload handler, most likely by ASGI middleware "
+                            "that read the body without replaying it."
+                        ),
+                    ) from ex
+
+                bytes_received += len(chunk)
                 if bytes_received > max_body_bytes:
                     # Log the streaming-cap rejection so operators can tell a
                     # misconfigured server.maxUploadSize (legitimate uploads being
@@ -886,10 +925,15 @@ def create_upload_routes(
                     # frames unwind - the same as an upstream ClientDisconnect.
                     # Resource use stays bounded to one in-flight request.
                     raise HTTPException(status_code=413, detail="File too large")
-            return message
 
-        limited_request = StarletteRequest(request.scope, limited_receive)
-        form = await limited_request.form()
+                # Report more body unconditionally and let exhaustion above mark
+                # the end, so framing never depends on how `stream()` chunks an
+                # empty tail. A trailing empty chunk is harmless to the parser.
+                return {"type": "http.request", "body": chunk, "more_body": True}
+
+            limited_request = StarletteRequest(request.scope, limited_receive)
+            form = await limited_request.form()
+
         uploads = [value for value in form.values() if isinstance(value, UploadFile)]
 
         if len(uploads) != 1:

--- a/lib/tests/streamlit/web/server/starlette/starlette_routes_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_routes_test.py
@@ -786,6 +786,181 @@ def test_upload_put_chunked_body_capped_before_full_read() -> None:
     mock_logger.warning.assert_called_once()
 
 
+def test_upload_put_succeeds_when_middleware_cached_body() -> None:
+    """An upload succeeds after a middleware cached the request body.
+
+    Regression test for #16697.
+    """
+    endpoint = _endpoint_for(_upload_routes(), "PUT")
+
+    body, boundary = _multipart_body(b"hello world")
+    receive_calls = 0
+
+    def _count_receive() -> None:
+        nonlocal receive_calls
+        receive_calls += 1
+
+    request = _make_upload_request(
+        [{"type": "http.request", "body": body, "more_body": False}],
+        boundary=boundary,
+        on_receive=_count_receive,
+    )
+
+    async def read_body_then_upload() -> Response:
+        # Stand in for the middleware: populates Starlette's cached body and
+        # exhausts the underlying ASGI channel.
+        await request.body()
+        return await endpoint(request)
+
+    with patch_config_options({"server.enableXsrfProtection": False}):
+        response = asyncio.run(read_body_then_upload())
+
+    assert response.status_code == 204
+    # The middleware's read is the only trip to the raw ASGI channel. Any further
+    # call would mean the handler is reading a drained channel again, which is
+    # what hung before the fix.
+    assert receive_calls == 1
+
+
+@pytest.mark.parametrize(
+    "include_intermediate_empty_chunk",
+    [
+        pytest.param(False, id="contiguous_chunks"),
+        pytest.param(True, id="with_intermediate_empty_chunk"),
+    ],
+)
+def test_upload_put_parses_multi_chunk_body(
+    include_intermediate_empty_chunk: bool,
+) -> None:
+    """A body delivered across several ASGI messages parses and is stored.
+
+    The handler rebuilds ASGI framing from ``stream()`` chunks, so a multi-message
+    body must still parse; the pre-existing chunked test only covers the oversized
+    abort path. Regression test for #16697.
+    """
+    runtime = MagicMock()
+    runtime.is_active_session.return_value = True
+    upload_mgr = MemoryUploadedFileManager("/_stcore/upload_file")
+    endpoint = _endpoint_for(
+        create_upload_routes(runtime, upload_mgr, ""),
+        "PUT",
+    )
+
+    body, boundary = _multipart_body(b"chunked payload", filename="chunked.txt")
+    split_at = len(body) // 2
+    messages: list[dict[str, Any]] = [
+        {"type": "http.request", "body": body[:split_at], "more_body": True}
+    ]
+    if include_intermediate_empty_chunk:
+        # An empty message mid-body must not truncate the parse.
+        messages.append({"type": "http.request", "body": b"", "more_body": True})
+    messages.append(
+        {"type": "http.request", "body": body[split_at:], "more_body": False}
+    )
+
+    request = _make_upload_request(messages, boundary=boundary)
+
+    with patch_config_options({"server.enableXsrfProtection": False}):
+        response = asyncio.run(endpoint(request))
+
+    assert response.status_code == 204
+    stored = upload_mgr.get_files("session123", ["fileid"])
+    assert len(stored) == 1
+    assert stored[0].name == "chunked.txt"
+    assert stored[0].data == b"chunked payload"
+
+
+def test_upload_put_enforces_size_cap_on_cached_body() -> None:
+    """The streaming size cap still applies when the body came from the cache.
+
+    Guards against trading the #16697 hang for a lost size limit: reading the
+    cached body must still count bytes against ``server.maxUploadSize``.
+    """
+    endpoint = _endpoint_for(_upload_routes(), "PUT")
+
+    body, boundary = _multipart_body(b"x" * 100)
+    request = _make_upload_request(
+        [{"type": "http.request", "body": body, "more_body": False}],
+        boundary=boundary,
+    )
+
+    async def read_body_then_upload() -> Response:
+        await request.body()
+        return await endpoint(request)
+
+    with (
+        patch_config_options(
+            {"server.enableXsrfProtection": False, "server.maxUploadSize": 0}
+        ),
+        patch(
+            "streamlit.web.server.starlette.starlette_routes"
+            "._MAX_UPLOAD_MULTIPART_OVERHEAD_BYTES",
+            8,
+        ),
+        pytest.raises(HTTPException) as exc_info,
+    ):
+        asyncio.run(read_body_then_upload())
+
+    assert exc_info.value.status_code == 413
+
+
+def test_upload_put_body_consumed_without_caching_returns_400() -> None:
+    """A body streamed away without being cached is rejected 400, not hung.
+
+    Regression test for #16697.
+    """
+    endpoint = _endpoint_for(_upload_routes(), "PUT")
+
+    body, boundary = _multipart_body(b"hello world")
+    request = _make_upload_request(
+        [{"type": "http.request", "body": body, "more_body": False}],
+        boundary=boundary,
+    )
+
+    async def stream_body_then_upload() -> Response:
+        # Consumes the stream without populating the cached body.
+        async for _ in request.stream():
+            pass
+        return await endpoint(request)
+
+    with (
+        patch_config_options({"server.enableXsrfProtection": False}),
+        patch("streamlit.web.server.starlette.starlette_routes._LOGGER") as mock_logger,
+        pytest.raises(HTTPException) as exc_info,
+    ):
+        asyncio.run(stream_body_then_upload())
+
+    assert exc_info.value.status_code == 400
+    assert "already consumed" in exc_info.value.detail
+    # The client only sees the status code, so the cause must reach the logs for
+    # whoever has to fix the offending middleware.
+    mock_logger.warning.assert_called_once()
+
+
+def test_upload_put_unrelated_runtime_error_is_not_reported_as_400() -> None:
+    """A ``RuntimeError`` from the ASGI channel keeps its 500 rather than becoming 400.
+
+    Only Starlette's "Stream consumed" means the body is unrecoverable.
+    """
+    endpoint = _endpoint_for(_upload_routes(), "PUT")
+
+    body, boundary = _multipart_body(b"hello world")
+    # `more_body=True` with nothing following: the helper's ``receive`` raises
+    # StopIteration, which asyncio surfaces as an unrelated RuntimeError.
+    request = _make_upload_request(
+        [{"type": "http.request", "body": body, "more_body": True}],
+        boundary=boundary,
+    )
+
+    with (
+        patch_config_options({"server.enableXsrfProtection": False}),
+        pytest.raises(RuntimeError) as exc_info,
+    ):
+        asyncio.run(endpoint(request))
+
+    assert "StopIteration" in str(exc_info.value)
+
+
 def test_upload_put_stores_file_and_returns_204() -> None:
     """A valid single-file upload is stored and the handler returns 204."""
     runtime = MagicMock()


### PR DESCRIPTION
## Describe your changes

Prevent uploads from hanging when in-process ASGI middleware, including Sentry, has already cached the request body — leaving a file chip spinning forever, or a chat submit button permanently disabled. The upload handler now reads the original request's cache-aware `stream()` while retaining its size cap; a body consumed without caching or replaying returns 400 and logs the likely cause.

Regression from #16207 (1.61.0): wrapping the raw ASGI `receive()` channel left uploads hung when a layer such as Sentry's `StarletteIntegration` had already called `body()` on the same `Request` (default capture cutoff ~10 KB). Before #16207 the handler called `await request.form()` on the original request, which is cache-aware.

Reproduced on `st.file_uploader` and on `st.chat_input` attachments; `st.camera_input` and `st.audio_input` share the same `/_stcore/upload_file` route.

- End-of-body comes from generator exhaustion rather than an empty chunk, so framing does not depend on how `stream()` chunks an empty tail across `starlette>=0.46.0,<2`.
- Only `RuntimeError("Stream consumed")` maps to 400; any other channel `RuntimeError` keeps its 500 so operators are not sent after the wrong cause.
- Rejected Starlette's native `form(max_part_size=...)`: `MultiPartParser.on_part_data` size-checks only the non-file branch, so file parts are unchecked and that path would have silently dropped #16207's protection rather than merely weakening it.

**What this does not fix:** a layer that drains the channel without replaying it downstream still hangs. The bytes are gone, and the handler cannot distinguish "no more body" from "body still in flight" without a disconnect. Buffer-and-replay middleware was never affected.

## GitHub Issue Link (if applicable)

Fixes #16697. Upstream counterpart: [getsentry/sentry-python#7285](https://github.com/getsentry/sentry-python/issues/7285) — worth fixing here regardless, since that addresses one trigger rather than the pattern.

## Testing Plan

- **Unit Tests (Python)** — regression tests in `starlette_routes_test.py`, each verified to fail against the unfixed handler: upload succeeds after a middleware cached the body (asserting the raw channel is touched exactly once), the size cap still fires on a cached body, an un-cached consumed body returns 400, and an unrelated channel `RuntimeError` keeps its 500. A parametrized multi-chunk case covers the reconstructed ASGI framing, which the pre-existing chunked test only exercised on the 413 abort path.
- **E2E Tests** — `test_mega_tester_app_uploads_small_file` drives `/_stcore/upload_file` in external app mode, which nothing previously covered. It asserts terminal widget state (spinner absent), not just the chip name, since the chip renders while the PUT is still in flight. Verified against a deliberately stalled upload: the chip-name assertion alone passes, the spinner assertion fails. **Verified in local mode only** — external mode needs a hosted URL, so behavior against a real deployment is unconfirmed. Separate commit so it can be dropped if reviewers would rather land it after seeing external CI.
- Verified end to end with the reporter's own launch pattern (in-process `sentry_sdk.init()`, then `cli.main()`), driving a real browser against the full server: the sub-10KB upload that previously hung now completes. Confirmed on sentry-sdk 2.61.1 (the reported version) and 2.68.1, and on starlette 0.46.0 (the dependency floor) as well as 1.6.0.
- Manual QA against the live trigger, each case run with and without the fix: `st.file_uploader` and `st.chat_input` attachments both hang before and succeed after; `st.camera_input` capture uploads successfully after. Separately, since the framing change affects every upload rather than only the middleware case, checked a 4.9 MB upload (many real chunks), three files in one interaction, and an oversized upload against `server.maxUploadSize` — the last surfaces an error chip with no spinner left behind, rather than stalling.

Note on scope: triggering this requires an **in-process** ASGI layer. Reverse proxies, ingress, and WAFs cannot cause it — they forward a complete request, so uvicorn builds a fresh `receive()` channel. Snowflake's warehouse runtime is also unaffected, since it drives `Runtime` directly rather than through `streamlit.web.server`.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core upload parsing for every PUT to `/_stcore/upload_file`; behavior is well-covered by new tests but affects a security-sensitive path (size limits, multipart handling).
> 
> **Overview**
> Fixes **#16697**: `st.file_uploader` (and other widgets using `/_stcore/upload_file`) could hang indefinitely when in-process ASGI middleware such as Sentry’s Starlette integration had already read the request body. A regression from wrapping the raw `receive()` channel meant the upload handler blocked on an exhausted stream while keep-alive stayed open.
> 
> The **PUT upload handler** now drives multipart parsing from the original request’s cache-aware `request.stream()`, rebuilding ASGI messages with the existing **streaming `server.maxUploadSize` cap** intact. Bodies that were streamed away without caching get a **400** plus a server log instead of hanging; only Starlette’s `"Stream consumed"` `RuntimeError` is mapped that way.
> 
> **Tests:** new unit regressions for cached-body success, multi-chunk bodies, size limits on cached bodies, and consumed-stream failures; a Playwright **external** test uploads a tiny CSV and asserts the file chip finishes (no spinner, no alert).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2278ce0050c9292ddab80a2f6ce1c055f218ca6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->