### PR TITLE
[fix] Harden AppTest for keys, disabled widgets, and navigation

### DIFF
--- a/lib/streamlit/testing/v1/__init__.py
+++ b/lib/streamlit/testing/v1/__init__.py
@@ -13,5 +13,6 @@
 # limitations under the License.
 
 from streamlit.testing.v1.app_test import AppTest
+from streamlit.testing.v1.element_tree import AppTestError
 
-__all__ = ["AppTest"]
+__all__ = ["AppTest", "AppTestError"]

--- a/lib/streamlit/testing/v1/app_test.py
+++ b/lib/streamlit/testing/v1/app_test.py
@@ -33,6 +33,7 @@ from streamlit.runtime.memory_media_file_storage import MemoryMediaFileStorage
 from streamlit.runtime.pages_manager import PagesManager
 from streamlit.runtime.scriptrunner.script_cache import ScriptCache
 from streamlit.runtime.secrets import Secrets
+from streamlit.runtime.state import SCRIPT_RUN_WITHOUT_ERRORS_KEY
 from streamlit.runtime.state.common import TESTING_KEY
 from streamlit.runtime.state.safe_session_state import SafeSessionState
 from streamlit.runtime.state.session_state import SessionState
@@ -100,6 +101,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Iterator, Sequence
 
     from streamlit.proto.WidgetStates_pb2 import WidgetStates
+    from streamlit.source_util import PageHash, PageInfo
 
 TMP_DIR = tempfile.TemporaryDirectory()
 
@@ -185,7 +187,7 @@ class AppTest:
         self._page_hash = ""
         # Pages registered by the most recent run, used to resolve switch_page()
         # against st.navigation hashes (which follow url_path, not filename).
-        self._registered_pages: dict[str, Any] = {}
+        self._registered_pages: dict[PageHash, PageInfo] = {}
         # Cache the discovered component manager so installed CCv2 components are
         # only scanned once per AppTest instance instead of on every rerun.
         self._bidi_component_manager: BidiComponentManager | None = None
@@ -420,7 +422,7 @@ class AppTest:
             new_pages = pages_manager.get_pages()
             if (
                 any("url_pathname" in info for info in new_pages.values())
-                or not self.exception
+                or self.session_state[SCRIPT_RUN_WITHOUT_ERRORS_KEY]
             ):
                 self._registered_pages = new_pages
         # Last event is SHUTDOWN, so the corresponding data includes query string
@@ -485,10 +487,11 @@ class AppTest:
         main script supplied to ``AppTest.from_file()`` remains the path root
         after switching pages.
 
-        Call ``run()`` at least once before switching so ``st.navigation``
-        pages can be resolved by registered script path. Switching before the
-        first run hashes the filename slug, which misses a custom
-        ``url_path``.
+        Call ``run()`` at least once before switching pages. Before the first
+        run, Streamlit identifies the page by its filename, which does not
+        match a page that ``st.navigation`` registers with a custom
+        ``url_path``. If page registration depends on Session State, call
+        ``run()`` after updating the state and before switching pages.
 
         Parameters
         ----------
@@ -543,10 +546,18 @@ class AppTest:
             if (script_path := info.get("script_path"))
             and Path(str(script_path)).resolve() == target
         ]
-        if len(path_matches) == 1:
-            return path_matches[0]
-        if len(path_matches) > 1:
-            raise ValueError(f"Multiple navigation pages use script {page_path_str!r}.")
+        if path_matches:
+            # A file can be registered under multiple URL paths. Prefer the
+            # page whose URL matches the filename, then registration order.
+            return next(
+                (
+                    page_hash
+                    for page_hash in path_matches
+                    if self._registered_pages[page_hash].get("url_pathname")
+                    == page_name
+                ),
+                path_matches[0],
+            )
 
         # st.navigation registers url_pathname even for callable-only pages.
         # Do not fall back to a filename-slug hash: that can collide with a
@@ -565,6 +576,8 @@ class AppTest:
             raise ValueError(
                 f"Could not find a navigation page for {page_path_str!r}. "
                 "AppTest.switch_page() matches registered script paths. "
+                "If page registration depends on Session State, call "
+                "AppTest.run() after updating the state and before switching. "
                 f"Known pages: {known_pages}."
             )
         return filename_hash
@@ -758,13 +771,14 @@ class AppTest:
 
     @property
     def container(self) -> BlockList:
-        """Sequence of ``st.container`` blocks.
+        """Sequence of all ``st.container`` blocks, including horizontal containers.
+
+        The implicit row that ``st.columns`` creates is not included.
 
         Returns
         -------
         BlockList
-            Sequence of ``st.container`` / flex-container blocks. Individual
-            blocks can be accessed by index or user key. For example,
+            Individual blocks can be accessed by index or key. For example,
             ``at.container[0]`` or ``at.container(key="filters")``.
         """
         return self._tree.container
@@ -1328,9 +1342,11 @@ class AppTest:
         return self._tree.get(element_type)
 
     def get_by_key(self, key: str) -> Node:
-        """Return the unique current node with this user key.
+        """Return the element, widget, or container with the given key.
 
-        Works for widgets, keyed display elements, and keyed containers.
+        Use this method when the key is unique across the app and the element
+        type does not matter. To disambiguate a key reused across types, use a
+        typed collection such as ``at.text_input(key="x")``.
 
         Parameters
         ----------

--- a/lib/streamlit/testing/v1/app_test.py
+++ b/lib/streamlit/testing/v1/app_test.py
@@ -534,22 +534,23 @@ class AppTest:
         if filename_hash in self._registered_pages:
             return filename_hash
 
-        # File pages registered by st.navigation include a script_path. If any
-        # exist and none matched, fail instead of silently opening the default
-        # page (https://github.com/streamlit/streamlit/issues/16611).
-        registered_files = [
-            str(info["script_path"])
-            for info in self._registered_pages.values()
-            if info.get("script_path")
-        ]
+        # st.navigation registers url_pathname even for callable-only pages.
+        # Fail instead of silently opening the default page when the requested
+        # file is not in that registry (https://github.com/streamlit/streamlit/issues/16611).
         has_navigation_registry = any(
             "url_pathname" in info for info in self._registered_pages.values()
         )
-        if registered_files and has_navigation_registry:
+        if has_navigation_registry:
+            known_pages = [
+                str(info["script_path"])
+                if info.get("script_path")
+                else str(info.get("url_pathname") or info.get("page_name") or page_hash)
+                for page_hash, info in self._registered_pages.items()
+            ]
             raise ValueError(
                 f"Could not find a navigation page for {page_path_str!r}. "
                 "AppTest.switch_page() matches registered script paths. "
-                f"Known script paths: {registered_files}."
+                f"Known pages: {known_pages}."
             )
         return filename_hash
 

--- a/lib/streamlit/testing/v1/app_test.py
+++ b/lib/streamlit/testing/v1/app_test.py
@@ -412,12 +412,15 @@ class AppTest:
                 widget_state, self.query_params, timeout, self._page_hash
             )
             self._tree._runner = self
-            # A run that fails before st.navigation leaves a main-page-only
-            # fallback. Keep the last navigation registry so switch_page()
-            # does not silently fall back to a filename hash.
+            # A failed run that never reaches st.navigation leaves a
+            # main-page-only fallback. Keep the last navigation registry in
+            # that case so switch_page() does not silently hash the filename.
+            # A successful run that no longer calls st.navigation must drop
+            # the stale map.
             new_pages = pages_manager.get_pages()
-            if any("url_pathname" in info for info in new_pages.values()) or not any(
-                "url_pathname" in info for info in self._registered_pages.values()
+            if (
+                any("url_pathname" in info for info in new_pages.values())
+                or not self.exception
             ):
                 self._registered_pages = new_pages
         # Last event is SHUTDOWN, so the corresponding data includes query string

--- a/lib/streamlit/testing/v1/app_test.py
+++ b/lib/streamlit/testing/v1/app_test.py
@@ -39,6 +39,7 @@ from streamlit.runtime.state.session_state import SessionState
 from streamlit.source_util import page_icon_and_name
 from streamlit.testing.v1.element_tree import (
     Block,
+    BlockList,
     Button,
     ButtonGroup,
     Caption,
@@ -182,6 +183,9 @@ class AppTest:
         self.args = args
         self.kwargs = kwargs
         self._page_hash = ""
+        # Pages registered by the most recent run, used to resolve switch_page()
+        # against st.navigation hashes (which follow url_path, not filename).
+        self._registered_pages: dict[str, Any] = {}
         # Cache the discovered component manager so installed CCv2 components are
         # only scanned once per AppTest instance instead of on every rerun.
         self._bidi_component_manager: BidiComponentManager | None = None
@@ -408,6 +412,7 @@ class AppTest:
                 widget_state, self.query_params, timeout, self._page_hash
             )
             self._tree._runner = self
+            self._registered_pages = pages_manager.get_pages()
         # Last event is SHUTDOWN, so the corresponding data includes query string
         query_string = script_runner.event_data[-1]["client_state"].query_string
         self.query_params = parse.parse_qs(query_string)
@@ -502,9 +507,51 @@ class AppTest:
                 f"{str(full_page_path.resolve())!r}."
             )
         page_path_str = str(full_page_path.resolve())
-        _, page_name = page_icon_and_name(Path(page_path_str))
-        self._page_hash = calc_hash(page_name)
+        self._page_hash = self._resolve_page_hash(page_path_str)
         return self
+
+    def _resolve_page_hash(self, page_path_str: str) -> str:
+        """Map a page file to the script hash a real session would use.
+
+        ``st.Page`` hashes ``url_path``, which may differ from the filename.
+        After the first run, match the resolved script path against pages
+        registered by ``st.navigation`` or a ``pages/`` directory.
+        """
+        _, page_name = page_icon_and_name(Path(page_path_str))
+        filename_hash = calc_hash(page_name)
+        target = Path(page_path_str).resolve()
+
+        path_matches = [
+            page_hash
+            for page_hash, info in self._registered_pages.items()
+            if (script_path := info.get("script_path"))
+            and Path(str(script_path)).resolve() == target
+        ]
+        if len(path_matches) == 1:
+            return path_matches[0]
+        if len(path_matches) > 1:
+            raise ValueError(f"Multiple navigation pages use script {page_path_str!r}.")
+        if filename_hash in self._registered_pages:
+            return filename_hash
+
+        # File pages registered by st.navigation include a script_path. If any
+        # exist and none matched, fail instead of silently opening the default
+        # page (https://github.com/streamlit/streamlit/issues/16611).
+        registered_files = [
+            str(info["script_path"])
+            for info in self._registered_pages.values()
+            if info.get("script_path")
+        ]
+        has_navigation_registry = any(
+            "url_pathname" in info for info in self._registered_pages.values()
+        )
+        if registered_files and has_navigation_registry:
+            raise ValueError(
+                f"Could not find a navigation page for {page_path_str!r}. "
+                "AppTest.switch_page() matches registered script paths. "
+                f"Known script paths: {registered_files}."
+            )
+        return filename_hash
 
     @property
     def main(self) -> Block:
@@ -692,6 +739,19 @@ class AppTest:
             is an extension of the Block class.
         """
         return self._tree.columns
+
+    @property
+    def container(self) -> BlockList:
+        """Sequence of ``st.container`` blocks.
+
+        Returns
+        -------
+        BlockList
+            Sequence of ``st.container`` / flex-container blocks. Individual
+            blocks can be accessed by index or user key. For example,
+            ``at.container[0]`` or ``at.container(key="filters")``.
+        """
+        return self._tree.container
 
     @property
     def dataframe(self) -> ElementList[Dataframe]:
@@ -1250,6 +1310,30 @@ class AppTest:
             the ``st.slider`` widget with a given key.
         """
         return self._tree.get(element_type)
+
+    def get_by_key(self, key: str) -> Node:
+        """Return the unique current node with this user key.
+
+        Works for widgets, keyed display elements, and keyed containers.
+
+        Parameters
+        ----------
+        key : str
+            The user-provided ``key`` of the element or container.
+
+        Returns
+        -------
+        Element or Block
+            The matching node.
+
+        Raises
+        ------
+        KeyError
+            If no current node has this key.
+        AppTestError
+            If more than one current node has this key.
+        """
+        return self._tree.get_by_key(key)
 
     def __repr__(self) -> str:
         return repr_(self)

--- a/lib/streamlit/testing/v1/app_test.py
+++ b/lib/streamlit/testing/v1/app_test.py
@@ -412,7 +412,14 @@ class AppTest:
                 widget_state, self.query_params, timeout, self._page_hash
             )
             self._tree._runner = self
-            self._registered_pages = pages_manager.get_pages()
+            # A run that fails before st.navigation leaves a main-page-only
+            # fallback. Keep the last navigation registry so switch_page()
+            # does not silently fall back to a filename hash.
+            new_pages = pages_manager.get_pages()
+            if any("url_pathname" in info for info in new_pages.values()) or not any(
+                "url_pathname" in info for info in self._registered_pages.values()
+            ):
+                self._registered_pages = new_pages
         # Last event is SHUTDOWN, so the corresponding data includes query string
         query_string = script_runner.event_data[-1]["client_state"].query_string
         self.query_params = parse.parse_qs(query_string)

--- a/lib/streamlit/testing/v1/app_test.py
+++ b/lib/streamlit/testing/v1/app_test.py
@@ -475,6 +475,11 @@ class AppTest:
         main script supplied to ``AppTest.from_file()`` remains the path root
         after switching pages.
 
+        Call ``run()`` at least once before switching so ``st.navigation``
+        pages can be resolved by registered script path. Switching before the
+        first run hashes the filename slug, which misses a custom
+        ``url_path``.
+
         Parameters
         ----------
         page_path: str
@@ -490,7 +495,8 @@ class AppTest:
         ------
         ValueError
             If ``page_path`` does not point to a file relative to the main
-            script.
+            script, or if ``st.navigation`` is active and the file is not a
+            registered page.
 
         Examples
         --------
@@ -531,12 +537,11 @@ class AppTest:
             return path_matches[0]
         if len(path_matches) > 1:
             raise ValueError(f"Multiple navigation pages use script {page_path_str!r}.")
-        if filename_hash in self._registered_pages:
-            return filename_hash
 
         # st.navigation registers url_pathname even for callable-only pages.
-        # Fail instead of silently opening the default page when the requested
-        # file is not in that registry (https://github.com/streamlit/streamlit/issues/16611).
+        # Do not fall back to a filename-slug hash: that can collide with a
+        # callable page or a custom url_path and silently open the wrong page
+        # (https://github.com/streamlit/streamlit/issues/16611).
         has_navigation_registry = any(
             "url_pathname" in info for info in self._registered_pages.values()
         )

--- a/lib/streamlit/testing/v1/element_tree.py
+++ b/lib/streamlit/testing/v1/element_tree.py
@@ -97,7 +97,7 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 
 
-class AppTestError(Exception):
+class AppTestError(builtins.Exception):
     """Raised when an AppTest query or interaction is invalid.
 
     AppTest can run apps that contain unimplemented or browser-only elements.
@@ -211,6 +211,8 @@ class UnknownElement(Element):
                 if state is not None:
                     return state[proto_id]
             except (KeyError, ValueError, AttributeError, TypeError):
+                # Missing or unreadable widget state is expected for
+                # unimplemented elements; fall back to a proto field.
                 pass
         return getattr(self.proto, "value", None)
 
@@ -1683,7 +1685,9 @@ class Slider(Widget, Generic[SliderValueT]):
         self, v: SliderValueT | Sequence[SliderValueT]
     ) -> Slider[SliderValueT]:
         """Set the (single) value of the slider."""
-        return super().set_value(v)
+        self._assert_can_interact()
+        self._value = v
+        return self
 
     @property
     def _widget_state(self) -> WidgetState:

--- a/lib/streamlit/testing/v1/element_tree.py
+++ b/lib/streamlit/testing/v1/element_tree.py
@@ -216,8 +216,8 @@ class UnknownElement(Element):
                 state = self.root.session_state
                 if state is not None:
                     return state[proto_id]
-            except (KeyError, ValueError, AttributeError, TypeError):
-                # Missing or unreadable widget state is expected for
+            except (KeyError, ValueError):
+                # Missing widget state or a non-widget id is expected for
                 # unimplemented elements; fall back to a proto field.
                 pass
         return _unknown_element_content(self.proto)
@@ -300,8 +300,9 @@ class ElementList(Generic[El_co]):
     def __call__(self, key: str) -> El_co:
         """Return the first element in this collection with the given user key.
 
-        Unlike ``get_by_key``, this keeps first-match behavior so existing
-        typed lookups such as ``at.button("x")`` stay compatible.
+        The same key can appear on different element types, so this returns the
+        first match in this collection. Use ``get_by_key`` when an ambiguous
+        key should raise.
         """
         for e in self._list:
             if getattr(e, "key", None) == key:
@@ -361,9 +362,9 @@ class BlockList:
     def __call__(self, key: str) -> Block:
         """Return the first block in this collection with the given user key.
 
-        Unlike ``get_by_key``, this keeps first-match behavior so typed
-        lookups such as ``at.container("x")`` stay compatible with
-        ``at.button("x")``.
+        The same key can appear on different block types, so this returns the
+        first match in this collection. Use ``get_by_key`` when an ambiguous
+        key should raise.
         """
         for e in self._list:
             if e.key == key:
@@ -1724,9 +1725,7 @@ class Slider(Widget, Generic[SliderValueT]):
         self, v: SliderValueT | Sequence[SliderValueT]
     ) -> Slider[SliderValueT]:
         """Set the (single) value of the slider."""
-        self._assert_can_interact()
-        self._value = v
-        return self
+        return cast("Slider[SliderValueT]", super().set_value(v))
 
     @property
     def _widget_state(self) -> WidgetState:
@@ -2077,6 +2076,7 @@ class Block:
     children: dict[int, Node]
     proto: Any = field(repr=False)
     root: ElementTree = field(repr=False)
+    _block_id: str = field(repr=False, default="", init=False)
 
     def __init__(
         self,
@@ -2112,11 +2112,13 @@ class Block:
     def key(self) -> str | None:
         """User key for this block, if the corresponding command set one."""
         proto = self.proto
-        block_id = getattr(self, "_block_id", None) or (
+        block_id = self._block_id or (
             getattr(proto, "id", None) if proto is not None else None
         )
         if block_id:
             return user_key_from_element_id(block_id)
+        if self.type == "form" and proto is not None:
+            return cast("str", proto.form.form_id)
         return None
 
     def get_by_key(self, key: str) -> Node:
@@ -2200,9 +2202,7 @@ class Block:
     def container(self) -> BlockList:
         """``st.container`` blocks, including horizontal/flex containers.
 
-        The implicit row wrapper created by ``st.columns`` is excluded so
-        index lookups such as ``at.container[0]`` stay aligned with
-        user-created containers.
+        The implicit row wrapper created by ``st.columns`` is excluded.
         """
         return BlockList(
             [
@@ -2211,6 +2211,8 @@ class Block:
                 if isinstance(e, Block)
                 and e is not self
                 and e.type in {"container", "flex_container"}
+                # st.columns currently emits a flex-container whose direct
+                # children are Column blocks; that wrapper is not st.container.
                 and not any(isinstance(child, Column) for child in e.children.values())
             ]
         )
@@ -2470,7 +2472,6 @@ class ChatMessage(Block):
         self.type = "chat_message"
         self.name = proto.name
         self.avatar = proto.avatar
-        self._block_id = ""
 
 
 @dataclass(repr=False)
@@ -2505,7 +2506,6 @@ class Column(Block):
         self.type = "column"
         self.weight = proto.weight
         self.gap = self._GAP_SIZE_TO_STRING.get(proto.gap_config.gap_size)
-        self._block_id = ""
 
 
 @dataclass(repr=False)
@@ -2524,7 +2524,6 @@ class Expander(Block):
         self.type = "expander"
         self.icon = proto.icon
         self.label = proto.label
-        self._block_id = ""
 
 
 @dataclass(repr=False)
@@ -2541,7 +2540,6 @@ class Status(Block):
         self.type = "status"
         self.icon = proto.icon
         self.label = proto.label
-        self._block_id = ""
 
     @property
     def state(self) -> str:
@@ -2573,7 +2571,6 @@ class Tab(Block):
         self.root = root
         self.type = "tab"
         self.label = proto.label
-        self._block_id = ""
 
 
 Node: TypeAlias = Element | Block
@@ -2616,6 +2613,7 @@ class ElementTree(Block):
         self.children = {}
         self.root = self
         self.type = "root"
+        self._block_id = ""
 
     @property
     def main(self) -> Block:

--- a/lib/streamlit/testing/v1/element_tree.py
+++ b/lib/streamlit/testing/v1/element_tree.py
@@ -292,7 +292,11 @@ class ElementList(Generic[El_co]):
         return hash(tuple(self._list))
 
     def __call__(self, key: str) -> El_co:
-        """Return the unique element in this collection with the given user key."""
+        """Return the first element in this collection with the given user key.
+
+        Unlike ``get_by_key``, this keeps first-match behavior so existing
+        typed lookups such as ``at.button("x")`` stay compatible.
+        """
         for e in self._list:
             if getattr(e, "key", None) == key:
                 return e
@@ -2056,6 +2060,7 @@ class Block:
         else:
             self.type = "unknown"
         self.root = root
+        self._block_id = getattr(proto, "id", "") or "" if proto is not None else ""
 
     def __len__(self) -> int:
         return len(self.children)
@@ -2072,9 +2077,9 @@ class Block:
     def key(self) -> str | None:
         """User key for this block, if the corresponding command set one."""
         proto = self.proto
-        if proto is None:
-            return None
-        block_id = getattr(proto, "id", None)
+        block_id = getattr(self, "_block_id", None) or (
+            getattr(proto, "id", None) if proto is not None else None
+        )
         if block_id:
             return user_key_from_element_id(block_id)
         return None
@@ -2158,7 +2163,12 @@ class Block:
 
     @property
     def container(self) -> BlockList:
-        """``st.container`` / flex-container blocks."""
+        """``st.container`` blocks, including horizontal/flex containers.
+
+        The implicit row wrapper created by ``st.columns`` is excluded so
+        index lookups such as ``at.container[0]`` stay aligned with
+        user-created containers.
+        """
         return BlockList(
             [
                 e
@@ -2166,6 +2176,7 @@ class Block:
                 if isinstance(e, Block)
                 and e is not self
                 and e.type in {"container", "flex_container"}
+                and not any(isinstance(child, Column) for child in e.children.values())
             ]
         )
 
@@ -2401,6 +2412,7 @@ class SpecialBlock(Block):
         else:
             self.type = "unknown"
         self.root = root
+        self._block_id = getattr(proto, "id", "") or "" if proto is not None else ""
 
 
 @dataclass(repr=False)
@@ -2423,6 +2435,7 @@ class ChatMessage(Block):
         self.type = "chat_message"
         self.name = proto.name
         self.avatar = proto.avatar
+        self._block_id = ""
 
 
 @dataclass(repr=False)
@@ -2457,6 +2470,7 @@ class Column(Block):
         self.type = "column"
         self.weight = proto.weight
         self.gap = self._GAP_SIZE_TO_STRING.get(proto.gap_config.gap_size)
+        self._block_id = ""
 
 
 @dataclass(repr=False)
@@ -2475,6 +2489,7 @@ class Expander(Block):
         self.type = "expander"
         self.icon = proto.icon
         self.label = proto.label
+        self._block_id = ""
 
 
 @dataclass(repr=False)
@@ -2491,6 +2506,7 @@ class Status(Block):
         self.type = "status"
         self.icon = proto.icon
         self.label = proto.label
+        self._block_id = ""
 
     @property
     def state(self) -> str:
@@ -2522,6 +2538,7 @@ class Tab(Block):
         self.root = root
         self.type = "tab"
         self.label = proto.label
+        self._block_id = ""
 
 
 Node: TypeAlias = Element | Block
@@ -2751,6 +2768,7 @@ def parse_tree_from_messages(messages: list[ForwardMsg]) -> ElementTree:
                 new_node = Tab(block.tab, root=root)
             else:
                 new_node = Block(proto=block, root=root)
+            new_node._block_id = block.id or ""
         elif delta.WhichOneof("type") == "new_transient":
             # new_transient (e.g. spinner) - skip these in the element tree
             continue

--- a/lib/streamlit/testing/v1/element_tree.py
+++ b/lib/streamlit/testing/v1/element_tree.py
@@ -97,6 +97,15 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 
 
+class AppTestError(Exception):
+    """Raised when an AppTest query or interaction is invalid.
+
+    AppTest can run apps that contain unimplemented or browser-only elements.
+    This error is reserved for an explicit test action that a browser user
+    could not perform, such as updating a disabled widget.
+    """
+
+
 def _format_value_for_widget(format_func: Callable[[Any], str], value: Any) -> str:
     """Format a widget value into its option label.
 
@@ -190,17 +199,20 @@ class UnknownElement(Element):
         self.proto = getattr(proto, ty)
         self.root = root
         self.type = ty
-        self.key = None
+        proto_id = getattr(self.proto, "id", "") or ""
+        self.key = user_key_from_element_id(proto_id) if proto_id else None
 
     @property
     def value(self) -> Any:
-        try:
-            state = self.root.session_state
-            assert state is not None
-            return state[self.proto.id]
-        except ValueError:
-            # No id field, not a widget
-            return self.proto.value
+        proto_id = getattr(self.proto, "id", None)
+        if proto_id:
+            try:
+                state = self.root.session_state
+                if state is not None:
+                    return state[proto_id]
+            except (KeyError, ValueError, AttributeError, TypeError):
+                pass
+        return getattr(self.proto, "value", None)
 
 
 @dataclass(repr=False)
@@ -218,8 +230,18 @@ class Widget(Element, ABC):
         self.key = user_key_from_element_id(self.id)
         self._value = None
 
+    def _assert_can_interact(self) -> None:
+        """Reject interactions that a browser user cannot perform."""
+        if getattr(self.proto, "disabled", False):
+            key_part = f" (key={self.key!r})" if self.key else ""
+            raise AppTestError(
+                f"Cannot update a disabled {self.type} widget{key_part}. "
+                "A browser user cannot interact with a disabled widget."
+            )
+
     def set_value(self, v: Any) -> Self:
         """Set the value of the widget."""
+        self._assert_can_interact()
         self._value = v
         return self
 
@@ -267,6 +289,13 @@ class ElementList(Generic[El_co]):
     def __hash__(self) -> int:
         return hash(tuple(self._list))
 
+    def __call__(self, key: str) -> El_co:
+        """Return the unique element in this collection with the given user key."""
+        for e in self._list:
+            if getattr(e, "key", None) == key:
+                return e
+        raise KeyError(key)
+
     @property
     def values(self) -> Sequence[Any]:
         return [e.value for e in self]
@@ -276,11 +305,28 @@ W_co = TypeVar("W_co", bound=Widget, covariant=True)
 
 
 class WidgetList(ElementList[W_co], Generic[W_co]):
-    def __call__(self, key: str) -> W_co:
+    """ElementList narrowed to widgets for typing."""
+
+
+class BlockList:
+    """Sequence of layout blocks with optional lookup by user key."""
+
+    def __init__(self, els: Sequence[Block]) -> None:
+        self._list = list(els)
+
+    def __len__(self) -> int:
+        return len(self._list)
+
+    def __iter__(self) -> Iterator[Block]:
+        return iter(self._list)
+
+    def __getitem__(self, idx: int) -> Block:
+        return self._list[idx]
+
+    def __call__(self, key: str) -> Block:
         for e in self._list:
             if e.key == key:
                 return e
-
         raise KeyError(key)
 
 
@@ -361,8 +407,7 @@ class Button(Widget):
 
     def set_value(self, v: bool) -> Button:
         """Set the value of the button."""
-        self._value = v
-        return self
+        return super().set_value(v)
 
     def click(self) -> Button:
         """Set the value of the button to True."""
@@ -403,8 +448,7 @@ class DownloadButton(Widget):
 
     def set_value(self, v: bool) -> DownloadButton:
         """Set the value of the download button."""
-        self._value = v
-        return self
+        return super().set_value(v)
 
     def click(self) -> DownloadButton:
         """Set the value of the download button to True."""
@@ -425,8 +469,7 @@ class ChatInput(Widget):
 
     def set_value(self, v: str | None) -> ChatInput:
         """Set the value of the widget."""
-        self._value = v
-        return self
+        return super().set_value(v)
 
     @property
     def _widget_state(self) -> WidgetState:
@@ -479,8 +522,7 @@ class Checkbox(Widget):
 
     def set_value(self, v: bool) -> Checkbox:
         """Set the value of the widget."""
-        self._value = v
-        return self
+        return super().set_value(v)
 
     def check(self) -> Checkbox:
         """Set the value of the widget to True."""
@@ -550,8 +592,7 @@ class ColorPicker(Widget):
 
     def set_value(self, v: str) -> ColorPicker:
         """Set the value of the widget as a hex string."""
-        self._value = v
-        return self
+        return super().set_value(v)
 
     def pick(self, v: str) -> ColorPicker:
         """Set the value of the widget as a hex string. May omit the "#" prefix."""
@@ -609,8 +650,7 @@ class DateInput(Widget):
 
     def set_value(self, v: DateValue) -> DateInput:
         """Set the value of the widget."""
-        self._value = v
-        return self
+        return super().set_value(v)
 
     @property
     def _widget_state(self) -> WidgetState:
@@ -891,8 +931,7 @@ class ButtonGroup(Widget, Generic[T]):
         For single-select mode, pass a single value or None to clear the selection.
         For multi-select mode, pass a list of values (use empty list to clear).
         """
-        self._value = v
-        return self
+        return super().set_value(v)
 
     def select(self, v: T) -> ButtonGroup[T]:
         """Add a selection to the widget.
@@ -978,8 +1017,7 @@ class Feedback(Widget):
 
     def set_value(self, v: int | None) -> Feedback:
         """Set the value of the feedback widget. (int or None)"""  # noqa: D400
-        self._value = v
-        return self
+        return super().set_value(v)
 
 
 @dataclass(repr=False)
@@ -1052,6 +1090,7 @@ class FileUploader(Widget):
         """
         from uuid import uuid4
 
+        self._assert_can_interact()
         if files is None:
             self._files = None
         elif isinstance(files, tuple) and len(files) == 3 and isinstance(files[0], str):
@@ -1094,6 +1133,7 @@ class FileUploader(Widget):
         """
         from uuid import uuid4
 
+        self._assert_can_interact()
         if self._files is None or isinstance(self._files, InitialValue):
             self._files = []
         self._files.append((str(uuid4()), filename, content, mime_type))
@@ -1107,6 +1147,7 @@ class FileUploader(Widget):
         FileUploader
             The FileUploader instance for method chaining.
         """
+        self._assert_can_interact()
         self._files = None
         return self
 
@@ -1245,8 +1286,7 @@ class MenuButton(Widget, Generic[T]):
 
     def set_value(self, v: T | None) -> MenuButton[T]:
         """Set the selected option value."""
-        self._value = v
-        return self
+        return super().set_value(v)
 
     def click(self, v: T) -> MenuButton[T]:
         """Click an option by value, simulating user selection."""
@@ -1318,9 +1358,7 @@ class Multiselect(Widget, Generic[T]):
 
     def set_value(self, v: list[T]) -> Multiselect[T]:
         """Set the value of the multiselect widget. (list)"""  # noqa: D400
-
-        self._value = v
-        return self
+        return super().set_value(v)
 
     def select(self, v: T) -> Multiselect[T]:
         """
@@ -1377,8 +1415,7 @@ class NumberInput(Widget):
 
     def set_value(self, v: Number | None) -> NumberInput:
         """Set the value of the ``st.number_input`` widget."""
-        self._value = v
-        return self
+        return super().set_value(v)
 
     @property
     def _widget_state(self) -> WidgetState:
@@ -1460,8 +1497,7 @@ class Radio(Widget, Generic[T]):
 
     def set_value(self, v: T | None) -> Radio[T]:
         """Set the selection by value."""
-        self._value = v
-        return self
+        return super().set_value(v)
 
     @property
     def _widget_state(self) -> WidgetState:
@@ -1522,8 +1558,7 @@ class Selectbox(Widget, Generic[T]):
 
     def set_value(self, v: T | None) -> Selectbox[T]:
         """Set the selection by value."""
-        self._value = v
-        return self
+        return super().set_value(v)
 
     def select(self, v: T | None) -> Selectbox[T]:
         """Set the selection by value."""
@@ -1568,8 +1603,7 @@ class SelectSlider(Widget, Generic[T]):
 
     def set_value(self, v: T | Sequence[T]) -> SelectSlider[T]:
         """Set the (single) selection by value."""
-        self._value = v
-        return self
+        return super().set_value(v)
 
     @property
     def _widget_state(self) -> WidgetState:
@@ -1649,8 +1683,7 @@ class Slider(Widget, Generic[SliderValueT]):
         self, v: SliderValueT | Sequence[SliderValueT]
     ) -> Slider[SliderValueT]:
         """Set the (single) value of the slider."""
-        self._value = v
-        return self
+        return super().set_value(v)
 
     @property
     def _widget_state(self) -> WidgetState:
@@ -1734,8 +1767,7 @@ class TextArea(Widget):
 
     def set_value(self, v: str | None) -> TextArea:
         """Set the value of the widget."""
-        self._value = v
-        return self
+        return super().set_value(v)
 
     @property
     def _widget_state(self) -> WidgetState:
@@ -1786,8 +1818,7 @@ class TextInput(Widget):
 
     def set_value(self, v: str | None) -> TextInput:
         """Set the value of the widget."""
-        self._value = v
-        return self
+        return super().set_value(v)
 
     @property
     def _widget_state(self) -> WidgetState:
@@ -1840,8 +1871,7 @@ class TimeInput(Widget):
 
     def set_value(self, v: TimeValue | None) -> TimeInput:
         """Set the value of the widget."""
-        self._value = v
-        return self
+        return super().set_value(v)
 
     @property
     def _widget_state(self) -> WidgetState:
@@ -1900,8 +1930,7 @@ class DateTimeInput(Widget):
 
     def set_value(self, v: DateTimeWidgetValue | None) -> DateTimeInput:
         """Set the value of the widget."""
-        self._value = v
-        return self
+        return super().set_value(v)
 
     @property
     def _widget_state(self) -> WidgetState:
@@ -1986,8 +2015,7 @@ class Toggle(Widget):
 
     def set_value(self, v: bool) -> Toggle:
         """Set the value of the widget."""
-        self._value = v
-        return self
+        return super().set_value(v)
 
 
 @dataclass(repr=False)
@@ -2038,7 +2066,31 @@ class Block:
 
     @property
     def key(self) -> str | None:
+        """User key for this block, if the corresponding command set one."""
+        proto = self.proto
+        if proto is None:
+            return None
+        block_id = getattr(proto, "id", None)
+        if block_id:
+            return user_key_from_element_id(block_id)
         return None
+
+    def get_by_key(self, key: str) -> Node:
+        """Return the unique current node with this user key.
+
+        Works for widgets, keyed display elements, and keyed containers.
+        Raises ``KeyError`` if no node matches and ``AppTestError`` if
+        more than one node matches.
+        """
+        matches = [e for e in self if e is not self and getattr(e, "key", None) == key]
+        if len(matches) == 1:
+            return matches[0]
+        if not matches:
+            raise KeyError(key)
+        raise AppTestError(
+            f"Multiple elements have key {key!r}. "
+            "Scope the query to a container or use a typed collection."
+        )
 
     # We could implement these using __getattr__ but that would have
     # much worse type information.
@@ -2099,6 +2151,19 @@ class Block:
     @property
     def columns(self) -> Sequence[Column]:
         return self.get("column")  # type: ignore
+
+    @property
+    def container(self) -> BlockList:
+        """``st.container`` / flex-container blocks."""
+        return BlockList(
+            [
+                e
+                for e in self
+                if isinstance(e, Block)
+                and e is not self
+                and e.type in {"container", "flex_container"}
+            ]
+        )
 
     @property
     def dataframe(self) -> ElementList[Dataframe]:

--- a/lib/streamlit/testing/v1/element_tree.py
+++ b/lib/streamlit/testing/v1/element_tree.py
@@ -55,6 +55,7 @@ from streamlit.proto.Markdown_pb2 import Markdown as MarkdownProto
 from streamlit.proto.Slider_pb2 import Slider as SliderProto
 from streamlit.proto.WidgetStates_pb2 import WidgetState, WidgetStates
 from streamlit.runtime.state.common import TESTING_KEY, user_key_from_element_id
+from streamlit.testing.v1.errors import AppTestError
 
 if TYPE_CHECKING:
     from pandas import DataFrame as PandasDataframe
@@ -97,13 +98,18 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 
 
-class AppTestError(builtins.Exception):
-    """Raised when an AppTest query or interaction is invalid.
+def _unknown_element_content(proto: Any) -> Any:
+    """Best-effort payload for an unimplemented element's proto.
 
-    AppTest can run apps that contain unimplemented or browser-only elements.
-    This error is reserved for an explicit test action that a browser user
-    could not perform, such as updating a disabled widget.
+    Many display protos store content in ``body``, ``text``, or ``label``
+    rather than ``value`` (for example ``st.html``).
     """
+    fields = getattr(getattr(proto, "DESCRIPTOR", None), "fields_by_name", None)
+    if fields:
+        for name in ("value", "body", "text", "label"):
+            if name in fields:
+                return getattr(proto, name)
+    return getattr(proto, "value", None)
 
 
 def _format_value_for_widget(format_func: Callable[[Any], str], value: Any) -> str:
@@ -214,7 +220,7 @@ class UnknownElement(Element):
                 # Missing or unreadable widget state is expected for
                 # unimplemented elements; fall back to a proto field.
                 pass
-        return getattr(self.proto, "value", None)
+        return _unknown_element_content(self.proto)
 
 
 @dataclass(repr=False)
@@ -323,13 +329,42 @@ class BlockList:
     def __len__(self) -> int:
         return len(self._list)
 
+    @property
+    def len(self) -> int:
+        return len(self)
+
+    @overload
+    def __getitem__(self, idx: int) -> Block: ...
+
+    @overload
+    def __getitem__(self, idx: slice) -> BlockList: ...
+
+    def __getitem__(self, idx: int | slice) -> Block | BlockList:
+        if isinstance(idx, slice):
+            return BlockList(self._list[idx])
+        return self._list[idx]
+
     def __iter__(self) -> Iterator[Block]:
         return iter(self._list)
 
-    def __getitem__(self, idx: int) -> Block:
-        return self._list[idx]
+    def __repr__(self) -> str:
+        return util.repr_(self)
+
+    def __eq__(self, other: BlockList | object) -> bool:
+        if isinstance(other, BlockList):
+            return self._list == other._list
+        return self._list == other
+
+    def __hash__(self) -> int:
+        return hash(tuple(self._list))
 
     def __call__(self, key: str) -> Block:
+        """Return the first block in this collection with the given user key.
+
+        Unlike ``get_by_key``, this keeps first-match behavior so typed
+        lookups such as ``at.container("x")`` stay compatible with
+        ``at.button("x")``.
+        """
         for e in self._list:
             if e.key == key:
                 return e

--- a/lib/streamlit/testing/v1/errors.py
+++ b/lib/streamlit/testing/v1/errors.py
@@ -12,7 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from streamlit.testing.v1.app_test import AppTest
-from streamlit.testing.v1.errors import AppTestError
+"""AppTest errors.
 
-__all__ = ["AppTest", "AppTestError"]
+Kept in a dedicated module so ``AppTestError`` can inherit from the builtin
+``Exception`` without colliding with the ``Exception`` element class in
+``element_tree``.
+"""
+
+from __future__ import annotations
+
+
+class AppTestError(Exception):
+    """Raised when an AppTest query or interaction is invalid.
+
+    AppTest can run apps that contain unimplemented or browser-only elements.
+    This error is reserved for an explicit test action that a browser user
+    could not perform, such as updating a disabled widget.
+    """

--- a/lib/tests/streamlit/runtime/state/session_state_test.py
+++ b/lib/tests/streamlit/runtime/state/session_state_test.py
@@ -4881,9 +4881,10 @@ class DisabledWidgetAppTest(unittest.TestCase):
         at = AppTest.from_function(script).run()
         assert at.checkbox[0].value is False
 
-        # Simulate the frontend sending a value for the disabled widget, as a
-        # stale UI or a forged BackMsg would.
-        at.checkbox[0].set_value(True).run()
+        # Bypass AppTest's disabled-widget guard so we can send a forged
+        # frontend value and assert the server still discards it.
+        at.checkbox[0]._value = True
+        at.run()
 
         assert at.checkbox[0].value is False
         assert "callback_ran" not in at.session_state
@@ -4921,8 +4922,10 @@ class DisabledWidgetAppTest(unittest.TestCase):
 
         at = AppTest.from_function(script).run()
 
-        # Simulate the frontend reporting a click for the disabled button.
-        at.button[0].click().run()
+        # Bypass AppTest's disabled-widget guard so we can send a forged
+        # frontend click and assert the server still discards it.
+        at.button[0]._value = True
+        at.run()
 
         assert at.button[0].value is False
         assert "clicked" not in at.session_state

--- a/lib/tests/streamlit/testing/app_test_test.py
+++ b/lib/tests/streamlit/testing/app_test_test.py
@@ -623,3 +623,30 @@ def test_switch_page_keeps_navigation_registry_after_failed_run(
     assert at.exception
     with pytest.raises(ValueError, match="navigation page"):
         at.switch_page("orphan.py")
+
+
+def test_switch_page_drops_registry_when_navigation_is_skipped(
+    tmp_path: Path,
+) -> None:
+    """A successful run that skips st.navigation must not keep the old pages."""
+    (tmp_path / "orphan.py").write_text(
+        'import streamlit as st\nst.text("orphan page")\n', encoding="utf-8"
+    )
+    (tmp_path / "app.py").write_text(
+        "import streamlit as st\n"
+        "if st.session_state.get('plain'):\n"
+        "    st.text('plain page')\n"
+        "else:\n"
+        "    def home():\n"
+        "        st.text('home page')\n"
+        "    pg = st.navigation([st.Page(home, title='Home')])\n"
+        "    pg.run()\n",
+        encoding="utf-8",
+    )
+
+    at = AppTest.from_file(tmp_path / "app.py").run()
+    assert at.text[0].value == "home page"
+    at.session_state["plain"] = True
+    at.run()
+    assert at.text[0].value == "plain page"
+    at.switch_page("orphan.py")

--- a/lib/tests/streamlit/testing/app_test_test.py
+++ b/lib/tests/streamlit/testing/app_test_test.py
@@ -499,7 +499,8 @@ def test_run_tolerates_unimplemented_elements() -> None:
     assert at.title[0].value == "still works"
     assert len(at.get("progress")) == 1
     assert at.get("progress")[0].value == 40
-    assert at.get("html")[0].value is None
+    assert at.get("html")[0].value == "<b>hi</b>"
+    assert at.get("page_link")[0].value == "Example"
 
 
 def test_switch_page_respects_custom_url_path(tmp_path: Path) -> None:

--- a/lib/tests/streamlit/testing/app_test_test.py
+++ b/lib/tests/streamlit/testing/app_test_test.py
@@ -20,6 +20,7 @@ import pytest
 
 from streamlit.runtime.pages_manager import PagesManager
 from streamlit.testing.v1 import AppTest
+from streamlit.util import calc_hash
 
 
 def test_smoke():
@@ -503,6 +504,26 @@ def test_run_tolerates_unimplemented_elements() -> None:
     assert at.get("page_link")[0].value == "Example"
 
 
+def test_unimplemented_id_bearing_element_exposes_key_and_value() -> None:
+    """Unknown elements with IDs expose their key and Session State value."""
+
+    def script():
+        import streamlit as st
+
+        st.plotly_chart(
+            {"data": [{"x": [1], "y": [2], "type": "scatter"}]},
+            key="chart",
+            on_select="rerun",
+        )
+
+    at = AppTest.from_function(script).run()
+    chart = at.get("plotly_chart")[0]
+    assert chart.key == "chart"
+    assert chart.value == {
+        "selection": {"points": [], "point_indices": [], "box": [], "lasso": []}
+    }
+
+
 def test_switch_page_respects_custom_url_path(tmp_path: Path) -> None:
     """switch_page must use the navigation page hash, not the filename slug.
 
@@ -532,6 +553,34 @@ def test_switch_page_respects_custom_url_path(tmp_path: Path) -> None:
     assert at.text[0].value == "other page"
 
 
+def test_switch_page_prefers_filename_url_for_duplicate_script(
+    tmp_path: Path,
+) -> None:
+    """A file registered twice resolves to the URL matching its filename."""
+    (tmp_path / "home.py").write_text(
+        'import streamlit as st\nst.text("home page")\n', encoding="utf-8"
+    )
+    (tmp_path / "shared.py").write_text(
+        'import streamlit as st\nst.text("shared page")\n', encoding="utf-8"
+    )
+    (tmp_path / "app.py").write_text(
+        "import streamlit as st\n"
+        "pg = st.navigation([\n"
+        "    st.Page('home.py', title='Home'),\n"
+        "    st.Page('shared.py', title='Alternate', url_path='alternate'),\n"
+        "    st.Page('shared.py', title='Shared', url_path='shared'),\n"
+        "])\n"
+        "pg.run()\n",
+        encoding="utf-8",
+    )
+
+    at = AppTest.from_file(tmp_path / "app.py").run()
+    at.switch_page("shared.py")
+    assert at._page_hash == calc_hash("shared")
+    at.run()
+    assert at.text[0].value == "shared page"
+
+
 def test_switch_page_unknown_navigation_page_raises(tmp_path: Path) -> None:
     """Unknown navigation files must raise instead of opening the default page."""
     (tmp_path / "home.py").write_text(
@@ -548,7 +597,7 @@ def test_switch_page_unknown_navigation_page_raises(tmp_path: Path) -> None:
     )
 
     at = AppTest.from_file(tmp_path / "app.py").run()
-    with pytest.raises(ValueError, match="navigation page"):
+    with pytest.raises(ValueError, match="after updating the state"):
         at.switch_page("orphan.py")
 
 
@@ -651,3 +700,32 @@ def test_switch_page_drops_registry_when_navigation_is_skipped(
     at.run()
     assert at.text[0].value == "plain page"
     at.switch_page("orphan.py")
+    assert at._page_hash == calc_hash("orphan")
+
+
+def test_switch_page_drops_registry_after_rendered_exception(
+    tmp_path: Path,
+) -> None:
+    """A successful st.exception run must not keep the old navigation pages."""
+    (tmp_path / "orphan.py").write_text(
+        'import streamlit as st\nst.text("orphan page")\n', encoding="utf-8"
+    )
+    (tmp_path / "app.py").write_text(
+        "import streamlit as st\n"
+        "if st.session_state.get('show_exception'):\n"
+        "    st.exception(RuntimeError('displayed'))\n"
+        "else:\n"
+        "    def home():\n"
+        "        st.text('home page')\n"
+        "    pg = st.navigation([st.Page(home, title='Home')])\n"
+        "    pg.run()\n",
+        encoding="utf-8",
+    )
+
+    at = AppTest.from_file(tmp_path / "app.py").run()
+    assert at.text[0].value == "home page"
+    at.session_state["show_exception"] = True
+    at.run()
+    assert at.exception[0].message == "displayed"
+    at.switch_page("orphan.py")
+    assert at._page_hash == calc_hash("orphan")

--- a/lib/tests/streamlit/testing/app_test_test.py
+++ b/lib/tests/streamlit/testing/app_test_test.py
@@ -571,3 +571,28 @@ def test_switch_page_rejects_unregistered_file_in_callable_navigation(
     assert at.text[0].value == "home page"
     with pytest.raises(ValueError, match="navigation page"):
         at.switch_page("orphan.py")
+
+
+def test_switch_page_does_not_match_callable_url_path_slug(tmp_path: Path) -> None:
+    """A file slug must not steal a callable page that hashes the same url_path."""
+    (tmp_path / "settings.py").write_text(
+        'import streamlit as st\nst.text("file settings")\n', encoding="utf-8"
+    )
+    (tmp_path / "app.py").write_text(
+        "import streamlit as st\n"
+        "def home():\n"
+        "    st.text('home page')\n"
+        "def settings():\n"
+        "    st.text('callable settings')\n"
+        "pg = st.navigation([\n"
+        "    st.Page(home, title='Home'),\n"
+        "    st.Page(settings, title='Settings'),\n"
+        "])\n"
+        "pg.run()\n",
+        encoding="utf-8",
+    )
+
+    at = AppTest.from_file(tmp_path / "app.py").run()
+    assert at.text[0].value == "home page"
+    with pytest.raises(ValueError, match="navigation page"):
+        at.switch_page("settings.py")

--- a/lib/tests/streamlit/testing/app_test_test.py
+++ b/lib/tests/streamlit/testing/app_test_test.py
@@ -596,3 +596,30 @@ def test_switch_page_does_not_match_callable_url_path_slug(tmp_path: Path) -> No
     assert at.text[0].value == "home page"
     with pytest.raises(ValueError, match="navigation page"):
         at.switch_page("settings.py")
+
+
+def test_switch_page_keeps_navigation_registry_after_failed_run(
+    tmp_path: Path,
+) -> None:
+    """A run that fails before st.navigation must not erase the last registry."""
+    (tmp_path / "orphan.py").write_text(
+        'import streamlit as st\nst.text("orphan page")\n', encoding="utf-8"
+    )
+    (tmp_path / "app.py").write_text(
+        "import streamlit as st\n"
+        "if st.session_state.get('fail'):\n"
+        "    raise RuntimeError('boom')\n"
+        "def home():\n"
+        "    st.text('home page')\n"
+        "pg = st.navigation([st.Page(home, title='Home')])\n"
+        "pg.run()\n",
+        encoding="utf-8",
+    )
+
+    at = AppTest.from_file(tmp_path / "app.py").run()
+    assert at.text[0].value == "home page"
+    at.session_state["fail"] = True
+    at.run()
+    assert at.exception
+    with pytest.raises(ValueError, match="navigation page"):
+        at.switch_page("orphan.py")

--- a/lib/tests/streamlit/testing/app_test_test.py
+++ b/lib/tests/streamlit/testing/app_test_test.py
@@ -451,3 +451,101 @@ def test_removed_widget_does_not_persist_on_rerun() -> None:
     at = at.text_input(key="question_2").set_value("bbbbbb").run()
     assert len(at.text_input) == 1
     assert at.text_input(key="question_2").value == "bbbbbb"
+
+
+def test_sidebar_widgets_removed_when_not_rendered() -> None:
+    """Widgets omitted on a rerun must leave the sidebar tree.
+
+    Regression test for https://github.com/streamlit/streamlit/issues/9814
+    """
+
+    def script():
+        import streamlit as st
+
+        st.session_state.setdefault("logged_in", False)
+        if st.session_state.logged_in:
+            if st.sidebar.button("Logout"):
+                st.session_state.logged_in = False
+                st.rerun()
+        elif st.button("Login"):
+            st.session_state.logged_in = True
+            st.rerun()
+
+    at = AppTest.from_function(script).run()
+    assert len(at.sidebar.button) == 0
+    assert len(at.button) == 1
+
+    at = at.button[0].click().run()
+    assert (len(at.button), len(at.sidebar.button)) == (1, 1)
+
+    at = at.sidebar.button[0].click().run()
+    assert (len(at.button), len(at.sidebar.button)) == (1, 0)
+
+
+def test_run_tolerates_unimplemented_elements() -> None:
+    """Apps that use unimplemented commands must still run and stay inspectable."""
+
+    def script():
+        import streamlit as st
+
+        st.progress(40, text="halfway")
+        st.html("<b>hi</b>")
+        st.balloons()
+        st.page_link("https://example.com", label="Example")
+        st.title("still works")
+
+    at = AppTest.from_function(script).run()
+    assert not at.exception
+    assert at.title[0].value == "still works"
+    assert len(at.get("progress")) == 1
+    assert at.get("progress")[0].value == 40
+    assert at.get("html")[0].value is None
+
+
+def test_switch_page_respects_custom_url_path(tmp_path: Path) -> None:
+    """switch_page must use the navigation page hash, not the filename slug.
+
+    Regression test for https://github.com/streamlit/streamlit/issues/16611
+    """
+    (tmp_path / "home.py").write_text(
+        'import streamlit as st\nst.text("home page")\n', encoding="utf-8"
+    )
+    (tmp_path / "other.py").write_text(
+        'import streamlit as st\nst.text("other page")\n', encoding="utf-8"
+    )
+    (tmp_path / "app.py").write_text(
+        "import streamlit as st\n"
+        "pg = st.navigation([\n"
+        "    st.Page('home.py', title='Home'),\n"
+        "    st.Page('other.py', title='Other', url_path='custom'),\n"
+        "])\n"
+        "pg.run()\n",
+        encoding="utf-8",
+    )
+
+    at = AppTest.from_file(tmp_path / "app.py").run()
+    assert at.text[0].value == "home page"
+
+    at.switch_page("other.py").run()
+    assert not at.exception
+    assert at.text[0].value == "other page"
+
+
+def test_switch_page_unknown_navigation_page_raises(tmp_path: Path) -> None:
+    """Unknown navigation files must raise instead of opening the default page."""
+    (tmp_path / "home.py").write_text(
+        'import streamlit as st\nst.text("home page")\n', encoding="utf-8"
+    )
+    (tmp_path / "orphan.py").write_text(
+        'import streamlit as st\nst.text("orphan page")\n', encoding="utf-8"
+    )
+    (tmp_path / "app.py").write_text(
+        "import streamlit as st\n"
+        "pg = st.navigation([st.Page('home.py', title='Home')])\n"
+        "pg.run()\n",
+        encoding="utf-8",
+    )
+
+    at = AppTest.from_file(tmp_path / "app.py").run()
+    with pytest.raises(ValueError, match="navigation page"):
+        at.switch_page("orphan.py")

--- a/lib/tests/streamlit/testing/app_test_test.py
+++ b/lib/tests/streamlit/testing/app_test_test.py
@@ -549,3 +549,25 @@ def test_switch_page_unknown_navigation_page_raises(tmp_path: Path) -> None:
     at = AppTest.from_file(tmp_path / "app.py").run()
     with pytest.raises(ValueError, match="navigation page"):
         at.switch_page("orphan.py")
+
+
+def test_switch_page_rejects_unregistered_file_in_callable_navigation(
+    tmp_path: Path,
+) -> None:
+    """Callable-only navigation must not silently open the default page."""
+    (tmp_path / "orphan.py").write_text(
+        'import streamlit as st\nst.text("orphan page")\n', encoding="utf-8"
+    )
+    (tmp_path / "app.py").write_text(
+        "import streamlit as st\n"
+        "def home():\n"
+        "    st.text('home page')\n"
+        "pg = st.navigation([st.Page(home, title='Home')])\n"
+        "pg.run()\n",
+        encoding="utf-8",
+    )
+
+    at = AppTest.from_file(tmp_path / "app.py").run()
+    assert at.text[0].value == "home page"
+    with pytest.raises(ValueError, match="navigation page"):
+        at.switch_page("orphan.py")

--- a/lib/tests/streamlit/testing/element_tree_test.py
+++ b/lib/tests/streamlit/testing/element_tree_test.py
@@ -2014,6 +2014,38 @@ def test_container_key_and_get_by_key() -> None:
         at.container("missing")
 
 
+def test_container_excludes_columns_row() -> None:
+    """st.columns emits a flex_container row that must not appear in at.container."""
+
+    def script():
+        import streamlit as st
+
+        with st.container(key="filters"):
+            st.text("inside")
+        left, right = st.columns(2)
+        left.text("left")
+        right.text("right")
+
+    at = AppTest.from_function(script).run()
+    assert len(at.container) == 1
+    assert at.container[0].key == "filters"
+    assert len(at.columns) == 2
+
+
+def test_expander_key_and_get_by_key() -> None:
+    """Keyed expanders expose .key even though the tree stores the sub-proto."""
+
+    def script():
+        import streamlit as st
+
+        with st.expander("Details", key="details"):
+            st.text("hidden")
+
+    at = AppTest.from_function(script).run()
+    assert at.expander[0].key == "details"
+    assert at.get_by_key("details").label == "Details"
+
+
 def test_disabled_widget_rejects_update() -> None:
     """Disabled widgets reject forged interactions.
 

--- a/lib/tests/streamlit/testing/element_tree_test.py
+++ b/lib/tests/streamlit/testing/element_tree_test.py
@@ -1771,6 +1771,27 @@ def test_element_list_slice_repr_and_equality():
     assert at.markdown != ["not", "matching"]
 
 
+def test_block_list_slice_repr_and_len() -> None:
+    """BlockList matches ElementList for slice, repr, len, and equality."""
+
+    def script():
+        import streamlit as st
+
+        with st.container(key="one"):
+            st.text("a")
+        with st.container(key="two"):
+            st.text("b")
+
+    at = AppTest.from_function(script).run()
+    subset = at.container[0:1]
+    assert isinstance(subset, type(at.container))
+    assert subset.len == 1
+    assert subset[0].key == "one"
+    assert repr(at.container)
+    assert at.container == list(at.container)
+    assert at.container != ["not", "matching"]
+
+
 def test_button_value_reflects_set_value_before_run():
     """Button.value returns the locally set value before a rerun commits it."""
 
@@ -2044,6 +2065,16 @@ def test_expander_key_and_get_by_key() -> None:
     at = AppTest.from_function(script).run()
     assert at.expander[0].key == "details"
     assert at.get_by_key("details").label == "Details"
+
+
+def test_app_test_error_is_public_builtin_exception() -> None:
+    """AppTestError lives outside element_tree so it is a real builtin Exception."""
+    from streamlit.testing.v1 import AppTestError as PublicError
+    from streamlit.testing.v1.errors import AppTestError as ErrorsError
+
+    assert PublicError is AppTestError
+    assert PublicError is ErrorsError
+    assert issubclass(PublicError, Exception)
 
 
 def test_disabled_widget_rejects_update() -> None:

--- a/lib/tests/streamlit/testing/element_tree_test.py
+++ b/lib/tests/streamlit/testing/element_tree_test.py
@@ -2035,6 +2035,39 @@ def test_container_key_and_get_by_key() -> None:
         at.container("missing")
 
 
+def test_form_key_and_get_by_key() -> None:
+    """Forms expose their form ID as a user key."""
+
+    def script():
+        import streamlit as st
+
+        with st.form("form-key"):
+            st.text_input("Name")
+            st.form_submit_button("Submit")
+
+    at = AppTest.from_function(script).run()
+    form = at.get_by_key("form-key")
+    assert form.type == "form"
+    assert form.key == "form-key"
+
+
+def test_get_by_key_rejects_ambiguous_key() -> None:
+    """A form ID can match a widget key, so get_by_key must reject the clash."""
+
+    def script():
+        import streamlit as st
+
+        with st.form("shared"):
+            st.text_input("Query", key="shared")
+            st.form_submit_button("Submit")
+
+    at = AppTest.from_function(script).run()
+    assert at.get("form")[0].key == "shared"
+    assert at.text_input("shared").key == "shared"
+    with pytest.raises(AppTestError, match="Multiple elements"):
+        at.get_by_key("shared")
+
+
 def test_container_excludes_columns_row() -> None:
     """st.columns emits a flex_container row that must not appear in at.container."""
 
@@ -2096,3 +2129,28 @@ def test_disabled_widget_rejects_update() -> None:
         at.button("k_btn").click()
     at = at.run()
     assert at.text_input("k_text").value == "initial"
+
+
+@pytest.mark.parametrize(
+    ("widget_type", "method_name", "args"),
+    [
+        ("file_uploader", "set_value", (("test.txt", b"data", "text/plain"),)),
+        ("file_uploader", "upload", ("test.txt", b"data")),
+        ("file_uploader", "clear", ()),
+        ("slider", "set_value", (7,)),
+    ],
+)
+def test_disabled_widget_specialized_interactions_reject_updates(
+    widget_type: str,
+    method_name: str,
+    args: tuple[object, ...],
+) -> None:
+    """Specialized widget methods enforce the disabled interaction guard."""
+    at = AppTest.from_string(
+        "import streamlit as st\n"
+        "st.file_uploader('File', disabled=True, key='file')\n"
+        "st.slider('Number', 0, 10, disabled=True, key='slider')\n"
+    ).run()
+    widget = getattr(at, widget_type)[0]
+    with pytest.raises(AppTestError, match="disabled"):
+        getattr(widget, method_name)(*args)

--- a/lib/tests/streamlit/testing/element_tree_test.py
+++ b/lib/tests/streamlit/testing/element_tree_test.py
@@ -26,7 +26,7 @@ from streamlit.components.v2.manifest_scanner import ComponentConfig, ComponentM
 from streamlit.dataframe import lazy_df_source as dataframe_source
 from streamlit.elements.markdown import MARKDOWN_HORIZONTAL_RULE_EXPRESSION
 from streamlit.testing.v1.app_test import AppTest
-from streamlit.testing.v1.element_tree import _format_value_for_widget
+from streamlit.testing.v1.element_tree import AppTestError, _format_value_for_widget
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -1989,3 +1989,47 @@ def test_spinner_transient_delta_is_skipped():
     at = AppTest.from_function(script).run()
     assert not at.exception
     assert at.text[0].value == "done"
+
+
+def test_container_key_and_get_by_key() -> None:
+    """Keyed containers expose .key and can be looked up semantically.
+
+    Regression test for https://github.com/streamlit/streamlit/issues/13163
+    """
+
+    def script():
+        import streamlit as st
+
+        with st.container(key="filters"):
+            st.text_input("Query", key="query")
+        st.button("Outside", key="outside")
+
+    at = AppTest.from_function(script).run()
+    assert at.container("filters").key == "filters"
+    assert at.get_by_key("filters").key == "filters"
+    assert at.container("filters").text_input[0].key == "query"
+    assert at.get_by_key("query").key == "query"
+    assert at.get_by_key("outside").label == "Outside"
+    with pytest.raises(KeyError):
+        at.container("missing")
+
+
+def test_disabled_widget_rejects_update() -> None:
+    """Disabled widgets reject forged interactions.
+
+    Regression test for https://github.com/streamlit/streamlit/issues/12844
+    """
+
+    def script():
+        import streamlit as st
+
+        st.text_input("Text", value="initial", disabled=True, key="k_text")
+        st.button("Go", disabled=True, key="k_btn")
+
+    at = AppTest.from_function(script).run()
+    with pytest.raises(AppTestError, match="disabled"):
+        at.text_input("k_text").set_value("new value")
+    with pytest.raises(AppTestError, match="disabled"):
+        at.button("k_btn").click()
+    at = at.run()
+    assert at.text_input("k_text").value == "initial"


### PR DESCRIPTION
## Summary
- Keep AppTest runnable for apps that use unimplemented commands (`progress`, `html`, `balloons`, `page_link`, …): unknown nodes stay inspectable instead of crashing on `.value`.
- Reject interactions a browser user cannot perform (`AppTestError` on disabled widgets; #12844).
- Expose container keys and add `at.container(key=…)` / `at.get_by_key()` (#13163).
- Resolve `switch_page()` against pages registered by `st.navigation` so custom `url_path` works, and raise instead of silently opening the default page (#16611).
- Add the #9814 sidebar cleanup regression (already fixed by the stale-queue clear).

Investigation notes: https://github.com/streamlit/streamlit/wiki/2026-07-22-app-testing-fixes

## GitHub Issue Link (if applicable)

Closes #16611
Closes #13163
Closes #12844
Closes #9814

## Test plan
- [x] `pytest -c lib/pyproject.toml lib/tests/streamlit/testing/` (114 passed)
- [ ] App with only unimplemented elements (`st.progress`, `st.html`, `st.balloons`) still `.run()`s
- [ ] `st.container(key="filters")` is reachable via `at.container("filters")` and `at.get_by_key("filters")`
- [ ] Disabled `st.text_input` / `st.button` raise `AppTestError` on `set_value` / `click`
- [ ] `st.navigation` file page with `url_path="custom"` is reached by `switch_page("other.py")`
- [ ] Login/logout sidebar button disappears after logout


Made with [Cursor](https://cursor.com)