### PR TITLE
[refactor] Improve `st.context` and `st.user` typing

### DIFF
--- a/.cursor/rules/python_lib.mdc
+++ b/.cursor/rules/python_lib.mdc
@@ -69,8 +69,10 @@ typing errors in parameters or return types by using mypy, ty, and `assert_type`
 
 - **These are NOT pytest tests** — they are checked by mypy and ty, never executed at runtime.
 - All assertions and imports go inside `if TYPE_CHECKING:` blocks.
-- Do **not** use `def test_*()` functions or `import streamlit as st`.
-- Import from Mixin classes directly (e.g. `LayoutsMixin().expander`).
+- Do **not** use `def test_*()` functions. Import mixin methods directly
+  (e.g. `LayoutsMixin().expander`). For module-level objects such as
+  `st.context`, `st.user`, `st.bottom`, and `st.App`, import
+  `streamlit as st`.
 - Always include `from __future__ import annotations` at the top.
 - Overloads discriminated on `bool` need an explicit fallback overload for
   non-literal values, because mypy does not expand `bool` into
@@ -90,12 +92,13 @@ typing errors in parameters or return types by using mypy, ty, and `assert_type`
   instead, so the suppression can be removed once ty catches up.
 - For dict-like return values backed by `AttributeDictionary` /
   `ReadOnlyAttributeDictionary` subclasses (e.g. dataframe/chart selection
-  state, `ButtonColumn` click state, `st.data_editor` edit state), assert both
-  attribute and bracket access (e.g. `state.selection.rows` and
-  `state["selection"]["rows"]`, or `edit_state.edited_rows` and
-  `edit_state["edited_rows"]`). Use a separate `TypedDict` (`*Input`) for
-  values users assign (e.g. `selection_default`), not the returned
-  attribute-dictionary class.
+  state, `ButtonColumn` click state, `st.data_editor` edit state), and for
+  module-level objects that support both notations (`st.context`, `st.user`,
+  `st.user.tokens`), assert both attribute and bracket access (e.g.
+  `state.selection.rows` and `state["selection"]["rows"]`, or
+  `st.context.timezone` and `st.context["timezone"]`). Use a separate
+  `TypedDict` (`*Input`) for values users assign (e.g. `selection_default`),
+  not the returned attribute-dictionary class.
 
 ## Docstrings for Public API
 

--- a/.github/instructions/python_lib.instructions.md
+++ b/.github/instructions/python_lib.instructions.md
@@ -67,8 +67,10 @@ typing errors in parameters or return types by using mypy, ty, and `assert_type`
 
 - **These are NOT pytest tests** — they are checked by mypy and ty, never executed at runtime.
 - All assertions and imports go inside `if TYPE_CHECKING:` blocks.
-- Do **not** use `def test_*()` functions or `import streamlit as st`.
-- Import from Mixin classes directly (e.g. `LayoutsMixin().expander`).
+- Do **not** use `def test_*()` functions. Import mixin methods directly
+  (e.g. `LayoutsMixin().expander`). For module-level objects such as
+  `st.context`, `st.user`, `st.bottom`, and `st.App`, import
+  `streamlit as st`.
 - Always include `from __future__ import annotations` at the top.
 - Overloads discriminated on `bool` need an explicit fallback overload for
   non-literal values, because mypy does not expand `bool` into
@@ -88,12 +90,13 @@ typing errors in parameters or return types by using mypy, ty, and `assert_type`
   instead, so the suppression can be removed once ty catches up.
 - For dict-like return values backed by `AttributeDictionary` /
   `ReadOnlyAttributeDictionary` subclasses (e.g. dataframe/chart selection
-  state, `ButtonColumn` click state, `st.data_editor` edit state), assert both
-  attribute and bracket access (e.g. `state.selection.rows` and
-  `state["selection"]["rows"]`, or `edit_state.edited_rows` and
-  `edit_state["edited_rows"]`). Use a separate `TypedDict` (`*Input`) for
-  values users assign (e.g. `selection_default`), not the returned
-  attribute-dictionary class.
+  state, `ButtonColumn` click state, `st.data_editor` edit state), and for
+  module-level objects that support both notations (`st.context`, `st.user`,
+  `st.user.tokens`), assert both attribute and bracket access (e.g.
+  `state.selection.rows` and `state["selection"]["rows"]`, or
+  `st.context.timezone` and `st.context["timezone"]`). Use a separate
+  `TypedDict` (`*Input`) for values users assign (e.g. `selection_default`),
+  not the returned attribute-dictionary class.
 
 ## Docstrings for Public API
 

--- a/lib/streamlit/AGENTS.md
+++ b/lib/streamlit/AGENTS.md
@@ -61,8 +61,10 @@ typing errors in parameters or return types by using mypy, ty, and `assert_type`
 
 - **These are NOT pytest tests** — they are checked by mypy and ty, never executed at runtime.
 - All assertions and imports go inside `if TYPE_CHECKING:` blocks.
-- Do **not** use `def test_*()` functions or `import streamlit as st`.
-- Import from Mixin classes directly (e.g. `LayoutsMixin().expander`).
+- Do **not** use `def test_*()` functions. Import mixin methods directly
+  (e.g. `LayoutsMixin().expander`). For module-level objects such as
+  `st.context`, `st.user`, `st.bottom`, and `st.App`, import
+  `streamlit as st`.
 - Always include `from __future__ import annotations` at the top.
 - Overloads discriminated on `bool` need an explicit fallback overload for
   non-literal values, because mypy does not expand `bool` into
@@ -82,12 +84,13 @@ typing errors in parameters or return types by using mypy, ty, and `assert_type`
   instead, so the suppression can be removed once ty catches up.
 - For dict-like return values backed by `AttributeDictionary` /
   `ReadOnlyAttributeDictionary` subclasses (e.g. dataframe/chart selection
-  state, `ButtonColumn` click state, `st.data_editor` edit state), assert both
-  attribute and bracket access (e.g. `state.selection.rows` and
-  `state["selection"]["rows"]`, or `edit_state.edited_rows` and
-  `edit_state["edited_rows"]`). Use a separate `TypedDict` (`*Input`) for
-  values users assign (e.g. `selection_default`), not the returned
-  attribute-dictionary class.
+  state, `ButtonColumn` click state, `st.data_editor` edit state), and for
+  module-level objects that support both notations (`st.context`, `st.user`,
+  `st.user.tokens`), assert both attribute and bracket access (e.g.
+  `state.selection.rows` and `state["selection"]["rows"]`, or
+  `st.context.timezone` and `st.context["timezone"]`). Use a separate
+  `TypedDict` (`*Input`) for values users assign (e.g. `selection_default`),
+  not the returned attribute-dictionary class.
 
 ## Docstrings for Public API
 

--- a/lib/streamlit/runtime/context.py
+++ b/lib/streamlit/runtime/context.py
@@ -28,8 +28,8 @@ from streamlit.util import AttributeDictionary
 if TYPE_CHECKING:
     from streamlit.runtime.session_manager import ClientContext
 
-# Public property names on ``st.context``. Used for key notation and
-# membership so ``__getitem__`` is not treated as a sequence protocol.
+# Public property names for key notation and membership. Keep in sync with
+# ContextProxy properties so bracket access does not drift from attribute access.
 _CONTEXT_KEYS: Final = frozenset(
     {
         "headers",
@@ -160,13 +160,17 @@ class ContextProxy:
     You can access any ``st.context`` property via attribute or key notation.
     For example, use ``st.context.timezone`` or ``st.context["timezone"]``.
 
+    ``st.context`` is not a dictionary: it does not support ``.get()``,
+    ``.keys()``, or iteration.
+
     ``st.context.headers`` and ``st.context.cookies`` each return a dictionary
     of named values.
 
     """
 
-    # Property bag, not a sequence. Without this, ``__getitem__`` would make
-    # ``in`` and ``iter()`` probe integer keys.
+    # ``__getitem__`` alone would make ``st.context`` satisfy the legacy
+    # sequence-iteration protocol. Setting ``__iter__`` to ``None`` keeps
+    # ``iter(st.context)`` a ``TypeError`` instead of probing integer keys.
     __iter__ = None
 
     @property
@@ -492,13 +496,20 @@ class ContextProxy:
     def __getitem__(self, key: Literal["is_embedded"]) -> bool | None: ...
 
     @overload
-    def __getitem__(self, key: str) -> Any: ...
+    def __getitem__(
+        self, key: str
+    ) -> (
+        StreamlitHeaders | StreamlitCookies | StreamlitTheme | str | int | bool | None
+    ): ...
 
     def __getitem__(self, key: str) -> Any:
-        # Only public properties are valid keys. ``getattr`` still runs each
-        # property so metrics and the theme-read gate stay in effect.
+        # Only public properties are valid keys. ``getattr`` runs the property
+        # getter so ``gather_metrics`` still records the access.
         if key not in _CONTEXT_KEYS:
-            raise KeyError(f'st.context has no key "{key}".')
+            raise KeyError(
+                f'st.context has no key "{key}". '
+                f"Valid keys are: {', '.join(sorted(_CONTEXT_KEYS))}."
+            )
         return getattr(self, key)
 
     def __contains__(self, key: object) -> bool:

--- a/lib/streamlit/runtime/context.py
+++ b/lib/streamlit/runtime/context.py
@@ -154,14 +154,16 @@ class ContextProxy:
     """A read-only interface to user session context.
 
     ``st.context`` exposes session context for the current user, including
-    headers, cookies, theme, timezone, locale, URL, IP address, and whether
-    the app is embedded.
+    headers, cookies, theme, timezone, timezone offset, locale, URL, IP
+    address, and whether the app is embedded.
 
     You can access any ``st.context`` property via attribute or key notation.
     For example, use ``st.context.timezone`` or ``st.context["timezone"]``.
 
     ``st.context`` is not a dictionary: it does not support ``.get()``,
-    ``.keys()``, or iteration.
+    ``.keys()``, or iteration. Membership (``"timezone" in st.context``)
+    is supported and checks whether the name is a public property; it
+    does not read property values.
 
     ``st.context.headers`` and ``st.context.cookies`` each return a dictionary
     of named values.

--- a/lib/streamlit/runtime/context.py
+++ b/lib/streamlit/runtime/context.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from collections.abc import Iterable, Iterator, Mapping
 from functools import lru_cache
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Literal, overload
+from typing import TYPE_CHECKING, Any, Final, Literal, overload
 
 from streamlit import runtime
 from streamlit.runtime.context_util import maybe_add_page_path, maybe_trim_page_path
@@ -27,6 +27,22 @@ from streamlit.util import AttributeDictionary
 
 if TYPE_CHECKING:
     from streamlit.runtime.session_manager import ClientContext
+
+# Public property names on ``st.context``. Used for key notation and
+# membership so ``__getitem__`` is not treated as a sequence protocol.
+_CONTEXT_KEYS: Final = frozenset(
+    {
+        "headers",
+        "cookies",
+        "theme",
+        "timezone",
+        "timezone_offset",
+        "locale",
+        "url",
+        "ip_address",
+        "is_embedded",
+    }
+)
 
 
 def _get_client_context() -> ClientContext | None:
@@ -135,15 +151,23 @@ class StreamlitCookies(Mapping[str, str]):
 
 
 class ContextProxy:
-    """An interface to access user session context.
+    """A read-only interface to user session context.
 
-    ``st.context`` provides a read-only interface to access headers and cookies
-    for the current user session.
+    ``st.context`` exposes session context for the current user, including
+    headers, cookies, theme, timezone, locale, URL, IP address, and whether
+    the app is embedded.
 
-    Each property (``st.context.headers`` and ``st.context.cookies``) returns
-    a dictionary of named values.
+    You can access any ``st.context`` property via attribute or key notation.
+    For example, use ``st.context.timezone`` or ``st.context["timezone"]``.
+
+    ``st.context.headers`` and ``st.context.cookies`` each return a dictionary
+    of named values.
 
     """
+
+    # Property bag, not a sequence. Without this, ``__getitem__`` would make
+    # ``in`` and ``iter()`` probe integer keys.
+    __iter__ = None
 
     @property
     @gather_metrics("context.headers")
@@ -439,3 +463,43 @@ class ContextProxy:
         if ctx is None or ctx.context_info is None:
             return None
         return ctx.context_info.is_embedded
+
+    @overload
+    def __getitem__(self, key: Literal["headers"]) -> StreamlitHeaders: ...
+
+    @overload
+    def __getitem__(self, key: Literal["cookies"]) -> StreamlitCookies: ...
+
+    @overload
+    def __getitem__(self, key: Literal["theme"]) -> StreamlitTheme: ...
+
+    @overload
+    def __getitem__(self, key: Literal["timezone"]) -> str | None: ...
+
+    @overload
+    def __getitem__(self, key: Literal["timezone_offset"]) -> int | None: ...
+
+    @overload
+    def __getitem__(self, key: Literal["locale"]) -> str | None: ...
+
+    @overload
+    def __getitem__(self, key: Literal["url"]) -> str | None: ...
+
+    @overload
+    def __getitem__(self, key: Literal["ip_address"]) -> str | None: ...
+
+    @overload
+    def __getitem__(self, key: Literal["is_embedded"]) -> bool | None: ...
+
+    @overload
+    def __getitem__(self, key: str) -> Any: ...
+
+    def __getitem__(self, key: str) -> Any:
+        # Only public properties are valid keys. ``getattr`` still runs each
+        # property so metrics and the theme-read gate stay in effect.
+        if key not in _CONTEXT_KEYS:
+            raise KeyError(f'st.context has no key "{key}".')
+        return getattr(self, key)
+
+    def __contains__(self, key: object) -> bool:
+        return key in _CONTEXT_KEYS

--- a/lib/streamlit/user_info.py
+++ b/lib/streamlit/user_info.py
@@ -497,12 +497,6 @@ class TokensProxy(Mapping[str, str]):
     def __init__(self, tokens: dict[str, str]) -> None:
         self._tokens = tokens
 
-    @overload
-    def __getitem__(self, key: Literal["id", "access"]) -> str: ...
-
-    @overload
-    def __getitem__(self, key: str) -> str: ...
-
     def __getitem__(self, key: str) -> str:
         return self._tokens[key]
 
@@ -666,7 +660,8 @@ class UserInfoProxy(Mapping[str, str | bool | TokensProxy | None]):
 
     """
 
-    # Narrows ``.is_logged_in`` to ``bool``. Other claims keep the open Mapping types.
+    # Narrow the documented is_logged_in field; provider-specific claims retain
+    # the mapping's general value type.
     is_logged_in: bool
 
     @overload

--- a/lib/streamlit/user_info.py
+++ b/lib/streamlit/user_info.py
@@ -490,7 +490,8 @@ class TokensProxy(Mapping[str, str]):
             # Use the tokens for API verification
     """
 
-    # Documented token names so ``.id`` and ``.access`` type-check as ``str``.
+    # Declare the documented token names so IDEs autocomplete ``.id`` and
+    # ``.access``; any other name still resolves through ``__getattr__``.
     id: str
     access: str
 

--- a/lib/streamlit/user_info.py
+++ b/lib/streamlit/user_info.py
@@ -21,8 +21,10 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Final,
+    Literal,
     NoReturn,
     cast,
+    overload,
 )
 
 from streamlit import config, logger, runtime
@@ -488,8 +490,18 @@ class TokensProxy(Mapping[str, str]):
             # Use the tokens for API verification
     """
 
+    # Documented token names so ``.id`` and ``.access`` type-check as ``str``.
+    id: str
+    access: str
+
     def __init__(self, tokens: dict[str, str]) -> None:
         self._tokens = tokens
+
+    @overload
+    def __getitem__(self, key: Literal["id", "access"]) -> str: ...
+
+    @overload
+    def __getitem__(self, key: str) -> str: ...
 
     def __getitem__(self, key: str) -> str:
         return self._tokens[key]
@@ -653,6 +665,18 @@ class UserInfoProxy(Mapping[str, str | bool | TokensProxy | None]):
         }
 
     """
+
+    # Narrows ``.is_logged_in`` to ``bool``. Other claims keep the open Mapping types.
+    is_logged_in: bool
+
+    @overload
+    def __getitem__(self, key: Literal["is_logged_in"]) -> bool: ...
+
+    @overload
+    def __getitem__(self, key: Literal["tokens"]) -> TokensProxy: ...
+
+    @overload
+    def __getitem__(self, key: str) -> str | bool | TokensProxy | None: ...
 
     def __getitem__(self, key: str) -> str | bool | TokensProxy | None:
         if key == "tokens":

--- a/lib/tests/streamlit/runtime/context_test.py
+++ b/lib/tests/streamlit/runtime/context_test.py
@@ -23,6 +23,7 @@ from parameterized import parameterized
 import streamlit as st
 from streamlit.runtime.context import (
     _CONTEXT_KEYS,
+    ContextProxy,
     StreamlitCookies,
     StreamlitHeaders,
     StreamlitTheme,
@@ -135,6 +136,15 @@ class StContextTest(unittest.TestCase):
         mock_add_path.assert_called_once_with(
             "https://example.com/", mock_ctx.pages_manager
         )
+
+    def test_context_keys_match_public_properties(self) -> None:
+        """Allowlist must stay in sync with ContextProxy public properties."""
+        public_properties = {
+            name
+            for name, value in vars(ContextProxy).items()
+            if isinstance(value, property) and not name.startswith("_")
+        }
+        assert public_properties == _CONTEXT_KEYS
 
     @parameterized.expand([(key,) for key in sorted(_CONTEXT_KEYS)])
     @patch(

--- a/lib/tests/streamlit/runtime/context_test.py
+++ b/lib/tests/streamlit/runtime/context_test.py
@@ -22,6 +22,7 @@ from parameterized import parameterized
 
 import streamlit as st
 from streamlit.runtime.context import (
+    _CONTEXT_KEYS,
     StreamlitCookies,
     StreamlitHeaders,
     StreamlitTheme,
@@ -134,6 +135,43 @@ class StContextTest(unittest.TestCase):
         mock_add_path.assert_called_once_with(
             "https://example.com/", mock_ctx.pages_manager
         )
+
+    @parameterized.expand([(key,) for key in sorted(_CONTEXT_KEYS)])
+    @patch(
+        "streamlit.runtime.context._get_client_context", MagicMock(return_value=None)
+    )
+    def test_getitem_matches_attribute(self, property_name: str) -> None:
+        """Bracket access returns the same value as attribute access."""
+        attr_value = getattr(st.context, property_name)
+        item_value = st.context[property_name]
+        if property_name in {"headers", "cookies"}:
+            assert item_value.to_dict() == attr_value.to_dict()
+        else:
+            assert item_value == attr_value
+
+    def test_getitem_unknown_key(self) -> None:
+        """Unknown keys raise KeyError."""
+        with pytest.raises(KeyError, match=r'st.context has no key "not_a_property"'):
+            st.context["not_a_property"]
+
+    def test_contains_known_and_unknown_keys(self) -> None:
+        """Membership uses the public property allowlist."""
+        assert "timezone" in st.context
+        assert "theme" in st.context
+        assert "not_a_property" not in st.context
+
+    @patch("streamlit.runtime.context.get_script_run_ctx")
+    def test_contains_does_not_read_properties(
+        self, mock_get_script_run_ctx: MagicMock
+    ) -> None:
+        """Membership must not trigger property getters such as theme."""
+        assert "theme" in st.context
+        mock_get_script_run_ctx.assert_not_called()
+
+    def test_context_is_not_iterable(self) -> None:
+        """st.context is a property bag, not a sequence."""
+        with pytest.raises(TypeError):
+            iter(st.context)
 
     @parameterized.expand(
         [

--- a/lib/tests/streamlit/runtime/context_test.py
+++ b/lib/tests/streamlit/runtime/context_test.py
@@ -147,17 +147,41 @@ class StContextTest(unittest.TestCase):
         assert public_properties == _CONTEXT_KEYS
 
     @parameterized.expand([(key,) for key in sorted(_CONTEXT_KEYS)])
-    @patch(
-        "streamlit.runtime.context._get_client_context", MagicMock(return_value=None)
-    )
-    def test_getitem_matches_attribute(self, property_name: str) -> None:
-        """Bracket access returns the same value as attribute access."""
+    @patch("streamlit.runtime.context.get_script_run_ctx")
+    @patch("streamlit.runtime.context._get_client_context")
+    def test_getitem_matches_attribute(
+        self,
+        property_name: str,
+        mock_get_client_context: MagicMock,
+        mock_get_script_run_ctx: MagicMock,
+    ) -> None:
+        """Bracket access returns the same populated value as attribute access."""
+        mock_get_client_context.return_value = _create_mock_client_context(
+            headers=[("host", "example.com")],
+            cookies={"session": "abc"},
+            remote_ip="8.8.8.8",
+        )
+        mock_context_info = MagicMock()
+        mock_context_info.timezone = "Europe/Berlin"
+        mock_context_info.timezone_offset = -120
+        mock_context_info.locale = "en-US"
+        mock_context_info.color_scheme = "dark"
+        mock_context_info.is_embedded = True
+        mock_context_info.url = "https://example.com/app"
+        mock_ctx = MagicMock()
+        mock_ctx.context_info = mock_context_info
+        mock_ctx.pages_manager.get_pages.return_value = {}
+        mock_get_script_run_ctx.return_value = mock_ctx
+
         attr_value = getattr(st.context, property_name)
         item_value = st.context[property_name]
         if property_name in {"headers", "cookies"}:
-            assert item_value.to_dict() == attr_value.to_dict()
+            assert item_value.to_dict() == attr_value.to_dict() != {}
+        elif property_name == "theme":
+            assert item_value.type == attr_value.type == "dark"
         else:
             assert item_value == attr_value
+            assert item_value is not None
 
     def test_getitem_unknown_key(self) -> None:
         """Unknown keys raise KeyError."""

--- a/lib/tests/streamlit/typing/context_types.py
+++ b/lib/tests/streamlit/typing/context_types.py
@@ -56,6 +56,14 @@ if TYPE_CHECKING:
     assert_type(st.context.is_embedded, bool | None)
     assert_type(st.context["is_embedded"], bool | None)
 
+    def _dynamic_context_key() -> str:
+        return "timezone"
+
+    assert_type(
+        st.context[_dynamic_context_key()],
+        StreamlitHeaders | StreamlitCookies | StreamlitTheme | str | int | bool | None,
+    )
+
     # =====================================================================
     # StreamlitTheme: attribute and bracket access
     # =====================================================================

--- a/lib/tests/streamlit/typing/context_types.py
+++ b/lib/tests/streamlit/typing/context_types.py
@@ -18,10 +18,62 @@ from typing import TYPE_CHECKING, Literal
 
 from typing_extensions import assert_type
 
+# Perform type checking tests for st.context. These are checked by mypy and ty,
+# never executed at runtime.
 if TYPE_CHECKING:
-    from streamlit.runtime.context import StreamlitTheme
+    # NOTE: st.context is a module-level attribute, not a Mixin method, so we
+    # must import streamlit as st here rather than importing from a Mixin class.
+    import streamlit as st
+    from streamlit.runtime.context import (
+        ContextProxy,
+        StreamlitCookies,
+        StreamlitHeaders,
+        StreamlitTheme,
+    )
+
+    assert_type(st.context, ContextProxy)
+
+    # =====================================================================
+    # ContextProxy properties
+    # =====================================================================
+
+    assert_type(st.context.headers, StreamlitHeaders)
+    assert_type(st.context["headers"], StreamlitHeaders)
+    assert_type(st.context.cookies, StreamlitCookies)
+    assert_type(st.context["cookies"], StreamlitCookies)
+    assert_type(st.context.theme, StreamlitTheme)
+    assert_type(st.context["theme"], StreamlitTheme)
+    assert_type(st.context.timezone, str | None)
+    assert_type(st.context["timezone"], str | None)
+    assert_type(st.context.timezone_offset, int | None)
+    assert_type(st.context["timezone_offset"], int | None)
+    assert_type(st.context.locale, str | None)
+    assert_type(st.context["locale"], str | None)
+    assert_type(st.context.url, str | None)
+    assert_type(st.context["url"], str | None)
+    assert_type(st.context.ip_address, str | None)
+    assert_type(st.context["ip_address"], str | None)
+    assert_type(st.context.is_embedded, bool | None)
+    assert_type(st.context["is_embedded"], bool | None)
+
+    # =====================================================================
+    # StreamlitTheme: attribute and bracket access
+    # =====================================================================
+
+    assert_type(st.context.theme.type, Literal["dark", "light"] | None)
+    assert_type(st.context.theme["type"], Literal["dark", "light"] | None)
 
     theme = StreamlitTheme({"type": "dark"})
-
     assert_type(theme.type, Literal["dark", "light"] | None)
     assert_type(theme["type"], Literal["dark", "light"] | None)
+
+    # =====================================================================
+    # StreamlitHeaders / StreamlitCookies: Mapping access
+    # =====================================================================
+
+    assert_type(st.context.headers["host"], str)
+    assert_type(st.context.headers.get_all("pragma"), list[str])
+    assert_type(st.context.headers.to_dict(), dict[str, str])
+
+    assert_type(st.context.cookies["_ga"], str)
+    assert_type(st.context.cookies.to_dict(), dict[str, str])

--- a/lib/tests/streamlit/typing/user_types.py
+++ b/lib/tests/streamlit/typing/user_types.py
@@ -1,0 +1,64 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from typing_extensions import assert_type
+
+# Perform type checking tests for st.user. These are checked by mypy and ty,
+# never executed at runtime.
+if TYPE_CHECKING:
+    # NOTE: st.user is a module-level attribute, not a Mixin method, so we must
+    # import streamlit as st here rather than importing from a Mixin class.
+    import streamlit as st
+    from streamlit.user_info import TokensProxy, UserInfoProxy
+
+    assert_type(st.user, UserInfoProxy)
+
+    # =====================================================================
+    # is_logged_in and tokens: attribute and bracket access
+    # =====================================================================
+
+    assert_type(st.user.is_logged_in, bool)
+    assert_type(st.user["is_logged_in"], bool)
+
+    assert_type(st.user.tokens, TokensProxy)
+    assert_type(st.user["tokens"], TokensProxy)
+
+    # =====================================================================
+    # TokensProxy: documented token names, attribute and bracket access
+    # =====================================================================
+
+    assert_type(st.user.tokens.id, str)
+    assert_type(st.user.tokens["id"], str)
+    assert_type(st.user.tokens.access, str)
+    assert_type(st.user.tokens["access"], str)
+    assert_type(st.user["tokens"].id, str)
+    assert_type(st.user["tokens"]["id"], str)
+    assert_type(st.user["tokens"].access, str)
+    assert_type(st.user["tokens"]["access"], str)
+
+    # Other token names stay str.
+    assert_type(st.user.tokens["refresh"], str)
+
+    # =====================================================================
+    # Provider-specific OIDC claims stay on the open Mapping types
+    # =====================================================================
+
+    assert_type(st.user.email, str | bool | TokensProxy | None)
+    assert_type(st.user["email"], str | bool | TokensProxy | None)
+    assert_type(st.user.name, str | bool | TokensProxy | None)
+    assert_type(st.user["name"], str | bool | TokensProxy | None)

--- a/lib/tests/streamlit/typing/user_types.py
+++ b/lib/tests/streamlit/typing/user_types.py
@@ -55,7 +55,7 @@ if TYPE_CHECKING:
     assert_type(st.user.tokens["refresh"], str)
 
     # =====================================================================
-    # Provider-specific OIDC claims stay on the open Mapping types
+    # Provider-specific OIDC claims keep the mapping's general value type.
     # =====================================================================
 
     assert_type(st.user.email, str | bool | TokensProxy | None)


### PR DESCRIPTION
## Describe your changes

Adds key notation for `st.context` so `st.context["timezone"]` matches `st.context.timezone`. Users already use this dual notation on `st.user` and `st.session_state`; without it, `st.context["timezone"]` raises `TypeError`.

`st.context` stays a property bag, not a `Mapping`, so membership uses an allowlist and does not run getters such as `theme`. Unknown names raise `KeyError`.

Also narrows `st.user.is_logged_in` to `bool` for both notations, and declares the documented `st.user.tokens` names (`id`, `access`) so they surface in IDE autocompletion.

## GitHub Issue Link (if applicable)

## Testing Plan

- [x] Unit Tests (JS and/or Python)
  - `lib/tests/streamlit/runtime/context_test.py` — bracket access, unknown keys, membership, non-iteration, and allowlist-vs-properties guard
  - `lib/tests/streamlit/typing/context_types.py` and `user_types.py` — attribute and bracket types
- [ ] E2E Tests
- [ ] Any manual testing needed?

Python API only; no UI change.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

Made with [Cursor](https://cursor.com)