### PR TITLE
[spec] Defensive Streamlit agent-skill discovery

### DIFF
--- a/specs/2026-08-29-defensive-meta-skill-discovery/tech-spec.md
+++ b/specs/2026-08-29-defensive-meta-skill-discovery/tech-spec.md
@@ -7,283 +7,180 @@ created: 2026-08-29
 
 ## Summary
 
-Harden the **meta-skill** that `streamlit skills` installs
-(`lib/streamlit/.agents/meta-skill/developing-with-streamlit`) so coding agents reliably
-find the version-matched bundled skill inside the project's installed Streamlit.
+Harden the **meta-skill** that `streamlit skills` installs so agents find this
+**project's** bundled Streamlit skill (`<streamlit>/.agents/skills/developing-with-streamlit/SKILL.md`).
+Failures are unobservable in production, so discovery must not return a confidently wrong
+path.
 
-The delivery path this spec optimizes for is **`streamlit skills` only** (project
-default, `--global`, and the Windows no-symlink fallback to global). Third-party
-installers (`npx skills add streamlit/agent-skills`, `gh skill`, …) are out of band.
-
-Failures are not observable in production, so discovery must be **read-only,
-multi-candidate, and explicit**: filesystem before subprocess, never a single guess,
-never an unhandled traceback, never a polluted stdout path treated as a Streamlit
-install.
-
-This is a contract change for `scripts/discover.py` and the meta `SKILL.md`, plus a small
-cross-platform cleanup of the bundled content skill. No Streamlit user-facing API
-changes.
+Scope is **`streamlit skills` only** (project default, `--global`, Windows no-symlink
+fallback to global). Third-party installers are out of band. No `st.*` API changes.
 
 ## Problem
 
-Users install skills with **`streamlit skills`**, which copies from the **local wheel**
-(no GitHub fetch):
+`streamlit skills` copies from the **local wheel** (no GitHub fetch; see #15933):
 
-| Mode | What gets installed | Role of `discover.py` |
+| Mode | Installed | `discover.py` |
 |---|---|---|
-| **Project** (default) | Symlinks to bundled **content** skills in the active Streamlit package | Not used — the agent reads the content `SKILL.md` directly |
-| **Global** (`--global`) | Copy of the vendored **meta-skill** into `~/.agents/skills/` (and `~/.claude/skills/` when present) | Required — the agent must locate this project's Streamlit at runtime |
-| **Windows without Developer Mode** | Project install cannot symlink, so the CLI falls back to the same global copy | Required — same as `--global` |
+| **Project** (default) | Symlinks to bundled **content** skills | Unused |
+| **Global** (`--global`) | Meta-skill → `~/.agents/skills/` (and `~/.claude/skills/` if present) | Required |
+| **Windows, no Developer Mode** | Same global copy (symlink fallback) | Required |
 
-This spec is about making that CLI path reliable. The meta-skill's `discover.py` locates
-`<streamlit>/.agents/skills/developing-with-streamlit/SKILL.md` for the **project's**
-interpreter. On Windows, the no-symlink fallback means `discover.py` is often the only
-bridge to the docs.
+Today `discover.py` picks **one** interpreter and stops. Wrong or noisy answers:
 
-Today the script **picks one interpreter and stops**. That produces confidently wrong
-answers rather than errors:
-
-| Failure | What the agent sees |
+| Failure | Result |
 |---|---|
-| Stale `$VIRTUAL_ENV` without current Streamlit, project `.venv` has it | `ERROR: predates bundled skills` or `not installed` — project venv never probed. Reproduced; the sole vendored test in `skills_test.py` works around this by **forcing** `VIRTUAL_ENV` because `sys.executable` is ignored. |
-| Banner/noise on probe stdout (`pipenv`/`poetry`/`conda`/`sitecustomize`) | `Path(stdout.strip())` concatenates noise + path → silent "predates skills" / wrong directory |
-| Windows conda (`%CONDA_PREFIX%\python.exe`) | `find_venv_python` only checks `bin/python` and `Scripts/python.exe` — conda branch never hits |
-| `python3` → Microsoft Store stub (`WindowsApps`) | "Failed to import streamlit" plus Store marketing text; no `py -3` candidate |
-| Non-ASCII user path + `text=True` (cp1252) | `UnicodeEncodeError` / decode crash, not an `ERROR:` block |
-| `uv run --quiet python` | May **create/sync** a venv (not read-only); 30s timeout looks like an import hang |
-| Missing Streamlit on the **first** candidate | Install/upgrade advice, even when another candidate would have worked |
-| Skill files on disk but subprocess/import required | Sandbox, Store stub, broken transitive dep, or slow interpreter → fail even though `site-packages/streamlit/.agents/skills/` is readable |
-| Unexpected exception | Raw traceback, no `ERROR:` block, no docs fallback |
+| Stale `$VIRTUAL_ENV` without Streamlit, project `.venv` has it | Project venv never probed. The only vendored test forces `VIRTUAL_ENV` because `sys.executable` is ignored (`skills_test.py`). |
+| Probe stdout banners | `Path(stdout.strip())` → silent "predates skills" |
+| Windows conda `%CONDA_PREFIX%\python.exe` | Not checked (`bin/python` / `Scripts/python.exe` only) |
+| `python3` Store stub (`WindowsApps`) | Misreported as "not installed"; no `py -3` |
+| `text=True` on cp1252 | Crash on non-ASCII user paths |
+| `uv run` without `--no-sync` | May create/sync a venv |
+| First candidate missing Streamlit | Install advice even when another candidate would work |
+| Skill files on disk, subprocess required | Sandbox / stub / broken import → fail |
+| Uncaught exception | Traceback, no docs fallback |
+| Local `streamlit.py` on `sys.path[0]` | `find_spec` / `import` both resolve the demo file |
 
-The meta `SKILL.md` is a one-line Usage block (`python <SKILL_DIR>/...`) with no fallback,
-no quoting, no Windows launcher, and no resolution of `<SKILL_DIR>`. `allowed-tools`
-pre-approves `python` / `python3` only and does not match the body (`<SKILL_DIR>` vs
-`${CLAUDE_SKILL_DIR}`), so on Claude Code the grant often never fires — and it nudges
-Windows agents toward the Store stub.
+The meta `SKILL.md` is a one-line `python <SKILL_DIR>/...` with no fallback. Its
+`allowed-tools` pre-approves `python`/`python3` only and does not match the body.
 
-The **content** skill still tells agents to use POSIX `grep \| head` and `lsof \| awk`
-(`lib/streamlit/.agents/skills/developing-with-streamlit/SKILL.md`). Those fail on
-Windows PowerShell, which is the majority audience for this skill.
+Python CI is Ubuntu-only; discovery coverage is one forced happy path.
 
-Python CI (`python-tests.yml`) is Ubuntu-only. Discovery coverage in this repo is one
-forced happy path.
+**Same name, two skills:** project mode puts the **content** skill at
+`.agents/skills/developing-with-streamlit`; global puts the **meta** skill at
+`~/.agents/skills/developing-with-streamlit`. Assumed: project-local wins over user-global.
+Not renaming in this work.
 
 ## Goals
 
-1. **Filesystem first, then interpreters.** For known env prefixes, look for the
-   Streamlit package on disk (`Lib/site-packages` / `lib/python*/site-packages`) **before**
-   spawning Python. Then enumerate interpreters until one yields a usable bundled
-   `SKILL.md`. A bad `$VIRTUAL_ENV` must not hide the project `.venv`.
-2. **Read-only.** Discovery must not install packages, create venvs, or sync lockfiles.
-3. **Do not import Streamlit.** Locate the package with `importlib.util.find_spec` in
-   any subprocess probe. Never `import streamlit`.
-4. **Windows-first layouts.** Conda prefix `python.exe`, `py -3`, skip Store stubs, UTF-8
-   I/O, quoted paths, MSYS `/c/...` project dirs.
-5. **Failures are identified.** Stable `ERROR[<ID>]` plus every candidate attempted.
-   Unhandled tracebacks are bugs: a top-level guard converts them to `ERROR[INTERNAL]`
-   (exit 6) and always ends with the docs fallback URL.
-6. **Agents can proceed without the script.** The meta `SKILL.md` includes a short,
-   ordered, read-only **manual discovery** section (see §5.1). Agents follow it when
-   `discover.py` cannot run or returns a non-zero exit. No "pip install streamlit"
-   unless the user asked or every candidate truly lacks Streamlit.
-7. **Windows CI, not just Ubuntu unit tests.** A focused `windows-latest` job runs the
-   discovery tests and an end-to-end `discover.py` smoke (see §7). Failures are not
-   observable in the field; Windows is the majority audience.
+1. Return a usable bundled `SKILL.md` from this **project** when one exists, without
+   importing Streamlit and without installing/syncing packages.
+2. Never treat a missing/old/wrong candidate as terminal if a later one would work.
+3. On total failure: stable error, attempt log, docs URL, and a short manual ladder in
+   `SKILL.md`.
+4. Prove the Windows layouts on a real `windows-latest` runner (narrow job).
 
 ## Out of scope
 
-- Renaming the meta-skill to avoid sharing `name: developing-with-streamlit` with the
-  content skill (untested interaction; project-over-global resolution is assumed).
-- Auto-detecting Hatch, pixi, pyenv-virtualenv, direnv, or `UV_PROJECT_ENVIRONMENT`.
-  Covered by `--python` and the manual ladder.
-- Changing project-mode symlink install or the Windows "no Developer Mode → global"
-  fallback in `lib/streamlit/web/skills.py` (keep that fallback; make global discovery
-  trustworthy instead).
-- Third-party skill installers (`npx skills`, `gh skill`, library-skills) and keeping
-  [`streamlit/agent-skills`](https://github.com/streamlit/agent-skills) in lockstep.
-  Source of truth is the copy vendored in the Streamlit wheel that `streamlit skills`
-  installs.
-- Cursor `paths` / `globs`, Codex `agents/openai.yaml`, Gemini-specific frontmatter,
-  `context: fork`, `disable-model-invocation`.
-- Production telemetry for skill failures (still not measurable).
-- Running the entire Streamlit Python test suite on Windows.
+- Hatch, pixi, pyenv-virtualenv, direnv, `UV_PROJECT_ENVIRONMENT` (use `--python` or the
+  manual ladder).
+- Changing symlink install / the Windows global fallback in `skills.py`.
+- `npx skills` / GitHub `agent-skills` lockstep.
+- Cursor/Codex/Gemini-only frontmatter.
+- Full Windows Python test matrix.
+- Renaming the meta-skill.
+- Content-skill POSIX `grep`/`lsof` cleanup — **follow-up PR** (orthogonal; dropping
+  `lsof` also changes “list all Streamlit ports” behavior).
+
+## Locked decisions
+
+| Topic | Decision |
+|---|---|
+| Probe order | **Per candidate:** filesystem then subprocess, then the next candidate. Not “all filesystem, then all subprocess” (that lets a low-priority conda prefix beat an editable `$VIRTUAL_ENV`). |
+| Project vs `$VIRTUAL_ENV` | **Project-local `.venv` / `venv` first** (this skill is for the app). `$VIRTUAL_ENV` next. Both having modern Streamlit must not prefer a leftover activated env. Override: `--python`. |
+| Unusable Streamlit | `TOO_OLD` / `INCOMPLETE` / `LAYOUT_CHANGED` are **recorded**, not terminal. Only a usable `SKILL.md` short-circuits. |
+| “Read-only” | Means **no intentional install/sync**. Filesystem + direct `python -c` by default. `poetry run` / `uv run --no-sync` only if no prefix worked. Python may still run `.pth` / `sitecustomize`. |
+| `--project-dir` | Expand `~` / env vars; light MSYS `/c/...` → `C:\...`. If still not a directory → **`ERROR[INVALID_ARGS]`**, do not fall back to cwd. |
+| `--python` | Keep. Exclusive. The hatch/pixi/“use this env” escape hatch. |
+| `allowed-tools` | `Read`, `Glob`, and **script-anchored** `Bash(${CLAUDE_SKILL_DIR}/scripts/discover.py *)`. **Not** `Bash(python *)`. Accept a one-time prompt. No `PowerShell(...)` twin. |
+| Agent branching | Exit 0 → Read the stdout path. Non-zero → manual ladder. IDs are for humans and tests. |
+| `compatibility` | **Omit.** Hosts may hide the skill. |
+| Extra dir names | `.venv` always; `venv` only if `pyvenv.cfg` exists. **Not** `env/`. |
+| Version vs missing files | Metadata version `< 1.57` → `TOO_OLD`. Version `>= 1.57` (or unknown) but files missing → `INCOMPLETE`. `.agents/skills/` present, expected file missing → `LAYOUT_CHANGED`. |
 
 ## Proposal
 
-Ship as one unit (script + meta `SKILL.md` always travel together) **in the Streamlit
-package**. `streamlit skills --global` already copies that vendored tree from local disk
-(`_install_global_skills` in `lib/streamlit/web/skills.py`); there is no network step and
-no dependency on the GitHub `agent-skills` repo for this work.
+### 1. Per-candidate discovery
 
-### 1. Two-stage discovery (filesystem, then interpreter)
+Walk candidates in this order. For each **env prefix**, try filesystem lookup; on miss,
+if there is an interpreter, run the subprocess probe. Continue until a **usable**
+`SKILL.md` is found or the list (or wall clock) is exhausted.
 
-**Option A (preferred): filesystem-first, then subprocess.** For each known env
-**prefix** (same order as below), look for the Streamlit package on disk. If
-`.../streamlit/.agents/skills/developing-with-streamlit/SKILL.md` exists, print that path
-and exit 0 — no Python spawn, no import, no timeout. This is the highest-value change:
-it works when the agent sandbox blocks subprocesses, when `python` is a Store stub, when
-a transitive import would crash, and when the venv is unactivated.
+1. `--python` — exclusive; do not continue on failure
+2. `<project>/.venv`, then `<project>/venv` if `pyvenv.cfg` exists
+3. Same on parent, then git root (skip duplicates)
+4. `$VIRTUAL_ENV`
+5. `$CONDA_PREFIX`
+6. `sys.executable` if not already listed (`launcher`)
+7. `pipenv` / `poetry` / `pdm` / `uv run --no-sync --quiet python` when the CLI is on
+   `PATH` and the lockfile/`Pipfile` exists at `project_dir` or an ancestor up to git root
+8. Windows: `py -3`
+9. System: Windows `python` then `python3`; POSIX `python3` then `python`. Skip
+   `WindowsApps` stubs (and 0-byte aliases)
 
-**Option B: only harden the existing subprocess path.** Reject as the sole approach.
-Too many failure modes never reach a working interpreter.
+`find_venv_python(root)`:
 
-Stage 1 and stage 2 **share one reporter** (`report_skill(streamlit_pkg: Path) -> int`)
-so exit 0 / 2 / 4 cannot drift. Stage 1 reuses stage 2's prefix order.
+| Platform | Paths |
+|---|---|
+| Windows | `<root>\python.exe` (conda), `<root>\Scripts\python.exe` |
+| POSIX | `<root>/bin/python`, `<root>/bin/python3` |
 
-**Stage 1 — filesystem probe** of env prefixes:
-
-`$VIRTUAL_ENV` → `<project>/{.venv,venv,env}` → parent of those names → git-root of
-those names → `$CONDA_PREFIX`
-
-For each prefix, look for a `streamlit` directory in:
+**Filesystem (per prefix):**
 
 | Layout | Path |
 |---|---|
-| Windows venv / conda | `<prefix>\Lib\site-packages\streamlit` |
-| POSIX venv / conda | `<prefix>/lib/python*/site-packages/streamlit` (if several, prefer one that already has the skill file; else parse `pyvenv.cfg` `version_info` when present) |
-| Some conda | `<prefix>/lib/site-packages/streamlit` |
+| Windows | `<prefix>\Lib\site-packages\streamlit` |
+| POSIX | `<prefix>/lib/python*/site-packages/streamlit` (if several, prefer one that already has the skill file; else `pyvenv.cfg` `version_info`) |
 
-`--python` skips stage 1 for other prefixes: resolve that interpreter's prefix
-(`pyvenv.cfg` / parent of `Scripts` or `bin`) and probe only that tree, still exclusive
-on failure.
+Editable installs (`.pth`) are a filesystem miss; the subprocess `find_spec` step handles
+them.
 
-**Editable installs** (`.pth` / `streamlit` not under that `site-packages`) are a
-deliberate stage-1 miss. Stage 2 `find_spec` still finds them.
+**Wall clock:** 60s global budget. Stop enumerating when hit; attempt log marks the rest
+`not tried`. Per-candidate timeouts: ~15s direct, ~30s manager wrappers.
 
-**Stage 2 — interpreter probe** for poetry/pdm/pipenv/uv, non-standard layouts, and
-editable installs. `detect_interpreter` is a **generator** of `(cmd, tag)`. Deduplicate
-by resolved executable. Skip missing, not executable, or Windows Store stubs
-(`WindowsApps` in the path, or a 0-byte / alias stub).
+### 2. Subprocess probe
 
-**Keep today's priority, but fall through on failure** (do not reorder `$VIRTUAL_ENV`
-below `.venv`). An activated env that actually has Streamlit still wins; a stale one no
-longer poisons discovery.
+Never `import streamlit`. Child uses `python -P` (not `-I`: `-I` implies `-E` and drops
+`PYTHONUTF8`). Strip `''` from `sys.path` before `find_spec`. Require a real package:
 
-Try order (first **successful probe** wins):
+- `spec.submodule_search_locations` is set (not a lone `streamlit.py`)
+- `Path(spec.origin).name == "__init__.py"` and parent name is `streamlit`
+- That path is **not** under `project_dir` (reject local shadowing)
 
-1. `--python <executable>` — **exclusive**. If this probe fails, stop and report that
-   failure (the caller opted in). Do not fall through.
-2. `$VIRTUAL_ENV` (`virtual-env`)
-3. `<project>/.venv`, then `venv`, then `env` (`venv-local`)
-4. Same names on `<project>/..` (`venv-parent`)
-5. Same names at git root, when that root is not already (3) or (4) (`venv-git-root`)
-6. `$CONDA_PREFIX` (`conda`)
-7. `sys.executable` if not already listed (`launcher`) — so
-   `.venv\Scripts\python.exe discover.py` works without pinning `VIRTUAL_ENV`.
-   **Never** emit `ERROR[NO_PROJECT_PYTHON]` while this process is a working Python:
-   `sys.executable` is a last-resort candidate even if earlier tags missed.
-8. `pipenv run python` / `poetry run python` / `pdm run python` / `uv run --no-sync --quiet python`
-   only when the CLI is on `PATH` **and** the matching lockfile/`Pipfile` exists at
-   `project_dir` **or** an ancestor up to the git root (`pipenv` / `poetry` / `pdm` / `uv`)
-9. Windows: `py -3` (`py-launcher`)
-10. System: **Windows** `python` then `python3`; **POSIX** `python3` then `python`.
-    On Windows, `python3` is often the Store stub — do not prefer it.
+Print `STREAMLIT_PKG=<package-dir>` (last such line wins). Parent ignores banners.
+Empty/garbage stdout → record `PROBE_FAILED`, continue.
 
-`find_venv_python(root)` must check **platform-native** locations and ignore the other
-OS's leftovers (e.g. a POSIX `bin/python` copied onto Windows):
+Child env: `PYTHONIOENCODING=utf-8`, `PYTHONUTF8=1`. Parent `encoding="utf-8"`;
+`errors="replace"` only as a decode guard. Reconfigure **this** script’s stdout to UTF-8
+**without** replacing characters (must not corrupt the success path).
 
-| Platform | Paths (first existing file wins) |
-|---|---|
-| Windows | `<root>\python.exe` (conda/micromamba), `<root>\Scripts\python.exe`, `<root>\Scripts\python3.exe` |
-| POSIX | `<root>/bin/python`, `<root>/bin/python3` |
+Catch `TimeoutExpired`, `FileNotFoundError`, `PermissionError`, `OSError`, `ValueError`,
+`UnicodeError`. `main()` converts anything else to `ERROR[INTERNAL]` (no traceback).
 
-On Windows, rewrite `--project-dir` / `VIRTUAL_ENV` / `CONDA_PREFIX` that look like
-MSYS/Git Bash (`/c/Users/...`, `/cygdrive/c/...`) to `C:\Users\...` before `is_dir()` /
-`is_file()` checks.
+Custom argparse so invalid flags print `ERROR[INVALID_ARGS]`, not argparse’s default
+usage block as the first line.
 
-`--project-dir` runs `expanduser` + `expandvars`. If it is still not a directory, **warn
-on stderr and use cwd** rather than exiting 5 — agents pass `~/...` constantly. Only
-`--python` pointing at a missing file is a hard `ERROR[INVALID_ARGS]`.
+### 3. Outcomes, exit codes, precedence
 
-Manager wrappers are last-resort among project tools, and **must not mutate the env**:
-`uv run --no-sync` (not bare `uv run`). Prefer a discovered `python.exe` over `uv run`
-whenever `.venv` exists (already true if local venv is tried first).
+Shared helper classifies a package dir (filesystem or probe). Usable `SKILL.md` → print
+**exactly one** absolute path on stdout, exit 0.
 
-### 2. Subprocess probe (stage 2)
+Read `importlib.metadata.version("streamlit")` from that install when possible (in the
+child, or from `dist-info` next to the package). Do not infer “too old” from missing
+files alone.
 
-Do **not** `import streamlit`. Child snippet (conceptual):
+| ID | Exit | Meaning |
+|---|---|---|
+| (success) | 0 | Usable `SKILL.md`; stdout is that path only |
+| `ERROR[NO_STREAMLIT]` | 1 | Every candidate lacked Streamlit |
+| `ERROR[STREAMLIT_TOO_OLD]` | 2 | Best leftover: version `< 1.57` |
+| `ERROR[NO_PROJECT_PYTHON]` | 3 | Nothing started (`sys.executable` should make this rare) |
+| `ERROR[SKILLS_LAYOUT_CHANGED]` | 4 | `.agents/skills/` exists, expected file missing |
+| `ERROR[INVALID_ARGS]` | 5 | Bad `--python` / `--project-dir` / unknown flag |
+| `ERROR[INTERNAL]` | 6 | Unexpected exception |
+| `ERROR[STREAMLIT_INCOMPLETE]` | 7 | Version `>= 1.57` or unknown, skill files missing |
+| `ERROR[PROBE_FAILED]` | 1 | Used only in the attempt log for a candidate; overall exit follows the table below if nothing usable was found |
 
-```python
-import importlib.util
-import pathlib
-import sys
+**Non-success precedence** (after all candidates, highest listed wins):
 
-spec = importlib.util.find_spec("streamlit")
-if spec is None or not spec.origin:
-    sys.stderr.write("STREAMLIT_MISSING\n")
-    raise SystemExit(1)
-root = pathlib.Path(spec.origin).resolve().parent
-print(f"STREAMLIT_PKG={root}", flush=True)
-```
+`LAYOUT_CHANGED` > `INCOMPLETE` > `TOO_OLD` > `NO_STREAMLIT` / `PROBE_FAILED` >
+`NO_PROJECT_PYTHON`
 
-Parent parses **only** a `STREAMLIT_PKG=` line, **scanning from the end** (last match
-wins) so wrapper/sitecustomize banners cannot corrupt the path. Empty / malformed stdout
-is `ERROR[PROBE_FAILED]`, never `Path("")` resolving to cwd.
+Every non-zero stderr block **ends** with `https://docs.streamlit.io/llms-full.txt`.
+Non-`INVALID_ARGS` failures also include an attempt log (`tried` / `not tried`).
 
-Child env: `PYTHONIOENCODING=utf-8`, `PYTHONUTF8=1`. Parent
-`subprocess.run(..., text=True, encoding="utf-8", errors="replace")`. Reconfigure the
-script's own stdout/stderr to UTF-8 when possible so printed paths survive Windows
-code pages.
-
-Timeouts: ~20s for a direct executable; ~45s for manager wrappers (still no sync). Catch
-`TimeoutExpired`, `FileNotFoundError`, `PermissionError`, `OSError`, `ValueError`,
-`UnicodeError`, and filesystem errors around `iterdir()` (exit 4 listing). Convert all
-to `ERROR[<ID>]`.
-
-`main()` is wrapped so **any other exception** becomes `ERROR[INTERNAL]` (exit 6) plus
-the docs URL — never a traceback to the agent.
-
-Shared reporter, given a package root:
-
-- `<root>/.agents/skills/developing-with-streamlit/SKILL.md` exists → print that
-  **absolute path only** on stdout, exit 0 (agent happy-path unchanged).
-- `.agents/skills/` exists but the expected file does not → exit 4, list entries.
-- Streamlit found, no `.agents/skills/` → exit 2 (pre-1.57).
-
-### 3. Error contract
-
-Stderr starts with a stable identifier, then human text. Agents match the id; humans
-read the rest.
-
-| ID | When |
-|---|---|
-| `ERROR[NO_PROJECT_PYTHON]` | No candidate started (should be rare: `sys.executable` is always a last resort) |
-| `ERROR[NO_STREAMLIT]` | Every candidate started; none had Streamlit |
-| `ERROR[STREAMLIT_TOO_OLD]` | Best candidate found Streamlit but no bundled skills |
-| `ERROR[SKILLS_LAYOUT_CHANGED]` | `.agents/skills/` present, expected `SKILL.md` missing |
-| `ERROR[PROBE_FAILED]` | Candidate ran; stdout unparseable, timeout, permission, decode |
-| `ERROR[INVALID_ARGS]` | `--python` missing/not a file; unknown CLI args |
-| `ERROR[INTERNAL]` | Unexpected exception (exit 6). Never a traceback |
-
-**Every** non-zero stderr block **ends** with:
-
-```text
-If you cannot resolve a local skill, read:
-  https://docs.streamlit.io/llms-full.txt
-```
-
-Do not omit this on `INVALID_ARGS` or `INTERNAL`. The agent always has a next step.
-
-On any non-zero exit except `INVALID_ARGS`, also print an **attempt log**:
-
-```text
-Tried:
-  - virtual-env  C:\stale\venv\Scripts\python.exe  no streamlit
-  - venv-local   C:\proj\.venv\Scripts\python.exe  STREAMLIT_TOO_OLD  (1.56)
-  - launcher     C:\proj\.venv\Scripts\python.exe  (skipped, duplicate)
-  - py-launcher  py -3                             store-stub skipped
-```
-
-**Install/upgrade advice is last, not first.** Only emit `uv add` / `conda install` /
-quoted `python -m pip install` after **all** candidates were tried and none had a modern
-Streamlit. If `$VIRTUAL_ENV` failed but the project venv was not usable either, say
-"re-run with `--python` pointing at the interpreter that runs the app" before suggesting
-installs. Never lead with "upgrade Streamlit" when the path was a parse error.
-
-Quote every path in advice (`shlex.quote` on POSIX; double quotes on Windows). Drop
-`source .venv/bin/activate`. If `pyvenv.cfg` contains a `uv =` line or `uv.lock` is
-present, advise `uv add streamlit` / `uv pip install streamlit`, not
-`python -m pip` (uv venvs have no pip).
+Install/upgrade advice is **last**, only if no candidate had a modern complete skill.
+Quote paths. No `source .venv/bin/activate`. Prefer `uv add` / `uv pip` when `uv.lock`
+is present.
 
 ### 4. CLI
 
@@ -291,233 +188,138 @@ present, advise `uv add streamlit` / `uv pip install streamlit`, not
 python scripts/discover.py --project-dir <DIR> [--python <EXECUTABLE>]
 ```
 
-`--project-dir` still defaults to cwd. `--python` is the deterministic override.
-
-Success stdout remains a single absolute path to the bundled `SKILL.md` (plus optional
-trailing newline). Do not print JSON to stdout — agents already mishandle mixed stdout;
-keep the probe sentinel internal.
+`--project-dir` defaults to cwd when omitted. When passed and invalid after expansion →
+exit 5.
 
 ### 5. Meta-skill `SKILL.md`
 
-Low-freedom instructions. Agents must not improvise a fourth discovery method.
+Stay in the six spec fields: `name`, `description`, `license`, `metadata`,
+`allowed-tools` (no `compatibility`). Description: third person, triggers in this field,
+≤1024 chars. `license: Apache-2.0`.
 
-**Frontmatter** (stay inside the Agent Skills spec's six fields so claude.ai /
-`package_skill.py` do not hard-error):
+```yaml
+allowed-tools: Read Glob Bash(${CLAUDE_SKILL_DIR}/scripts/discover.py *)
+```
 
-- `name` / `description` — keep triggers **in `description`** (portable). Rewrite
-  description in third person; stay ≤1024 chars.
-- `license: Apache-2.0`
-- `compatibility:` local filesystem and a Python 3 interpreter; normal discovery is
-  offline. Do **not** write "requires Streamlit ≥1.57" in a way that causes hosts to
-  **skip** the skill — the whole point of the meta-skill is to find or fall back.
-- `allowed-tools` — keep the experimental field (Claude Code / Codex; other hosts
-  ignore it). It is a one-turn **pre-approval**, not a sandbox.
+A permission prompt is acceptable; the manual ladder covers a declined prompt. Do not
+pre-approve arbitrary `python`.
 
-  **Do not rely on `${CLAUDE_SKILL_DIR}` inside `allowed-tools`.** Substitution in that
-  field is unreliable (reported Claude Code bug: the grant never matches, so the agent
-  is re-prompted anyway). The **body** may still use `${CLAUDE_SKILL_DIR}` /
-  `${CLAUDE_PROJECT_DIR}` (substitution in markdown works). In frontmatter, list
-  launcher prefixes that match without a skill-dir variable, plus `Read` and `Glob`:
-
-  `Read Glob Bash(py -3 *) Bash(python *) Bash(python3 *)` and a `PowerShell(...)`
-  twin if the host has that tool.
-
-  Add a `py` variant for Windows. A one-time approval may still appear; that is
-  acceptable. Do **not** grant unrestricted `Bash(*)`.
-
-Documented command (Claude substitutes these in the **markdown body**; other hosts
-leave them literal — tell the agent to replace unexpanded vars). Windows first:
+Body (once; Windows `py -3` first, POSIX `python3`):
 
 ```text
 py -3 "${CLAUDE_SKILL_DIR}/scripts/discover.py" --project-dir "${CLAUDE_PROJECT_DIR}"
 ```
 
-POSIX:
+If variables appear unexpanded, replace with this `SKILL.md`’s directory and the project
+root. Quote paths. Git Bash: Windows path (`pwd -W`), not `/c/Users/...`. Do not
+activate a venv to discover.
 
-```bash
-python3 "${CLAUDE_SKILL_DIR}/scripts/discover.py" --project-dir "${CLAUDE_PROJECT_DIR}"
-```
+Exit 0 → Read the single stdout path. Non-zero → §5.1. Do not invent Streamlit APIs
+meanwhile.
 
-Body, in order:
+#### 5.1 Manual discovery
 
-1. **Mandatory:** resolve the bundled skill (or `llms-full.txt`) before writing Streamlit
-   code from memory.
-2. Skill dir = directory of this `SKILL.md` (`scripts/discover.py` lives next to it).
-   Well-known roots: `~/.agents/skills/`, `~/.claude/skills/`, `~/.cursor/skills/`,
-   `~/.codex/skills/`, `.github/skills/`. Quote all paths (Windows homes have spaces).
-   Git Bash: pass a Windows project path (`pwd -W` / `cygpath -w`), not `/c/Users/...`.
-3. Launcher order: **Windows** `py -3`, then `python` (not `python3` first).
-   **POSIX** `python3`, then `python`. Any 3.10+ interpreter may *start* the script;
-   the script re-detects the project interpreter. Do not `activate` a venv just to
-   discover.
-4. Exit 0 → last non-empty stdout line is a file → **Read it**.
-   Non-zero → read stderr, honor `ERROR[<ID>]`, then go to §5.1 (do not improvise).
+Short, read-only. Stop at the first existing file.
 
-Do not add Cursor/Codex/Gemini-only files. They do not improve Python discovery.
+1. Interpreter that runs the app: `.venv\Scripts\python.exe` / `.venv/bin/python`.
+   **Windows PowerShell:**
 
-#### 5.1 Manual discovery (required section)
-
-This is a first-class part of the meta-skill, not an appendix. Keep it **short**
-(about half a page). Agents with no shell, a declined permission prompt, a Store-stub
-`python`, or a sandbox must still reach the bundled docs.
-
-Tone: imperative, ordered, **read-only**. Do not tell the agent to install or upgrade
-Streamlit here.
-
-**Goal:** find and **Read**
-`<streamlit-package>/.agents/skills/developing-with-streamlit/SKILL.md`.
-
-Try in this order; stop at the first path that exists:
-
-1. **Project interpreter, no import of the app.** Identify the Python that runs the
-   user's app (do not activate anything):
-   - `.venv\Scripts\python.exe` or `venv\Scripts\python.exe` (Windows)
-   - `.venv/bin/python` (macOS/Linux)
-   - `py -3` if those are missing
-   Then run (quoted):
-
-   ```text
-   "<that-python>" -c "import importlib.util, pathlib; s = importlib.util.find_spec('streamlit'); p = pathlib.Path(s.origin).resolve().parent / '.agents' / 'skills' / 'developing-with-streamlit' / 'SKILL.md'; print(p)"
+   ```powershell
+   & ".\.venv\Scripts\python.exe" -c "import importlib.util, pathlib, sys; sys.path = [p for p in sys.path if p]; s = importlib.util.find_spec('streamlit');
+   assert s and s.origin and s.submodule_search_locations; p = pathlib.Path(s.origin).resolve().parent / '.agents' / 'skills' / 'developing-with-streamlit' / 'SKILL.md'; print(p if p.is_file() else '')"
    ```
 
-   Read the printed path if the file exists.
+   `py -3` is only if that venv python is missing; it is not a substitute for a quoted
+   venv path. If `find_spec` is `None` or origin is `streamlit.py`, go to step 2.
 
-   Optional equivalent: `pip show streamlit` or `uv pip show streamlit` and append
-   `/.agents/skills/developing-with-streamlit/SKILL.md` to `Location:`. Skip if pip
-   is missing (typical uv venv).
+   Optional: `pip show streamlit` / `uv pip show streamlit` → append
+   `/streamlit/.agents/skills/developing-with-streamlit/SKILL.md` to `Location:` (the
+   location is `site-packages`, not the package dir). Skip if pip is absent.
 
-2. **Filesystem search (no Python required).** Glob or search the project (and parent)
-   for either of:
+2. Glob project, parent, and home:
+
    - `**/site-packages/streamlit/.agents/skills/developing-with-streamlit/SKILL.md`
    - `**/Lib/site-packages/streamlit/.agents/skills/developing-with-streamlit/SKILL.md`
-     (Windows venvs)
 
-   Prefer a hit under the project's `.venv` / `venv` over a user-level install. Read
-   that `SKILL.md`.
+   Prefer a hit under the project `.venv`/`venv`.
 
-3. **Online fallback only.** If neither step finds a file,
-   `https://docs.streamlit.io/llms-full.txt`. Do not modify the environment.
+3. `https://docs.streamlit.io/llms-full.txt`. Do not change dependencies.
 
-If step 1 prints `None` / crashes, continue to step 2; do not invent Streamlit APIs
-from training data while these steps are unfinished.
+### 6. Tests and CI
 
-### 6. Content skill POSIX commands
+New `lib/tests/streamlit/web/meta_skill_discover_test.py` (`.agents/*` is
+coverage-excluded). Load `discover.py` by path.
 
-In `lib/streamlit/.agents/skills/developing-with-streamlit/SKILL.md`:
+Must include: per-candidate order (editable `$VIRTUAL_ENV` not beaten by conda
+filesystem); project `.venv` beats `$VIRTUAL_ENV` when both have a skill; non-terminal
+`TOO_OLD`; local `streamlit.py` rejected; success stdout is **exactly one line**;
+sentinel last-wins; Store stub skip; conda `python.exe` at prefix; invalid
+`--project-dir` → exit 5; `--python` exclusive; wall-clock marks `not tried`; fake
+`.venv` e2e without a real wheel.
 
-- Replace the `grep -rl ... | head` scan with agent-tool-neutral steps (Glob/Grep for
-  `import streamlit` / `from streamlit`, or a one-liner using the project interpreter).
-- Replace `lsof | grep | awk` with: check the app's configured port (default 8501) via
-  whatever the agent has (open `http://localhost:8501`, or a short Python
-  `socket` connect). Do not require Unix process tools.
+Vendored happy path: succeed via `sys.executable` **without** injecting `VIRTUAL_ENV`.
 
-### 7. Tests and CI
+**Windows job (PR2):** `windows-latest`, one CPython, `python -m pytest` on this file
+(no `make`, no frontend). Path filter: `lib/streamlit/.agents/**`, this test file,
+`lib/streamlit/web/skills.py`, packaging / `MANIFEST` / `pyproject` package-data.
+Call `python -m venv` / `pytest` directly.
 
-Failures in the field are invisible, so tests have to cover the cases we already
-reproduced. Split coverage:
+Two smokes, not one:
 
-**Ubuntu (existing `python-tests.yml` plus a dedicated file
-`lib/tests/streamlit/web/meta_skill_discover_test.py`).** Load `discover.py` via
-`importlib.util.spec_from_file_location`. `.agents/*` is excluded from coverage; these
-tests are guardrails, not coverage-driven. Respect repo ruff `select = ["ALL"]`
-(`S603`/`T201` on the script already have local noqa).
+1. **Stage 1:** plant `Lib\site-packages\streamlit\.agents\...` — proves filesystem hit.
+2. **Stage 2:** skill files **only** importable via that venv’s `python.exe` (not planted
+   where stage 1 would see them, e.g. editable-style / only on that interpreter’s
+   `sys.path`). Assert discovery used `.venv\Scripts\python.exe`. Success stdout still
+   exposes no interpreter; the fixture encoding is how we know which stage ran.
 
-Layouts that are just path math (conda prefix files, Store-stub skip, banner parse,
-`~` expansion, `--no-sync`, uv `pyvenv.cfg` advice, **filesystem probe hit**) can run
-here, including **simulated** Windows paths on Linux. One end-to-end subprocess run
-against a **fake** `.venv` (planted `site-packages/streamlit/.agents/.../SKILL.md`, no
-real Streamlit wheel required) plus the existing vendored happy path.
+Space in the project path; skip `py -3` if missing. Optional `continue-on-error` only
+while the job is new.
 
-Minimum cases:
+### 7. PR split
 
-- Filesystem probe hit (POSIX `lib/python*/site-packages` and Windows `Lib/site-packages`)
-- Stage 1 miss + stage 2 `find_spec` hit (editable-style layout)
-- Stale `$VIRTUAL_ENV` (no / old Streamlit) **falls through** to project `.venv`
-- `--python` exclusive override
-- `sys.executable` used when no venv markers exist; `NO_PROJECT_PYTHON` not emitted
-- Banner on probe stdout: last `STREAMLIT_PKG=` wins
-- Empty / garbage stdout → `ERROR[PROBE_FAILED]`, not cwd
-- Unexpected exception → `ERROR[INTERNAL]` (exit 6), no traceback, docs URL present
-- `~` expansion on `--project-dir`
-- Conda-shaped prefix: `python.exe` at root and `bin/python`
-- Store-stub path skipped
-- `uv run` invocation includes `--no-sync` (do not require uv in CI)
-- uv-managed `pyvenv.cfg` → install advice is not `python -m pip`
-- `iterdir` `OSError` on exit 4 does not traceback
-- Exit 2 (no skills dir) and exit 4 (restructured layout)
-- Happy path: vendored script still resolves bundled content `SKILL.md`
-
-The existing `TestVendoredMetaSkillDiscovery` happy path stays, but should succeed
-via `sys.executable` **without** injecting `VIRTUAL_ENV`.
-
-**Windows CI (required, narrow).** Do **not** run the full Python unit matrix on
-`windows-latest`. Add a small job (new workflow or a single job next to
-`python-tests.yml`) whose only job is discovery:
-
-| | |
+| PR | Work |
 |---|---|
-| Runner | `windows-latest` |
-| Python | One CPython from `actions/setup-python` (3.12 is enough; not the full version matrix) |
-| Shell | PowerShell for the smoke (this is what Windows agents use). Pytest can use the default. |
-| Install | `pip install -e lib` (or the repo's existing editable install) so the vendored meta-skill and bundled content skill are present. No Playwright, no frontend build. |
-| Tests | The discovery pytest file **on Windows**, plus one **process-level smoke**: create `.venv` with `python -m venv`, plant `Lib\site-packages\streamlit\.agents\...` (filesystem stage, no real wheel required) **and** a second smoke that runs `discover.py` without `VIRTUAL_ENV` and asserts `.venv\Scripts\python.exe`. |
-| Windows-only asserts | `Scripts\python.exe` resolution; conda-style `<prefix>\python.exe`; quoted path with a space in the project dir; UTF-8 user-dir smoke if cheap. Skip `py -3` if the launcher is absent on the runner. |
-| Triggers | Same as unit tests (`pull_request` / `push` to `develop`), optionally path-filtered to `lib/streamlit/.agents/**` and the discovery test file so unrelated PRs do not pay for a Windows runner. |
-| Time | Target a few minutes. Fail the PR if the smoke cannot import `discover.py` or resolve the bundled skill. |
+| **1** | `discover.py` + meta `SKILL.md` + Ubuntu tests |
+| **2** | Narrow `windows-latest` job |
+| **3** (optional) | Content-skill POSIX cleanup |
 
-Ubuntu tests are not a substitute for this job: `subprocess`, `PATHEXT`, `python.exe` vs
-`python`, default text encoding, and venv layout only show up on a real Windows runner.
-
-### 8. Files to change
+## Files (PR1)
 
 | File | Change |
 |---|---|
-| `lib/streamlit/.agents/meta-skill/developing-with-streamlit/scripts/discover.py` | Two-stage discovery, error IDs, `--python`, UTF-8, Windows layouts |
-| `lib/streamlit/.agents/meta-skill/developing-with-streamlit/SKILL.md` | Frontmatter, launchers, §5.1 manual discovery |
-| `lib/streamlit/.agents/skills/developing-with-streamlit/SKILL.md` | Replace POSIX `grep`/`lsof` with agent-tool-neutral steps |
-| `lib/tests/streamlit/web/meta_skill_discover_test.py` | New guardrail tests (coverage-excluded `.agents/*`) |
-| `lib/tests/streamlit/web/skills_test.py` | Happy path without forced `VIRTUAL_ENV` |
-| `.github/workflows/` | Narrow `windows-latest` discovery job |
-
-`streamlit skills --global` copies the vendored meta-skill as-is; no installer changes
-unless a test for that copy path needs updating.
+| `lib/streamlit/.agents/meta-skill/developing-with-streamlit/scripts/discover.py` | Per-candidate discovery |
+| `lib/streamlit/.agents/meta-skill/developing-with-streamlit/SKILL.md` | Launchers + §5.1 |
+| `lib/tests/streamlit/web/meta_skill_discover_test.py` | Guardrail tests |
+| `lib/tests/streamlit/web/skills_test.py` | Drop forced `VIRTUAL_ENV` |
 
 ## Alternatives considered
 
-**Filesystem-first vs subprocess-only.** Subprocess-only is less code but fails in
-sandboxes, with Store stubs, and with broken transitive deps even when the skill files
-are on disk. Filesystem-first is the preferred stage 1; stage 2 remains for editable
-installs and manager wrappers. Do not ship stage 2 without stage 1.
+**All-filesystem then all-subprocess.** Rejected: conda-on-disk beats editable
+`$VIRTUAL_ENV`. Per-candidate keeps filesystem-before-spawn without reordering priority.
 
-**JSON on stdout for agents.** More structure, worse agent compliance. Sentinel stays
-inside the child probe; agent-facing success remains one path.
+**Keep `$VIRTUAL_ENV` first.** Rejected when both have a usable skill: agent shells leak
+stale activations. `--python` covers an intentional non-project env.
 
-**`import streamlit` kept for version accuracy.** Reject: optional-dep import failures,
-local `streamlit.py` shadowing, stdout noise, Windows Defender timeouts. Filesystem
-layout is the version signal we need (`/.agents/skills/` ⇒ ≥1.57).
+**Filesystem-only auto discovery.** Rejected: editable installs and Poetry cache envs
+need `find_spec`. Manager CLIs stay last-resort and `--no-sync`.
 
-**`allowed-tools` with `${CLAUDE_SKILL_DIR}` in the rule.** Official docs say substitution
-works in frontmatter; in practice it often does not, so the grant never matches. Prefer
-launcher prefixes (`py -3`, `python`, `python3`) plus `Read`/`Glob`, and accept a
-one-time approval. Do not drop the field entirely (it still helps when the prefix
-matches).
+**`Bash(python *)`.** Rejected: arbitrary code, global install. Script-anchored grant +
+prompt is enough.
 
-**Defer tests (script + SKILL.md only).** Reject. Failures are unmeasurable; tests are
-the mitigation. `.agents/*` is coverage-excluded, so the new test file is required
-guardrail, not a coverage chase.
+**Infer too-old from missing `.agents/skills/`.** Rejected: stripped modern wheels look
+the same. Use distribution metadata.
 
-**`compatibility: Requires Streamlit >= 1.57`.** Hosts that honor the field may hide the
-skill exactly when discovery is needed.
+**Fall back invalid `--project-dir` to cwd.** Rejected: silently scans the wrong tree.
 
 ## Checklist
 
 | Item | Notes |
 |---|---|
-| Works on SiS, Cloud, etc? | N/A — local agent tooling only |
-| No breaking API changes | No `st.*` API. Agent success stdout still a path. Error stderr format changes (additive IDs) |
-| No new dependencies | stdlib only |
-| Metrics collected | No — failures remain unobservable; tests are the mitigation |
-| Security/legal | Discovery stays read-only; do not auto-install packages. `allowed-tools` stays narrowly scoped (global install) |
-| Docs | Meta + content `SKILL.md` only, including the §5.1 manual discovery section; optional note in `streamlit skills` CLI help if it describes discovery |
-| Dual-repo | Not required. `streamlit skills` installs the wheel-vendored copy; GitHub `agent-skills` is out of band |
-| Windows CI | Required: narrow `windows-latest` discovery job + smoke (`discover.py` against `.venv\Scripts\python.exe`). Not the full Python matrix |
+| Works on SiS, Cloud, etc? | N/A — local agent tooling |
+| No breaking API changes | No `st.*`. Success stdout still one path |
+| No new dependencies | stdlib |
+| Metrics collected | No |
+| Security/legal | No auto-install. No `Bash(python *)` |
+| Docs | Meta `SKILL.md` only in PR1 |
+| Dual-repo | Not required |
+| Windows CI | PR2, narrow job |

--- a/specs/2026-08-29-defensive-meta-skill-discovery/tech-spec.md
+++ b/specs/2026-08-29-defensive-meta-skill-discovery/tech-spec.md
@@ -8,318 +8,291 @@ created: 2026-08-29
 ## Summary
 
 Harden the **meta-skill** that `streamlit skills` installs so agents find this
-**project's** bundled Streamlit skill (`<streamlit>/.agents/skills/developing-with-streamlit/SKILL.md`).
-Failures are unobservable in production, so discovery must not return a confidently wrong
-path.
+**project's** bundled Streamlit skill
+(`<streamlit>/.agents/skills/developing-with-streamlit/SKILL.md`).
+Failures are unobservable, so discovery must not return a confidently wrong path.
 
 Scope is **`streamlit skills` only** (project default, `--global`, Windows no-symlink
-fallback to global). Third-party installers are out of band. No `st.*` API changes.
+fallback). Third-party installers are out of band. No `st.*` API changes.
 
 ## Problem
 
-`streamlit skills` copies from the **local wheel** (no GitHub fetch; see #15933):
+`streamlit skills` copies from the **local wheel** (no GitHub fetch; see
+[#15933](https://github.com/streamlit/streamlit/issues/15933)):
 
 | Mode | Installed | `discover.py` |
 |---|---|---|
 | **Project** (default) | Symlinks to bundled **content** skills | Unused |
 | **Global** (`--global`) | Meta-skill → `~/.agents/skills/` (and `~/.claude/skills/` if present) | Required |
-| **Windows, no Developer Mode** | Same global copy (symlink fallback) | Required |
+| **Windows, no Developer Mode** | Same global copy | Required |
 
-Today `discover.py` picks **one** interpreter and stops. Wrong or noisy answers:
+Today the script picks **one** interpreter and stops. Known wrong answers: stale
+`$VIRTUAL_ENV` hides the project `.venv`; probe stdout banners become a fake path;
+Windows conda `%CONDA_PREFIX%\python.exe` is missed; `python3` is often a Store stub;
+`uv run` may sync; a local `streamlit.py` shadows `find_spec`; uncaught exceptions
+print a traceback. The only vendored test forces `VIRTUAL_ENV` because
+`sys.executable` is ignored. CI is Ubuntu-only.
 
-| Failure | Result |
-|---|---|
-| Stale `$VIRTUAL_ENV` without Streamlit, project `.venv` has it | Project venv never probed. The only vendored test forces `VIRTUAL_ENV` because `sys.executable` is ignored (`skills_test.py`). |
-| Probe stdout banners | `Path(stdout.strip())` → silent "predates skills" |
-| Windows conda `%CONDA_PREFIX%\python.exe` | Not checked (`bin/python` / `Scripts/python.exe` only) |
-| `python3` Store stub (`WindowsApps`) | Misreported as "not installed"; no `py -3` |
-| `text=True` on cp1252 | Crash on non-ASCII user paths |
-| `uv run` without `--no-sync` | May create/sync a venv |
-| First candidate missing Streamlit | Install advice even when another candidate would work |
-| Skill files on disk, subprocess required | Sandbox / stub / broken import → fail |
-| Uncaught exception | Traceback, no docs fallback |
-| Local `streamlit.py` on `sys.path[0]` | `find_spec` / `import` both resolve the demo file |
-
-The meta `SKILL.md` is a one-line `python <SKILL_DIR>/...` with no fallback. Its
-`allowed-tools` pre-approves `python`/`python3` only and does not match the body.
-
-Python CI is Ubuntu-only; discovery coverage is one forced happy path.
-
-**Same name, two skills:** project mode puts the **content** skill at
-`.agents/skills/developing-with-streamlit`; global puts the **meta** skill at
-`~/.agents/skills/developing-with-streamlit`. Assumed: project-local wins over user-global.
-Not renaming in this work.
+**Same name, two skills:** project content skill at `.agents/skills/developing-with-streamlit`
+vs global meta-skill at `~/.agents/skills/developing-with-streamlit`. Assumed:
+project-local wins. Not renaming here.
 
 ## Goals
 
-1. Return a usable bundled `SKILL.md` from this **project** when one exists, without
-   importing Streamlit and without installing/syncing packages.
-2. Never treat a missing/old/wrong candidate as terminal if a later one would work.
-3. On total failure: stable error, attempt log, docs URL, and a short manual ladder in
-   `SKILL.md`.
-4. Prove the Windows layouts on a real `windows-latest` runner (narrow job).
+1. Return a usable bundled `SKILL.md` for this **project** when one exists, without
+   importing Streamlit and without installing or synchronizing dependencies.
+2. Keep searching after a miss, old install, or failed probe; only a usable skill
+   short-circuits.
+3. On total failure: one error, attempt log, docs URL, manual ladder. Never execute
+   install advice unless the user asked.
+4. Validate Windows layouts in CI **in the same change** as the script (or earlier).
 
 ## Out of scope
 
-- Hatch, pixi, pyenv-virtualenv, direnv, `UV_PROJECT_ENVIRONMENT` (use `--python` or the
-  manual ladder).
-- Changing symlink install / the Windows global fallback in `skills.py`.
+- Hatch, pixi, pyenv-virtualenv, direnv, `UV_PROJECT_ENVIRONMENT` (`--python` or manual
+  ladder).
+- Changing symlink install / Windows global fallback in `skills.py`.
 - `npx skills` / GitHub `agent-skills` lockstep.
 - Cursor/Codex/Gemini-only frontmatter.
-- Full Windows Python test matrix.
+- Full Windows Python matrix.
 - Renaming the meta-skill.
-- Content-skill POSIX `grep`/`lsof` cleanup — **follow-up PR** (orthogonal; dropping
-  `lsof` also changes “list all Streamlit ports” behavior).
+- Content-skill POSIX `grep`/`lsof` — **follow-up PR**.
+- Distinguishing `TOO_OLD` vs `INCOMPLETE` via `dist-info` (v1: one “found Streamlit,
+  no usable skill” outcome).
 
 ## Locked decisions
 
 | Topic | Decision |
 |---|---|
-| Probe order | **Per candidate:** filesystem then subprocess, then the next candidate. Not “all filesystem, then all subprocess” (that lets a low-priority conda prefix beat an editable `$VIRTUAL_ENV`). |
-| Project vs `$VIRTUAL_ENV` | **Project-local `.venv` / `venv` first** (this skill is for the app). `$VIRTUAL_ENV` next. Both having modern Streamlit must not prefer a leftover activated env. Override: `--python`. |
-| Unusable Streamlit | `TOO_OLD` / `INCOMPLETE` / `LAYOUT_CHANGED` are **recorded**, not terminal. Only a usable `SKILL.md` short-circuits. |
-| “Read-only” | Means **no intentional install/sync**. Filesystem + direct `python -c` by default. `poetry run` / `uv run --no-sync` only if no prefix worked. Python may still run `.pth` / `sitecustomize`. |
-| `--project-dir` | Expand `~` / env vars; light MSYS `/c/...` → `C:\...`. If still not a directory → **`ERROR[INVALID_ARGS]`**, do not fall back to cwd. |
-| `--python` | Keep. Exclusive. The hatch/pixi/“use this env” escape hatch. |
-| `allowed-tools` | `Read`, `Glob`, and **script-anchored** `Bash(${CLAUDE_SKILL_DIR}/scripts/discover.py *)`. **Not** `Bash(python *)`. Accept a one-time prompt. No `PowerShell(...)` twin. |
-| Agent branching | Exit 0 → Read the stdout path. Non-zero → manual ladder. IDs are for humans and tests. |
-| `compatibility` | **Omit.** Hosts may hide the skill. |
-| Extra dir names | `.venv` always; `venv` only if `pyvenv.cfg` exists. **Not** `env/`. |
-| Version vs missing files | Metadata version `< 1.57` → `TOO_OLD`. Version `>= 1.57` (or unknown) but files missing → `INCOMPLETE`. `.agents/skills/` present, expected file missing → `LAYOUT_CHANGED`. |
+| Probe order | **Per candidate:** filesystem then subprocess, then the next candidate. |
+| Project vs `$VIRTUAL_ENV` | **Project `.venv`/`venv` first.** Agent shells often have `$VIRTUAL_ENV` pointing at the *agent*, not the app. `--python` if the user really wants the activated env. `--verbose` prints the winner on stderr so a wrong pick is diagnosable. |
+| Unusable Streamlit | Recorded, not terminal. After all candidates, report the outcome of the **highest-priority candidate that was actually inspected** (severity only *within* that candidate). |
+| Dependency guarantee | **No dependency installation or synchronization.** Manager CLIs (`uv run --no-sync`, `poetry run`, …) may still *create* an empty env; they run only if no prefix worked. Direct `python -c` may run `.pth` / `sitecustomize`. |
+| `--project-dir` | Expand `~` / env vars; light MSYS `/c/...` → `C:\...`. Unexpanded `${...}` or a path that does not exist → **WARNING on stderr, use cwd**. Hard `ERROR[INVALID_ARGS]` only for a bad `--python` or unknown flags. |
+| `--python` | Keep. Exclusive. |
+| `--verbose` | Winning tag + interpreter on **stderr**. Stdout stays one path. |
+| `allowed-tools` | `Read`, `Glob`, plus launcher-anchored grants that **match the body** (`py -3` / `python3` / `python` + script path + `*`). Not `Bash(python *)`. Prompt is OK. |
+| Shadowing | Reject a lone `streamlit.py` (no `submodule_search_locations`, origin not `__init__.py`). **Do not** reject every path under `project_dir` (breaks in-tree / editable Streamlit). |
+| Child flags | **No `python -P`** (3.11+ only; Streamlit supports 3.10). Sanitize `sys.path` in the snippet. Drop inherited `PYTHONPATH` / `PYTHONHOME`. |
+| Store stubs | Only the App Execution Alias dir (`%LOCALAPPDATA%\Microsoft\WindowsApps\`). Do not reject every path containing `WindowsApps` (real Store Python lives elsewhere). |
+| Agent branching | Exit 0 → Read stdout path. Non-zero → manual ladder. |
+| Extra dirs | `.venv` always; `venv` only with `pyvenv.cfg`. Not `env/`. |
+| Git walk | Cap at **20** ancestors (same as `_MAX_REPO_ROOT_WALK_DEPTH` in `skills.py`). |
+| Frontmatter | `name`, `description`, `license`, `allowed-tools`. No `compatibility`, no unused `metadata`. |
+| Windows CI | **Same PR as the script** (or land first). PR1 is not behavior-only. |
 
 ## Proposal
 
 ### 1. Per-candidate discovery
 
-Walk candidates in this order. For each **env prefix**, try filesystem lookup; on miss,
-if there is an interpreter, run the subprocess probe. Continue until a **usable**
-`SKILL.md` is found or the list (or wall clock) is exhausted.
+For each candidate: filesystem lookup, then subprocess if needed. Stop only on a
+**usable** `SKILL.md`, or when the subprocess-time budget is exhausted.
 
-1. `--python` — exclusive; do not continue on failure
+1. `--python` — exclusive
 2. `<project>/.venv`, then `<project>/venv` if `pyvenv.cfg` exists
-3. Same on parent, then git root (skip duplicates)
+3. Same on parent, then git root (≤20 levels, skip duplicates)
 4. `$VIRTUAL_ENV`
 5. `$CONDA_PREFIX`
-6. `sys.executable` if not already listed (`launcher`)
-7. `pipenv` / `poetry` / `pdm` / `uv run --no-sync --quiet python` when the CLI is on
-   `PATH` and the lockfile/`Pipfile` exists at `project_dir` or an ancestor up to git root
+6. `sys.executable` if not already listed — **best-effort version** (often the agent’s
+   Python, not the app’s)
+7. `pipenv` / `poetry` / `pdm` / `uv run --no-sync --quiet python` only if the CLI is on
+   `PATH` and the lockfile/`Pipfile` exists at `project_dir` or an ancestor
 8. Windows: `py -3`
-9. System: Windows `python` then `python3`; POSIX `python3` then `python`. Skip
-   `WindowsApps` stubs (and 0-byte aliases)
+9. System: Windows `python` then `python3`; POSIX `python3` then `python`
 
-`find_venv_python(root)`:
+`find_venv_python`: Windows `<root>\python.exe` (conda) and `<root>\Scripts\python.exe`;
+POSIX `<root>/bin/python` and `python3`.
 
-| Platform | Paths |
-|---|---|
-| Windows | `<root>\python.exe` (conda), `<root>\Scripts\python.exe` |
-| POSIX | `<root>/bin/python`, `<root>/bin/python3` |
+Filesystem: `<prefix>\Lib\site-packages\streamlit` (Windows),
+`<prefix>/lib/python*/site-packages/streamlit` (POSIX; if several, prefer one that
+already has the skill file). Editable installs are a filesystem miss.
 
-**Filesystem (per prefix):**
-
-| Layout | Path |
-|---|---|
-| Windows | `<prefix>\Lib\site-packages\streamlit` |
-| POSIX | `<prefix>/lib/python*/site-packages/streamlit` (if several, prefer one that already has the skill file; else `pyvenv.cfg` `version_info`) |
-
-Editable installs (`.pth`) are a filesystem miss; the subprocess `find_spec` step handles
-them.
-
-**Wall clock:** 60s global budget. Stop enumerating when hit; attempt log marks the rest
-`not tried`. Per-candidate timeouts: ~15s direct, ~30s manager wrappers.
+**Budget:** charge **subprocess time only** (filesystem is free). Global 60s.
+Direct probe timeout ~10s; manager wrappers ~30s. Attempt log marks the rest
+`not tried`.
 
 ### 2. Subprocess probe
 
-Never `import streamlit`. Child uses `python -P` (not `-I`: `-I` implies `-E` and drops
-`PYTHONUTF8`). Strip `''` from `sys.path` before `find_spec`. Require a real package:
+Never `import streamlit`. No `-P` / `-I`. Child snippet (3.10-safe):
 
-- `spec.submodule_search_locations` is set (not a lone `streamlit.py`)
-- `Path(spec.origin).name == "__init__.py"` and parent name is `streamlit`
-- That path is **not** under `project_dir` (reject local shadowing)
+- Remove `''` and any `sys.path` entry that resolves to cwd
+- `find_spec("streamlit")`
+- Accept only a package: `submodule_search_locations` set, origin file is
+  `streamlit/__init__.py`
+- Print `STREAMLIT_PKG=<package-dir>` (parent parses the **last** such line)
 
-Print `STREAMLIT_PKG=<package-dir>` (last such line wins). Parent ignores banners.
-Empty/garbage stdout → record `PROBE_FAILED`, continue.
+Child env: `PYTHONIOENCODING=utf-8`, `PYTHONUTF8=1`, and **omit** `PYTHONPATH` /
+`PYTHONHOME`. Parent `encoding="utf-8"`; `errors="replace"` only as a decode guard.
+Reconfigure this process’s **stdout and stderr** to UTF-8 without replacing characters.
 
-Child env: `PYTHONIOENCODING=utf-8`, `PYTHONUTF8=1`. Parent `encoding="utf-8"`;
-`errors="replace"` only as a decode guard. Reconfigure **this** script’s stdout to UTF-8
-**without** replacing characters (must not corrupt the success path).
+Catch `TimeoutExpired`, `FileNotFoundError`, `PermissionError`, `OSError`,
+`ValueError`, `UnicodeError`. Anything else → `ERROR[INTERNAL]`. Custom argparse:
+invalid flags start with `ERROR[INVALID_ARGS]`.
 
-Catch `TimeoutExpired`, `FileNotFoundError`, `PermissionError`, `OSError`, `ValueError`,
-`UnicodeError`. `main()` converts anything else to `ERROR[INTERNAL]` (no traceback).
+### 3. Outcomes
 
-Custom argparse so invalid flags print `ERROR[INVALID_ARGS]`, not argparse’s default
-usage block as the first line.
+Usable `SKILL.md` → **exactly one** path on stdout, exit 0. If `--verbose`, stderr
+also has `discovered via: <tag> <interpreter>`.
 
-### 3. Outcomes, exit codes, precedence
+Do not infer version from missing files. v1: Streamlit found but no usable bundled
+skill → one outcome (exit 2), message “upgrade or reinstall, or use the docs.”
+`.agents/skills/` present but the expected file missing → exit 4 (`LAYOUT_CHANGED`).
 
-Shared helper classifies a package dir (filesystem or probe). Usable `SKILL.md` → print
-**exactly one** absolute path on stdout, exit 0.
-
-Read `importlib.metadata.version("streamlit")` from that install when possible (in the
-child, or from `dist-info` next to the package). Do not infer “too old” from missing
-files alone.
-
-| ID | Exit | Meaning |
+| ID | Exit | When |
 |---|---|---|
-| (success) | 0 | Usable `SKILL.md`; stdout is that path only |
-| `ERROR[NO_STREAMLIT]` | 1 | Every candidate lacked Streamlit |
-| `ERROR[STREAMLIT_TOO_OLD]` | 2 | Best leftover: version `< 1.57` |
-| `ERROR[NO_PROJECT_PYTHON]` | 3 | Nothing started (`sys.executable` should make this rare) |
-| `ERROR[SKILLS_LAYOUT_CHANGED]` | 4 | `.agents/skills/` exists, expected file missing |
-| `ERROR[INVALID_ARGS]` | 5 | Bad `--python` / `--project-dir` / unknown flag |
+| (success) | 0 | Usable `SKILL.md` |
+| `ERROR[NO_STREAMLIT]` | 1 | At least one candidate was inspected; none had Streamlit |
+| `ERROR[NO_USABLE_SKILL]` | 2 | Highest-priority inspected candidate had Streamlit but no usable bundled skill |
+| `ERROR[NO_PROJECT_PYTHON]` | 3 | Nothing started |
+| `ERROR[SKILLS_LAYOUT_CHANGED]` | 4 | Highest-priority inspected candidate has `.agents/skills/` without the expected file |
+| `ERROR[INVALID_ARGS]` | 5 | Bad `--python` or unknown flag |
 | `ERROR[INTERNAL]` | 6 | Unexpected exception |
-| `ERROR[STREAMLIT_INCOMPLETE]` | 7 | Version `>= 1.57` or unknown, skill files missing |
-| `ERROR[PROBE_FAILED]` | 1 | Used only in the attempt log for a candidate; overall exit follows the table below if nothing usable was found |
+| `ERROR[PROBE_FAILED]` | 7 | Candidates were attempted but **none** were successfully inspected (timeouts, stubs, garbage stdout). Message: could not inspect any interpreter — **not** “Streamlit is not installed.” |
 
-**Non-success precedence** (after all candidates, highest listed wins):
+**Final error** = outcome of the **highest-priority inspected** candidate. Severity is
+not compared across candidates (a low-priority `LAYOUT_CHANGED` must not hide a
+project-venv `NO_STREAMLIT`). If nothing was inspected → `PROBE_FAILED` or
+`NO_PROJECT_PYTHON`.
 
-`LAYOUT_CHANGED` > `INCOMPLETE` > `TOO_OLD` > `NO_STREAMLIT` / `PROBE_FAILED` >
-`NO_PROJECT_PYTHON`
+Every non-zero stderr block ends with
+https://docs.streamlit.io/llms-full.txt.
 
-Every non-zero stderr block **ends** with `https://docs.streamlit.io/llms-full.txt`.
-Non-`INVALID_ARGS` failures also include an attempt log (`tried` / `not tried`).
-
-Install/upgrade advice is **last**, only if no candidate had a modern complete skill.
-Quote paths. No `source .venv/bin/activate`. Prefer `uv add` / `uv pip` when `uv.lock`
-is present.
+Install advice is last, quoted, and **must not be run unless the user approves**.
+No `source activate`. Prefer `uv add` / `uv pip` when `uv.lock` is present.
 
 ### 4. CLI
 
 ```text
-python scripts/discover.py --project-dir <DIR> [--python <EXECUTABLE>]
+python scripts/discover.py --project-dir <DIR> [--python <EXECUTABLE>] [--verbose]
 ```
-
-`--project-dir` defaults to cwd when omitted. When passed and invalid after expansion →
-exit 5.
 
 ### 5. Meta-skill `SKILL.md`
 
-Stay in the six spec fields: `name`, `description`, `license`, `metadata`,
-`allowed-tools` (no `compatibility`). Description: third person, triggers in this field,
-≤1024 chars. `license: Apache-2.0`.
-
 ```yaml
-allowed-tools: Read Glob Bash(${CLAUDE_SKILL_DIR}/scripts/discover.py *)
+allowed-tools: Read Glob Bash(py -3 ${CLAUDE_SKILL_DIR}/scripts/discover.py *) Bash(python3 ${CLAUDE_SKILL_DIR}/scripts/discover.py *) Bash(python ${CLAUDE_SKILL_DIR}/scripts/discover.py *)
 ```
 
-A permission prompt is acceptable; the manual ladder covers a declined prompt. Do not
-pre-approve arbitrary `python`.
+These prefixes match the body (interpreter + script). They do not grant arbitrary
+`python -c`. A prompt is OK if substitution fails.
 
-Body (once; Windows `py -3` first, POSIX `python3`):
+Body — Windows first, POSIX second; quote paths; if `${CLAUDE_PROJECT_DIR}` is
+literal, use the project cwd (script warns and does the same):
 
 ```text
 py -3 "${CLAUDE_SKILL_DIR}/scripts/discover.py" --project-dir "${CLAUDE_PROJECT_DIR}"
+python3 "${CLAUDE_SKILL_DIR}/scripts/discover.py" --project-dir "${CLAUDE_PROJECT_DIR}"
 ```
 
-If variables appear unexpanded, replace with this `SKILL.md`’s directory and the project
-root. Quote paths. Git Bash: Windows path (`pwd -W`), not `/c/Users/...`. Do not
-activate a venv to discover.
-
-Exit 0 → Read the single stdout path. Non-zero → §5.1. Do not invent Streamlit APIs
-meanwhile.
+Exit 0 → Read the stdout path. Non-zero → §5.1.
 
 #### 5.1 Manual discovery
 
-Short, read-only. Stop at the first existing file.
+Read-only. Stop at the first existing file. **One physical line** each.
 
-1. Interpreter that runs the app: `.venv\Scripts\python.exe` / `.venv/bin/python`.
-   **Windows PowerShell:**
+Windows PowerShell:
 
-   ```powershell
-   & ".\.venv\Scripts\python.exe" -c "import importlib.util, pathlib, sys; sys.path = [p for p in sys.path if p]; s = importlib.util.find_spec('streamlit');
-   assert s and s.origin and s.submodule_search_locations; p = pathlib.Path(s.origin).resolve().parent / '.agents' / 'skills' / 'developing-with-streamlit' / 'SKILL.md'; print(p if p.is_file() else '')"
-   ```
+```powershell
+& ".\.venv\Scripts\python.exe" -c "import importlib.util, pathlib, sys; sys.path=[p for p in sys.path if p and pathlib.Path(p).resolve()!=pathlib.Path('.').resolve()]; s=importlib.util.find_spec('streamlit'); p=(pathlib.Path(s.origin).resolve().parent/'.agents'/'skills'/'developing-with-streamlit'/'SKILL.md') if (s and s.origin and s.submodule_search_locations and pathlib.Path(s.origin).name=='__init__.py') else None; print(p if p is not None and p.is_file() else '')"
+```
 
-   `py -3` is only if that venv python is missing; it is not a substitute for a quoted
-   venv path. If `find_spec` is `None` or origin is `streamlit.py`, go to step 2.
+POSIX:
 
-   Optional: `pip show streamlit` / `uv pip show streamlit` → append
-   `/streamlit/.agents/skills/developing-with-streamlit/SKILL.md` to `Location:` (the
-   location is `site-packages`, not the package dir). Skip if pip is absent.
+```bash
+".venv/bin/python" -c "import importlib.util, pathlib, sys; sys.path=[p for p in sys.path if p and pathlib.Path(p).resolve()!=pathlib.Path('.').resolve()]; s=importlib.util.find_spec('streamlit'); p=(pathlib.Path(s.origin).resolve().parent/'.agents'/'skills'/'developing-with-streamlit'/'SKILL.md') if (s and s.origin and s.submodule_search_locations and pathlib.Path(s.origin).name=='__init__.py') else None; print(p if p is not None and p.is_file() else '')"
+```
 
-2. Glob project, parent, and home:
+Empty print / missing venv → step 2. `py -3` only if the venv interpreter is missing.
+Optional: `"<that-python>" -m pip show streamlit` and append
+`/streamlit/.agents/skills/developing-with-streamlit/SKILL.md` to `Location:`.
+
+2. Glob **project and parent only** (not `$HOME` — slow, wrong install, and many
+   agent globs skip gitignored `.venv`):
 
    - `**/site-packages/streamlit/.agents/skills/developing-with-streamlit/SKILL.md`
    - `**/Lib/site-packages/streamlit/.agents/skills/developing-with-streamlit/SKILL.md`
 
-   Prefer a hit under the project `.venv`/`venv`.
+   Prefer a hit under the project `.venv`/`venv`. Search tools may need to include
+   ignored files.
 
-3. `https://docs.streamlit.io/llms-full.txt`. Do not change dependencies.
+3. `https://docs.streamlit.io/llms-full.txt`. Do not change dependencies unless the
+   user asked.
 
 ### 6. Tests and CI
 
-New `lib/tests/streamlit/web/meta_skill_discover_test.py` (`.agents/*` is
-coverage-excluded). Load `discover.py` by path.
+`lib/tests/streamlit/web/meta_skill_discover_test.py`. Required cases: per-candidate
+order; project `.venv` beats `$VIRTUAL_ENV`; non-terminal unusable skill; lone
+`streamlit.py` rejected **and** in-tree `lib/streamlit` accepted; success stdout is
+one line; sentinel last-wins; Store-alias skip; conda `python.exe`; unexpanded
+`--project-dir` → cwd + warning; `--python` exclusive; wall-clock `not tried`;
+overall `PROBE_FAILED` when every probe fails; fake `.venv` e2e.
 
-Must include: per-candidate order (editable `$VIRTUAL_ENV` not beaten by conda
-filesystem); project `.venv` beats `$VIRTUAL_ENV` when both have a skill; non-terminal
-`TOO_OLD`; local `streamlit.py` rejected; success stdout is **exactly one line**;
-sentinel last-wins; Store stub skip; conda `python.exe` at prefix; invalid
-`--project-dir` → exit 5; `--python` exclusive; wall-clock marks `not tried`; fake
-`.venv` e2e without a real wheel.
+Vendored happy path: `sys.executable`, no forced `VIRTUAL_ENV`.
 
-Vendored happy path: succeed via `sys.executable` **without** injecting `VIRTUAL_ENV`.
+**Windows job in this PR:** `windows-latest`, `actions/setup-python` (3.12), then
+`python -m pip install pytest` and `python -m pip install -e lib` (or the repo’s
+existing editable install if that already pulls pytest). Run
+`python -m pytest lib/tests/streamlit/web/meta_skill_discover_test.py`. No `make`,
+no frontend. Path filter: `.agents/**`, this test, `web/skills.py`, packaging
+files.
 
-**Windows job (PR2):** `windows-latest`, one CPython, `python -m pytest` on this file
-(no `make`, no frontend). Path filter: `lib/streamlit/.agents/**`, this test file,
-`lib/streamlit/web/skills.py`, packaging / `MANIFEST` / `pyproject` package-data.
-Call `python -m venv` / `pytest` directly.
+Smokes:
 
-Two smokes, not one:
+1. **Filesystem:** plant `Lib\site-packages\streamlit\.agents\...`.
+2. **Subprocess:** do **not** plant under `Lib\site-packages`. Add a `.pth` in the
+   venv that points at a directory containing only that interpreter’s Streamlit
+   tree. Stage 1 must miss; stage 2 must hit via `.venv\Scripts\python.exe`.
 
-1. **Stage 1:** plant `Lib\site-packages\streamlit\.agents\...` — proves filesystem hit.
-2. **Stage 2:** skill files **only** importable via that venv’s `python.exe` (not planted
-   where stage 1 would see them, e.g. editable-style / only on that interpreter’s
-   `sys.path`). Assert discovery used `.venv\Scripts\python.exe`. Success stdout still
-   exposes no interpreter; the fixture encoding is how we know which stage ran.
+Also: space in the project path; skip `py -3` if missing.
 
-Space in the project path; skip `py -3` if missing. Optional `continue-on-error` only
-while the job is new.
-
-### 7. PR split
+### 7. PRs
 
 | PR | Work |
 |---|---|
-| **1** | `discover.py` + meta `SKILL.md` + Ubuntu tests |
-| **2** | Narrow `windows-latest` job |
-| **3** (optional) | Content-skill POSIX cleanup |
+| **1** | `discover.py` + meta `SKILL.md` + Ubuntu tests + **Windows discovery job** |
+| **2** (optional) | Content-skill POSIX cleanup |
 
 ## Files (PR1)
 
 | File | Change |
 |---|---|
-| `lib/streamlit/.agents/meta-skill/developing-with-streamlit/scripts/discover.py` | Per-candidate discovery |
-| `lib/streamlit/.agents/meta-skill/developing-with-streamlit/SKILL.md` | Launchers + §5.1 |
-| `lib/tests/streamlit/web/meta_skill_discover_test.py` | Guardrail tests |
+| `.../meta-skill/.../scripts/discover.py` | Per-candidate discovery |
+| `.../meta-skill/.../SKILL.md` | Launchers + manual ladder |
+| `lib/tests/streamlit/web/meta_skill_discover_test.py` | Guardrails |
 | `lib/tests/streamlit/web/skills_test.py` | Drop forced `VIRTUAL_ENV` |
+| `.github/workflows/` | Narrow `windows-latest` discovery job |
 
 ## Alternatives considered
 
-**All-filesystem then all-subprocess.** Rejected: conda-on-disk beats editable
-`$VIRTUAL_ENV`. Per-candidate keeps filesystem-before-spawn without reordering priority.
+**`python -P`.** Rejected: 3.11+ only. In-snippet `sys.path` cleanup covers 3.10.
 
-**Keep `$VIRTUAL_ENV` first.** Rejected when both have a usable skill: agent shells leak
-stale activations. `--python` covers an intentional non-project env.
+**Reject every path under `project_dir`.** Rejected: Streamlit’s own editable checkout
+is `lib/streamlit`. Structural package checks are enough.
 
-**Filesystem-only auto discovery.** Rejected: editable installs and Poetry cache envs
-need `find_spec`. Manager CLIs stay last-resort and `--no-sync`.
+**`Bash(${CLAUDE_SKILL_DIR}/scripts/discover.py *)` alone.** Never matches
+`py -3 …/discover.py`. Grant the interpreter + script prefix instead.
 
-**`Bash(python *)`.** Rejected: arbitrary code, global install. Script-anchored grant +
-prompt is enough.
+**Severity across candidates.** Rejected: a random conda `LAYOUT_CHANGED` must not
+outrank the project venv’s `NO_STREAMLIT`.
 
-**Infer too-old from missing `.agents/skills/`.** Rejected: stripped modern wheels look
-the same. Use distribution metadata.
+**Hard-fail invalid `--project-dir`.** Too harsh when `${CLAUDE_PROJECT_DIR}` is
+literal. Warn + cwd; hard-fail only `--python`.
 
-**Fall back invalid `--project-dir` to cwd.** Rejected: silently scans the wrong tree.
+**`TOO_OLD` vs `INCOMPLETE` + exit 7.** Deferred. Agent behavior is the same; no
+telemetry. v1 uses one “no usable skill” exit.
+
+**Filesystem-only auto discovery.** Editable / Poetry cache still need `find_spec`.
+
+**Glob `$HOME`.** Slow and picks the wrong install.
 
 ## Checklist
 
 | Item | Notes |
 |---|---|
-| Works on SiS, Cloud, etc? | N/A — local agent tooling |
-| No breaking API changes | No `st.*`. Success stdout still one path |
-| No new dependencies | stdlib |
-| Metrics collected | No |
-| Security/legal | No auto-install. No `Bash(python *)` |
-| Docs | Meta `SKILL.md` only in PR1 |
+| Works on SiS, Cloud, etc? | N/A |
+| No breaking API changes | Success stdout still one path |
+| No new dependencies | stdlib (CI installs pytest on the Windows runner) |
+| Metrics collected | No; `--verbose` is the debug hook |
+| Security/legal | No auto-install. No `Bash(python *)`. Install advice needs user approval |
+| Docs | Meta `SKILL.md` |
 | Dual-repo | Not required |
-| Windows CI | PR2, narrow job |
+| Windows CI | Required in PR1 |

--- a/specs/2026-08-29-defensive-meta-skill-discovery/tech-spec.md
+++ b/specs/2026-08-29-defensive-meta-skill-discovery/tech-spec.md
@@ -1,0 +1,523 @@
+---
+author: lukasmasuch
+created: 2026-08-29
+---
+
+# Defensive Streamlit agent-skill discovery
+
+## Summary
+
+Harden the **meta-skill** that `streamlit skills` installs
+(`lib/streamlit/.agents/meta-skill/developing-with-streamlit`) so coding agents reliably
+find the version-matched bundled skill inside the project's installed Streamlit.
+
+The delivery path this spec optimizes for is **`streamlit skills` only** (project
+default, `--global`, and the Windows no-symlink fallback to global). Third-party
+installers (`npx skills add streamlit/agent-skills`, `gh skill`, …) are out of band.
+
+Failures are not observable in production, so discovery must be **read-only,
+multi-candidate, and explicit**: filesystem before subprocess, never a single guess,
+never an unhandled traceback, never a polluted stdout path treated as a Streamlit
+install.
+
+This is a contract change for `scripts/discover.py` and the meta `SKILL.md`, plus a small
+cross-platform cleanup of the bundled content skill. No Streamlit user-facing API
+changes.
+
+## Problem
+
+Users install skills with **`streamlit skills`**, which copies from the **local wheel**
+(no GitHub fetch):
+
+| Mode | What gets installed | Role of `discover.py` |
+|---|---|---|
+| **Project** (default) | Symlinks to bundled **content** skills in the active Streamlit package | Not used — the agent reads the content `SKILL.md` directly |
+| **Global** (`--global`) | Copy of the vendored **meta-skill** into `~/.agents/skills/` (and `~/.claude/skills/` when present) | Required — the agent must locate this project's Streamlit at runtime |
+| **Windows without Developer Mode** | Project install cannot symlink, so the CLI falls back to the same global copy | Required — same as `--global` |
+
+This spec is about making that CLI path reliable. The meta-skill's `discover.py` locates
+`<streamlit>/.agents/skills/developing-with-streamlit/SKILL.md` for the **project's**
+interpreter. On Windows, the no-symlink fallback means `discover.py` is often the only
+bridge to the docs.
+
+Today the script **picks one interpreter and stops**. That produces confidently wrong
+answers rather than errors:
+
+| Failure | What the agent sees |
+|---|---|
+| Stale `$VIRTUAL_ENV` without current Streamlit, project `.venv` has it | `ERROR: predates bundled skills` or `not installed` — project venv never probed. Reproduced; the sole vendored test in `skills_test.py` works around this by **forcing** `VIRTUAL_ENV` because `sys.executable` is ignored. |
+| Banner/noise on probe stdout (`pipenv`/`poetry`/`conda`/`sitecustomize`) | `Path(stdout.strip())` concatenates noise + path → silent "predates skills" / wrong directory |
+| Windows conda (`%CONDA_PREFIX%\python.exe`) | `find_venv_python` only checks `bin/python` and `Scripts/python.exe` — conda branch never hits |
+| `python3` → Microsoft Store stub (`WindowsApps`) | "Failed to import streamlit" plus Store marketing text; no `py -3` candidate |
+| Non-ASCII user path + `text=True` (cp1252) | `UnicodeEncodeError` / decode crash, not an `ERROR:` block |
+| `uv run --quiet python` | May **create/sync** a venv (not read-only); 30s timeout looks like an import hang |
+| Missing Streamlit on the **first** candidate | Install/upgrade advice, even when another candidate would have worked |
+| Skill files on disk but subprocess/import required | Sandbox, Store stub, broken transitive dep, or slow interpreter → fail even though `site-packages/streamlit/.agents/skills/` is readable |
+| Unexpected exception | Raw traceback, no `ERROR:` block, no docs fallback |
+
+The meta `SKILL.md` is a one-line Usage block (`python <SKILL_DIR>/...`) with no fallback,
+no quoting, no Windows launcher, and no resolution of `<SKILL_DIR>`. `allowed-tools`
+pre-approves `python` / `python3` only and does not match the body (`<SKILL_DIR>` vs
+`${CLAUDE_SKILL_DIR}`), so on Claude Code the grant often never fires — and it nudges
+Windows agents toward the Store stub.
+
+The **content** skill still tells agents to use POSIX `grep \| head` and `lsof \| awk`
+(`lib/streamlit/.agents/skills/developing-with-streamlit/SKILL.md`). Those fail on
+Windows PowerShell, which is the majority audience for this skill.
+
+Python CI (`python-tests.yml`) is Ubuntu-only. Discovery coverage in this repo is one
+forced happy path.
+
+## Goals
+
+1. **Filesystem first, then interpreters.** For known env prefixes, look for the
+   Streamlit package on disk (`Lib/site-packages` / `lib/python*/site-packages`) **before**
+   spawning Python. Then enumerate interpreters until one yields a usable bundled
+   `SKILL.md`. A bad `$VIRTUAL_ENV` must not hide the project `.venv`.
+2. **Read-only.** Discovery must not install packages, create venvs, or sync lockfiles.
+3. **Do not import Streamlit.** Locate the package with `importlib.util.find_spec` in
+   any subprocess probe. Never `import streamlit`.
+4. **Windows-first layouts.** Conda prefix `python.exe`, `py -3`, skip Store stubs, UTF-8
+   I/O, quoted paths, MSYS `/c/...` project dirs.
+5. **Failures are identified.** Stable `ERROR[<ID>]` plus every candidate attempted.
+   Unhandled tracebacks are bugs: a top-level guard converts them to `ERROR[INTERNAL]`
+   (exit 6) and always ends with the docs fallback URL.
+6. **Agents can proceed without the script.** The meta `SKILL.md` includes a short,
+   ordered, read-only **manual discovery** section (see §5.1). Agents follow it when
+   `discover.py` cannot run or returns a non-zero exit. No "pip install streamlit"
+   unless the user asked or every candidate truly lacks Streamlit.
+7. **Windows CI, not just Ubuntu unit tests.** A focused `windows-latest` job runs the
+   discovery tests and an end-to-end `discover.py` smoke (see §7). Failures are not
+   observable in the field; Windows is the majority audience.
+
+## Out of scope
+
+- Renaming the meta-skill to avoid sharing `name: developing-with-streamlit` with the
+  content skill (untested interaction; project-over-global resolution is assumed).
+- Auto-detecting Hatch, pixi, pyenv-virtualenv, direnv, or `UV_PROJECT_ENVIRONMENT`.
+  Covered by `--python` and the manual ladder.
+- Changing project-mode symlink install or the Windows "no Developer Mode → global"
+  fallback in `lib/streamlit/web/skills.py` (keep that fallback; make global discovery
+  trustworthy instead).
+- Third-party skill installers (`npx skills`, `gh skill`, library-skills) and keeping
+  [`streamlit/agent-skills`](https://github.com/streamlit/agent-skills) in lockstep.
+  Source of truth is the copy vendored in the Streamlit wheel that `streamlit skills`
+  installs.
+- Cursor `paths` / `globs`, Codex `agents/openai.yaml`, Gemini-specific frontmatter,
+  `context: fork`, `disable-model-invocation`.
+- Production telemetry for skill failures (still not measurable).
+- Running the entire Streamlit Python test suite on Windows.
+
+## Proposal
+
+Ship as one unit (script + meta `SKILL.md` always travel together) **in the Streamlit
+package**. `streamlit skills --global` already copies that vendored tree from local disk
+(`_install_global_skills` in `lib/streamlit/web/skills.py`); there is no network step and
+no dependency on the GitHub `agent-skills` repo for this work.
+
+### 1. Two-stage discovery (filesystem, then interpreter)
+
+**Option A (preferred): filesystem-first, then subprocess.** For each known env
+**prefix** (same order as below), look for the Streamlit package on disk. If
+`.../streamlit/.agents/skills/developing-with-streamlit/SKILL.md` exists, print that path
+and exit 0 — no Python spawn, no import, no timeout. This is the highest-value change:
+it works when the agent sandbox blocks subprocesses, when `python` is a Store stub, when
+a transitive import would crash, and when the venv is unactivated.
+
+**Option B: only harden the existing subprocess path.** Reject as the sole approach.
+Too many failure modes never reach a working interpreter.
+
+Stage 1 and stage 2 **share one reporter** (`report_skill(streamlit_pkg: Path) -> int`)
+so exit 0 / 2 / 4 cannot drift. Stage 1 reuses stage 2's prefix order.
+
+**Stage 1 — filesystem probe** of env prefixes:
+
+`$VIRTUAL_ENV` → `<project>/{.venv,venv,env}` → parent of those names → git-root of
+those names → `$CONDA_PREFIX`
+
+For each prefix, look for a `streamlit` directory in:
+
+| Layout | Path |
+|---|---|
+| Windows venv / conda | `<prefix>\Lib\site-packages\streamlit` |
+| POSIX venv / conda | `<prefix>/lib/python*/site-packages/streamlit` (if several, prefer one that already has the skill file; else parse `pyvenv.cfg` `version_info` when present) |
+| Some conda | `<prefix>/lib/site-packages/streamlit` |
+
+`--python` skips stage 1 for other prefixes: resolve that interpreter's prefix
+(`pyvenv.cfg` / parent of `Scripts` or `bin`) and probe only that tree, still exclusive
+on failure.
+
+**Editable installs** (`.pth` / `streamlit` not under that `site-packages`) are a
+deliberate stage-1 miss. Stage 2 `find_spec` still finds them.
+
+**Stage 2 — interpreter probe** for poetry/pdm/pipenv/uv, non-standard layouts, and
+editable installs. `detect_interpreter` is a **generator** of `(cmd, tag)`. Deduplicate
+by resolved executable. Skip missing, not executable, or Windows Store stubs
+(`WindowsApps` in the path, or a 0-byte / alias stub).
+
+**Keep today's priority, but fall through on failure** (do not reorder `$VIRTUAL_ENV`
+below `.venv`). An activated env that actually has Streamlit still wins; a stale one no
+longer poisons discovery.
+
+Try order (first **successful probe** wins):
+
+1. `--python <executable>` — **exclusive**. If this probe fails, stop and report that
+   failure (the caller opted in). Do not fall through.
+2. `$VIRTUAL_ENV` (`virtual-env`)
+3. `<project>/.venv`, then `venv`, then `env` (`venv-local`)
+4. Same names on `<project>/..` (`venv-parent`)
+5. Same names at git root, when that root is not already (3) or (4) (`venv-git-root`)
+6. `$CONDA_PREFIX` (`conda`)
+7. `sys.executable` if not already listed (`launcher`) — so
+   `.venv\Scripts\python.exe discover.py` works without pinning `VIRTUAL_ENV`.
+   **Never** emit `ERROR[NO_PROJECT_PYTHON]` while this process is a working Python:
+   `sys.executable` is a last-resort candidate even if earlier tags missed.
+8. `pipenv run python` / `poetry run python` / `pdm run python` / `uv run --no-sync --quiet python`
+   only when the CLI is on `PATH` **and** the matching lockfile/`Pipfile` exists at
+   `project_dir` **or** an ancestor up to the git root (`pipenv` / `poetry` / `pdm` / `uv`)
+9. Windows: `py -3` (`py-launcher`)
+10. System: **Windows** `python` then `python3`; **POSIX** `python3` then `python`.
+    On Windows, `python3` is often the Store stub — do not prefer it.
+
+`find_venv_python(root)` must check **platform-native** locations and ignore the other
+OS's leftovers (e.g. a POSIX `bin/python` copied onto Windows):
+
+| Platform | Paths (first existing file wins) |
+|---|---|
+| Windows | `<root>\python.exe` (conda/micromamba), `<root>\Scripts\python.exe`, `<root>\Scripts\python3.exe` |
+| POSIX | `<root>/bin/python`, `<root>/bin/python3` |
+
+On Windows, rewrite `--project-dir` / `VIRTUAL_ENV` / `CONDA_PREFIX` that look like
+MSYS/Git Bash (`/c/Users/...`, `/cygdrive/c/...`) to `C:\Users\...` before `is_dir()` /
+`is_file()` checks.
+
+`--project-dir` runs `expanduser` + `expandvars`. If it is still not a directory, **warn
+on stderr and use cwd** rather than exiting 5 — agents pass `~/...` constantly. Only
+`--python` pointing at a missing file is a hard `ERROR[INVALID_ARGS]`.
+
+Manager wrappers are last-resort among project tools, and **must not mutate the env**:
+`uv run --no-sync` (not bare `uv run`). Prefer a discovered `python.exe` over `uv run`
+whenever `.venv` exists (already true if local venv is tried first).
+
+### 2. Subprocess probe (stage 2)
+
+Do **not** `import streamlit`. Child snippet (conceptual):
+
+```python
+import importlib.util
+import pathlib
+import sys
+
+spec = importlib.util.find_spec("streamlit")
+if spec is None or not spec.origin:
+    sys.stderr.write("STREAMLIT_MISSING\n")
+    raise SystemExit(1)
+root = pathlib.Path(spec.origin).resolve().parent
+print(f"STREAMLIT_PKG={root}", flush=True)
+```
+
+Parent parses **only** a `STREAMLIT_PKG=` line, **scanning from the end** (last match
+wins) so wrapper/sitecustomize banners cannot corrupt the path. Empty / malformed stdout
+is `ERROR[PROBE_FAILED]`, never `Path("")` resolving to cwd.
+
+Child env: `PYTHONIOENCODING=utf-8`, `PYTHONUTF8=1`. Parent
+`subprocess.run(..., text=True, encoding="utf-8", errors="replace")`. Reconfigure the
+script's own stdout/stderr to UTF-8 when possible so printed paths survive Windows
+code pages.
+
+Timeouts: ~20s for a direct executable; ~45s for manager wrappers (still no sync). Catch
+`TimeoutExpired`, `FileNotFoundError`, `PermissionError`, `OSError`, `ValueError`,
+`UnicodeError`, and filesystem errors around `iterdir()` (exit 4 listing). Convert all
+to `ERROR[<ID>]`.
+
+`main()` is wrapped so **any other exception** becomes `ERROR[INTERNAL]` (exit 6) plus
+the docs URL — never a traceback to the agent.
+
+Shared reporter, given a package root:
+
+- `<root>/.agents/skills/developing-with-streamlit/SKILL.md` exists → print that
+  **absolute path only** on stdout, exit 0 (agent happy-path unchanged).
+- `.agents/skills/` exists but the expected file does not → exit 4, list entries.
+- Streamlit found, no `.agents/skills/` → exit 2 (pre-1.57).
+
+### 3. Error contract
+
+Stderr starts with a stable identifier, then human text. Agents match the id; humans
+read the rest.
+
+| ID | When |
+|---|---|
+| `ERROR[NO_PROJECT_PYTHON]` | No candidate started (should be rare: `sys.executable` is always a last resort) |
+| `ERROR[NO_STREAMLIT]` | Every candidate started; none had Streamlit |
+| `ERROR[STREAMLIT_TOO_OLD]` | Best candidate found Streamlit but no bundled skills |
+| `ERROR[SKILLS_LAYOUT_CHANGED]` | `.agents/skills/` present, expected `SKILL.md` missing |
+| `ERROR[PROBE_FAILED]` | Candidate ran; stdout unparseable, timeout, permission, decode |
+| `ERROR[INVALID_ARGS]` | `--python` missing/not a file; unknown CLI args |
+| `ERROR[INTERNAL]` | Unexpected exception (exit 6). Never a traceback |
+
+**Every** non-zero stderr block **ends** with:
+
+```text
+If you cannot resolve a local skill, read:
+  https://docs.streamlit.io/llms-full.txt
+```
+
+Do not omit this on `INVALID_ARGS` or `INTERNAL`. The agent always has a next step.
+
+On any non-zero exit except `INVALID_ARGS`, also print an **attempt log**:
+
+```text
+Tried:
+  - virtual-env  C:\stale\venv\Scripts\python.exe  no streamlit
+  - venv-local   C:\proj\.venv\Scripts\python.exe  STREAMLIT_TOO_OLD  (1.56)
+  - launcher     C:\proj\.venv\Scripts\python.exe  (skipped, duplicate)
+  - py-launcher  py -3                             store-stub skipped
+```
+
+**Install/upgrade advice is last, not first.** Only emit `uv add` / `conda install` /
+quoted `python -m pip install` after **all** candidates were tried and none had a modern
+Streamlit. If `$VIRTUAL_ENV` failed but the project venv was not usable either, say
+"re-run with `--python` pointing at the interpreter that runs the app" before suggesting
+installs. Never lead with "upgrade Streamlit" when the path was a parse error.
+
+Quote every path in advice (`shlex.quote` on POSIX; double quotes on Windows). Drop
+`source .venv/bin/activate`. If `pyvenv.cfg` contains a `uv =` line or `uv.lock` is
+present, advise `uv add streamlit` / `uv pip install streamlit`, not
+`python -m pip` (uv venvs have no pip).
+
+### 4. CLI
+
+```text
+python scripts/discover.py --project-dir <DIR> [--python <EXECUTABLE>]
+```
+
+`--project-dir` still defaults to cwd. `--python` is the deterministic override.
+
+Success stdout remains a single absolute path to the bundled `SKILL.md` (plus optional
+trailing newline). Do not print JSON to stdout — agents already mishandle mixed stdout;
+keep the probe sentinel internal.
+
+### 5. Meta-skill `SKILL.md`
+
+Low-freedom instructions. Agents must not improvise a fourth discovery method.
+
+**Frontmatter** (stay inside the Agent Skills spec's six fields so claude.ai /
+`package_skill.py` do not hard-error):
+
+- `name` / `description` — keep triggers **in `description`** (portable). Rewrite
+  description in third person; stay ≤1024 chars.
+- `license: Apache-2.0`
+- `compatibility:` local filesystem and a Python 3 interpreter; normal discovery is
+  offline. Do **not** write "requires Streamlit ≥1.57" in a way that causes hosts to
+  **skip** the skill — the whole point of the meta-skill is to find or fall back.
+- `allowed-tools` — keep the experimental field (Claude Code / Codex; other hosts
+  ignore it). It is a one-turn **pre-approval**, not a sandbox.
+
+  **Do not rely on `${CLAUDE_SKILL_DIR}` inside `allowed-tools`.** Substitution in that
+  field is unreliable (reported Claude Code bug: the grant never matches, so the agent
+  is re-prompted anyway). The **body** may still use `${CLAUDE_SKILL_DIR}` /
+  `${CLAUDE_PROJECT_DIR}` (substitution in markdown works). In frontmatter, list
+  launcher prefixes that match without a skill-dir variable, plus `Read` and `Glob`:
+
+  `Read Glob Bash(py -3 *) Bash(python *) Bash(python3 *)` and a `PowerShell(...)`
+  twin if the host has that tool.
+
+  Add a `py` variant for Windows. A one-time approval may still appear; that is
+  acceptable. Do **not** grant unrestricted `Bash(*)`.
+
+Documented command (Claude substitutes these in the **markdown body**; other hosts
+leave them literal — tell the agent to replace unexpanded vars). Windows first:
+
+```text
+py -3 "${CLAUDE_SKILL_DIR}/scripts/discover.py" --project-dir "${CLAUDE_PROJECT_DIR}"
+```
+
+POSIX:
+
+```bash
+python3 "${CLAUDE_SKILL_DIR}/scripts/discover.py" --project-dir "${CLAUDE_PROJECT_DIR}"
+```
+
+Body, in order:
+
+1. **Mandatory:** resolve the bundled skill (or `llms-full.txt`) before writing Streamlit
+   code from memory.
+2. Skill dir = directory of this `SKILL.md` (`scripts/discover.py` lives next to it).
+   Well-known roots: `~/.agents/skills/`, `~/.claude/skills/`, `~/.cursor/skills/`,
+   `~/.codex/skills/`, `.github/skills/`. Quote all paths (Windows homes have spaces).
+   Git Bash: pass a Windows project path (`pwd -W` / `cygpath -w`), not `/c/Users/...`.
+3. Launcher order: **Windows** `py -3`, then `python` (not `python3` first).
+   **POSIX** `python3`, then `python`. Any 3.10+ interpreter may *start* the script;
+   the script re-detects the project interpreter. Do not `activate` a venv just to
+   discover.
+4. Exit 0 → last non-empty stdout line is a file → **Read it**.
+   Non-zero → read stderr, honor `ERROR[<ID>]`, then go to §5.1 (do not improvise).
+
+Do not add Cursor/Codex/Gemini-only files. They do not improve Python discovery.
+
+#### 5.1 Manual discovery (required section)
+
+This is a first-class part of the meta-skill, not an appendix. Keep it **short**
+(about half a page). Agents with no shell, a declined permission prompt, a Store-stub
+`python`, or a sandbox must still reach the bundled docs.
+
+Tone: imperative, ordered, **read-only**. Do not tell the agent to install or upgrade
+Streamlit here.
+
+**Goal:** find and **Read**
+`<streamlit-package>/.agents/skills/developing-with-streamlit/SKILL.md`.
+
+Try in this order; stop at the first path that exists:
+
+1. **Project interpreter, no import of the app.** Identify the Python that runs the
+   user's app (do not activate anything):
+   - `.venv\Scripts\python.exe` or `venv\Scripts\python.exe` (Windows)
+   - `.venv/bin/python` (macOS/Linux)
+   - `py -3` if those are missing
+   Then run (quoted):
+
+   ```text
+   "<that-python>" -c "import importlib.util, pathlib; s = importlib.util.find_spec('streamlit'); p = pathlib.Path(s.origin).resolve().parent / '.agents' / 'skills' / 'developing-with-streamlit' / 'SKILL.md'; print(p)"
+   ```
+
+   Read the printed path if the file exists.
+
+   Optional equivalent: `pip show streamlit` or `uv pip show streamlit` and append
+   `/.agents/skills/developing-with-streamlit/SKILL.md` to `Location:`. Skip if pip
+   is missing (typical uv venv).
+
+2. **Filesystem search (no Python required).** Glob or search the project (and parent)
+   for either of:
+   - `**/site-packages/streamlit/.agents/skills/developing-with-streamlit/SKILL.md`
+   - `**/Lib/site-packages/streamlit/.agents/skills/developing-with-streamlit/SKILL.md`
+     (Windows venvs)
+
+   Prefer a hit under the project's `.venv` / `venv` over a user-level install. Read
+   that `SKILL.md`.
+
+3. **Online fallback only.** If neither step finds a file,
+   `https://docs.streamlit.io/llms-full.txt`. Do not modify the environment.
+
+If step 1 prints `None` / crashes, continue to step 2; do not invent Streamlit APIs
+from training data while these steps are unfinished.
+
+### 6. Content skill POSIX commands
+
+In `lib/streamlit/.agents/skills/developing-with-streamlit/SKILL.md`:
+
+- Replace the `grep -rl ... | head` scan with agent-tool-neutral steps (Glob/Grep for
+  `import streamlit` / `from streamlit`, or a one-liner using the project interpreter).
+- Replace `lsof | grep | awk` with: check the app's configured port (default 8501) via
+  whatever the agent has (open `http://localhost:8501`, or a short Python
+  `socket` connect). Do not require Unix process tools.
+
+### 7. Tests and CI
+
+Failures in the field are invisible, so tests have to cover the cases we already
+reproduced. Split coverage:
+
+**Ubuntu (existing `python-tests.yml` plus a dedicated file
+`lib/tests/streamlit/web/meta_skill_discover_test.py`).** Load `discover.py` via
+`importlib.util.spec_from_file_location`. `.agents/*` is excluded from coverage; these
+tests are guardrails, not coverage-driven. Respect repo ruff `select = ["ALL"]`
+(`S603`/`T201` on the script already have local noqa).
+
+Layouts that are just path math (conda prefix files, Store-stub skip, banner parse,
+`~` expansion, `--no-sync`, uv `pyvenv.cfg` advice, **filesystem probe hit**) can run
+here, including **simulated** Windows paths on Linux. One end-to-end subprocess run
+against a **fake** `.venv` (planted `site-packages/streamlit/.agents/.../SKILL.md`, no
+real Streamlit wheel required) plus the existing vendored happy path.
+
+Minimum cases:
+
+- Filesystem probe hit (POSIX `lib/python*/site-packages` and Windows `Lib/site-packages`)
+- Stage 1 miss + stage 2 `find_spec` hit (editable-style layout)
+- Stale `$VIRTUAL_ENV` (no / old Streamlit) **falls through** to project `.venv`
+- `--python` exclusive override
+- `sys.executable` used when no venv markers exist; `NO_PROJECT_PYTHON` not emitted
+- Banner on probe stdout: last `STREAMLIT_PKG=` wins
+- Empty / garbage stdout → `ERROR[PROBE_FAILED]`, not cwd
+- Unexpected exception → `ERROR[INTERNAL]` (exit 6), no traceback, docs URL present
+- `~` expansion on `--project-dir`
+- Conda-shaped prefix: `python.exe` at root and `bin/python`
+- Store-stub path skipped
+- `uv run` invocation includes `--no-sync` (do not require uv in CI)
+- uv-managed `pyvenv.cfg` → install advice is not `python -m pip`
+- `iterdir` `OSError` on exit 4 does not traceback
+- Exit 2 (no skills dir) and exit 4 (restructured layout)
+- Happy path: vendored script still resolves bundled content `SKILL.md`
+
+The existing `TestVendoredMetaSkillDiscovery` happy path stays, but should succeed
+via `sys.executable` **without** injecting `VIRTUAL_ENV`.
+
+**Windows CI (required, narrow).** Do **not** run the full Python unit matrix on
+`windows-latest`. Add a small job (new workflow or a single job next to
+`python-tests.yml`) whose only job is discovery:
+
+| | |
+|---|---|
+| Runner | `windows-latest` |
+| Python | One CPython from `actions/setup-python` (3.12 is enough; not the full version matrix) |
+| Shell | PowerShell for the smoke (this is what Windows agents use). Pytest can use the default. |
+| Install | `pip install -e lib` (or the repo's existing editable install) so the vendored meta-skill and bundled content skill are present. No Playwright, no frontend build. |
+| Tests | The discovery pytest file **on Windows**, plus one **process-level smoke**: create `.venv` with `python -m venv`, plant `Lib\site-packages\streamlit\.agents\...` (filesystem stage, no real wheel required) **and** a second smoke that runs `discover.py` without `VIRTUAL_ENV` and asserts `.venv\Scripts\python.exe`. |
+| Windows-only asserts | `Scripts\python.exe` resolution; conda-style `<prefix>\python.exe`; quoted path with a space in the project dir; UTF-8 user-dir smoke if cheap. Skip `py -3` if the launcher is absent on the runner. |
+| Triggers | Same as unit tests (`pull_request` / `push` to `develop`), optionally path-filtered to `lib/streamlit/.agents/**` and the discovery test file so unrelated PRs do not pay for a Windows runner. |
+| Time | Target a few minutes. Fail the PR if the smoke cannot import `discover.py` or resolve the bundled skill. |
+
+Ubuntu tests are not a substitute for this job: `subprocess`, `PATHEXT`, `python.exe` vs
+`python`, default text encoding, and venv layout only show up on a real Windows runner.
+
+### 8. Files to change
+
+| File | Change |
+|---|---|
+| `lib/streamlit/.agents/meta-skill/developing-with-streamlit/scripts/discover.py` | Two-stage discovery, error IDs, `--python`, UTF-8, Windows layouts |
+| `lib/streamlit/.agents/meta-skill/developing-with-streamlit/SKILL.md` | Frontmatter, launchers, §5.1 manual discovery |
+| `lib/streamlit/.agents/skills/developing-with-streamlit/SKILL.md` | Replace POSIX `grep`/`lsof` with agent-tool-neutral steps |
+| `lib/tests/streamlit/web/meta_skill_discover_test.py` | New guardrail tests (coverage-excluded `.agents/*`) |
+| `lib/tests/streamlit/web/skills_test.py` | Happy path without forced `VIRTUAL_ENV` |
+| `.github/workflows/` | Narrow `windows-latest` discovery job |
+
+`streamlit skills --global` copies the vendored meta-skill as-is; no installer changes
+unless a test for that copy path needs updating.
+
+## Alternatives considered
+
+**Filesystem-first vs subprocess-only.** Subprocess-only is less code but fails in
+sandboxes, with Store stubs, and with broken transitive deps even when the skill files
+are on disk. Filesystem-first is the preferred stage 1; stage 2 remains for editable
+installs and manager wrappers. Do not ship stage 2 without stage 1.
+
+**JSON on stdout for agents.** More structure, worse agent compliance. Sentinel stays
+inside the child probe; agent-facing success remains one path.
+
+**`import streamlit` kept for version accuracy.** Reject: optional-dep import failures,
+local `streamlit.py` shadowing, stdout noise, Windows Defender timeouts. Filesystem
+layout is the version signal we need (`/.agents/skills/` ⇒ ≥1.57).
+
+**`allowed-tools` with `${CLAUDE_SKILL_DIR}` in the rule.** Official docs say substitution
+works in frontmatter; in practice it often does not, so the grant never matches. Prefer
+launcher prefixes (`py -3`, `python`, `python3`) plus `Read`/`Glob`, and accept a
+one-time approval. Do not drop the field entirely (it still helps when the prefix
+matches).
+
+**Defer tests (script + SKILL.md only).** Reject. Failures are unmeasurable; tests are
+the mitigation. `.agents/*` is coverage-excluded, so the new test file is required
+guardrail, not a coverage chase.
+
+**`compatibility: Requires Streamlit >= 1.57`.** Hosts that honor the field may hide the
+skill exactly when discovery is needed.
+
+## Checklist
+
+| Item | Notes |
+|---|---|
+| Works on SiS, Cloud, etc? | N/A — local agent tooling only |
+| No breaking API changes | No `st.*` API. Agent success stdout still a path. Error stderr format changes (additive IDs) |
+| No new dependencies | stdlib only |
+| Metrics collected | No — failures remain unobservable; tests are the mitigation |
+| Security/legal | Discovery stays read-only; do not auto-install packages. `allowed-tools` stays narrowly scoped (global install) |
+| Docs | Meta + content `SKILL.md` only, including the §5.1 manual discovery section; optional note in `streamlit skills` CLI help if it describes discovery |
+| Dual-repo | Not required. `streamlit skills` installs the wheel-vendored copy; GitHub `agent-skills` is out of band |
+| Windows CI | Required: narrow `windows-latest` discovery job + smoke (`discover.py` against `.venv\Scripts\python.exe`). Not the full Python matrix |


### PR DESCRIPTION
## Summary
- Tech spec for making the meta-skill that `streamlit skills` installs (`--global` and the Windows no-symlink fallback) reliably find the project's bundled Streamlit skill.
- Two-stage discovery (filesystem-first, then `find_spec` without importing Streamlit), Windows layouts/`py -3`/Store-stub skip, stable `ERROR[<ID>]` plus a short read-only manual fallback for agents.
- Narrow `windows-latest` discovery CI; no `npx` / GitHub `agent-skills` lockstep.

## Test plan
- [ ] Review `specs/2026-08-29-defensive-meta-skill-discovery/tech-spec.md` for scope (filesystem-first, `streamlit skills` only, Windows CI).
- [ ] Confirm out-of-scope items (Hatch/pixi, dual-repo, full Windows Python matrix).
- [ ] After approval, implement against this spec in a follow-up PR.


Made with [Cursor](https://cursor.com)