### PR TITLE
[fix] Harden meta-skill Streamlit skill discovery

### DIFF
--- a/.cursor/rules/python_lib.mdc
+++ b/.cursor/rules/python_lib.mdc
@@ -48,7 +48,9 @@ Changes to these high-fan-out internals can affect every command, message, sessi
 
 ## Embedded agent skills
 
-User-facing skills ship under `lib/streamlit/.agents/skills/` (for example, `developing-with-streamlit`). Keep them current as features land; follow `lib/streamlit/.agents/skills/AGENTS.md`.
+User-facing content skills ship under `lib/streamlit/.agents/skills/` (for example, `developing-with-streamlit`). Keep them current as features land; follow `lib/streamlit/.agents/skills/AGENTS.md`.
+
+The version-agnostic global meta-skill lives separately under `lib/streamlit/.agents/meta-skill/`. Tests for its discovery script are in `lib/tests/streamlit/web/meta_skill_discover_test.py`.
 
 ## Unit Tests
 

--- a/.cursor/rules/workflows.mdc
+++ b/.cursor/rules/workflows.mdc
@@ -103,7 +103,7 @@ runner's system Python.
 | `performance.yml` | Push to `develop`, `run-performance` label on PR | Performance benchmarks (Playwright, Python, Lighthouse) |
 | `load-testing.yml` | `run-load-testing` label or manual | Server load testing with concurrent Playwright sessions |
 | `python-bare-executions.yml` | Push/PR to `develop` | Bare Python execution tests |
-| `windows-meta-skill-discovery.yml` | Push/PR (path-filtered: meta-skill, discovery tests, `skills.py`, packaging) | Windows `windows-latest` job for meta-skill `discover.py` (Python 3.12, pytest only; no `make` / frontend) |
+| `windows-meta-skill-discovery.yml` | Push/PR (path-filtered: `.agents/`, discovery tests, `skills.py`, packaging) | Windows `windows-latest` job for meta-skill `discover.py` (Python 3.12, pytest only; no `make` / frontend) |
 | `flaky-test-verification.yml` | `flaky-verify` label | Runs E2E tests multiple times to verify flakiness fixes |
 | `flaky-js-test-verification.yml` | `flaky-verify-js` label | Runs JS unit tests multiple times to verify flakiness fixes |
 

--- a/.cursor/rules/workflows.mdc
+++ b/.cursor/rules/workflows.mdc
@@ -103,7 +103,7 @@ runner's system Python.
 | `performance.yml` | Push to `develop`, `run-performance` label on PR | Performance benchmarks (Playwright, Python, Lighthouse) |
 | `load-testing.yml` | `run-load-testing` label or manual | Server load testing with concurrent Playwright sessions |
 | `python-bare-executions.yml` | Push/PR to `develop` | Bare Python execution tests |
-| `windows-meta-skill-discovery.yml` | Push/PR (path-filtered: `.agents/`, discovery tests, `skills.py`, packaging) | Windows `windows-latest` job for meta-skill `discover.py` (Python 3.12, pytest only; no `make` / frontend) |
+| `windows-meta-skill-discovery.yml` | Push/PR (path-filtered: `.agents/`, discovery tests, `skills.py`, packaging) | Windows `windows-latest` job for meta-skill `discover.py` (uv smoke on every supported Python, then pytest on 3.12; no `make` / frontend) |
 | `flaky-test-verification.yml` | `flaky-verify` label | Runs E2E tests multiple times to verify flakiness fixes |
 | `flaky-js-test-verification.yml` | `flaky-verify-js` label | Runs JS unit tests multiple times to verify flakiness fixes |
 

--- a/.cursor/rules/workflows.mdc
+++ b/.cursor/rules/workflows.mdc
@@ -103,6 +103,7 @@ runner's system Python.
 | `performance.yml` | Push to `develop`, `run-performance` label on PR | Performance benchmarks (Playwright, Python, Lighthouse) |
 | `load-testing.yml` | `run-load-testing` label or manual | Server load testing with concurrent Playwright sessions |
 | `python-bare-executions.yml` | Push/PR to `develop` | Bare Python execution tests |
+| `windows-meta-skill-discovery.yml` | Push/PR (path-filtered: meta-skill, discovery tests, `skills.py`, packaging) | Windows `windows-latest` job for meta-skill `discover.py` (Python 3.12, pytest only; no `make` / frontend) |
 | `flaky-test-verification.yml` | `flaky-verify` label | Runs E2E tests multiple times to verify flakiness fixes |
 | `flaky-js-test-verification.yml` | `flaky-verify-js` label | Runs JS unit tests multiple times to verify flakiness fixes |
 

--- a/.github/instructions/python_lib.instructions.md
+++ b/.github/instructions/python_lib.instructions.md
@@ -46,7 +46,9 @@ Changes to these high-fan-out internals can affect every command, message, sessi
 
 ## Embedded agent skills
 
-User-facing skills ship under `lib/streamlit/.agents/skills/` (for example, `developing-with-streamlit`). Keep them current as features land; follow `lib/streamlit/.agents/skills/AGENTS.md`.
+User-facing content skills ship under `lib/streamlit/.agents/skills/` (for example, `developing-with-streamlit`). Keep them current as features land; follow `lib/streamlit/.agents/skills/AGENTS.md`.
+
+The version-agnostic global meta-skill lives separately under `lib/streamlit/.agents/meta-skill/`. Tests for its discovery script are in `lib/tests/streamlit/web/meta_skill_discover_test.py`.
 
 ## Unit Tests
 

--- a/.github/instructions/workflows.instructions.md
+++ b/.github/instructions/workflows.instructions.md
@@ -101,7 +101,7 @@ runner's system Python.
 | `performance.yml` | Push to `develop`, `run-performance` label on PR | Performance benchmarks (Playwright, Python, Lighthouse) |
 | `load-testing.yml` | `run-load-testing` label or manual | Server load testing with concurrent Playwright sessions |
 | `python-bare-executions.yml` | Push/PR to `develop` | Bare Python execution tests |
-| `windows-meta-skill-discovery.yml` | Push/PR (path-filtered: `.agents/`, discovery tests, `skills.py`, packaging) | Windows `windows-latest` job for meta-skill `discover.py` (Python 3.12, pytest only; no `make` / frontend) |
+| `windows-meta-skill-discovery.yml` | Push/PR (path-filtered: `.agents/`, discovery tests, `skills.py`, packaging) | Windows `windows-latest` job for meta-skill `discover.py` (uv smoke on every supported Python, then pytest on 3.12; no `make` / frontend) |
 | `flaky-test-verification.yml` | `flaky-verify` label | Runs E2E tests multiple times to verify flakiness fixes |
 | `flaky-js-test-verification.yml` | `flaky-verify-js` label | Runs JS unit tests multiple times to verify flakiness fixes |
 

--- a/.github/instructions/workflows.instructions.md
+++ b/.github/instructions/workflows.instructions.md
@@ -101,7 +101,7 @@ runner's system Python.
 | `performance.yml` | Push to `develop`, `run-performance` label on PR | Performance benchmarks (Playwright, Python, Lighthouse) |
 | `load-testing.yml` | `run-load-testing` label or manual | Server load testing with concurrent Playwright sessions |
 | `python-bare-executions.yml` | Push/PR to `develop` | Bare Python execution tests |
-| `windows-meta-skill-discovery.yml` | Push/PR (path-filtered: meta-skill, discovery tests, `skills.py`, packaging) | Windows `windows-latest` job for meta-skill `discover.py` (Python 3.12, pytest only; no `make` / frontend) |
+| `windows-meta-skill-discovery.yml` | Push/PR (path-filtered: `.agents/`, discovery tests, `skills.py`, packaging) | Windows `windows-latest` job for meta-skill `discover.py` (Python 3.12, pytest only; no `make` / frontend) |
 | `flaky-test-verification.yml` | `flaky-verify` label | Runs E2E tests multiple times to verify flakiness fixes |
 | `flaky-js-test-verification.yml` | `flaky-verify-js` label | Runs JS unit tests multiple times to verify flakiness fixes |
 

--- a/.github/instructions/workflows.instructions.md
+++ b/.github/instructions/workflows.instructions.md
@@ -101,6 +101,7 @@ runner's system Python.
 | `performance.yml` | Push to `develop`, `run-performance` label on PR | Performance benchmarks (Playwright, Python, Lighthouse) |
 | `load-testing.yml` | `run-load-testing` label or manual | Server load testing with concurrent Playwright sessions |
 | `python-bare-executions.yml` | Push/PR to `develop` | Bare Python execution tests |
+| `windows-meta-skill-discovery.yml` | Push/PR (path-filtered: meta-skill, discovery tests, `skills.py`, packaging) | Windows `windows-latest` job for meta-skill `discover.py` (Python 3.12, pytest only; no `make` / frontend) |
 | `flaky-test-verification.yml` | `flaky-verify` label | Runs E2E tests multiple times to verify flakiness fixes |
 | `flaky-js-test-verification.yml` | `flaky-verify-js` label | Runs JS unit tests multiple times to verify flakiness fixes |
 

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -95,6 +95,7 @@ runner's system Python.
 | `performance.yml` | Push to `develop`, `run-performance` label on PR | Performance benchmarks (Playwright, Python, Lighthouse) |
 | `load-testing.yml` | `run-load-testing` label or manual | Server load testing with concurrent Playwright sessions |
 | `python-bare-executions.yml` | Push/PR to `develop` | Bare Python execution tests |
+| `windows-meta-skill-discovery.yml` | Push/PR (path-filtered: meta-skill, discovery tests, `skills.py`, packaging) | Windows `windows-latest` job for meta-skill `discover.py` (Python 3.12, pytest only; no `make` / frontend) |
 | `flaky-test-verification.yml` | `flaky-verify` label | Runs E2E tests multiple times to verify flakiness fixes |
 | `flaky-js-test-verification.yml` | `flaky-verify-js` label | Runs JS unit tests multiple times to verify flakiness fixes |
 

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -95,7 +95,7 @@ runner's system Python.
 | `performance.yml` | Push to `develop`, `run-performance` label on PR | Performance benchmarks (Playwright, Python, Lighthouse) |
 | `load-testing.yml` | `run-load-testing` label or manual | Server load testing with concurrent Playwright sessions |
 | `python-bare-executions.yml` | Push/PR to `develop` | Bare Python execution tests |
-| `windows-meta-skill-discovery.yml` | Push/PR (path-filtered: meta-skill, discovery tests, `skills.py`, packaging) | Windows `windows-latest` job for meta-skill `discover.py` (Python 3.12, pytest only; no `make` / frontend) |
+| `windows-meta-skill-discovery.yml` | Push/PR (path-filtered: `.agents/`, discovery tests, `skills.py`, packaging) | Windows `windows-latest` job for meta-skill `discover.py` (Python 3.12, pytest only; no `make` / frontend) |
 | `flaky-test-verification.yml` | `flaky-verify` label | Runs E2E tests multiple times to verify flakiness fixes |
 | `flaky-js-test-verification.yml` | `flaky-verify-js` label | Runs JS unit tests multiple times to verify flakiness fixes |
 

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -95,7 +95,7 @@ runner's system Python.
 | `performance.yml` | Push to `develop`, `run-performance` label on PR | Performance benchmarks (Playwright, Python, Lighthouse) |
 | `load-testing.yml` | `run-load-testing` label or manual | Server load testing with concurrent Playwright sessions |
 | `python-bare-executions.yml` | Push/PR to `develop` | Bare Python execution tests |
-| `windows-meta-skill-discovery.yml` | Push/PR (path-filtered: `.agents/`, discovery tests, `skills.py`, packaging) | Windows `windows-latest` job for meta-skill `discover.py` (Python 3.12, pytest only; no `make` / frontend) |
+| `windows-meta-skill-discovery.yml` | Push/PR (path-filtered: `.agents/`, discovery tests, `skills.py`, packaging) | Windows `windows-latest` job for meta-skill `discover.py` (uv smoke on every supported Python, then pytest on 3.12; no `make` / frontend) |
 | `flaky-test-verification.yml` | `flaky-verify` label | Runs E2E tests multiple times to verify flakiness fixes |
 | `flaky-js-test-verification.yml` | `flaky-verify-js` label | Runs JS unit tests multiple times to verify flakiness fixes |
 

--- a/.github/workflows/windows-meta-skill-discovery.yml
+++ b/.github/workflows/windows-meta-skill-discovery.yml
@@ -1,0 +1,56 @@
+name: Windows Meta-Skill Discovery
+
+on:
+  push:
+    branches:
+      - "develop"
+    paths:
+      - "lib/streamlit/.agents/**"
+      - "lib/tests/streamlit/web/meta_skill_discover_test.py"
+      - "lib/streamlit/web/skills.py"
+      - "lib/pyproject.toml"
+      - ".github/workflows/windows-meta-skill-discovery.yml"
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "lib/streamlit/.agents/**"
+      - "lib/tests/streamlit/web/meta_skill_discover_test.py"
+      - "lib/streamlit/web/skills.py"
+      - "lib/pyproject.toml"
+      - ".github/workflows/windows-meta-skill-discovery.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-windows-meta-skill-discovery
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  meta-skill-discover:
+    runs-on: windows-latest
+
+    defaults:
+      run:
+        shell: pwsh
+
+    steps:
+      - name: Checkout Streamlit code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install pytest and editable Streamlit
+        run: |
+          Copy-Item README.md lib/README.md
+          python -m pip install pytest
+          python -m pip install -e lib
+
+      - name: Run meta-skill discovery tests
+        run: |
+          python -m pytest -c lib/pyproject.toml lib/tests/streamlit/web/meta_skill_discover_test.py -o addopts= -q

--- a/.github/workflows/windows-meta-skill-discovery.yml
+++ b/.github/workflows/windows-meta-skill-discovery.yml
@@ -29,6 +29,7 @@ permissions:
 jobs:
   meta-skill-discover:
     runs-on: windows-latest
+    timeout-minutes: 15
 
     defaults:
       run:

--- a/.github/workflows/windows-meta-skill-discovery.yml
+++ b/.github/workflows/windows-meta-skill-discovery.yml
@@ -47,6 +47,7 @@ jobs:
 
       - name: Install pytest and editable Streamlit
         run: |
+          # lib/pyproject.toml expects README.md beside it; the file lives at repo root.
           Copy-Item README.md lib/README.md
           python -m pip install pytest
           python -m pip install -e lib

--- a/.github/workflows/windows-meta-skill-discovery.yml
+++ b/.github/workflows/windows-meta-skill-discovery.yml
@@ -54,4 +54,6 @@ jobs:
 
       - name: Run meta-skill discovery tests
         run: |
-          python -m pytest -c lib/pyproject.toml lib/tests/streamlit/web/meta_skill_discover_test.py -o addopts= -q
+          # -o addopts= drops pytest-cov from lib/pyproject.toml (not installed here).
+          # --noconftest skips lib/tests/conftest.py (imports Streamlit, needs protobufs).
+          python -m pytest -c lib/pyproject.toml lib/tests/streamlit/web/meta_skill_discover_test.py -o addopts= --noconftest -q

--- a/.github/workflows/windows-meta-skill-discovery.yml
+++ b/.github/workflows/windows-meta-skill-discovery.yml
@@ -9,6 +9,7 @@ on:
       - "lib/tests/streamlit/web/meta_skill_discover_test.py"
       - "lib/streamlit/web/skills.py"
       - "lib/pyproject.toml"
+      - ".github/actions/build_info/action.yml"
       - ".github/workflows/windows-meta-skill-discovery.yml"
   pull_request:
     types: [opened, synchronize, reopened]
@@ -17,6 +18,7 @@ on:
       - "lib/tests/streamlit/web/meta_skill_discover_test.py"
       - "lib/streamlit/web/skills.py"
       - "lib/pyproject.toml"
+      - ".github/actions/build_info/action.yml"
       - ".github/workflows/windows-meta-skill-discovery.yml"
 
 concurrency:
@@ -29,7 +31,7 @@ permissions:
 jobs:
   meta-skill-discover:
     runs-on: windows-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
 
     defaults:
       run:
@@ -40,6 +42,68 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+
+      - name: Set Python version vars
+        uses: ./.github/actions/build_info
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          enable-cache: true
+          ignore-nothing-to-cache: true
+          github-token: ${{ github.token }}
+
+      - name: Smoke discover.py on every supported Python
+        env:
+          DISCOVER_PY: lib/streamlit/.agents/meta-skill/developing-with-streamlit/scripts/discover.py
+        run: |
+          $ErrorActionPreference = "Stop"
+          $script = $env:DISCOVER_PY
+          $check = Join-Path $env:TEMP "compile_discover.py"
+          @'
+          import ast
+          import pathlib
+          import sys
+
+          path = pathlib.Path(sys.argv[1])
+          source = path.read_text(encoding="utf-8")
+          compile(source, str(path), "exec")
+          mod = ast.parse(source)
+          probe = None
+          for node in mod.body:
+              names = []
+              value = None
+              if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+                  names = [node.target.id]
+                  value = node.value
+              elif isinstance(node, ast.Assign):
+                  names = [t.id for t in node.targets if isinstance(t, ast.Name)]
+                  value = node.value
+              if "_PROBE_SNIPPET" in names:
+                  probe = ast.literal_eval(value)
+                  break
+          if not isinstance(probe, str):
+              raise SystemExit("_PROBE_SNIPPET missing")
+          compile(probe, "<probe>", "exec")
+          print("compiled script and probe")
+          '@ | Set-Content -Path $check -Encoding utf8
+
+          $labels = $env:PYTHON_VERSIONS | ConvertFrom-Json
+          foreach ($label in $labels) {
+            $py = switch ($label) {
+              "min" { $env:PYTHON_MIN_VERSION }
+              "max" { $env:PYTHON_MAX_VERSION }
+              default { $label }
+            }
+            Write-Host "Smoke discover.py on Python $py"
+            uv python install $py
+            if ($LASTEXITCODE -ne 0) { throw "uv python install failed for $py" }
+            # --no-project: do not sync this repo's uv.lock against the smoke interpreter.
+            uv run --python $py --no-project python $check $script
+            if ($LASTEXITCODE -ne 0) { throw "compile failed on $py" }
+            uv run --python $py --no-project python $script --help
+            if ($LASTEXITCODE -ne 0) { throw "--help failed on $py" }
+          }
 
       - name: Set up Python 3.12
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,7 +138,7 @@ Subagents run autonomously in a fresh context, which optimizes for context size 
 
 ### Bundled user-facing skills
 
-Streamlit ships user-facing skills with the library under `lib/streamlit/.agents/skills/` (for example, `developing-with-streamlit`). When adding or editing those skills, follow [`lib/streamlit/.agents/skills/AGENTS.md`](./lib/streamlit/.agents/skills/AGENTS.md).
+Streamlit ships user-facing content skills under `lib/streamlit/.agents/skills/` (for example, `developing-with-streamlit`). When adding or editing those skills, follow [`lib/streamlit/.agents/skills/AGENTS.md`](./lib/streamlit/.agents/skills/AGENTS.md). The version-agnostic global meta-skill lives separately under `lib/streamlit/.agents/meta-skill/`.
 
 ## Style Guide
 

--- a/lib/streamlit/.agents/meta-skill/developing-with-streamlit/SKILL.md
+++ b/lib/streamlit/.agents/meta-skill/developing-with-streamlit/SKILL.md
@@ -11,7 +11,7 @@ Streamlit (>=1.57) ships detailed reference documentation for building Streamlit
 
 ## Usage
 
-Run the discovery script with the user's project directory. Quote paths. If `${CLAUDE_PROJECT_DIR}` is left unexpanded (shown as a literal), the script warns and uses the project cwd.
+Run the discovery script with the user's project directory. Quote paths. If `${CLAUDE_PROJECT_DIR}` is left unexpanded (shown as a literal), the script warns and uses the current working directory.
 
 Windows (try first):
 
@@ -49,7 +49,7 @@ POSIX:
 ".venv/bin/python" -c "import importlib.util, pathlib, sys; sys.path=[p for p in sys.path if p and pathlib.Path(p).resolve()!=pathlib.Path('.').resolve()]; s=importlib.util.find_spec('streamlit'); p=(pathlib.Path(s.origin).resolve().parent/'.agents'/'skills'/'developing-with-streamlit'/'SKILL.md') if (s and s.origin and s.submodule_search_locations and pathlib.Path(s.origin).name=='__init__.py') else None; print(p if p is not None and p.is_file() else '')"
 ```
 
-Empty print / missing venv → step 2. `py -3` only if the venv interpreter is missing. Optional: `"<that-python>" -m pip show streamlit` and append `/streamlit/.agents/skills/developing-with-streamlit/SKILL.md` to `Location:`.
+If the command prints nothing, or the venv interpreter does not exist, continue to step 2. Use `py -3` only when the venv interpreter is missing. Optional: `"<that-python>" -m pip show streamlit` and append `/streamlit/.agents/skills/developing-with-streamlit/SKILL.md` to `Location:`.
 
 ### 2. Glob (project and parent only)
 

--- a/lib/streamlit/.agents/meta-skill/developing-with-streamlit/SKILL.md
+++ b/lib/streamlit/.agents/meta-skill/developing-with-streamlit/SKILL.md
@@ -2,7 +2,7 @@
 name: developing-with-streamlit
 description: "Use for ALL Streamlit tasks: creating, editing, debugging, beautifying, styling, theming, optimizing, or deploying Streamlit apps. Also custom components, st.components.v2, HTML/JS/CSS work. Discovers and loads version-matched reference docs from the user's installed Streamlit (>=1.57). Triggers: streamlit, st., dashboard, app.py, beautify, style, CSS, color, background, theme, button, widget styling, custom component, st.components, CCv2, session state, performance, cache, fragment, slow rerun, deploy."
 license: Apache-2.0
-allowed-tools: Read Glob Bash(py -3 ${CLAUDE_SKILL_DIR}/scripts/discover.py *) Bash(python3 ${CLAUDE_SKILL_DIR}/scripts/discover.py *) Bash(python ${CLAUDE_SKILL_DIR}/scripts/discover.py *)
+allowed-tools: Read Glob Bash(py -3 ${CLAUDE_SKILL_DIR}/scripts/discover.py *) Bash(python3 ${CLAUDE_SKILL_DIR}/scripts/discover.py *) Bash(python ${CLAUDE_SKILL_DIR}/scripts/discover.py *) Bash(py -3 scripts/discover.py *) Bash(python3 scripts/discover.py *) Bash(python scripts/discover.py *)
 ---
 
 # Developing with Streamlit
@@ -11,7 +11,11 @@ Streamlit (>=1.57) ships detailed reference documentation for building Streamlit
 
 ## Usage
 
-Run the discovery script with the user's project directory. Quote paths. If `${CLAUDE_PROJECT_DIR}` is left unexpanded (shown as a literal), the script warns and uses the current working directory.
+`scripts/discover.py` lives in **this skill directory** (the folder that contains this file), not in the user's project. Quote paths. Pass `--project-dir` as the user's Streamlit app (workspace root).
+
+If a `${...}` placeholder is left unexpanded or the path is missing, the script warns and falls back: `CLAUDE_PROJECT_DIR` or `CURSOR_PROJECT_DIR` when that variable names an existing directory, otherwise cwd. Omitting `--project-dir` uses that same fallback.
+
+Do not run `scripts/discover.py` relative to the project cwd. Substitute this skill's absolute directory for `${CLAUDE_SKILL_DIR}` when the host does not expand it (Cursor, Codex, Copilot, Gemini, and other Agent Skills hosts). Relative `scripts/discover.py` is correct only when the process cwd is this skill directory.
 
 Windows (try first):
 
@@ -28,8 +32,6 @@ python "${CLAUDE_SKILL_DIR}/scripts/discover.py" --project-dir "${CLAUDE_PROJECT
 
 - Exit 0: stdout is one path — the bundled `SKILL.md`. **Read** that path; it points into `references/`.
 - Non-zero: follow [Manual discovery](#manual-discovery). Do not install or change packages unless the user asked.
-
-`${CLAUDE_SKILL_DIR}` is this skill's directory (the folder that contains this file). Passing `--project-dir` matters because the script resolves `.venv` / `venv`, lockfiles, and environment prefixes relative to it.
 
 ## Manual discovery
 

--- a/lib/streamlit/.agents/meta-skill/developing-with-streamlit/SKILL.md
+++ b/lib/streamlit/.agents/meta-skill/developing-with-streamlit/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: developing-with-streamlit
 description: "Use for ALL Streamlit tasks: creating, editing, debugging, beautifying, styling, theming, optimizing, or deploying Streamlit apps. Also custom components, st.components.v2, HTML/JS/CSS work. Discovers and loads version-matched reference docs from the user's installed Streamlit (>=1.57). Triggers: streamlit, st., dashboard, app.py, beautify, style, CSS, color, background, theme, button, widget styling, custom component, st.components, CCv2, session state, performance, cache, fragment, slow rerun, deploy."
-allowed-tools: Bash(python ${CLAUDE_SKILL_DIR}/scripts/discover.py:*) Bash(python3 ${CLAUDE_SKILL_DIR}/scripts/discover.py:*)
+license: Apache-2.0
+allowed-tools: Read Glob Bash(py -3 ${CLAUDE_SKILL_DIR}/scripts/discover.py *) Bash(python3 ${CLAUDE_SKILL_DIR}/scripts/discover.py *) Bash(python ${CLAUDE_SKILL_DIR}/scripts/discover.py *)
 ---
 
 # Developing with Streamlit
@@ -10,15 +11,55 @@ Streamlit (>=1.57) ships detailed reference documentation for building Streamlit
 
 ## Usage
 
-Run the discovery script with the user's project directory:
+Run the discovery script with the user's project directory. Quote paths. If `${CLAUDE_PROJECT_DIR}` is left unexpanded (shown as a literal), the script warns and uses the project cwd.
 
-```bash
-python <SKILL_DIR>/scripts/discover.py --project-dir <USER_PROJECT_DIR>
+Windows (try first):
+
+```text
+py -3 "${CLAUDE_SKILL_DIR}/scripts/discover.py" --project-dir "${CLAUDE_PROJECT_DIR}"
 ```
 
-The script prints either:
+POSIX (and Windows fallback):
 
-- **A path on stdout** (exit 0) — the bundled `SKILL.md`. Read it; it points into `references/`.
-- **An `ERROR:` block on stderr** (non-zero exit). Follow the printed instructions and re-run.
+```text
+python3 "${CLAUDE_SKILL_DIR}/scripts/discover.py" --project-dir "${CLAUDE_PROJECT_DIR}"
+python "${CLAUDE_SKILL_DIR}/scripts/discover.py" --project-dir "${CLAUDE_PROJECT_DIR}"
+```
 
-`<SKILL_DIR>` is the directory containing this file; `<USER_PROJECT_DIR>` is the absolute path to the user's project. Passing `--project-dir` matters because the script resolves `.venv`, `../.venv`, `Pipfile`, `poetry.lock`, `pdm.lock`, and `uv.lock` relative to it.
+- Exit 0: stdout is one path — the bundled `SKILL.md`. **Read** that path; it points into `references/`.
+- Non-zero: follow [Manual discovery](#manual-discovery). Do not install or change packages unless the user asked.
+
+`<SKILL_DIR>` is the directory containing this file. Passing `--project-dir` matters because the script resolves `.venv` / `venv`, lockfiles, and environment prefixes relative to it.
+
+## Manual discovery
+
+Read-only. Stop at the first existing file. **One physical line** each.
+
+### 1. Project interpreter
+
+Windows PowerShell:
+
+```powershell
+& ".\.venv\Scripts\python.exe" -c "import importlib.util, pathlib, sys; sys.path=[p for p in sys.path if p and pathlib.Path(p).resolve()!=pathlib.Path('.').resolve()]; s=importlib.util.find_spec('streamlit'); p=(pathlib.Path(s.origin).resolve().parent/'.agents'/'skills'/'developing-with-streamlit'/'SKILL.md') if (s and s.origin and s.submodule_search_locations and pathlib.Path(s.origin).name=='__init__.py') else None; print(p if p is not None and p.is_file() else '')"
+```
+
+POSIX:
+
+```bash
+".venv/bin/python" -c "import importlib.util, pathlib, sys; sys.path=[p for p in sys.path if p and pathlib.Path(p).resolve()!=pathlib.Path('.').resolve()]; s=importlib.util.find_spec('streamlit'); p=(pathlib.Path(s.origin).resolve().parent/'.agents'/'skills'/'developing-with-streamlit'/'SKILL.md') if (s and s.origin and s.submodule_search_locations and pathlib.Path(s.origin).name=='__init__.py') else None; print(p if p is not None and p.is_file() else '')"
+```
+
+Empty print / missing venv → step 2. `py -3` only if the venv interpreter is missing. Optional: `"<that-python>" -m pip show streamlit` and append `/streamlit/.agents/skills/developing-with-streamlit/SKILL.md` to `Location:`.
+
+### 2. Glob (project and parent only)
+
+Do not glob `$HOME` — it is slow, can pick the wrong install, and many agent globs skip gitignored `.venv`. Prefer a hit under the project `.venv`/`venv`. Search tools may need to include ignored files.
+
+- `**/site-packages/streamlit/.agents/skills/developing-with-streamlit/SKILL.md`
+- `**/Lib/site-packages/streamlit/.agents/skills/developing-with-streamlit/SKILL.md`
+
+### 3. Docs fallback
+
+https://docs.streamlit.io/llms-full.txt
+
+Do not change dependencies unless the user asked.

--- a/lib/streamlit/.agents/meta-skill/developing-with-streamlit/SKILL.md
+++ b/lib/streamlit/.agents/meta-skill/developing-with-streamlit/SKILL.md
@@ -29,7 +29,7 @@ python "${CLAUDE_SKILL_DIR}/scripts/discover.py" --project-dir "${CLAUDE_PROJECT
 - Exit 0: stdout is one path — the bundled `SKILL.md`. **Read** that path; it points into `references/`.
 - Non-zero: follow [Manual discovery](#manual-discovery). Do not install or change packages unless the user asked.
 
-`<SKILL_DIR>` is the directory containing this file. Passing `--project-dir` matters because the script resolves `.venv` / `venv`, lockfiles, and environment prefixes relative to it.
+`${CLAUDE_SKILL_DIR}` is this skill's directory (the folder that contains this file). Passing `--project-dir` matters because the script resolves `.venv` / `venv`, lockfiles, and environment prefixes relative to it.
 
 ## Manual discovery
 

--- a/lib/streamlit/.agents/meta-skill/developing-with-streamlit/scripts/discover.py
+++ b/lib/streamlit/.agents/meta-skill/developing-with-streamlit/scripts/discover.py
@@ -722,6 +722,7 @@ def _fallback_project_dir() -> Path:
                 file=sys.stderr,
             )
     except OSError:
+        # `__file__` may be unreadable; skip the cwd warning and keep cwd.
         pass
     return cwd
 

--- a/lib/streamlit/.agents/meta-skill/developing-with-streamlit/scripts/discover.py
+++ b/lib/streamlit/.agents/meta-skill/developing-with-streamlit/scripts/discover.py
@@ -16,25 +16,25 @@
 
 """Discover the Streamlit package's bundled agent-skills SKILL.md.
 
-Usage:
-    python scripts/discover.py [--project-dir PATH]
+Usage::
 
-When --project-dir is given, the script resolves `.venv`, `../.venv`,
-`Pipfile`, `poetry.lock`, `pdm.lock`, and `uv.lock` relative to that path (so
-its checks land on the user's project rather than on the script's installed
-location).
+    python scripts/discover.py [--project-dir PATH] [--python EXECUTABLE] [--verbose]
+
+When ``--project-dir`` is given, the script resolves project virtualenvs and
+lockfiles relative to that path. Unexpanded ``${...}`` placeholders and missing
+paths warn and fall back to the current working directory.
 
 Exit codes:
     0 - success; prints the absolute path to the bundled SKILL.md on stdout.
-    1 - Streamlit is not installed in the detected interpreter.
-    2 - Streamlit is installed but predates bundled skills (no .agents/skills/).
-    3 - no usable Python interpreter was found.
-    4 - .agents/skills/ exists but the expected developing-with-streamlit/SKILL.md
-        is missing from the documented sub-path (likely upstream restructured).
-        The agent should read the listed available skills directly.
-    5 - invalid script argument.
+    1 - ``ERROR[NO_STREAMLIT]``: inspected interpreters did not have Streamlit.
+    2 - ``ERROR[NO_USABLE_SKILL]``: Streamlit was found without a usable bundled skill.
+    3 - ``ERROR[NO_PROJECT_PYTHON]``: no interpreter candidate was found.
+    4 - ``ERROR[SKILLS_LAYOUT_CHANGED]``: ``.agents/skills/`` exists without the expected file.
+    5 - ``ERROR[INVALID_ARGS]``: bad ``--python`` or unknown flags.
+    6 - ``ERROR[INTERNAL]``: unexpected exception.
+    7 - ``ERROR[PROBE_FAILED]``: candidates were attempted but none were inspected.
 
-On non-zero exit, a human-readable "ERROR:" block is printed on stderr.
+On non-zero exit, a human-readable ``ERROR[CODE]`` block is printed on stderr.
 """
 
 from __future__ import annotations
@@ -42,267 +42,703 @@ from __future__ import annotations
 import argparse
 import os
 import shutil
-import subprocess  # noqa: S404 - used only to probe the project's own interpreter (see below).
+import subprocess  # noqa: S404 - used only to probe the project's own interpreter.
 import sys
+import time
+from dataclasses import dataclass
+from enum import IntEnum
 from pathlib import Path
+from typing import TYPE_CHECKING, Literal, NoReturn
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+# Tests patch this instead of ``os.name`` so pathlib keeps the host flavor.
+_IS_WINDOWS = os.name == "nt"
+_MAX_WALK_DEPTH = 20  # Same cap as skills._MAX_REPO_ROOT_WALK_DEPTH.
+_GLOBAL_BUDGET_S = 60.0
+_DIRECT_TIMEOUT_S = 10.0
+_MANAGER_TIMEOUT_S = 30.0
+_SKILL_REL = Path(".agents") / "skills" / "developing-with-streamlit" / "SKILL.md"
+_DOCS_URL = "https://docs.streamlit.io/llms-full.txt"
+_SENTINEL = "STREAMLIT_PKG="
+_INSPECTED_STATUSES = frozenset({"no_streamlit", "no_usable_skill", "layout_changed"})
+
+# 3.10-safe child snippet: never ``import streamlit``. Sanitize ``sys.path``
+# instead of using ``python -P`` (3.11+ only). Parent parses the last sentinel.
+_PROBE_SNIPPET = """\
+import importlib.util
+import pathlib
+import sys
+cwd = pathlib.Path(".").resolve()
+kept = []
+for p in sys.path:
+    if not p:
+        continue
+    try:
+        if pathlib.Path(p).resolve() == cwd:
+            continue
+    except OSError:
+        pass
+    kept.append(p)
+sys.path[:] = kept
+spec = importlib.util.find_spec("streamlit")
+ok = (
+    spec is not None
+    and spec.origin
+    and spec.submodule_search_locations
+    and pathlib.Path(spec.origin).name == "__init__.py"
+)
+if ok:
+    print("STREAMLIT_PKG=" + str(pathlib.Path(spec.origin).resolve().parent))
+"""
+
+
+class Outcome(IntEnum):
+    """CLI exit codes."""
+
+    SUCCESS = 0
+    NO_STREAMLIT = 1
+    NO_USABLE_SKILL = 2
+    NO_PROJECT_PYTHON = 3
+    SKILLS_LAYOUT_CHANGED = 4
+    INVALID_ARGS = 5
+    INTERNAL = 6
+    PROBE_FAILED = 7
+
+
+_ERROR_NAME: dict[Outcome, str] = {
+    Outcome.NO_STREAMLIT: "NO_STREAMLIT",
+    Outcome.NO_USABLE_SKILL: "NO_USABLE_SKILL",
+    Outcome.NO_PROJECT_PYTHON: "NO_PROJECT_PYTHON",
+    Outcome.SKILLS_LAYOUT_CHANGED: "SKILLS_LAYOUT_CHANGED",
+    Outcome.INVALID_ARGS: "INVALID_ARGS",
+    Outcome.INTERNAL: "INTERNAL",
+    Outcome.PROBE_FAILED: "PROBE_FAILED",
+}
+
+_ERROR_MESSAGE: dict[Outcome, str] = {
+    Outcome.NO_STREAMLIT: (
+        "Streamlit is not installed in the inspected Python environment."
+    ),
+    Outcome.NO_USABLE_SKILL: (
+        "Found Streamlit, but no usable bundled skill. "
+        "Upgrade or reinstall Streamlit, or use the docs."
+    ),
+    Outcome.NO_PROJECT_PYTHON: "No Python interpreter was found to inspect.",
+    Outcome.SKILLS_LAYOUT_CHANGED: (
+        "Streamlit's bundled skills directory exists, but the expected "
+        "developing-with-streamlit/SKILL.md is missing from the documented "
+        "sub-path. Upstream Streamlit likely reorganized the skill layout."
+    ),
+    Outcome.INVALID_ARGS: "Invalid arguments.",
+    Outcome.INTERNAL: "Unexpected error while discovering the bundled skill.",
+    Outcome.PROBE_FAILED: (
+        "Could not inspect any interpreter (timeout, stub, or unreadable "
+        "output). This does not mean Streamlit is not installed."
+    ),
+}
+
+_STATUS_TO_OUTCOME: dict[str, Outcome] = {
+    "no_streamlit": Outcome.NO_STREAMLIT,
+    "no_usable_skill": Outcome.NO_USABLE_SKILL,
+    "layout_changed": Outcome.SKILLS_LAYOUT_CHANGED,
+}
+
+
+@dataclass(frozen=True)
+class Candidate:
+    """One interpreter (or manager wrapper) to inspect, in probe order."""
+
+    tag: str
+    argv: list[str]
+    kind: Literal["direct", "manager"]
+    prefix: Path | None
+
+
+@dataclass
+class ProbeBudget:
+    """Wall-clock budget that charges subprocess time only."""
+
+    remaining: float = _GLOBAL_BUDGET_S
+
+    def timeout_for(self, kind: Literal["direct", "manager"]) -> float:
+        """Return the per-probe timeout, capped by remaining budget."""
+        cap = _DIRECT_TIMEOUT_S if kind == "direct" else _MANAGER_TIMEOUT_S
+        return min(cap, max(0.0, self.remaining))
+
+    def charge(self, elapsed: float) -> None:
+        """Subtract elapsed subprocess time from the remaining budget."""
+        self.remaining = max(0.0, self.remaining - elapsed)
+
+    def exhausted(self) -> bool:
+        """Return True when no subprocess time remains."""
+        return self.remaining <= 0.0
+
+
+@dataclass
+class Attempt:
+    """One candidate's recorded outcome for the attempt log."""
+
+    tag: str
+    display: str
+    status: str
+    detail: str = ""
+
+
+class _DiscoverArgumentParser(argparse.ArgumentParser):
+    """ArgumentParser whose errors start with ``ERROR[INVALID_ARGS]``."""
+
+    def error(self, message: str) -> NoReturn:
+        print(f"ERROR[INVALID_ARGS]: {message}", file=sys.stderr)
+        print(_DOCS_URL, file=sys.stderr)
+        raise SystemExit(int(Outcome.INVALID_ARGS))
+
+
+def _reconfigure_stdio() -> None:
+    """Reconfigure this process's stdout/stderr to UTF-8 without replacing."""
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            continue
+        try:
+            reconfigure(encoding="utf-8")
+        except (OSError, ValueError):
+            pass
+
+
+def _maybe_msys_path(raw: str) -> str:
+    """Convert a light MSYS path (``/c/foo``) to ``C:/foo`` on Windows."""
+    if not _IS_WINDOWS:
+        return raw
+    if (
+        len(raw) >= 2
+        and raw[0] == "/"
+        and raw[1].isalpha()
+        and (len(raw) == 2 or raw[2] == "/")
+    ):
+        drive = raw[1].upper()
+        rest = raw[3:].replace("/", "\\") if len(raw) > 3 else ""
+        return f"{drive}:\\{rest}" if rest else f"{drive}:\\"
+    return raw
+
+
+def _expand_user_path(raw: str) -> str:
+    """Expand ``~`` and environment variables, then apply light MSYS rewrite."""
+    return _maybe_msys_path(os.path.expandvars(os.path.expanduser(raw)))
 
 
 def find_venv_python(venv_root: Path) -> Path | None:
     """Return the venv's Python executable, cross-platform.
 
-    POSIX venvs put it at bin/python; Windows venvs put it at Scripts/python.exe.
+    Windows: ``<root>/python.exe`` (conda) then ``<root>/Scripts/python.exe``.
+    POSIX: ``<root>/bin/python`` then ``<root>/bin/python3``.
     """
-    for candidate in (
-        venv_root / "bin" / "python",
-        venv_root / "Scripts" / "python.exe",
-    ):
-        if candidate.is_file():
-            return candidate
-    return None
+    if _IS_WINDOWS:
+        candidates = (venv_root / "python.exe", venv_root / "Scripts" / "python.exe")
+    else:
+        candidates = (venv_root / "bin" / "python", venv_root / "bin" / "python3")
+    return next((path for path in candidates if path.is_file()), None)
 
 
 def find_git_root(start: Path) -> Path | None:
-    """Walk up from `start` looking for a `.git` directory or file.
+    """Walk up from ``start`` looking for a ``.git`` directory or file.
 
-    Returns the directory containing `.git` (the repo root), or None if no
-    git repository is found above `start`. Handles the worktree case where
-    `.git` is a file pointing at the real repo dir.
+    Capped at ``_MAX_WALK_DEPTH`` ancestors (same as ``skills.py``). Handles
+    the worktree case where ``.git`` is a file pointing at the real repo dir.
     """
-    for ancestor in [start, *start.parents]:
-        if (ancestor / ".git").exists():
-            return ancestor
+    current = start
+    try:
+        current = start.resolve()
+    except OSError:
+        current = start
+    for _ in range(_MAX_WALK_DEPTH):
+        if (current / ".git").exists():
+            return current
+        parent = current.parent
+        if parent == current:
+            return None
+        current = parent
     return None
 
 
-def detect_interpreter(project_dir: Path) -> tuple[list[str], str] | None:
-    """Pick the right Python interpreter, in documented priority order.
+def _find_lockfile(start: Path, name: str) -> Path | None:
+    """Return the first ``name`` found from ``start`` up to the walk cap."""
+    current = start
+    try:
+        current = start.resolve()
+    except OSError:
+        current = start
+    for _ in range(_MAX_WALK_DEPTH):
+        candidate = current / name
+        if candidate.is_file():
+            return candidate
+        parent = current.parent
+        if parent == current:
+            return None
+        current = parent
+    return None
 
-    Returns ``(cmd, tag)`` where ``cmd`` is the command for ``subprocess.run``
-    and ``tag`` identifies which detection branch fired (``virtual-env``,
-    ``venv-local``, ``venv-parent``, ``venv-git-root``, ``conda``, ``pipenv``,
-    ``poetry``, ``pdm``, ``uv``, or ``system``). The tag lets callers give
-    targeted install advice on exit 1 instead of a buffet of unrelated
-    package-manager commands.
+
+def _prefix_from_python(executable: Path) -> Path | None:
+    """Infer an environment prefix from a Python executable path."""
+    try:
+        exe = executable.resolve()
+    except OSError:
+        exe = executable
+    parent = exe.parent
+    if _IS_WINDOWS:
+        if parent.name.lower() == "scripts":
+            return parent.parent
+        if exe.suffix.lower() == ".exe":
+            return parent
+        return None
+    if parent.name == "bin":
+        return parent.parent
+    return None
+
+
+def _is_windows_store_alias(executable: Path) -> bool:
+    """Return True if ``executable`` is a Windows App Execution Alias stub.
+
+    Only the App Execution Alias directory
+    (``%LOCALAPPDATA%/Microsoft/WindowsApps/``) is rejected. Real Store
+    Python installs live elsewhere and must not be skipped.
     """
-    venv = os.environ.get("VIRTUAL_ENV")
-    if venv:
-        py = find_venv_python(Path(venv))
-        if py:
-            return [str(py)], "virtual-env"
+    if not _IS_WINDOWS:
+        return False
+    local = os.environ.get("LOCALAPPDATA")
+    if not local:
+        return False
+    try:
+        alias_dir = (Path(local) / "Microsoft" / "WindowsApps").resolve()
+        executable.resolve().relative_to(alias_dir)
+    except (OSError, ValueError):
+        return False
+    return True
 
-    py = find_venv_python(project_dir / ".venv")
-    if py:
-        return [str(py)], "venv-local"
 
-    py = find_venv_python(project_dir.parent / ".venv")
-    if py:
-        return [str(py)], "venv-parent"
+def _filesystem_lookup(prefix: Path) -> Path | None:
+    """Return a ``streamlit`` package dir under ``prefix``, if one exists.
 
-    # Walk up to the git repo root and look for a `.venv` there. Helpful for
-    # monorepos where the project's venv lives at repo root but the agent's
-    # cwd / --project-dir points deep into a subdirectory.
+    Editable installs are a filesystem miss and fall through to the subprocess
+    probe. On POSIX, if several ``lib/python*`` trees exist, prefer one that
+    already has the skill file.
+    """
+    if _IS_WINDOWS:
+        pkg = prefix / "Lib" / "site-packages" / "streamlit"
+        return pkg if pkg.is_dir() else None
+    hits = sorted(prefix.glob("lib/python*/site-packages/streamlit"))
+    dirs = [hit for hit in hits if hit.is_dir()]
+    if not dirs:
+        return None
+    with_skill = [hit for hit in dirs if (hit / _SKILL_REL).is_file()]
+    return with_skill[0] if with_skill else dirs[0]
+
+
+def _classify_package(pkg: Path) -> Path | Outcome:
+    """Classify a Streamlit package dir as usable skill, layout change, or not."""
+    skill = pkg / _SKILL_REL
+    if skill.is_file():
+        try:
+            return skill.resolve()
+        except OSError:
+            return skill
+    agents = pkg / ".agents" / "skills"
+    if agents.is_dir():
+        return Outcome.SKILLS_LAYOUT_CHANGED
+    return Outcome.NO_USABLE_SKILL
+
+
+def _is_usable_package_dir(pkg: Path) -> bool:
+    """Return True if ``pkg`` looks like the Streamlit package directory."""
+    try:
+        resolved = pkg.resolve()
+    except OSError:
+        return False
+    if not resolved.is_dir():
+        return False
+    return (resolved / "__init__.py").is_file()
+
+
+def _parse_streamlit_pkg(stdout: str) -> Path | None:
+    """Return the package dir from the last ``STREAMLIT_PKG=`` line in stdout."""
+    last: Path | None = None
+    for line in stdout.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(_SENTINEL):
+            value = stripped[len(_SENTINEL) :]
+            if value:
+                last = Path(value)
+    return last
+
+
+def _probe_env() -> dict[str, str]:
+    """Child env: UTF-8 I/O, without inherited ``PYTHONPATH`` / ``PYTHONHOME``."""
+    env = os.environ.copy()
+    env["PYTHONIOENCODING"] = "utf-8"
+    env["PYTHONUTF8"] = "1"
+    env.pop("PYTHONPATH", None)
+    env.pop("PYTHONHOME", None)
+    return env
+
+
+def _outcome_from_classify(classified: Path | Outcome) -> tuple[str, Path | None]:
+    """Convert a package classification into an attempt status and optional path."""
+    if isinstance(classified, Path):
+        return "usable", classified
+    if classified is Outcome.SKILLS_LAYOUT_CHANGED:
+        return "layout_changed", None
+    return "no_usable_skill", None
+
+
+def _direct_executable(candidate: Candidate) -> Path | None:
+    """Return the filesystem path of a direct interpreter candidate, if any."""
+    if candidate.kind != "direct" or not candidate.argv:
+        return None
+    raw = Path(candidate.argv[0])
+    if raw.is_file():
+        return raw
+    found = shutil.which(candidate.argv[0])
+    return Path(found) if found else None
+
+
+def _iter_candidates(project_dir: Path, python_flag: Path | None) -> list[Candidate]:
+    """Build the ordered candidate list. ``--python`` is exclusive."""
+    if python_flag is not None:
+        return [
+            Candidate(
+                tag="python-flag",
+                argv=[str(python_flag)],
+                kind="direct",
+                prefix=_prefix_from_python(python_flag),
+            )
+        ]
+
+    out: list[Candidate] = []
+    seen_exes: set[Path] = set()
+
+    def _remember(exe: Path) -> Path | None:
+        try:
+            resolved = exe.resolve()
+        except OSError:
+            resolved = exe
+        if resolved in seen_exes:
+            return None
+        seen_exes.add(resolved)
+        return resolved
+
+    def add_path(tag: str, exe: Path, prefix: Path | None) -> None:
+        if _remember(exe) is None:
+            return
+        out.append(Candidate(tag=tag, argv=[str(exe)], kind="direct", prefix=prefix))
+
+    def add_venv(tag: str, root: Path) -> None:
+        python = find_venv_python(root)
+        if python is None:
+            return
+        add_path(tag, python, root)
+
+    def add_venv_pair(tag: str, base: Path) -> None:
+        add_venv(tag, base / ".venv")
+        venv_dir = base / "venv"
+        if (venv_dir / "pyvenv.cfg").is_file():
+            add_venv(tag, venv_dir)
+
+    add_venv_pair("venv-local", project_dir)
+    parent = project_dir.parent
+    if parent != project_dir:
+        add_venv_pair("venv-parent", parent)
+
     git_root = find_git_root(project_dir)
-    if git_root is not None and git_root not in {project_dir, project_dir.parent}:
-        py = find_venv_python(git_root / ".venv")
-        if py:
-            return [str(py)], "venv-git-root"
+    if git_root is not None and git_root not in {project_dir, parent}:
+        add_venv_pair("venv-git-root", git_root)
+
+    virtual_env = os.environ.get("VIRTUAL_ENV")
+    if virtual_env:
+        root = Path(virtual_env)
+        python = find_venv_python(root)
+        if python is not None:
+            add_path("virtual-env", python, root)
 
     conda = os.environ.get("CONDA_PREFIX")
     if conda:
-        py = find_venv_python(Path(conda))
-        if py:
-            return [str(py)], "conda"
+        root = Path(conda)
+        python = find_venv_python(root)
+        if python is not None:
+            add_path("conda", python, root)
 
-    if shutil.which("pipenv") and (project_dir / "Pipfile").is_file():
-        return ["pipenv", "run", "python"], "pipenv"
+    sys_exe = Path(sys.executable)
+    if sys_exe.is_file():
+        add_path("sys-executable", sys_exe, _prefix_from_python(sys_exe))
 
-    if shutil.which("poetry") and (project_dir / "poetry.lock").is_file():
-        return ["poetry", "run", "python"], "poetry"
+    managers: tuple[tuple[str, str, list[str]], ...] = (
+        ("pipenv", "Pipfile", ["pipenv", "run", "python"]),
+        ("poetry", "poetry.lock", ["poetry", "run", "python"]),
+        ("pdm", "pdm.lock", ["pdm", "run", "python"]),
+        ("uv", "uv.lock", ["uv", "run", "--no-sync", "--quiet", "python"]),
+    )
+    for tag, lock_name, argv in managers:
+        if shutil.which(argv[0]) and _find_lockfile(project_dir, lock_name):
+            out.append(Candidate(tag=tag, argv=argv, kind="manager", prefix=None))
 
-    if shutil.which("pdm") and (project_dir / "pdm.lock").is_file():
-        return ["pdm", "run", "python"], "pdm"
+    if _IS_WINDOWS and shutil.which("py"):
+        out.append(
+            Candidate(tag="py-launcher", argv=["py", "-3"], kind="direct", prefix=None)
+        )
 
-    if shutil.which("uv") and (project_dir / "uv.lock").is_file():
-        return ["uv", "run", "--quiet", "python"], "uv"
+    names = ("python", "python3") if _IS_WINDOWS else ("python3", "python")
+    for name in names:
+        found = shutil.which(name)
+        if found:
+            path = Path(found)
+            add_path("system", path, _prefix_from_python(path))
 
-    for name in ("python3", "python"):
-        if shutil.which(name):
-            return [name], "system"
-
-    return None
+    return out
 
 
-def install_advice(cmd: list[str], tag: str) -> str:
-    """Return the package-manager-appropriate install command for the
-    detected interpreter.
+def _subprocess_probe(
+    candidate: Candidate,
+    project_dir: Path,
+    budget: ProbeBudget,
+) -> tuple[Path | None, str]:
+    """Run the find_spec probe. Returns ``(package_dir, status)``."""
+    timeout = budget.timeout_for(candidate.kind)
+    if timeout <= 0:
+        return None, "not_tried"
+    started = time.monotonic()
+    try:
+        result = subprocess.run(  # noqa: S603 - argv is a detected interpreter.
+            [*candidate.argv, "-c", _PROBE_SNIPPET],
+            capture_output=True,
+            encoding="utf-8",
+            errors="replace",
+            cwd=project_dir,
+            timeout=timeout,
+            check=False,
+            env=_probe_env(),
+        )
+    except subprocess.TimeoutExpired:
+        return None, "probe_failed"
+    except (FileNotFoundError, PermissionError, OSError, ValueError, UnicodeError):
+        return None, "probe_failed"
+    finally:
+        budget.charge(time.monotonic() - started)
 
-    ``detect_interpreter`` already chose a branch; we know which tool to
-    suggest. Dumping every install command and asking the agent to "match
-    the tool for your project" is how a poetry project gets a stray
-    ``pip install streamlit`` outside the lockfile.
-    """
-    if tag in {"virtual-env", "venv-local", "venv-parent", "venv-git-root"}:
-        # Use the venv's own python to run pip — independent of activation
-        # state on the user's shell.
-        return f"{cmd[0]} -m pip install streamlit"
-    if tag == "conda":
-        return "conda install -c conda-forge streamlit"
-    if tag == "pipenv":
-        return "pipenv install streamlit"
-    if tag == "poetry":
-        return "poetry add streamlit"
-    if tag == "pdm":
-        return "pdm add streamlit"
-    if tag == "uv":
-        return "uv add streamlit"
-    # tag == "system" (or unknown — defensive)
-    return (
-        f"{cmd[0]} -m pip install streamlit\n"
-        "    (better: create a project venv first with "
-        "`python -m venv .venv && source .venv/bin/activate`)"
+    pkg = _parse_streamlit_pkg(result.stdout or "")
+    if pkg is None:
+        if result.returncode == 0:
+            return None, "no_streamlit"
+        return None, "probe_failed"
+    if not _is_usable_package_dir(pkg):
+        return None, "no_streamlit"
+    return pkg, "ok"
+
+
+def _evaluate_candidate(
+    candidate: Candidate,
+    project_dir: Path,
+    budget: ProbeBudget,
+) -> tuple[Attempt, Path | None]:
+    """Filesystem lookup, then subprocess if needed."""
+    display = " ".join(candidate.argv)
+    exe = _direct_executable(candidate)
+    if exe is not None and _is_windows_store_alias(exe):
+        return Attempt(candidate.tag, display, "skipped_stub"), None
+
+    if candidate.prefix is not None:
+        pkg = _filesystem_lookup(candidate.prefix)
+        if pkg is not None:
+            status, skill = _outcome_from_classify(_classify_package(pkg))
+            return Attempt(candidate.tag, display, status), skill
+
+    if budget.exhausted() or budget.timeout_for(candidate.kind) <= 0:
+        return Attempt(candidate.tag, display, "not_tried"), None
+
+    pkg, probe_status = _subprocess_probe(candidate, project_dir, budget)
+    if probe_status != "ok" or pkg is None:
+        return Attempt(candidate.tag, display, probe_status), None
+    status, skill = _outcome_from_classify(_classify_package(pkg))
+    return Attempt(candidate.tag, display, status), skill
+
+
+def _install_advice(project_dir: Path, attempts: Sequence[Attempt]) -> str:
+    """Return quoted install advice. Must not be run unless the user asked."""
+    header = (
+        "If the user asked you to install Streamlit, you may run the command "
+        "below. Do not change dependencies unless the user asked."
+    )
+    if _find_lockfile(project_dir, "uv.lock") is not None:
+        command = "uv add streamlit\n    # or: uv pip install streamlit"
+    else:
+        tag = next((a.tag for a in attempts if a.status != "not_tried"), "")
+        display = next((a.display for a in attempts if a.tag == tag), "")
+        if tag in {"virtual-env", "venv-local", "venv-parent", "venv-git-root"}:
+            python = display.split()[0] if display else "python"
+            command = f"{python} -m pip install streamlit"
+        elif tag == "conda":
+            command = "conda install -c conda-forge streamlit"
+        elif tag == "pipenv":
+            command = "pipenv install streamlit"
+        elif tag == "poetry":
+            command = "poetry add streamlit"
+        elif tag == "pdm":
+            command = "pdm add streamlit"
+        elif tag == "uv":
+            command = "uv add streamlit"
+        else:
+            command = (
+                "python -m pip install streamlit\n"
+                "    # better: create a project venv first "
+                "(`uv venv` or `python -m venv .venv`)"
+            )
+    return f"{header}\n    {command}"
+
+
+def _print_failure(
+    outcome: Outcome, attempts: Sequence[Attempt], project_dir: Path
+) -> int:
+    """Print the error block and return the exit code."""
+    name = _ERROR_NAME[outcome]
+    print(f"ERROR[{name}]: {_ERROR_MESSAGE[outcome]}", file=sys.stderr)
+    print(file=sys.stderr)
+    print("Attempts:", file=sys.stderr)
+    if not attempts:
+        print("  (none)", file=sys.stderr)
+    for attempt in attempts:
+        extra = f" ({attempt.detail})" if attempt.detail else ""
+        print(
+            f"  {attempt.tag} [{attempt.display}]: {attempt.status}{extra}",
+            file=sys.stderr,
+        )
+    print(file=sys.stderr)
+    print(_install_advice(project_dir, attempts), file=sys.stderr)
+    print(file=sys.stderr)
+    print(_DOCS_URL, file=sys.stderr)
+    return int(outcome)
+
+
+def _resolve_project_dir(raw: str | None) -> Path:
+    """Resolve ``--project-dir``, warning and using cwd when it is unusable."""
+    if raw is None:
+        return Path.cwd()
+    expanded = _expand_user_path(raw)
+    if "${" in expanded:
+        print(
+            f"WARNING: --project-dir still contains unexpanded variables: {raw!r}; "
+            "using current working directory",
+            file=sys.stderr,
+        )
+        return Path.cwd()
+    path = Path(expanded)
+    if not path.is_dir():
+        print(
+            f"WARNING: --project-dir is not an existing directory: {path}; "
+            "using current working directory",
+            file=sys.stderr,
+        )
+        return Path.cwd()
+    try:
+        return path.resolve()
+    except OSError:
+        return path
+
+
+def _resolve_python_flag(raw: str) -> Path:
+    """Resolve ``--python`` or raise ``SystemExit`` with ``INVALID_ARGS``."""
+    expanded = _expand_user_path(raw)
+    path = Path(expanded)
+    if path.is_file():
+        return path
+    found = shutil.which(expanded)
+    if found:
+        return Path(found)
+    print(
+        f"ERROR[INVALID_ARGS]: --python is not a usable executable: {raw}",
+        file=sys.stderr,
+    )
+    print(_DOCS_URL, file=sys.stderr)
+    raise SystemExit(int(Outcome.INVALID_ARGS))
+
+
+def _discover(project_dir: Path, python_flag: Path | None, verbose: bool) -> int:
+    """Run per-candidate discovery and print the skill path or an error block."""
+    candidates = _iter_candidates(project_dir, python_flag)
+    if not candidates:
+        return _print_failure(Outcome.NO_PROJECT_PYTHON, [], project_dir)
+
+    budget = ProbeBudget()
+    attempts: list[Attempt] = []
+    first_inspected: Attempt | None = None
+
+    for candidate in candidates:
+        attempt, skill = _evaluate_candidate(candidate, project_dir, budget)
+        attempts.append(attempt)
+        if attempt.status == "usable" and skill is not None:
+            print(skill)
+            if verbose:
+                print(
+                    f"discovered via: {attempt.tag} {attempt.display}",
+                    file=sys.stderr,
+                )
+            return int(Outcome.SUCCESS)
+        if attempt.status in _INSPECTED_STATUSES and first_inspected is None:
+            first_inspected = attempt
+
+    if first_inspected is None:
+        any_started = any(attempt.status != "not_tried" for attempt in attempts)
+        code = Outcome.PROBE_FAILED if any_started else Outcome.NO_PROJECT_PYTHON
+        return _print_failure(code, attempts, project_dir)
+    return _print_failure(
+        _STATUS_TO_OUTCOME[first_inspected.status], attempts, project_dir
     )
 
 
-def main() -> int:
-    parser = argparse.ArgumentParser(
+def _run(argv: Sequence[str] | None) -> int:
+    """Parse CLI arguments and run discovery."""
+    parser = _DiscoverArgumentParser(
         description="Discover the bundled developing-with-streamlit SKILL.md.",
     )
     parser.add_argument(
         "--project-dir",
         default=None,
-        help="Absolute path to the user's project directory. Defaults to cwd.",
+        help=(
+            "Path to the user's project directory. Defaults to cwd. "
+            "Expands ~ and environment variables. Unexpanded ${...} or a "
+            "missing path warns and uses cwd."
+        ),
     )
-    try:
-        args = parser.parse_args()
-    except SystemExit as e:
-        return 5 if e.code else 0
-
-    if args.project_dir is not None:
-        project_dir = Path(args.project_dir)
-        if not project_dir.is_dir():
-            print(
-                f"ERROR: --project-dir is not a directory: {project_dir}",
-                file=sys.stderr,
-            )
-            return 5
-    else:
-        project_dir = Path.cwd()
-    project_dir = project_dir.resolve()
-
-    detection = detect_interpreter(project_dir)
-    if detection is None:
-        print(
-            "ERROR: No Python interpreter found.\n"
-            "Install Python 3.10+ (the easiest path is `uv` — see https://docs.astral.sh/uv/),\n"
-            "then install Streamlit (pip install streamlit) and re-run.",
-            file=sys.stderr,
-        )
-        return 3
-
-    cmd, tag = detection
-    py_display = " ".join(cmd)
-
-    probe = "import streamlit; print(streamlit.__path__[0])"
-    try:
-        result = subprocess.run(  # noqa: S603 - cmd is a detected interpreter path, not user input.
-            [*cmd, "-c", probe],
-            capture_output=True,
-            text=True,
-            cwd=project_dir,
-            timeout=30,
-            check=False,
-        )
-    except subprocess.TimeoutExpired:
-        print(
-            f"ERROR: import streamlit timed out (interpreter: {py_display})",
-            file=sys.stderr,
-        )
-        return 1
-    except FileNotFoundError:
-        print(
-            f"ERROR: detected interpreter not found on PATH: {py_display}",
-            file=sys.stderr,
-        )
-        return 3
-
-    if result.returncode != 0:
-        combined = (result.stderr or "") + (result.stdout or "")
-        if "ModuleNotFoundError" in combined:
-            advice = install_advice(cmd, tag)
-            extra = ""
-            if tag == "system":
-                # No env-manager artifact found. The user might still have
-                # one (hatch, pyenv-virtualenv, an unactivated conda env)
-                # we couldn't auto-detect.
-                extra = (
-                    "\n\nIf your project uses an environment manager we did not\n"
-                    "auto-detect (hatch, pyenv-virtualenv, an unactivated conda env),\n"
-                    "ACTIVATE it first so the right Python is found, then re-run."
-                )
-            print(
-                "ERROR: Streamlit is not installed in the detected Python environment.\n"
-                f"Interpreter:   {py_display}\n"
-                f"Detected via:  {tag}\n"
-                "\n"
-                f"Install with:  {advice}\n"
-                "\n"
-                f"Then re-run this script.{extra}",
-                file=sys.stderr,
-            )
-            return 1
-        print(
-            "ERROR: Failed to import streamlit.\n"
-            f"Interpreter: {py_display}\n"
-            "Output:\n"
-            f"{combined}",
-            file=sys.stderr,
-        )
-        return 1
-
-    streamlit_path = Path(result.stdout.strip()).resolve()
-    agents_skills_dir = streamlit_path / ".agents" / "skills"
-    primary_skill = agents_skills_dir / "developing-with-streamlit" / "SKILL.md"
-
-    if primary_skill.is_file():
-        print(primary_skill)
-        return 0
-
-    if agents_skills_dir.is_dir():
-        print(
-            "ERROR: Streamlit's bundled skills directory exists, but the expected\n"
-            "developing-with-streamlit/SKILL.md is missing from the documented sub-path.\n"
-            "This usually means upstream Streamlit reorganized the skill layout.\n"
-            "\n"
-            f"Streamlit path: {streamlit_path}\n"
-            f"Bundled skills directory: {agents_skills_dir}\n"
-            "Available entries:",
-            file=sys.stderr,
-        )
-        for entry in sorted(agents_skills_dir.iterdir()):
-            print(f"  {entry.name}", file=sys.stderr)
-        print(
-            "\n"
-            "Read whichever skill best matches the user's task. If none match,\n"
-            "fall back to the complete Streamlit documentation:\n"
-            "  https://docs.streamlit.io/llms-full.txt",
-            file=sys.stderr,
-        )
-        return 4
-
-    print(
-        f"ERROR: Streamlit is installed but predates bundled skills (< 1.57).\n"
-        f"Interpreter: {py_display}\n"
-        f"Streamlit path: {streamlit_path}\n"
-        "\n"
-        "For best results, upgrade to get version-matched bundled skills:\n"
-        "  pip install --upgrade streamlit\n"
-        "\n"
-        "If upgrading isn't an option, fall back to the complete Streamlit\n"
-        "documentation (full API + guides, formatted for LLMs):\n"
-        "  https://docs.streamlit.io/llms-full.txt",
-        file=sys.stderr,
+    parser.add_argument(
+        "--python",
+        default=None,
+        help="Inspect only this interpreter. Exclusive: other candidates are skipped.",
     )
-    return 2
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="On success, print the winning tag and interpreter on stderr.",
+    )
+    args = parser.parse_args(None if argv is None else list(argv))
+    project_dir = _resolve_project_dir(args.project_dir)
+    python_flag = _resolve_python_flag(args.python) if args.python else None
+    return _discover(project_dir, python_flag, args.verbose)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """CLI entry point. Unexpected exceptions become ``ERROR[INTERNAL]``."""
+    _reconfigure_stdio()
+    try:
+        return _run(argv)
+    except SystemExit as exc:
+        if exc.code is None:
+            return 0
+        if isinstance(exc.code, int):
+            return exc.code
+        return int(Outcome.INVALID_ARGS)
+    except Exception as exc:
+        print(f"ERROR[INTERNAL]: {exc}", file=sys.stderr)
+        print(_DOCS_URL, file=sys.stderr)
+        return int(Outcome.INTERNAL)
 
 
 if __name__ == "__main__":

--- a/lib/streamlit/.agents/meta-skill/developing-with-streamlit/scripts/discover.py
+++ b/lib/streamlit/.agents/meta-skill/developing-with-streamlit/scripts/discover.py
@@ -22,7 +22,9 @@ Usage::
 
 When ``--project-dir`` is given, the script resolves project virtualenvs and
 lockfiles relative to that path. Unexpanded ``${...}`` placeholders and missing
-paths warn and fall back to the current working directory.
+paths warn and fall back to the current working directory. When it is omitted,
+``CLAUDE_PROJECT_DIR`` then ``CURSOR_PROJECT_DIR`` are used if they name an
+existing directory (so a shell whose cwd is this skill still finds the app).
 
 Exit codes:
     0 - success; prints the absolute path to the bundled SKILL.md on stdout.
@@ -35,6 +37,12 @@ Exit codes:
     7 - ``ERROR[PROBE_FAILED]``: candidates were attempted but none were inspected.
 
 On non-zero exit, a human-readable ``ERROR[CODE]`` block is printed on stderr.
+
+Compatibility: stdlib-only. Agents run this file with the project or agent
+interpreter, so it must work on every Python version Streamlit currently
+supports (see ``requires-python`` in ``lib/pyproject.toml``). Do not add
+syntax, stdlib APIs, or interpreter flags newer than that floor — for
+example ``python -P`` is 3.11+ and must not be used on the probe child.
 """
 
 from __future__ import annotations
@@ -65,9 +73,13 @@ _SKILL_REL: Final = (
 )
 _DOCS_URL: Final = "https://docs.streamlit.io/llms-full.txt"
 _SENTINEL: Final = "STREAMLIT_PKG="
+# Workspace dirs published by coding agents. Used when ``--project-dir`` is
+# omitted so a shell whose cwd is this skill still finds the user's app.
+_PROJECT_DIR_ENV_VARS: Final = ("CLAUDE_PROJECT_DIR", "CURSOR_PROJECT_DIR")
 
-# Child process: locate Streamlit without importing it (works on 3.10).
-# - Drop cwd from sys.path; do not use python -P (3.11+ only).
+# Child process: locate Streamlit without importing it.
+# Keep this snippet valid on every Python Streamlit currently supports.
+# - Drop cwd from sys.path; do not use python -P (newer than Streamlit's floor).
 # - Parent keeps the last STREAMLIT_PKG= line.
 _PROBE_SNIPPET: Final = """\
 import importlib.util
@@ -664,27 +676,73 @@ def _print_failure(
     return int(outcome)
 
 
-def _resolve_project_dir(raw: str | None) -> Path:
-    """Resolve ``--project-dir``, warning and using cwd when it is unusable."""
-    if raw is None:
-        return Path.cwd()
+def _meta_skill_dir() -> Path:
+    """Return the directory that contains this skill's ``SKILL.md``."""
+    return Path(__file__).resolve().parent.parent
+
+
+def _usable_dir(raw: str) -> Path | None:
+    """Return ``raw`` as a directory after ``~`` / env expansion, or ``None``."""
     expanded = _expand_user_path(raw)
     if "${" in expanded:
-        print(
-            f"WARNING: --project-dir still contains unexpanded variables: {raw!r}; "
-            "using current working directory",
-            file=sys.stderr,
-        )
-        return Path.cwd()
+        return None
     path = Path(expanded)
     if not path.is_dir():
-        print(
-            f"WARNING: --project-dir is not an existing directory: {path}; "
-            "using current working directory",
-            file=sys.stderr,
-        )
-        return Path.cwd()
+        return None
     return _safe_resolve(path)
+
+
+def _env_project_dir() -> Path | None:
+    """Return a harness workspace directory when one is set and exists."""
+    for name in _PROJECT_DIR_ENV_VARS:
+        raw = os.environ.get(name)
+        if not raw:
+            continue
+        found = _usable_dir(raw)
+        if found is not None:
+            return found
+    return None
+
+
+def _fallback_project_dir() -> Path:
+    """Prefer an agent workspace env var; otherwise cwd.
+
+    Agent Skills hosts often run with cwd equal to this skill directory.
+    Warn in that case so the agent passes ``--project-dir`` next.
+    """
+    env_dir = _env_project_dir()
+    if env_dir is not None:
+        return env_dir
+    cwd = Path.cwd()
+    try:
+        if _safe_resolve(cwd) == _meta_skill_dir():
+            print(
+                "WARNING: current working directory is this skill's directory; "
+                "pass --project-dir as the user's Streamlit app",
+                file=sys.stderr,
+            )
+    except OSError:
+        pass
+    return cwd
+
+
+def _resolve_project_dir(raw: str | None) -> Path:
+    """Resolve ``--project-dir``, warning and using a fallback when it is unusable."""
+    if raw is None:
+        return _fallback_project_dir()
+    found = _usable_dir(raw)
+    if found is not None:
+        return found
+    reason = (
+        f"still contains unexpanded variables: {raw!r}"
+        if "${" in _expand_user_path(raw)
+        else f"is not an existing directory: {_expand_user_path(raw)}"
+    )
+    print(
+        f"WARNING: --project-dir {reason}; using the default project directory",
+        file=sys.stderr,
+    )
+    return _fallback_project_dir()
 
 
 def _resolve_python_flag(raw: str) -> Path:
@@ -750,9 +808,11 @@ def _run(argv: Sequence[str] | None) -> int:
         "--project-dir",
         default=None,
         help=(
-            "Path to the user's project directory. Defaults to cwd. "
-            "Expands ~ and environment variables. Unexpanded ${...} or a "
-            "missing path warns and uses cwd."
+            "Path to the user's project directory. Defaults to "
+            "CLAUDE_PROJECT_DIR or CURSOR_PROJECT_DIR when set to an "
+            "existing directory, otherwise cwd. Expands ~ and environment "
+            "variables. Unexpanded ${...} or a missing path warns and uses "
+            "that same fallback."
         ),
     )
     parser.add_argument(

--- a/lib/streamlit/.agents/meta-skill/developing-with-streamlit/scripts/discover.py
+++ b/lib/streamlit/.agents/meta-skill/developing-with-streamlit/scripts/discover.py
@@ -435,11 +435,15 @@ def _iter_candidates(project_dir: Path, python_flag: Path | None) -> list[_Candi
         add_path(tag, python, root)
 
     def add_venv_pair(tag: str, base: Path) -> None:
+        # ``.venv`` is conventionally a virtualenv. ``venv/`` is a common
+        # project folder name, so require PEP 405's pyvenv.cfg.
         add_venv(tag, base / ".venv")
         venv_dir = base / "venv"
         if (venv_dir / "pyvenv.cfg").is_file():
             add_venv(tag, venv_dir)
 
+    # Project venvs come first: agent shells often point $VIRTUAL_ENV at
+    # the agent's own environment, not the app's.
     add_venv_pair("venv-local", project_dir)
     parent = project_dir.parent
     if parent != project_dir:
@@ -536,7 +540,13 @@ def _evaluate_candidate(
     project_dir: Path,
     budget: _ProbeBudget,
 ) -> tuple[_Attempt, Path | None]:
-    """Try a filesystem lookup first, then the subprocess probe if needed."""
+    """Return an attempt log entry and a skill path if this candidate is usable.
+
+    Filesystem lookup runs first. Only a usable ``SKILL.md`` short-circuits the
+    subprocess. If the filesystem already classified the package and the probe
+    then fails, keep that filesystem status so a timeout does not hide
+    ``no_usable_skill`` / ``layout_changed``.
+    """
     display = " ".join(candidate.argv)
 
     def recorded(
@@ -548,6 +558,7 @@ def _evaluate_candidate(
     if exe is not None and _is_windows_store_alias(exe):
         return recorded("skipped_stub")
 
+    fs_status: str | None = None
     if candidate.prefix is not None:
         pkg = _filesystem_lookup(candidate.prefix)
         if pkg is not None:
@@ -555,9 +566,12 @@ def _evaluate_candidate(
             # Only a usable SKILL.md skips the subprocess for this candidate.
             if status == "usable" and skill is not None:
                 return recorded(status, skill)
+            fs_status = status
 
     pkg, probe_status = _subprocess_probe(candidate, project_dir, budget)
     if probe_status != "ok" or pkg is None:
+        if fs_status is not None and probe_status == "probe_failed":
+            return recorded(fs_status)
         return recorded(probe_status)
     status, skill = _classify_package(pkg)
     return recorded(status, skill)
@@ -577,14 +591,17 @@ def _quote_argv(parts: Sequence[str]) -> str:
 
 
 def _install_advice(project_dir: Path, attempts: Sequence[_Attempt]) -> str:
-    """Return quoted install advice. Must not be run unless the user asked."""
+    """Return install advice, quoted for the agent to show rather than execute."""
     header = (
         "If the user asked you to install Streamlit, you may run the command "
         "below. Do not change dependencies unless the user asked."
     )
     first = next(
-        (a for a in attempts if a.status not in {"not_tried", "skipped_stub"}),
-        None,
+        (a for a in attempts if a.status in _INSPECTED_STATUSES),
+        next(
+            (a for a in attempts if a.status not in {"not_tried", "skipped_stub"}),
+            None,
+        ),
     )
     upgrade = first is not None and first.status == "no_usable_skill"
     if upgrade:
@@ -675,7 +692,9 @@ def _resolve_python_flag(raw: str) -> Path:
     expanded = _expand_user_path(raw)
     path = Path(expanded)
     if path.is_file():
-        return path
+        # Absolutize against the invoker's cwd. The probe later runs with
+        # cwd=project_dir, so a relative argv[0] would select a different file.
+        return _absolute_no_follow(path)
     found = shutil.which(expanded)
     if found:
         return Path(found)

--- a/lib/streamlit/.agents/meta-skill/developing-with-streamlit/scripts/discover.py
+++ b/lib/streamlit/.agents/meta-skill/developing-with-streamlit/scripts/discover.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import shlex
 import shutil
 import subprocess  # noqa: S404 - used only to probe the project's own interpreter.
 import sys
@@ -172,6 +173,7 @@ class _Attempt:
     tag: str
     display: str
     status: str
+    argv: list[str]
 
 
 class _DiscoverArgumentParser(argparse.ArgumentParser):
@@ -192,6 +194,7 @@ def _reconfigure_stdio() -> None:
         try:
             reconfigure(encoding="utf-8")
         except (OSError, ValueError):
+            # Closed or redirected streams cannot be reconfigured.
             pass
 
 
@@ -220,6 +223,18 @@ def _safe_resolve(path: Path) -> Path:
     """Resolve ``path`` when the filesystem allows it; otherwise keep it as-is."""
     try:
         return path.resolve()
+    except OSError:
+        return path
+
+
+def _absolute_no_follow(path: Path) -> Path:
+    """Return an absolute path without following symlinks.
+
+    ``Path.resolve()`` collapses a venv ``bin/python`` symlink to the base
+    interpreter. Prefix inference and candidate dedup must keep the venv path.
+    """
+    try:
+        return Path(os.path.abspath(path))
     except OSError:
         return path
 
@@ -269,8 +284,12 @@ def _find_lockfile(start: Path, name: str) -> Path | None:
 
 
 def _prefix_from_python(executable: Path) -> Path | None:
-    """Infer an environment prefix from a Python executable path."""
-    exe = _safe_resolve(executable)
+    """Infer an environment prefix from a Python executable path.
+
+    Does not follow symlinks, so a venv ``bin/python`` is not collapsed to
+    the base interpreter (and that interpreter's site-packages).
+    """
+    exe = _absolute_no_follow(executable)
     parent = exe.parent
     if _IS_WINDOWS:
         if parent.name.lower() == "scripts":
@@ -312,9 +331,9 @@ def _filesystem_lookup(prefix: Path) -> Path | None:
     """
     if _IS_WINDOWS:
         pkg = prefix / "Lib" / "site-packages" / "streamlit"
-        return pkg if pkg.is_dir() else None
+        return pkg if (pkg / "__init__.py").is_file() else None
     hits = sorted(prefix.glob("lib/python*/site-packages/streamlit"))
-    dirs = [hit for hit in hits if hit.is_dir()]
+    dirs = [hit for hit in hits if (hit / "__init__.py").is_file()]
     if not dirs:
         return None
     with_skill = [hit for hit in dirs if (hit / _SKILL_REL).is_file()]
@@ -397,15 +416,15 @@ def _iter_candidates(project_dir: Path, python_flag: Path | None) -> list[_Candi
     out: list[_Candidate] = []
     seen_exes: set[Path] = set()
 
-    def _remember(exe: Path) -> Path | None:
-        resolved = _safe_resolve(exe)
-        if resolved in seen_exes:
-            return None
-        seen_exes.add(resolved)
-        return resolved
+    def _remember(exe: Path) -> bool:
+        key = _absolute_no_follow(exe)
+        if key in seen_exes:
+            return False
+        seen_exes.add(key)
+        return True
 
     def add_path(tag: str, exe: Path, prefix: Path | None) -> None:
-        if _remember(exe) is None:
+        if not _remember(exe):
             return
         out.append(_Candidate(tag=tag, argv=[str(exe)], kind="direct", prefix=prefix))
 
@@ -492,6 +511,7 @@ def _subprocess_probe(
             cwd=project_dir,
             timeout=timeout,
             check=False,
+            stdin=subprocess.DEVNULL,
             env=_probe_env(),
         )
     except subprocess.TimeoutExpired:
@@ -518,21 +538,42 @@ def _evaluate_candidate(
 ) -> tuple[_Attempt, Path | None]:
     """Try a filesystem lookup first, then the subprocess probe if needed."""
     display = " ".join(candidate.argv)
+
+    def recorded(
+        status: str, skill: Path | None = None
+    ) -> tuple[_Attempt, Path | None]:
+        return _Attempt(candidate.tag, display, status, candidate.argv), skill
+
     exe = _direct_executable(candidate)
     if exe is not None and _is_windows_store_alias(exe):
-        return _Attempt(candidate.tag, display, "skipped_stub"), None
+        return recorded("skipped_stub")
 
     if candidate.prefix is not None:
         pkg = _filesystem_lookup(candidate.prefix)
         if pkg is not None:
             status, skill = _classify_package(pkg)
-            return _Attempt(candidate.tag, display, status), skill
+            # Only a usable SKILL.md skips the subprocess for this candidate.
+            if status == "usable" and skill is not None:
+                return recorded(status, skill)
 
     pkg, probe_status = _subprocess_probe(candidate, project_dir, budget)
     if probe_status != "ok" or pkg is None:
-        return _Attempt(candidate.tag, display, probe_status), None
+        return recorded(probe_status)
     status, skill = _classify_package(pkg)
-    return _Attempt(candidate.tag, display, status), skill
+    return recorded(status, skill)
+
+
+def _quote_argv(parts: Sequence[str]) -> str:
+    """Return a copy-pasteable command line for ``parts``."""
+    if not _IS_WINDOWS:
+        return " ".join(shlex.quote(part) for part in parts)
+    quoted: list[str] = []
+    for part in parts:
+        if " " in part or "\t" in part:
+            quoted.append(f'"{part}"')
+        else:
+            quoted.append(part)
+    return " ".join(quoted)
 
 
 def _install_advice(project_dir: Path, attempts: Sequence[_Attempt]) -> str:
@@ -541,14 +582,31 @@ def _install_advice(project_dir: Path, attempts: Sequence[_Attempt]) -> str:
         "If the user asked you to install Streamlit, you may run the command "
         "below. Do not change dependencies unless the user asked."
     )
+    first = next(
+        (a for a in attempts if a.status not in {"not_tried", "skipped_stub"}),
+        None,
+    )
+    upgrade = first is not None and first.status == "no_usable_skill"
+    if upgrade:
+        header += (
+            " Streamlit is present but has no usable bundled skill; "
+            "upgrade or reinstall it."
+        )
     if _find_lockfile(project_dir, "uv.lock") is not None:
-        command = "uv add streamlit\n    # or: uv pip install streamlit"
+        command = (
+            "uv add --upgrade streamlit\n    # or: uv pip install --upgrade streamlit"
+            if upgrade
+            else "uv add streamlit\n    # or: uv pip install streamlit"
+        )
     else:
-        tag = next((a.tag for a in attempts if a.status != "not_tried"), "")
-        display = next((a.display for a in attempts if a.tag == tag), "")
+        tag = first.tag if first is not None else ""
+        python = first.argv[0] if first is not None and first.argv else "python"
+        pip = [python, "-m", "pip", "install"]
+        if upgrade:
+            pip.append("--upgrade")
+        pip.append("streamlit")
         if tag in {"virtual-env", "venv-local", "venv-parent", "venv-git-root"}:
-            python = display.split()[0] if display else "python"
-            command = f"{python} -m pip install streamlit"
+            command = _quote_argv(pip)
         elif tag == "conda":
             command = "conda install -c conda-forge streamlit"
         elif tag == "pipenv":
@@ -561,7 +619,7 @@ def _install_advice(project_dir: Path, attempts: Sequence[_Attempt]) -> str:
             command = "uv add streamlit"
         else:
             command = (
-                "python -m pip install streamlit\n"
+                f"{_quote_argv(pip)}\n"
                 "    # better: create a project venv first "
                 "(`uv venv` or `python -m venv .venv`)"
             )

--- a/lib/streamlit/.agents/meta-skill/developing-with-streamlit/scripts/discover.py
+++ b/lib/streamlit/.agents/meta-skill/developing-with-streamlit/scripts/discover.py
@@ -48,25 +48,27 @@ import time
 from dataclasses import dataclass
 from enum import IntEnum
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal, NoReturn
+from typing import TYPE_CHECKING, Final, Literal, NoReturn
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Iterator, Sequence
 
 # Tests patch this instead of ``os.name`` so pathlib keeps the host flavor.
 _IS_WINDOWS = os.name == "nt"
-_MAX_WALK_DEPTH = 20  # Same cap as skills._MAX_REPO_ROOT_WALK_DEPTH.
-_GLOBAL_BUDGET_S = 60.0
-_DIRECT_TIMEOUT_S = 10.0
-_MANAGER_TIMEOUT_S = 30.0
-_SKILL_REL = Path(".agents") / "skills" / "developing-with-streamlit" / "SKILL.md"
-_DOCS_URL = "https://docs.streamlit.io/llms-full.txt"
-_SENTINEL = "STREAMLIT_PKG="
-_INSPECTED_STATUSES = frozenset({"no_streamlit", "no_usable_skill", "layout_changed"})
+_MAX_WALK_DEPTH: Final = 20  # Same cap as skills._MAX_REPO_ROOT_WALK_DEPTH.
+_GLOBAL_BUDGET_S: Final = 60.0
+_DIRECT_TIMEOUT_S: Final = 10.0
+_MANAGER_TIMEOUT_S: Final = 30.0
+_SKILL_REL: Final = (
+    Path(".agents") / "skills" / "developing-with-streamlit" / "SKILL.md"
+)
+_DOCS_URL: Final = "https://docs.streamlit.io/llms-full.txt"
+_SENTINEL: Final = "STREAMLIT_PKG="
 
-# 3.10-safe child snippet: never ``import streamlit``. Sanitize ``sys.path``
-# instead of using ``python -P`` (3.11+ only). Parent parses the last sentinel.
-_PROBE_SNIPPET = """\
+# Child process: locate Streamlit without importing it (works on 3.10).
+# - Drop cwd from sys.path; do not use python -P (3.11+ only).
+# - Parent keeps the last STREAMLIT_PKG= line.
+_PROBE_SNIPPET: Final = """\
 import importlib.util
 import pathlib
 import sys
@@ -94,7 +96,7 @@ if ok:
 """
 
 
-class Outcome(IntEnum):
+class _Outcome(IntEnum):
     """CLI exit codes."""
 
     SUCCESS = 0
@@ -107,47 +109,38 @@ class Outcome(IntEnum):
     PROBE_FAILED = 7
 
 
-_ERROR_NAME: dict[Outcome, str] = {
-    Outcome.NO_STREAMLIT: "NO_STREAMLIT",
-    Outcome.NO_USABLE_SKILL: "NO_USABLE_SKILL",
-    Outcome.NO_PROJECT_PYTHON: "NO_PROJECT_PYTHON",
-    Outcome.SKILLS_LAYOUT_CHANGED: "SKILLS_LAYOUT_CHANGED",
-    Outcome.INVALID_ARGS: "INVALID_ARGS",
-    Outcome.INTERNAL: "INTERNAL",
-    Outcome.PROBE_FAILED: "PROBE_FAILED",
-}
-
-_ERROR_MESSAGE: dict[Outcome, str] = {
-    Outcome.NO_STREAMLIT: (
+_ERROR_MESSAGE: Final[dict[_Outcome, str]] = {
+    _Outcome.NO_STREAMLIT: (
         "Streamlit is not installed in the inspected Python environment."
     ),
-    Outcome.NO_USABLE_SKILL: (
+    _Outcome.NO_USABLE_SKILL: (
         "Found Streamlit, but no usable bundled skill. "
         "Upgrade or reinstall Streamlit, or use the docs."
     ),
-    Outcome.NO_PROJECT_PYTHON: "No Python interpreter was found to inspect.",
-    Outcome.SKILLS_LAYOUT_CHANGED: (
+    _Outcome.NO_PROJECT_PYTHON: "No Python interpreter was found to inspect.",
+    _Outcome.SKILLS_LAYOUT_CHANGED: (
         "Streamlit's bundled skills directory exists, but the expected "
         "developing-with-streamlit/SKILL.md is missing from the documented "
         "sub-path. Upstream Streamlit likely reorganized the skill layout."
     ),
-    Outcome.INVALID_ARGS: "Invalid arguments.",
-    Outcome.INTERNAL: "Unexpected error while discovering the bundled skill.",
-    Outcome.PROBE_FAILED: (
+    _Outcome.INVALID_ARGS: "Invalid arguments.",
+    _Outcome.INTERNAL: "Unexpected error while discovering the bundled skill.",
+    _Outcome.PROBE_FAILED: (
         "Could not inspect any interpreter (timeout, stub, or unreadable "
         "output). This does not mean Streamlit is not installed."
     ),
 }
 
-_STATUS_TO_OUTCOME: dict[str, Outcome] = {
-    "no_streamlit": Outcome.NO_STREAMLIT,
-    "no_usable_skill": Outcome.NO_USABLE_SKILL,
-    "layout_changed": Outcome.SKILLS_LAYOUT_CHANGED,
+_STATUS_TO_OUTCOME: Final[dict[str, _Outcome]] = {
+    "no_streamlit": _Outcome.NO_STREAMLIT,
+    "no_usable_skill": _Outcome.NO_USABLE_SKILL,
+    "layout_changed": _Outcome.SKILLS_LAYOUT_CHANGED,
 }
+_INSPECTED_STATUSES: Final = frozenset(_STATUS_TO_OUTCOME)
 
 
 @dataclass(frozen=True)
-class Candidate:
+class _Candidate:
     """One interpreter (or manager wrapper) to inspect, in probe order."""
 
     tag: str
@@ -157,7 +150,7 @@ class Candidate:
 
 
 @dataclass
-class ProbeBudget:
+class _ProbeBudget:
     """Wall-clock budget that charges subprocess time only."""
 
     remaining: float = _GLOBAL_BUDGET_S
@@ -171,19 +164,14 @@ class ProbeBudget:
         """Subtract elapsed subprocess time from the remaining budget."""
         self.remaining = max(0.0, self.remaining - elapsed)
 
-    def exhausted(self) -> bool:
-        """Return True when no subprocess time remains."""
-        return self.remaining <= 0.0
-
 
 @dataclass
-class Attempt:
+class _Attempt:
     """One candidate's recorded outcome for the attempt log."""
 
     tag: str
     display: str
     status: str
-    detail: str = ""
 
 
 class _DiscoverArgumentParser(argparse.ArgumentParser):
@@ -192,11 +180,11 @@ class _DiscoverArgumentParser(argparse.ArgumentParser):
     def error(self, message: str) -> NoReturn:
         print(f"ERROR[INVALID_ARGS]: {message}", file=sys.stderr)
         print(_DOCS_URL, file=sys.stderr)
-        raise SystemExit(int(Outcome.INVALID_ARGS))
+        raise SystemExit(int(_Outcome.INVALID_ARGS))
 
 
 def _reconfigure_stdio() -> None:
-    """Reconfigure this process's stdout/stderr to UTF-8 without replacing."""
+    """Set stdout/stderr encoding to UTF-8; skip streams that cannot be reconfigured."""
     for stream in (sys.stdout, sys.stderr):
         reconfigure = getattr(stream, "reconfigure", None)
         if reconfigure is None:
@@ -208,7 +196,7 @@ def _reconfigure_stdio() -> None:
 
 
 def _maybe_msys_path(raw: str) -> str:
-    """Convert a light MSYS path (``/c/foo``) to ``C:/foo`` on Windows."""
+    """Convert a light MSYS path (``/c/foo``) to a Windows drive path."""
     if not _IS_WINDOWS:
         return raw
     if (
@@ -228,6 +216,25 @@ def _expand_user_path(raw: str) -> str:
     return _maybe_msys_path(os.path.expandvars(os.path.expanduser(raw)))
 
 
+def _safe_resolve(path: Path) -> Path:
+    """Resolve ``path`` when the filesystem allows it; otherwise keep it as-is."""
+    try:
+        return path.resolve()
+    except OSError:
+        return path
+
+
+def _iter_ancestors(start: Path) -> Iterator[Path]:
+    """Yield ``start`` then each parent, up to ``_MAX_WALK_DEPTH`` levels."""
+    current = _safe_resolve(start)
+    for _ in range(_MAX_WALK_DEPTH):
+        yield current
+        parent = current.parent
+        if parent == current:
+            return
+        current = parent
+
+
 def find_venv_python(venv_root: Path) -> Path | None:
     """Return the venv's Python executable, cross-platform.
 
@@ -242,50 +249,28 @@ def find_venv_python(venv_root: Path) -> Path | None:
 
 
 def find_git_root(start: Path) -> Path | None:
-    """Walk up from ``start`` looking for a ``.git`` directory or file.
+    """Return the nearest git root at or above ``start``, if within the walk cap.
 
-    Capped at ``_MAX_WALK_DEPTH`` ancestors (same as ``skills.py``). Handles
-    the worktree case where ``.git`` is a file pointing at the real repo dir.
+    Matches ``skills.py``: at most ``_MAX_WALK_DEPTH`` ancestors, and ``.git``
+    may be a directory or a file (worktrees).
     """
-    current = start
-    try:
-        current = start.resolve()
-    except OSError:
-        current = start
-    for _ in range(_MAX_WALK_DEPTH):
-        if (current / ".git").exists():
-            return current
-        parent = current.parent
-        if parent == current:
-            return None
-        current = parent
-    return None
+    return next(
+        (path for path in _iter_ancestors(start) if (path / ".git").exists()),
+        None,
+    )
 
 
 def _find_lockfile(start: Path, name: str) -> Path | None:
-    """Return the first ``name`` found from ``start`` up to the walk cap."""
-    current = start
-    try:
-        current = start.resolve()
-    except OSError:
-        current = start
-    for _ in range(_MAX_WALK_DEPTH):
-        candidate = current / name
-        if candidate.is_file():
-            return candidate
-        parent = current.parent
-        if parent == current:
-            return None
-        current = parent
-    return None
+    """Return the nearest ``name`` file at or above ``start``, if within the walk cap."""
+    return next(
+        (path / name for path in _iter_ancestors(start) if (path / name).is_file()),
+        None,
+    )
 
 
 def _prefix_from_python(executable: Path) -> Path | None:
     """Infer an environment prefix from a Python executable path."""
-    try:
-        exe = executable.resolve()
-    except OSError:
-        exe = executable
+    exe = _safe_resolve(executable)
     parent = exe.parent
     if _IS_WINDOWS:
         if parent.name.lower() == "scripts":
@@ -336,18 +321,21 @@ def _filesystem_lookup(prefix: Path) -> Path | None:
     return with_skill[0] if with_skill else dirs[0]
 
 
-def _classify_package(pkg: Path) -> Path | Outcome:
-    """Classify a Streamlit package dir as usable skill, layout change, or not."""
+def _classify_package(pkg: Path) -> tuple[str, Path | None]:
+    """Return ``(status, skill_path)`` for a Streamlit package directory.
+
+    Status is ``usable``, ``layout_changed``, or ``no_usable_skill``.
+    """
     skill = pkg / _SKILL_REL
     if skill.is_file():
         try:
-            return skill.resolve()
+            return "usable", skill.resolve()
         except OSError:
-            return skill
+            return "usable", skill
     agents = pkg / ".agents" / "skills"
     if agents.is_dir():
-        return Outcome.SKILLS_LAYOUT_CHANGED
-    return Outcome.NO_USABLE_SKILL
+        return "layout_changed", None
+    return "no_usable_skill", None
 
 
 def _is_usable_package_dir(pkg: Path) -> bool:
@@ -383,16 +371,7 @@ def _probe_env() -> dict[str, str]:
     return env
 
 
-def _outcome_from_classify(classified: Path | Outcome) -> tuple[str, Path | None]:
-    """Convert a package classification into an attempt status and optional path."""
-    if isinstance(classified, Path):
-        return "usable", classified
-    if classified is Outcome.SKILLS_LAYOUT_CHANGED:
-        return "layout_changed", None
-    return "no_usable_skill", None
-
-
-def _direct_executable(candidate: Candidate) -> Path | None:
+def _direct_executable(candidate: _Candidate) -> Path | None:
     """Return the filesystem path of a direct interpreter candidate, if any."""
     if candidate.kind != "direct" or not candidate.argv:
         return None
@@ -403,11 +382,11 @@ def _direct_executable(candidate: Candidate) -> Path | None:
     return Path(found) if found else None
 
 
-def _iter_candidates(project_dir: Path, python_flag: Path | None) -> list[Candidate]:
+def _iter_candidates(project_dir: Path, python_flag: Path | None) -> list[_Candidate]:
     """Build the ordered candidate list. ``--python`` is exclusive."""
     if python_flag is not None:
         return [
-            Candidate(
+            _Candidate(
                 tag="python-flag",
                 argv=[str(python_flag)],
                 kind="direct",
@@ -415,14 +394,11 @@ def _iter_candidates(project_dir: Path, python_flag: Path | None) -> list[Candid
             )
         ]
 
-    out: list[Candidate] = []
+    out: list[_Candidate] = []
     seen_exes: set[Path] = set()
 
     def _remember(exe: Path) -> Path | None:
-        try:
-            resolved = exe.resolve()
-        except OSError:
-            resolved = exe
+        resolved = _safe_resolve(exe)
         if resolved in seen_exes:
             return None
         seen_exes.add(resolved)
@@ -431,7 +407,7 @@ def _iter_candidates(project_dir: Path, python_flag: Path | None) -> list[Candid
     def add_path(tag: str, exe: Path, prefix: Path | None) -> None:
         if _remember(exe) is None:
             return
-        out.append(Candidate(tag=tag, argv=[str(exe)], kind="direct", prefix=prefix))
+        out.append(_Candidate(tag=tag, argv=[str(exe)], kind="direct", prefix=prefix))
 
     def add_venv(tag: str, root: Path) -> None:
         python = find_venv_python(root)
@@ -480,11 +456,11 @@ def _iter_candidates(project_dir: Path, python_flag: Path | None) -> list[Candid
     )
     for tag, lock_name, argv in managers:
         if shutil.which(argv[0]) and _find_lockfile(project_dir, lock_name):
-            out.append(Candidate(tag=tag, argv=argv, kind="manager", prefix=None))
+            out.append(_Candidate(tag=tag, argv=argv, kind="manager", prefix=None))
 
     if _IS_WINDOWS and shutil.which("py"):
         out.append(
-            Candidate(tag="py-launcher", argv=["py", "-3"], kind="direct", prefix=None)
+            _Candidate(tag="py-launcher", argv=["py", "-3"], kind="direct", prefix=None)
         )
 
     names = ("python", "python3") if _IS_WINDOWS else ("python3", "python")
@@ -498,9 +474,9 @@ def _iter_candidates(project_dir: Path, python_flag: Path | None) -> list[Candid
 
 
 def _subprocess_probe(
-    candidate: Candidate,
+    candidate: _Candidate,
     project_dir: Path,
-    budget: ProbeBudget,
+    budget: _ProbeBudget,
 ) -> tuple[Path | None, str]:
     """Run the find_spec probe. Returns ``(package_dir, status)``."""
     timeout = budget.timeout_for(candidate.kind)
@@ -520,7 +496,7 @@ def _subprocess_probe(
         )
     except subprocess.TimeoutExpired:
         return None, "probe_failed"
-    except (FileNotFoundError, PermissionError, OSError, ValueError, UnicodeError):
+    except (OSError, ValueError, UnicodeError):
         return None, "probe_failed"
     finally:
         budget.charge(time.monotonic() - started)
@@ -536,33 +512,30 @@ def _subprocess_probe(
 
 
 def _evaluate_candidate(
-    candidate: Candidate,
+    candidate: _Candidate,
     project_dir: Path,
-    budget: ProbeBudget,
-) -> tuple[Attempt, Path | None]:
-    """Filesystem lookup, then subprocess if needed."""
+    budget: _ProbeBudget,
+) -> tuple[_Attempt, Path | None]:
+    """Try a filesystem lookup first, then the subprocess probe if needed."""
     display = " ".join(candidate.argv)
     exe = _direct_executable(candidate)
     if exe is not None and _is_windows_store_alias(exe):
-        return Attempt(candidate.tag, display, "skipped_stub"), None
+        return _Attempt(candidate.tag, display, "skipped_stub"), None
 
     if candidate.prefix is not None:
         pkg = _filesystem_lookup(candidate.prefix)
         if pkg is not None:
-            status, skill = _outcome_from_classify(_classify_package(pkg))
-            return Attempt(candidate.tag, display, status), skill
-
-    if budget.exhausted() or budget.timeout_for(candidate.kind) <= 0:
-        return Attempt(candidate.tag, display, "not_tried"), None
+            status, skill = _classify_package(pkg)
+            return _Attempt(candidate.tag, display, status), skill
 
     pkg, probe_status = _subprocess_probe(candidate, project_dir, budget)
     if probe_status != "ok" or pkg is None:
-        return Attempt(candidate.tag, display, probe_status), None
-    status, skill = _outcome_from_classify(_classify_package(pkg))
-    return Attempt(candidate.tag, display, status), skill
+        return _Attempt(candidate.tag, display, probe_status), None
+    status, skill = _classify_package(pkg)
+    return _Attempt(candidate.tag, display, status), skill
 
 
-def _install_advice(project_dir: Path, attempts: Sequence[Attempt]) -> str:
+def _install_advice(project_dir: Path, attempts: Sequence[_Attempt]) -> str:
     """Return quoted install advice. Must not be run unless the user asked."""
     header = (
         "If the user asked you to install Streamlit, you may run the command "
@@ -596,19 +569,17 @@ def _install_advice(project_dir: Path, attempts: Sequence[Attempt]) -> str:
 
 
 def _print_failure(
-    outcome: Outcome, attempts: Sequence[Attempt], project_dir: Path
+    outcome: _Outcome, attempts: Sequence[_Attempt], project_dir: Path
 ) -> int:
     """Print the error block and return the exit code."""
-    name = _ERROR_NAME[outcome]
-    print(f"ERROR[{name}]: {_ERROR_MESSAGE[outcome]}", file=sys.stderr)
+    print(f"ERROR[{outcome.name}]: {_ERROR_MESSAGE[outcome]}", file=sys.stderr)
     print(file=sys.stderr)
     print("Attempts:", file=sys.stderr)
     if not attempts:
         print("  (none)", file=sys.stderr)
     for attempt in attempts:
-        extra = f" ({attempt.detail})" if attempt.detail else ""
         print(
-            f"  {attempt.tag} [{attempt.display}]: {attempt.status}{extra}",
+            f"  {attempt.tag} [{attempt.display}]: {attempt.status}",
             file=sys.stderr,
         )
     print(file=sys.stderr)
@@ -638,10 +609,7 @@ def _resolve_project_dir(raw: str | None) -> Path:
             file=sys.stderr,
         )
         return Path.cwd()
-    try:
-        return path.resolve()
-    except OSError:
-        return path
+    return _safe_resolve(path)
 
 
 def _resolve_python_flag(raw: str) -> Path:
@@ -658,18 +626,20 @@ def _resolve_python_flag(raw: str) -> Path:
         file=sys.stderr,
     )
     print(_DOCS_URL, file=sys.stderr)
-    raise SystemExit(int(Outcome.INVALID_ARGS))
+    raise SystemExit(int(_Outcome.INVALID_ARGS))
 
 
 def _discover(project_dir: Path, python_flag: Path | None, verbose: bool) -> int:
     """Run per-candidate discovery and print the skill path or an error block."""
     candidates = _iter_candidates(project_dir, python_flag)
     if not candidates:
-        return _print_failure(Outcome.NO_PROJECT_PYTHON, [], project_dir)
+        return _print_failure(_Outcome.NO_PROJECT_PYTHON, [], project_dir)
 
-    budget = ProbeBudget()
-    attempts: list[Attempt] = []
-    first_inspected: Attempt | None = None
+    budget = _ProbeBudget()
+    attempts: list[_Attempt] = []
+    # Final error follows the first candidate that was actually inspected.
+    # A later layout_changed/no_usable_skill must not hide an earlier no_streamlit.
+    first_inspected: _Attempt | None = None
 
     for candidate in candidates:
         attempt, skill = _evaluate_candidate(candidate, project_dir, budget)
@@ -681,13 +651,13 @@ def _discover(project_dir: Path, python_flag: Path | None, verbose: bool) -> int
                     f"discovered via: {attempt.tag} {attempt.display}",
                     file=sys.stderr,
                 )
-            return int(Outcome.SUCCESS)
+            return int(_Outcome.SUCCESS)
         if attempt.status in _INSPECTED_STATUSES and first_inspected is None:
             first_inspected = attempt
 
     if first_inspected is None:
         any_started = any(attempt.status != "not_tried" for attempt in attempts)
-        code = Outcome.PROBE_FAILED if any_started else Outcome.NO_PROJECT_PYTHON
+        code = _Outcome.PROBE_FAILED if any_started else _Outcome.NO_PROJECT_PYTHON
         return _print_failure(code, attempts, project_dir)
     return _print_failure(
         _STATUS_TO_OUTCOME[first_inspected.status], attempts, project_dir
@@ -734,11 +704,11 @@ def main(argv: Sequence[str] | None = None) -> int:
             return 0
         if isinstance(exc.code, int):
             return exc.code
-        return int(Outcome.INVALID_ARGS)
+        return int(_Outcome.INVALID_ARGS)
     except Exception as exc:
         print(f"ERROR[INTERNAL]: {exc}", file=sys.stderr)
         print(_DOCS_URL, file=sys.stderr)
-        return int(Outcome.INTERNAL)
+        return int(_Outcome.INTERNAL)
 
 
 if __name__ == "__main__":

--- a/lib/streamlit/AGENTS.md
+++ b/lib/streamlit/AGENTS.md
@@ -40,7 +40,9 @@ Changes to these high-fan-out internals can affect every command, message, sessi
 
 ## Embedded agent skills
 
-User-facing skills ship under `lib/streamlit/.agents/skills/` (for example, `developing-with-streamlit`). Keep them current as features land; follow `lib/streamlit/.agents/skills/AGENTS.md`.
+User-facing content skills ship under `lib/streamlit/.agents/skills/` (for example, `developing-with-streamlit`). Keep them current as features land; follow `lib/streamlit/.agents/skills/AGENTS.md`.
+
+The version-agnostic global meta-skill lives separately under `lib/streamlit/.agents/meta-skill/`. Tests for its discovery script are in `lib/tests/streamlit/web/meta_skill_discover_test.py`.
 
 ## Unit Tests
 

--- a/lib/tests/streamlit/web/meta_skill_discover_test.py
+++ b/lib/tests/streamlit/web/meta_skill_discover_test.py
@@ -21,7 +21,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Final
 
 import pytest
 
@@ -30,7 +30,7 @@ import streamlit
 if TYPE_CHECKING:
     from types import ModuleType
 
-_DISCOVER_PY = (
+_DISCOVER_PY: Final = (
     Path(streamlit.__file__).resolve().parent
     / ".agents"
     / "meta-skill"
@@ -38,8 +38,9 @@ _DISCOVER_PY = (
     / "scripts"
     / "discover.py"
 )
-_DOCS_URL = "https://docs.streamlit.io/llms-full.txt"
-_SKILL_REL = Path(".agents") / "skills" / "developing-with-streamlit" / "SKILL.md"
+_SKILL_REL: Final = (
+    Path(".agents") / "skills" / "developing-with-streamlit" / "SKILL.md"
+)
 
 
 @pytest.fixture
@@ -60,15 +61,44 @@ def isolated_env(
     monkeypatch: pytest.MonkeyPatch, discover_mod: ModuleType, tmp_path: Path
 ) -> None:
     """Hide inherited interpreters so tests control the candidate list."""
+    _hide_inherited_interpreters(monkeypatch, discover_mod, tmp_path)
+    # Planted fixtures use POSIX ``bin/python`` layouts. Force that lookup
+    # so these helper tests also pass on the Windows CI job.
+    monkeypatch.setattr(discover_mod, "_IS_WINDOWS", False)
+
+
+def _hide_inherited_interpreters(
+    monkeypatch: pytest.MonkeyPatch, discover_mod: ModuleType, tmp_path: Path
+) -> None:
+    """Drop VIRTUAL_ENV, CONDA_PREFIX, sys.executable, and PATH lookups."""
     monkeypatch.delenv("VIRTUAL_ENV", raising=False)
     monkeypatch.delenv("CONDA_PREFIX", raising=False)
     monkeypatch.setattr(
         discover_mod.sys, "executable", str(tmp_path / "no-such-python")
     )
     monkeypatch.setattr(discover_mod.shutil, "which", lambda _name: None)
-    # Planted fixtures use POSIX ``bin/python`` layouts. Force that lookup
-    # so these helper tests also pass on the Windows CI job.
-    monkeypatch.setattr(discover_mod, "_IS_WINDOWS", False)
+
+
+def _subprocess_reports_no_streamlit(
+    *_args: object, **_kwargs: object
+) -> subprocess.CompletedProcess[str]:
+    """Fake ``subprocess.run``: exit 0 with empty stdout (no STREAMLIT_PKG line)."""
+    return subprocess.CompletedProcess(["python"], 0, stdout="", stderr="")
+
+
+def _run_discover(*cli_args: str) -> subprocess.CompletedProcess[str]:
+    """Run discover.py as a subprocess, ignoring inherited venv env vars."""
+    env = os.environ.copy()
+    env.pop("VIRTUAL_ENV", None)
+    env.pop("CONDA_PREFIX", None)
+    return subprocess.run(
+        [sys.executable, str(_DISCOVER_PY), *cli_args],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+        env=env,
+    )
 
 
 def _touch_exe(path: Path) -> Path:
@@ -260,19 +290,16 @@ def test_layout_changed_does_not_outrank_earlier_no_streamlit(
     (pkg / ".agents" / "skills").mkdir(parents=True)
     monkeypatch.setenv("VIRTUAL_ENV", str(later))
 
-    def _fake_run(
-        *_args: object, **_kwargs: object
-    ) -> subprocess.CompletedProcess[str]:
-        return subprocess.CompletedProcess(["python"], 0, stdout="", stderr="")
-
-    monkeypatch.setattr(discover_mod.subprocess, "run", _fake_run)
+    monkeypatch.setattr(
+        discover_mod.subprocess, "run", _subprocess_reports_no_streamlit
+    )
 
     code = discover_mod.main(["--project-dir", str(project)])
     captured = capsys.readouterr()
     assert code == 1
     assert captured.err.startswith("ERROR[NO_STREAMLIT]:")
     assert "ERROR[SKILLS_LAYOUT_CHANGED]" not in captured.err
-    assert _DOCS_URL in captured.err
+    assert discover_mod._DOCS_URL in captured.err
 
 
 def test_lone_streamlit_py_is_rejected(
@@ -323,12 +350,12 @@ def test_store_alias_skipped_only_for_windowsapps_dir(
     assert discover_mod._is_windows_store_alias(trick) is False
 
 
-def test_conda_python_exe_on_windows(
+def test_windows_find_venv_python_root_then_scripts(
     tmp_path: Path,
     discover_mod: ModuleType,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Windows conda prefixes expose ``python.exe`` next to the root."""
+    """Windows: conda-style ``python.exe`` at the prefix, else ``Scripts/python.exe``."""
     monkeypatch.setattr(discover_mod, "_IS_WINDOWS", True)
     prefix = tmp_path / "conda"
     root_exe = _touch_exe(prefix / "python.exe")
@@ -393,12 +420,9 @@ def test_python_flag_exclusive_ignores_project_venv(
     _plant_posix_venv(project / ".venv")
     chosen = _touch_exe(tmp_path / "chosen" / "bin" / "python")
 
-    def _fake_run(
-        *_args: object, **_kwargs: object
-    ) -> subprocess.CompletedProcess[str]:
-        return subprocess.CompletedProcess(["python"], 0, stdout="", stderr="")
-
-    monkeypatch.setattr(discover_mod.subprocess, "run", _fake_run)
+    monkeypatch.setattr(
+        discover_mod.subprocess, "run", _subprocess_reports_no_streamlit
+    )
 
     code = discover_mod.main(["--project-dir", str(project), "--python", str(chosen)])
     captured = capsys.readouterr()
@@ -418,7 +442,7 @@ def test_bad_python_flag_is_invalid_args(
     captured = capsys.readouterr()
     assert code == 5
     assert captured.err.startswith("ERROR[INVALID_ARGS]:")
-    assert _DOCS_URL in captured.err
+    assert discover_mod._DOCS_URL in captured.err
 
 
 def test_unknown_flag_is_invalid_args(
@@ -429,7 +453,7 @@ def test_unknown_flag_is_invalid_args(
     captured = capsys.readouterr()
     assert code == 5
     assert captured.err.startswith("ERROR[INVALID_ARGS]:")
-    assert _DOCS_URL in captured.err
+    assert discover_mod._DOCS_URL in captured.err
 
 
 def test_budget_marks_remaining_candidates_not_tried(
@@ -439,7 +463,7 @@ def test_budget_marks_remaining_candidates_not_tried(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """After the subprocess budget is exhausted, later candidates are ``not tried``."""
+    """After the subprocess budget is exhausted, later candidates are ``not_tried``."""
     project = tmp_path / "proj"
     project.mkdir()
     _touch_exe(project / ".venv" / "bin" / "python")
@@ -447,13 +471,10 @@ def test_budget_marks_remaining_candidates_not_tried(
     _touch_exe(later / "bin" / "python")
     monkeypatch.setenv("VIRTUAL_ENV", str(later))
 
-    def _fake_run(
-        *_args: object, **_kwargs: object
-    ) -> subprocess.CompletedProcess[str]:
-        return subprocess.CompletedProcess(["python"], 0, stdout="", stderr="")
-
     times = iter([0.0, 60.0])
-    monkeypatch.setattr(discover_mod.subprocess, "run", _fake_run)
+    monkeypatch.setattr(
+        discover_mod.subprocess, "run", _subprocess_reports_no_streamlit
+    )
     monkeypatch.setattr(discover_mod.time, "monotonic", lambda: next(times))
 
     code = discover_mod.main(["--project-dir", str(project)])
@@ -484,7 +505,7 @@ def test_probe_failed_when_nothing_inspected(
     assert code == 7
     assert captured.err.startswith("ERROR[PROBE_FAILED]:")
     assert "ERROR[NO_STREAMLIT]" not in captured.err
-    assert _DOCS_URL in captured.err
+    assert discover_mod._DOCS_URL in captured.err
 
 
 def test_skip_py_launcher_when_missing(
@@ -493,13 +514,8 @@ def test_skip_py_launcher_when_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Windows ``py -3`` is omitted when ``py`` is not on PATH."""
+    _hide_inherited_interpreters(monkeypatch, discover_mod, tmp_path)
     monkeypatch.setattr(discover_mod, "_IS_WINDOWS", True)
-    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
-    monkeypatch.delenv("CONDA_PREFIX", raising=False)
-    monkeypatch.setattr(
-        discover_mod.sys, "executable", str(tmp_path / "no-such-python")
-    )
-    monkeypatch.setattr(discover_mod.shutil, "which", lambda _name: None)
     project = tmp_path / "proj"
     project.mkdir()
     tags = [c.tag for c in discover_mod._iter_candidates(project, python_flag=None)]
@@ -507,26 +523,19 @@ def test_skip_py_launcher_when_missing(
 
 
 @pytest.mark.parametrize(
-    ("is_windows", "expected_first"),
-    [
-        (True, "python"),
-        (False, "python3"),
-    ],
+    "is_windows",
+    [True, False],
+    ids=["windows", "posix"],
 )
 def test_system_interpreter_order(
     tmp_path: Path,
     discover_mod: ModuleType,
     monkeypatch: pytest.MonkeyPatch,
     is_windows: bool,
-    expected_first: str,
 ) -> None:
     """Windows prefers ``python`` then ``python3``; POSIX the reverse."""
+    _hide_inherited_interpreters(monkeypatch, discover_mod, tmp_path)
     monkeypatch.setattr(discover_mod, "_IS_WINDOWS", is_windows)
-    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
-    monkeypatch.delenv("CONDA_PREFIX", raising=False)
-    monkeypatch.setattr(
-        discover_mod.sys, "executable", str(tmp_path / "no-such-python")
-    )
     python = _touch_exe(tmp_path / "python")
     python3 = _touch_exe(tmp_path / "python3")
     which_map = {"python": str(python), "python3": str(python3)}
@@ -538,9 +547,8 @@ def test_system_interpreter_order(
         for c in discover_mod._iter_candidates(project, python_flag=None)
         if c.tag == "system"
     ]
-    assert [Path(c.argv[0]).name for c in system] == (
-        ["python", "python3"] if expected_first == "python" else ["python3", "python"]
-    )
+    expected = ["python", "python3"] if is_windows else ["python3", "python"]
+    assert [Path(c.argv[0]).name for c in system] == expected
 
 
 def test_uv_argv_includes_no_sync(
@@ -620,12 +628,9 @@ def test_install_advice_prefers_uv_and_is_quoted(
     _touch_exe(project / ".venv" / "bin" / "python")
     (project / "uv.lock").write_text("", encoding="utf-8")
 
-    def _fake_run(
-        *_args: object, **_kwargs: object
-    ) -> subprocess.CompletedProcess[str]:
-        return subprocess.CompletedProcess(["python"], 0, stdout="", stderr="")
-
-    monkeypatch.setattr(discover_mod.subprocess, "run", _fake_run)
+    monkeypatch.setattr(
+        discover_mod.subprocess, "run", _subprocess_reports_no_streamlit
+    )
 
     code = discover_mod.main(["--project-dir", str(project)])
     captured = capsys.readouterr()
@@ -633,7 +638,7 @@ def test_install_advice_prefers_uv_and_is_quoted(
     assert "uv add streamlit" in captured.err
     assert "source " not in captured.err
     assert "activate" not in captured.err
-    assert captured.err.strip().endswith(_DOCS_URL)
+    assert captured.err.strip().endswith(discover_mod._DOCS_URL)
     assert captured.err.startswith("ERROR[NO_STREAMLIT]:")
 
 
@@ -678,7 +683,8 @@ def test_windows_filesystem_lookup_layout(
     pkg = prefix / "Lib" / "site-packages" / "streamlit"
     skill = _plant_skill(pkg)
     assert discover_mod._filesystem_lookup(prefix) == pkg
-    classified = discover_mod._classify_package(pkg)
+    status, classified = discover_mod._classify_package(pkg)
+    assert status == "usable"
     assert classified == skill.resolve()
 
 
@@ -695,48 +701,28 @@ def test_no_project_python_when_nothing_started(
     captured = capsys.readouterr()
     assert code == 3
     assert captured.err.startswith("ERROR[NO_PROJECT_PYTHON]:")
-    assert _DOCS_URL in captured.err
+    assert discover_mod._DOCS_URL in captured.err
 
 
-def test_fake_venv_e2e_discovers_planted_skill(tmp_path: Path) -> None:
+def test_subprocess_run_against_planted_venv_skill(tmp_path: Path) -> None:
     """End-to-end: a real project ``.venv`` with a planted skill is discovered."""
     project = tmp_path / "proj"
     project.mkdir()
     venv = _create_venv(project / ".venv")
     skill = _plant_skill(_venv_site_packages(venv) / "streamlit", content="# e2e\n")
-    env = os.environ.copy()
-    env.pop("VIRTUAL_ENV", None)
-    env.pop("CONDA_PREFIX", None)
-    result = subprocess.run(
-        [sys.executable, str(_DISCOVER_PY), "--project-dir", str(project), "--verbose"],
-        capture_output=True,
-        text=True,
-        timeout=60,
-        check=False,
-        env=env,
-    )
+    result = _run_discover("--project-dir", str(project), "--verbose")
     assert result.returncode == 0, result.stderr
     assert result.stdout.splitlines() == [str(skill.resolve())]
     assert "discovered via: venv-local" in result.stderr
 
 
-def test_fake_venv_e2e_project_path_with_space(tmp_path: Path) -> None:
+def test_subprocess_run_against_project_path_with_space(tmp_path: Path) -> None:
     """Discovery works when the project directory contains a space."""
     project = tmp_path / "my project"
     project.mkdir()
     venv = _create_venv(project / ".venv")
     skill = _plant_skill(_venv_site_packages(venv) / "streamlit")
-    env = os.environ.copy()
-    env.pop("VIRTUAL_ENV", None)
-    env.pop("CONDA_PREFIX", None)
-    result = subprocess.run(
-        [sys.executable, str(_DISCOVER_PY), "--project-dir", str(project)],
-        capture_output=True,
-        text=True,
-        timeout=60,
-        check=False,
-        env=env,
-    )
+    result = _run_discover("--project-dir", str(project))
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == str(skill.resolve())
 
@@ -754,17 +740,7 @@ def test_pth_hits_via_subprocess_not_filesystem(tmp_path: Path) -> None:
     )
     assert not (site_packages / "streamlit").exists()
 
-    env = os.environ.copy()
-    env.pop("VIRTUAL_ENV", None)
-    env.pop("CONDA_PREFIX", None)
-    result = subprocess.run(
-        [sys.executable, str(_DISCOVER_PY), "--project-dir", str(project), "--verbose"],
-        capture_output=True,
-        text=True,
-        timeout=60,
-        check=False,
-        env=env,
-    )
+    result = _run_discover("--project-dir", str(project), "--verbose")
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == str(skill.resolve())
     assert "venv-local" in result.stderr
@@ -780,17 +756,7 @@ def test_windows_filesystem_layout_smoke(tmp_path: Path) -> None:
     assert python.is_file()
     lib_pkg = venv / "Lib" / "site-packages" / "streamlit"
     skill = _plant_skill(lib_pkg)
-    env = os.environ.copy()
-    env.pop("VIRTUAL_ENV", None)
-    env.pop("CONDA_PREFIX", None)
-    result = subprocess.run(
-        [sys.executable, str(_DISCOVER_PY), "--project-dir", str(project), "--verbose"],
-        capture_output=True,
-        text=True,
-        timeout=60,
-        check=False,
-        env=env,
-    )
+    result = _run_discover("--project-dir", str(project), "--verbose")
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == str(skill.resolve())
     assert "venv-local" in result.stderr
@@ -808,17 +774,7 @@ def test_windows_pth_subprocess_smoke(tmp_path: Path) -> None:
     (site_packages / "discover_editable.pth").write_text(
         str(ext.resolve()) + "\n", encoding="utf-8"
     )
-    env = os.environ.copy()
-    env.pop("VIRTUAL_ENV", None)
-    env.pop("CONDA_PREFIX", None)
-    result = subprocess.run(
-        [sys.executable, str(_DISCOVER_PY), "--project-dir", str(project), "--verbose"],
-        capture_output=True,
-        text=True,
-        timeout=60,
-        check=False,
-        env=env,
-    )
+    result = _run_discover("--project-dir", str(project), "--verbose")
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == str(skill.resolve())
     python = venv / "Scripts" / "python.exe"

--- a/lib/tests/streamlit/web/meta_skill_discover_test.py
+++ b/lib/tests/streamlit/web/meta_skill_discover_test.py
@@ -42,6 +42,17 @@ _DISCOVER_PY: Final = (
 _SKILL_REL: Final = (
     Path(".agents") / "skills" / "developing-with-streamlit" / "SKILL.md"
 )
+_META_SKILL_MD: Final = _DISCOVER_PY.parent.parent / "SKILL.md"
+
+
+def test_skill_md_documents_cross_agent_launch() -> None:
+    """The meta-skill must be invokable without Claude-only substitutions."""
+    text = _META_SKILL_MD.read_text(encoding="utf-8")
+    assert "Bash(python3 ${CLAUDE_SKILL_DIR}/scripts/discover.py *)" in text
+    assert "Bash(python3 scripts/discover.py *)" in text
+    assert "CURSOR_PROJECT_DIR" in text
+    assert "Cursor" in text
+    assert "Codex" in text
 
 
 @pytest.fixture
@@ -74,6 +85,8 @@ def _hide_inherited_interpreters(
     """Drop VIRTUAL_ENV, CONDA_PREFIX, sys.executable, and PATH lookups."""
     monkeypatch.delenv("VIRTUAL_ENV", raising=False)
     monkeypatch.delenv("CONDA_PREFIX", raising=False)
+    monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+    monkeypatch.delenv("CURSOR_PROJECT_DIR", raising=False)
     monkeypatch.setattr(
         discover_mod.sys, "executable", str(tmp_path / "no-such-python")
     )
@@ -92,6 +105,8 @@ def _run_discover(*cli_args: str) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
     env.pop("VIRTUAL_ENV", None)
     env.pop("CONDA_PREFIX", None)
+    env.pop("CLAUDE_PROJECT_DIR", None)
+    env.pop("CURSOR_PROJECT_DIR", None)
     return subprocess.run(
         [sys.executable, str(_DISCOVER_PY), *cli_args],
         capture_output=True,
@@ -478,6 +493,93 @@ def test_missing_project_dir_warns_and_uses_cwd(
     assert code == 0
     assert "WARNING:" in captured.err
     assert captured.out.strip() == str(skill.resolve())
+
+
+def test_omitted_project_dir_uses_cursor_project_env(
+    tmp_path: Path,
+    discover_mod: ModuleType,
+    isolated_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Cursor's workspace env var is used when ``--project-dir`` is omitted."""
+    project = tmp_path / "app"
+    project.mkdir()
+    skill = _plant_posix_venv(project / ".venv")
+    cwd = tmp_path / "not-the-app"
+    cwd.mkdir()
+    monkeypatch.chdir(cwd)
+    monkeypatch.setenv("CURSOR_PROJECT_DIR", str(project))
+
+    code = discover_mod.main([])
+    captured = capsys.readouterr()
+    assert code == 0
+    assert captured.out.strip() == str(skill.resolve())
+
+
+def test_omitted_project_dir_prefers_claude_over_cursor_env(
+    tmp_path: Path,
+    discover_mod: ModuleType,
+    isolated_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``CLAUDE_PROJECT_DIR`` outranks ``CURSOR_PROJECT_DIR``."""
+    claude_proj = tmp_path / "claude-app"
+    claude_proj.mkdir()
+    claude_skill = _plant_posix_venv(claude_proj / ".venv")
+    cursor_proj = tmp_path / "cursor-app"
+    cursor_proj.mkdir()
+    _plant_posix_venv(cursor_proj / ".venv")
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(claude_proj))
+    monkeypatch.setenv("CURSOR_PROJECT_DIR", str(cursor_proj))
+
+    code = discover_mod.main([])
+    captured = capsys.readouterr()
+    assert code == 0
+    assert captured.out.strip() == str(claude_skill.resolve())
+
+
+def test_explicit_project_dir_overrides_agent_env(
+    tmp_path: Path,
+    discover_mod: ModuleType,
+    isolated_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--project-dir`` wins over harness workspace env vars."""
+    env_proj = tmp_path / "env-app"
+    env_proj.mkdir()
+    _plant_posix_venv(env_proj / ".venv")
+    cli_proj = tmp_path / "cli-app"
+    cli_proj.mkdir()
+    cli_skill = _plant_posix_venv(cli_proj / ".venv")
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(env_proj))
+    monkeypatch.setenv("CURSOR_PROJECT_DIR", str(env_proj))
+
+    code = discover_mod.main(["--project-dir", str(cli_proj)])
+    captured = capsys.readouterr()
+    assert code == 0
+    assert captured.out.strip() == str(cli_skill.resolve())
+
+
+def test_cwd_is_skill_dir_warns_when_no_project_env(
+    tmp_path: Path,
+    discover_mod: ModuleType,
+    isolated_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Warn when cwd is this skill so the agent passes ``--project-dir``."""
+    skill_dir = tmp_path / "developing-with-streamlit"
+    skill_dir.mkdir()
+    monkeypatch.setattr(discover_mod, "_meta_skill_dir", lambda: skill_dir.resolve())
+    monkeypatch.chdir(skill_dir)
+
+    code = discover_mod.main([])
+    captured = capsys.readouterr()
+    assert code != 0
+    assert "this skill's directory" in captured.err
 
 
 def test_python_flag_exclusive_ignores_project_venv(

--- a/lib/tests/streamlit/web/meta_skill_discover_test.py
+++ b/lib/tests/streamlit/web/meta_skill_discover_test.py
@@ -45,14 +45,14 @@ _SKILL_REL: Final = (
 
 
 @pytest.fixture
-def discover_mod() -> ModuleType:
+def discover_mod(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
     """Load ``discover.py`` as a module so helpers can be unit-tested."""
     spec = importlib.util.spec_from_file_location("meta_skill_discover", _DISCOVER_PY)
     assert spec is not None
     assert spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     # Dataclasses look up the module in sys.modules during class creation.
-    sys.modules[spec.name] = module
+    monkeypatch.setitem(sys.modules, spec.name, module)
     spec.loader.exec_module(module)
     return module
 
@@ -103,7 +103,11 @@ def _run_discover(*cli_args: str) -> subprocess.CompletedProcess[str]:
 
 
 def _touch_exe(path: Path) -> Path:
-    """Create an empty placeholder executable file."""
+    """Create an empty placeholder file (not a venv symlink; not ``X_OK``).
+
+    Production lookup checks ``is_file()``, not the executable bit. Dedicated
+    symlink tests cover real POSIX ``bin/python`` links.
+    """
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text("", encoding="utf-8")
     return path
@@ -500,6 +504,44 @@ def test_python_flag_exclusive_ignores_project_venv(
     assert "python-flag" in captured.err
 
 
+def test_relative_python_flag_uses_invocation_cwd_not_project_dir(
+    tmp_path: Path,
+    discover_mod: ModuleType,
+    isolated_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Relative ``--python`` is resolved against cwd, not ``--project-dir``."""
+    invoker = tmp_path / "invoker"
+    other = tmp_path / "other-project"
+    invoker.mkdir()
+    other.mkdir()
+    invoker_py = _touch_exe(invoker / ".venv" / "bin" / "python")
+    other_py = _touch_exe(other / ".venv" / "bin" / "python")
+
+    seen: list[list[str]] = []
+
+    def fake_run(
+        argv: list[str], *_args: object, **_kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        seen.append(list(argv))
+        return _subprocess_reports_no_streamlit()
+
+    monkeypatch.chdir(invoker)
+    monkeypatch.setattr(discover_mod.subprocess, "run", fake_run)
+
+    code = discover_mod.main(
+        ["--python", ".venv/bin/python", "--project-dir", str(other)]
+    )
+    captured = capsys.readouterr()
+    assert code == 1
+    assert captured.err.startswith("ERROR[NO_STREAMLIT]:")
+    assert seen
+    assert Path(seen[0][0]) == discover_mod._absolute_no_follow(invoker_py)
+    assert Path(seen[0][0]) != discover_mod._absolute_no_follow(other_py)
+    assert Path(seen[0][0]).is_absolute()
+
+
 def test_bad_python_flag_is_invalid_args(
     tmp_path: Path,
     discover_mod: ModuleType,
@@ -684,6 +726,27 @@ def test_duplicate_git_root_venv_is_skipped(
     assert tags == ["venv-local"]
 
 
+def test_install_advice_follows_first_inspected_attempt(
+    tmp_path: Path, discover_mod: ModuleType
+) -> None:
+    """Upgrade advice must follow the first inspected attempt, not the first probe."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    attempts = [
+        discover_mod._Attempt(
+            "venv-local", "/bad/python", "probe_failed", ["/bad/python"]
+        ),
+        discover_mod._Attempt(
+            "virtual-env", "/good/python", "no_usable_skill", ["/good/python"]
+        ),
+    ]
+    advice = discover_mod._install_advice(project, attempts)
+    assert "upgrade or reinstall" in advice
+    assert "--upgrade" in advice
+    assert "/good/python" in advice
+    assert "/bad/python" not in advice
+
+
 def test_install_advice_prefers_uv_and_is_quoted(
     tmp_path: Path,
     discover_mod: ModuleType,
@@ -849,6 +912,30 @@ def test_pth_hits_via_subprocess_not_filesystem(tmp_path: Path) -> None:
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == str(skill.resolve())
     assert "venv-local" in result.stderr
+
+
+def test_filesystem_no_usable_skill_kept_when_probe_fails(
+    tmp_path: Path,
+    discover_mod: ModuleType,
+    isolated_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A filesystem ``no_usable_skill`` must outrank a later probe timeout."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    _plant_posix_venv(project / ".venv", with_skill=False)
+
+    def _boom(*_args: object, **_kwargs: object) -> None:
+        raise subprocess.TimeoutExpired(cmd="python", timeout=10)
+
+    monkeypatch.setattr(discover_mod.subprocess, "run", _boom)
+
+    code = discover_mod.main(["--project-dir", str(project)])
+    captured = capsys.readouterr()
+    assert code == 2
+    assert captured.err.startswith("ERROR[NO_USABLE_SKILL]:")
+    assert "ERROR[PROBE_FAILED]" not in captured.err
 
 
 def test_unusable_filesystem_hit_falls_through_to_subprocess(

--- a/lib/tests/streamlit/web/meta_skill_discover_test.py
+++ b/lib/tests/streamlit/web/meta_skill_discover_test.py
@@ -1,0 +1,859 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Guardrails for the vendored meta-skill ``discover.py`` script."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+import streamlit
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+_DISCOVER_PY = (
+    Path(streamlit.__file__).resolve().parent
+    / ".agents"
+    / "meta-skill"
+    / "developing-with-streamlit"
+    / "scripts"
+    / "discover.py"
+)
+_DOCS_URL = "https://docs.streamlit.io/llms-full.txt"
+_SKILL_REL = Path(".agents") / "skills" / "developing-with-streamlit" / "SKILL.md"
+
+
+@pytest.fixture
+def discover_mod() -> ModuleType:
+    """Load ``discover.py`` as a module so helpers can be unit-tested."""
+    spec = importlib.util.spec_from_file_location("meta_skill_discover", _DISCOVER_PY)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    # Dataclasses look up the module in sys.modules during class creation.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def isolated_env(
+    monkeypatch: pytest.MonkeyPatch, discover_mod: ModuleType, tmp_path: Path
+) -> None:
+    """Hide inherited interpreters so tests control the candidate list."""
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    monkeypatch.delenv("CONDA_PREFIX", raising=False)
+    monkeypatch.setattr(
+        discover_mod.sys, "executable", str(tmp_path / "no-such-python")
+    )
+    monkeypatch.setattr(discover_mod.shutil, "which", lambda _name: None)
+    # Planted fixtures use POSIX ``bin/python`` layouts. Force that lookup
+    # so these helper tests also pass on the Windows CI job.
+    monkeypatch.setattr(discover_mod, "_IS_WINDOWS", False)
+
+
+def _touch_exe(path: Path) -> Path:
+    """Create an empty placeholder executable file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("", encoding="utf-8")
+    return path
+
+
+def _plant_skill(pkg: Path, content: str = "# skill\n") -> Path:
+    """Write a Streamlit package tree with the bundled content skill."""
+    pkg.mkdir(parents=True, exist_ok=True)
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    skill = pkg / _SKILL_REL
+    skill.parent.mkdir(parents=True, exist_ok=True)
+    skill.write_text(content, encoding="utf-8")
+    return skill
+
+
+def _posix_site_packages(prefix: Path, version: str = "python3.12") -> Path:
+    """Return ``prefix/lib/<version>/site-packages``, creating it."""
+    site_packages = prefix / "lib" / version / "site-packages"
+    site_packages.mkdir(parents=True, exist_ok=True)
+    return site_packages
+
+
+def _plant_posix_venv(root: Path, *, with_skill: bool = True) -> Path | None:
+    """Plant a POSIX-style venv prefix with ``bin/python`` and optional skill."""
+    _touch_exe(root / "bin" / "python")
+    pkg = _posix_site_packages(root) / "streamlit"
+    pkg.mkdir(parents=True, exist_ok=True)
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    if with_skill:
+        return _plant_skill(pkg)
+    return None
+
+
+def _venv_site_packages(venv_root: Path) -> Path:
+    """Return site-packages of a real ``python -m venv`` tree."""
+    if os.name == "nt":
+        return venv_root / "Lib" / "site-packages"
+    matches = sorted(venv_root.glob("lib/python*/site-packages"))
+    assert matches, f"no site-packages under {venv_root}"
+    return matches[0]
+
+
+def _create_venv(path: Path) -> Path:
+    """Create a real virtualenv at ``path``."""
+    subprocess.run(
+        [sys.executable, "-m", "venv", str(path)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return path
+
+
+def test_iter_candidates_order(
+    tmp_path: Path,
+    discover_mod: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Candidates follow the spec order: project venvs, then env vars, then sys."""
+    monkeypatch.setattr(discover_mod, "_IS_WINDOWS", False)
+    repo = tmp_path / "repo"
+    pkg = repo / "pkg"
+    project = pkg / "app"
+    project.mkdir(parents=True)
+    (repo / ".git").mkdir()
+
+    _plant_posix_venv(project / ".venv")
+    parent_venv = pkg / "venv"
+    _plant_posix_venv(parent_venv)
+    (parent_venv / "pyvenv.cfg").write_text("home = x\n", encoding="utf-8")
+    _plant_posix_venv(repo / ".venv")
+
+    virtual_env = tmp_path / "agent-venv"
+    _plant_posix_venv(virtual_env)
+    conda = tmp_path / "conda"
+    _plant_posix_venv(conda)
+    sys_py = _touch_exe(tmp_path / "sys" / "bin" / "python")
+    python3 = _touch_exe(tmp_path / "system" / "python3")
+    python = _touch_exe(tmp_path / "system" / "python")
+    uv_bin = _touch_exe(tmp_path / "bin" / "uv")
+    (project / "uv.lock").write_text("", encoding="utf-8")
+
+    monkeypatch.setenv("VIRTUAL_ENV", str(virtual_env))
+    monkeypatch.setenv("CONDA_PREFIX", str(conda))
+    monkeypatch.setattr(discover_mod.sys, "executable", str(sys_py))
+
+    which_map = {
+        "uv": str(uv_bin),
+        "python3": str(python3),
+        "python": str(python),
+    }
+    monkeypatch.setattr(discover_mod.shutil, "which", which_map.get)
+
+    candidates = discover_mod._iter_candidates(project, python_flag=None)
+    tags = [candidate.tag for candidate in candidates]
+    assert tags == [
+        "venv-local",
+        "venv-parent",
+        "venv-git-root",
+        "virtual-env",
+        "conda",
+        "sys-executable",
+        "uv",
+        "system",
+        "system",
+    ]
+    assert candidates[6].argv == ["uv", "run", "--no-sync", "--quiet", "python"]
+    assert candidates[7].argv[0] == str(python3)
+    assert candidates[8].argv[0] == str(python)
+
+
+def test_python_flag_is_exclusive(
+    tmp_path: Path, discover_mod: ModuleType, isolated_env: None
+) -> None:
+    """``--python`` returns only that candidate."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    _plant_posix_venv(project / ".venv")
+    chosen = _touch_exe(tmp_path / "chosen" / "bin" / "python")
+
+    candidates = discover_mod._iter_candidates(project, python_flag=chosen)
+    assert len(candidates) == 1
+    assert candidates[0].tag == "python-flag"
+    assert candidates[0].argv == [str(chosen)]
+
+
+def test_project_venv_beats_virtual_env(
+    tmp_path: Path,
+    discover_mod: ModuleType,
+    isolated_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Project ``.venv`` wins over a stale ``$VIRTUAL_ENV``."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    project_skill = _plant_posix_venv(project / ".venv", with_skill=True)
+    agent = tmp_path / "agent-venv"
+    _plant_posix_venv(agent, with_skill=True)
+    monkeypatch.setenv("VIRTUAL_ENV", str(agent))
+
+    code = discover_mod.main(["--project-dir", str(project)])
+    captured = capsys.readouterr()
+    assert code == 0
+    assert captured.out.strip() == str(project_skill.resolve())
+
+
+def test_unusable_skill_is_not_terminal(
+    tmp_path: Path,
+    discover_mod: ModuleType,
+    isolated_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """An old Streamlit in the project venv does not stop a later usable skill."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    _plant_posix_venv(project / ".venv", with_skill=False)
+    later = tmp_path / "later-venv"
+    later_skill = _plant_posix_venv(later, with_skill=True)
+    monkeypatch.setenv("VIRTUAL_ENV", str(later))
+
+    code = discover_mod.main(["--project-dir", str(project)])
+    captured = capsys.readouterr()
+    assert code == 0
+    assert captured.out.strip() == str(later_skill.resolve())
+
+
+def test_layout_changed_does_not_outrank_earlier_no_streamlit(
+    tmp_path: Path,
+    discover_mod: ModuleType,
+    isolated_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Final error is the highest-priority inspected candidate, not worst severity."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    _touch_exe(project / ".venv" / "bin" / "python")
+    later = tmp_path / "later-venv"
+    _touch_exe(later / "bin" / "python")
+    pkg = _posix_site_packages(later) / "streamlit"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    (pkg / ".agents" / "skills").mkdir(parents=True)
+    monkeypatch.setenv("VIRTUAL_ENV", str(later))
+
+    def _fake_run(
+        *_args: object, **_kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(["python"], 0, stdout="", stderr="")
+
+    monkeypatch.setattr(discover_mod.subprocess, "run", _fake_run)
+
+    code = discover_mod.main(["--project-dir", str(project)])
+    captured = capsys.readouterr()
+    assert code == 1
+    assert captured.err.startswith("ERROR[NO_STREAMLIT]:")
+    assert "ERROR[SKILLS_LAYOUT_CHANGED]" not in captured.err
+    assert _DOCS_URL in captured.err
+
+
+def test_lone_streamlit_py_is_rejected(
+    tmp_path: Path, discover_mod: ModuleType
+) -> None:
+    """A shadowed ``streamlit.py`` file is not a usable package."""
+    lone = tmp_path / "streamlit.py"
+    lone.write_text("print('nope')\n", encoding="utf-8")
+    assert discover_mod._is_usable_package_dir(lone) is False
+
+
+def test_in_tree_streamlit_package_is_accepted(discover_mod: ModuleType) -> None:
+    """The in-tree ``lib/streamlit`` package (editable checkout) is accepted."""
+    pkg = Path(streamlit.__file__).resolve().parent
+    assert pkg.name == "streamlit"
+    assert discover_mod._is_usable_package_dir(pkg) is True
+
+
+def test_sentinel_last_wins(discover_mod: ModuleType, tmp_path: Path) -> None:
+    """The parent keeps the last ``STREAMLIT_PKG=`` line, not a banner."""
+    blob = (
+        "hello from sitecustomize\n"
+        "STREAMLIT_PKG=/wrong\n"
+        "banner STREAMLIT_PKG=/nope\n"
+        f"STREAMLIT_PKG={tmp_path / 'right'}\n"
+    )
+    assert discover_mod._parse_streamlit_pkg(blob) == tmp_path / "right"
+
+
+def test_store_alias_skipped_only_for_windowsapps_dir(
+    tmp_path: Path,
+    discover_mod: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Skip App Execution Alias stubs, not every path containing WindowsApps."""
+    monkeypatch.setattr(discover_mod, "_IS_WINDOWS", True)
+    local = tmp_path / "la"
+    alias = local / "Microsoft" / "WindowsApps" / "python.exe"
+    _touch_exe(alias)
+    real = local / "Programs" / "Python" / "python.exe"
+    _touch_exe(real)
+    trick = tmp_path / "WindowsAppsStore" / "python.exe"
+    _touch_exe(trick)
+    monkeypatch.setenv("LOCALAPPDATA", str(local))
+
+    assert discover_mod._is_windows_store_alias(alias) is True
+    assert discover_mod._is_windows_store_alias(real) is False
+    assert discover_mod._is_windows_store_alias(trick) is False
+
+
+def test_conda_python_exe_on_windows(
+    tmp_path: Path,
+    discover_mod: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Windows conda prefixes expose ``python.exe`` next to the root."""
+    monkeypatch.setattr(discover_mod, "_IS_WINDOWS", True)
+    prefix = tmp_path / "conda"
+    root_exe = _touch_exe(prefix / "python.exe")
+    assert discover_mod.find_venv_python(prefix) == root_exe
+
+    scripts = tmp_path / "venv"
+    scripts_exe = _touch_exe(scripts / "Scripts" / "python.exe")
+    assert discover_mod.find_venv_python(scripts) == scripts_exe
+
+
+def test_unexpanded_project_dir_warns_and_uses_cwd(
+    tmp_path: Path,
+    discover_mod: ModuleType,
+    isolated_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A literal ``${CLAUDE_PROJECT_DIR}`` is a warning, not ``INVALID_ARGS``."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    skill = _plant_posix_venv(project / ".venv")
+    monkeypatch.chdir(project)
+
+    code = discover_mod.main(["--project-dir", "${CLAUDE_PROJECT_DIR}"])
+    captured = capsys.readouterr()
+    assert code == 0
+    assert "WARNING:" in captured.err
+    assert "ERROR[INVALID_ARGS]" not in captured.err
+    assert captured.out.strip() == str(skill.resolve())
+
+
+def test_missing_project_dir_warns_and_uses_cwd(
+    tmp_path: Path,
+    discover_mod: ModuleType,
+    isolated_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A path that does not exist warns and falls back to cwd."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    skill = _plant_posix_venv(project / ".venv")
+    monkeypatch.chdir(project)
+
+    code = discover_mod.main(["--project-dir", str(tmp_path / "missing")])
+    captured = capsys.readouterr()
+    assert code == 0
+    assert "WARNING:" in captured.err
+    assert captured.out.strip() == str(skill.resolve())
+
+
+def test_python_flag_exclusive_ignores_project_venv(
+    tmp_path: Path,
+    discover_mod: ModuleType,
+    isolated_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--python`` does not fall through to a project venv that has a skill."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    _plant_posix_venv(project / ".venv")
+    chosen = _touch_exe(tmp_path / "chosen" / "bin" / "python")
+
+    def _fake_run(
+        *_args: object, **_kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(["python"], 0, stdout="", stderr="")
+
+    monkeypatch.setattr(discover_mod.subprocess, "run", _fake_run)
+
+    code = discover_mod.main(["--project-dir", str(project), "--python", str(chosen)])
+    captured = capsys.readouterr()
+    assert code == 1
+    assert captured.err.startswith("ERROR[NO_STREAMLIT]:")
+    assert "python-flag" in captured.err
+
+
+def test_bad_python_flag_is_invalid_args(
+    tmp_path: Path,
+    discover_mod: ModuleType,
+    isolated_env: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A missing ``--python`` path is a hard ``ERROR[INVALID_ARGS]``."""
+    code = discover_mod.main(["--python", str(tmp_path / "missing-python")])
+    captured = capsys.readouterr()
+    assert code == 5
+    assert captured.err.startswith("ERROR[INVALID_ARGS]:")
+    assert _DOCS_URL in captured.err
+
+
+def test_unknown_flag_is_invalid_args(
+    discover_mod: ModuleType, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Unknown flags start with ``ERROR[INVALID_ARGS]`` and exit 5."""
+    code = discover_mod.main(["--nope"])
+    captured = capsys.readouterr()
+    assert code == 5
+    assert captured.err.startswith("ERROR[INVALID_ARGS]:")
+    assert _DOCS_URL in captured.err
+
+
+def test_budget_marks_remaining_candidates_not_tried(
+    tmp_path: Path,
+    discover_mod: ModuleType,
+    isolated_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """After the subprocess budget is exhausted, later candidates are ``not tried``."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    _touch_exe(project / ".venv" / "bin" / "python")
+    later = tmp_path / "later-venv"
+    _touch_exe(later / "bin" / "python")
+    monkeypatch.setenv("VIRTUAL_ENV", str(later))
+
+    def _fake_run(
+        *_args: object, **_kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(["python"], 0, stdout="", stderr="")
+
+    times = iter([0.0, 60.0])
+    monkeypatch.setattr(discover_mod.subprocess, "run", _fake_run)
+    monkeypatch.setattr(discover_mod.time, "monotonic", lambda: next(times))
+
+    code = discover_mod.main(["--project-dir", str(project)])
+    captured = capsys.readouterr()
+    assert code == 1
+    assert "not_tried" in captured.err
+
+
+def test_probe_failed_when_nothing_inspected(
+    tmp_path: Path,
+    discover_mod: ModuleType,
+    isolated_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Timeouts/stubs with no successful inspection are ``PROBE_FAILED``, not missing Streamlit."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    _touch_exe(project / ".venv" / "bin" / "python")
+
+    def _boom(*_args: object, **_kwargs: object) -> None:
+        raise subprocess.TimeoutExpired(cmd="python", timeout=10)
+
+    monkeypatch.setattr(discover_mod.subprocess, "run", _boom)
+
+    code = discover_mod.main(["--project-dir", str(project)])
+    captured = capsys.readouterr()
+    assert code == 7
+    assert captured.err.startswith("ERROR[PROBE_FAILED]:")
+    assert "ERROR[NO_STREAMLIT]" not in captured.err
+    assert _DOCS_URL in captured.err
+
+
+def test_skip_py_launcher_when_missing(
+    tmp_path: Path,
+    discover_mod: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Windows ``py -3`` is omitted when ``py`` is not on PATH."""
+    monkeypatch.setattr(discover_mod, "_IS_WINDOWS", True)
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    monkeypatch.delenv("CONDA_PREFIX", raising=False)
+    monkeypatch.setattr(
+        discover_mod.sys, "executable", str(tmp_path / "no-such-python")
+    )
+    monkeypatch.setattr(discover_mod.shutil, "which", lambda _name: None)
+    project = tmp_path / "proj"
+    project.mkdir()
+    tags = [c.tag for c in discover_mod._iter_candidates(project, python_flag=None)]
+    assert "py-launcher" not in tags
+
+
+@pytest.mark.parametrize(
+    ("is_windows", "expected_first"),
+    [
+        (True, "python"),
+        (False, "python3"),
+    ],
+)
+def test_system_interpreter_order(
+    tmp_path: Path,
+    discover_mod: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    is_windows: bool,
+    expected_first: str,
+) -> None:
+    """Windows prefers ``python`` then ``python3``; POSIX the reverse."""
+    monkeypatch.setattr(discover_mod, "_IS_WINDOWS", is_windows)
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    monkeypatch.delenv("CONDA_PREFIX", raising=False)
+    monkeypatch.setattr(
+        discover_mod.sys, "executable", str(tmp_path / "no-such-python")
+    )
+    python = _touch_exe(tmp_path / "python")
+    python3 = _touch_exe(tmp_path / "python3")
+    which_map = {"python": str(python), "python3": str(python3)}
+    monkeypatch.setattr(discover_mod.shutil, "which", which_map.get)
+    project = tmp_path / "proj"
+    project.mkdir()
+    system = [
+        c
+        for c in discover_mod._iter_candidates(project, python_flag=None)
+        if c.tag == "system"
+    ]
+    assert [Path(c.argv[0]).name for c in system] == (
+        ["python", "python3"] if expected_first == "python" else ["python3", "python"]
+    )
+
+
+def test_uv_argv_includes_no_sync(
+    tmp_path: Path,
+    discover_mod: ModuleType,
+    isolated_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The uv manager candidate must pass ``--no-sync`` so discovery never installs."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    (project / "uv.lock").write_text("", encoding="utf-8")
+    monkeypatch.setattr(
+        discover_mod.shutil,
+        "which",
+        lambda name: "/usr/bin/uv" if name == "uv" else None,
+    )
+    candidates = discover_mod._iter_candidates(project, python_flag=None)
+    uv = next(c for c in candidates if c.tag == "uv")
+    assert uv.argv == ["uv", "run", "--no-sync", "--quiet", "python"]
+    assert uv.kind == "manager"
+
+
+def test_git_walk_caps_at_twenty(tmp_path: Path, discover_mod: ModuleType) -> None:
+    """The git-root walk stops after 20 ancestors, matching ``skills.py``."""
+    current = tmp_path
+    (tmp_path / ".git").mkdir()
+    for index in range(25):
+        current /= f"d{index}"
+    current.mkdir(parents=True)
+    assert discover_mod.find_git_root(current) is None
+    shallow = tmp_path / "d0" / "d1"
+    assert discover_mod.find_git_root(shallow) == tmp_path.resolve()
+
+
+def test_venv_dir_requires_pyvenv_cfg(
+    tmp_path: Path, discover_mod: ModuleType, isolated_env: None
+) -> None:
+    """``venv/`` is listed only when ``pyvenv.cfg`` exists; ``.venv`` always is."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    _touch_exe(project / "venv" / "bin" / "python")
+    tags = [c.tag for c in discover_mod._iter_candidates(project, python_flag=None)]
+    assert "venv-local" not in tags
+
+    (project / "venv" / "pyvenv.cfg").write_text("home = x\n", encoding="utf-8")
+    tags = [c.tag for c in discover_mod._iter_candidates(project, python_flag=None)]
+    assert "venv-local" in tags
+
+    _touch_exe(project / ".venv" / "bin" / "python")
+    tags = [c.tag for c in discover_mod._iter_candidates(project, python_flag=None)]
+    assert tags.count("venv-local") == 2
+
+
+def test_duplicate_git_root_venv_is_skipped(
+    tmp_path: Path, discover_mod: ModuleType, isolated_env: None
+) -> None:
+    """When the project dir is the git root, do not emit ``venv-git-root``."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    (project / ".git").mkdir()
+    _plant_posix_venv(project / ".venv")
+    tags = [c.tag for c in discover_mod._iter_candidates(project, python_flag=None)]
+    assert tags == ["venv-local"]
+
+
+def test_install_advice_prefers_uv_and_is_quoted(
+    tmp_path: Path,
+    discover_mod: ModuleType,
+    isolated_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Failure stderr quotes install advice, prefers uv, and never suggests ``source activate``."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    _touch_exe(project / ".venv" / "bin" / "python")
+    (project / "uv.lock").write_text("", encoding="utf-8")
+
+    def _fake_run(
+        *_args: object, **_kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(["python"], 0, stdout="", stderr="")
+
+    monkeypatch.setattr(discover_mod.subprocess, "run", _fake_run)
+
+    code = discover_mod.main(["--project-dir", str(project)])
+    captured = capsys.readouterr()
+    assert code == 1
+    assert "uv add streamlit" in captured.err
+    assert "source " not in captured.err
+    assert "activate" not in captured.err
+    assert captured.err.strip().endswith(_DOCS_URL)
+    assert captured.err.startswith("ERROR[NO_STREAMLIT]:")
+
+
+def test_success_stdout_is_one_line_verbose_on_stderr(
+    tmp_path: Path,
+    discover_mod: ModuleType,
+    isolated_env: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Success prints exactly one path on stdout; ``--verbose`` logs the winner on stderr."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    skill = _plant_posix_venv(project / ".venv")
+    code = discover_mod.main(["--project-dir", str(project), "--verbose"])
+    captured = capsys.readouterr()
+    assert code == 0
+    assert captured.out.splitlines() == [str(skill.resolve())]
+    assert captured.err.startswith("discovered via: venv-local ")
+    assert str(project / ".venv" / "bin" / "python") in captured.err
+
+
+def test_msys_project_dir_on_windows(
+    tmp_path: Path,
+    discover_mod: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Light MSYS ``/c/...`` paths become ``C:\\...`` on Windows."""
+    monkeypatch.setattr(discover_mod, "_IS_WINDOWS", True)
+    converted = discover_mod._maybe_msys_path("/c/Users/me/app")
+    assert converted == "C:\\Users\\me\\app"
+    assert discover_mod._maybe_msys_path("/usr/bin") == "/usr/bin"
+
+
+def test_windows_filesystem_lookup_layout(
+    tmp_path: Path,
+    discover_mod: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Windows filesystem lookup uses ``Lib\\site-packages\\streamlit``."""
+    monkeypatch.setattr(discover_mod, "_IS_WINDOWS", True)
+    prefix = tmp_path / "venv"
+    pkg = prefix / "Lib" / "site-packages" / "streamlit"
+    skill = _plant_skill(pkg)
+    assert discover_mod._filesystem_lookup(prefix) == pkg
+    classified = discover_mod._classify_package(pkg)
+    assert classified == skill.resolve()
+
+
+def test_no_project_python_when_nothing_started(
+    tmp_path: Path,
+    discover_mod: ModuleType,
+    isolated_env: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """No candidates at all is ``NO_PROJECT_PYTHON``."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    code = discover_mod.main(["--project-dir", str(project)])
+    captured = capsys.readouterr()
+    assert code == 3
+    assert captured.err.startswith("ERROR[NO_PROJECT_PYTHON]:")
+    assert _DOCS_URL in captured.err
+
+
+def test_fake_venv_e2e_discovers_planted_skill(tmp_path: Path) -> None:
+    """End-to-end: a real project ``.venv`` with a planted skill is discovered."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    venv = _create_venv(project / ".venv")
+    skill = _plant_skill(_venv_site_packages(venv) / "streamlit", content="# e2e\n")
+    env = os.environ.copy()
+    env.pop("VIRTUAL_ENV", None)
+    env.pop("CONDA_PREFIX", None)
+    result = subprocess.run(
+        [sys.executable, str(_DISCOVER_PY), "--project-dir", str(project), "--verbose"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.splitlines() == [str(skill.resolve())]
+    assert "discovered via: venv-local" in result.stderr
+
+
+def test_fake_venv_e2e_project_path_with_space(tmp_path: Path) -> None:
+    """Discovery works when the project directory contains a space."""
+    project = tmp_path / "my project"
+    project.mkdir()
+    venv = _create_venv(project / ".venv")
+    skill = _plant_skill(_venv_site_packages(venv) / "streamlit")
+    env = os.environ.copy()
+    env.pop("VIRTUAL_ENV", None)
+    env.pop("CONDA_PREFIX", None)
+    result = subprocess.run(
+        [sys.executable, str(_DISCOVER_PY), "--project-dir", str(project)],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == str(skill.resolve())
+
+
+def test_pth_hits_via_subprocess_not_filesystem(tmp_path: Path) -> None:
+    """Stage 1 misses site-packages; stage 2 finds Streamlit via a ``.pth`` file."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    venv = _create_venv(project / ".venv")
+    site_packages = _venv_site_packages(venv)
+    ext = project / "editable_src"
+    skill = _plant_skill(ext / "streamlit")
+    (site_packages / "discover_editable.pth").write_text(
+        str(ext.resolve()) + "\n", encoding="utf-8"
+    )
+    assert not (site_packages / "streamlit").exists()
+
+    env = os.environ.copy()
+    env.pop("VIRTUAL_ENV", None)
+    env.pop("CONDA_PREFIX", None)
+    result = subprocess.run(
+        [sys.executable, str(_DISCOVER_PY), "--project-dir", str(project), "--verbose"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == str(skill.resolve())
+    assert "venv-local" in result.stderr
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows venv layout smoke")
+def test_windows_filesystem_layout_smoke(tmp_path: Path) -> None:
+    """Plant ``Lib\\site-packages`` in a real Windows venv; stage 1 must hit."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    venv = _create_venv(project / ".venv")
+    python = venv / "Scripts" / "python.exe"
+    assert python.is_file()
+    lib_pkg = venv / "Lib" / "site-packages" / "streamlit"
+    skill = _plant_skill(lib_pkg)
+    env = os.environ.copy()
+    env.pop("VIRTUAL_ENV", None)
+    env.pop("CONDA_PREFIX", None)
+    result = subprocess.run(
+        [sys.executable, str(_DISCOVER_PY), "--project-dir", str(project), "--verbose"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == str(skill.resolve())
+    assert "venv-local" in result.stderr
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows .pth subprocess smoke")
+def test_windows_pth_subprocess_smoke(tmp_path: Path) -> None:
+    """Do not plant under ``Lib\\site-packages``; hit via ``.venv\\Scripts\\python.exe``."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    venv = _create_venv(project / ".venv")
+    site_packages = venv / "Lib" / "site-packages"
+    ext = project / "editable_src"
+    skill = _plant_skill(ext / "streamlit")
+    (site_packages / "discover_editable.pth").write_text(
+        str(ext.resolve()) + "\n", encoding="utf-8"
+    )
+    env = os.environ.copy()
+    env.pop("VIRTUAL_ENV", None)
+    env.pop("CONDA_PREFIX", None)
+    result = subprocess.run(
+        [sys.executable, str(_DISCOVER_PY), "--project-dir", str(project), "--verbose"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == str(skill.resolve())
+    python = venv / "Scripts" / "python.exe"
+    assert str(python) in result.stderr or python.name.lower() in result.stderr.lower()
+
+
+def test_posix_prefers_skill_bearing_python_tree(
+    tmp_path: Path, discover_mod: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If several ``lib/python*`` trees exist, prefer one that already has the skill."""
+    monkeypatch.setattr(discover_mod, "_IS_WINDOWS", False)
+    prefix = tmp_path / "venv"
+    old_pkg = _posix_site_packages(prefix, "python3.10") / "streamlit"
+    old_pkg.mkdir(parents=True)
+    (old_pkg / "__init__.py").write_text("", encoding="utf-8")
+    new_pkg = _posix_site_packages(prefix, "python3.12") / "streamlit"
+    _plant_skill(new_pkg)
+    assert discover_mod._filesystem_lookup(prefix) == new_pkg
+
+
+def test_tilde_project_dir_expands(
+    tmp_path: Path,
+    discover_mod: ModuleType,
+    isolated_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--project-dir ~/...`` expands using ``HOME`` / ``USERPROFILE``."""
+    home = tmp_path / "home"
+    project = home / "proj"
+    project.mkdir(parents=True)
+    skill = _plant_posix_venv(project / ".venv")
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    code = discover_mod.main(["--project-dir", os.path.join("~", "proj")])
+    captured = capsys.readouterr()
+    assert code == 0
+    assert captured.out.strip() == str(skill.resolve())

--- a/lib/tests/streamlit/web/meta_skill_discover_test.py
+++ b/lib/tests/streamlit/web/meta_skill_discover_test.py
@@ -25,13 +25,14 @@ from typing import TYPE_CHECKING, Final
 
 import pytest
 
-import streamlit
-
 if TYPE_CHECKING:
     from types import ModuleType
 
+# Locate files from this test module so Windows CI can run without importing
+# Streamlit (generated protobufs are not present in that job).
+_LIB_STREAMLIT: Final = Path(__file__).resolve().parents[3] / "streamlit"
 _DISCOVER_PY: Final = (
-    Path(streamlit.__file__).resolve().parent
+    _LIB_STREAMLIT
     / ".agents"
     / "meta-skill"
     / "developing-with-streamlit"
@@ -106,6 +107,16 @@ def _touch_exe(path: Path) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text("", encoding="utf-8")
     return path
+
+
+def _symlink_or_skip(link: Path, target: Path) -> Path:
+    """Create ``link`` -> ``target``, or skip when the host cannot symlink."""
+    link.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        link.symlink_to(target)
+    except OSError as exc:
+        pytest.skip(f"cannot create symlink: {exc}")
+    return link
 
 
 def _plant_skill(pkg: Path, content: str = "# skill\n") -> Path:
@@ -229,6 +240,64 @@ def test_python_flag_is_exclusive(
     assert candidates[0].argv == [str(chosen)]
 
 
+def test_prefix_from_python_does_not_follow_venv_symlink(
+    tmp_path: Path, discover_mod: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A venv ``bin/python`` symlink must keep the venv prefix, not the base install."""
+    monkeypatch.setattr(discover_mod, "_IS_WINDOWS", False)
+    base_py = _touch_exe(tmp_path / "usr" / "bin" / "python")
+    venv_py = _symlink_or_skip(tmp_path / "venv" / "bin" / "python", base_py)
+    assert discover_mod._prefix_from_python(venv_py) == tmp_path / "venv"
+
+
+def test_python_flag_symlink_does_not_use_base_install_skill(
+    tmp_path: Path,
+    discover_mod: ModuleType,
+    isolated_env: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--python`` on a venv symlink must not short-circuit to the base install skill."""
+    base_py = _touch_exe(tmp_path / "usr" / "bin" / "python")
+    _plant_skill(
+        _posix_site_packages(tmp_path / "usr") / "streamlit", content="# base\n"
+    )
+    venv = tmp_path / "venv"
+    venv_py = _symlink_or_skip(venv / "bin" / "python", base_py)
+    venv_skill = _plant_skill(
+        _posix_site_packages(venv) / "streamlit", content="# venv\n"
+    )
+
+    code = discover_mod.main(["--python", str(venv_py)])
+    captured = capsys.readouterr()
+    assert code == 0
+    assert captured.out.strip() == str(venv_skill.resolve())
+
+
+def test_distinct_venv_python_symlinks_are_not_deduped(
+    tmp_path: Path,
+    discover_mod: ModuleType,
+    isolated_env: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Two venvs that share a resolved interpreter must both be inspected."""
+    target = _touch_exe(tmp_path / "cpython" / "bin" / "python")
+    project = tmp_path / "proj"
+    project.mkdir()
+    _symlink_or_skip(project / ".venv" / "bin" / "python", target)
+    local_pkg = _posix_site_packages(project / ".venv") / "streamlit"
+    local_pkg.mkdir(parents=True)
+    (local_pkg / "__init__.py").write_text("", encoding="utf-8")
+
+    parent_venv = tmp_path / ".venv"
+    _symlink_or_skip(parent_venv / "bin" / "python", target)
+    parent_skill = _plant_skill(_posix_site_packages(parent_venv) / "streamlit")
+
+    code = discover_mod.main(["--project-dir", str(project)])
+    captured = capsys.readouterr()
+    assert code == 0
+    assert captured.out.strip() == str(parent_skill.resolve())
+
+
 def test_project_venv_beats_virtual_env(
     tmp_path: Path,
     discover_mod: ModuleType,
@@ -313,7 +382,7 @@ def test_lone_streamlit_py_is_rejected(
 
 def test_in_tree_streamlit_package_is_accepted(discover_mod: ModuleType) -> None:
     """The in-tree ``lib/streamlit`` package (editable checkout) is accepted."""
-    pkg = Path(streamlit.__file__).resolve().parent
+    pkg = _LIB_STREAMLIT
     assert pkg.name == "streamlit"
     assert discover_mod._is_usable_package_dir(pkg) is True
 
@@ -642,6 +711,29 @@ def test_install_advice_prefers_uv_and_is_quoted(
     assert captured.err.startswith("ERROR[NO_STREAMLIT]:")
 
 
+def test_install_advice_quotes_venv_python_with_space(
+    tmp_path: Path,
+    discover_mod: ModuleType,
+    isolated_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Install advice quotes a venv interpreter whose path contains a space."""
+    project = tmp_path / "my project"
+    project.mkdir()
+    python = _touch_exe(project / ".venv" / "bin" / "python")
+
+    monkeypatch.setattr(
+        discover_mod.subprocess, "run", _subprocess_reports_no_streamlit
+    )
+
+    code = discover_mod.main(["--project-dir", str(project)])
+    captured = capsys.readouterr()
+    assert code == 1
+    quoted = discover_mod.shlex.quote(str(python))
+    assert f"{quoted} -m pip install streamlit" in captured.err
+
+
 def test_success_stdout_is_one_line_verbose_on_stderr(
     tmp_path: Path,
     discover_mod: ModuleType,
@@ -686,6 +778,19 @@ def test_windows_filesystem_lookup_layout(
     status, classified = discover_mod._classify_package(pkg)
     assert status == "usable"
     assert classified == skill.resolve()
+
+
+def test_filesystem_lookup_requires_init_py(
+    tmp_path: Path, discover_mod: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A ``streamlit`` directory without ``__init__.py`` is a filesystem miss."""
+    monkeypatch.setattr(discover_mod, "_IS_WINDOWS", False)
+    prefix = tmp_path / "venv"
+    pkg = _posix_site_packages(prefix) / "streamlit"
+    pkg.mkdir(parents=True)
+    assert discover_mod._filesystem_lookup(prefix) is None
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    assert discover_mod._filesystem_lookup(prefix) == pkg
 
 
 def test_no_project_python_when_nothing_started(
@@ -744,6 +849,32 @@ def test_pth_hits_via_subprocess_not_filesystem(tmp_path: Path) -> None:
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == str(skill.resolve())
     assert "venv-local" in result.stderr
+
+
+def test_unusable_filesystem_hit_falls_through_to_subprocess(
+    tmp_path: Path,
+    discover_mod: ModuleType,
+    isolated_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A skill-less site-packages tree must still run the interpreter probe."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    _plant_posix_venv(project / ".venv", with_skill=False)
+    real_pkg = tmp_path / "real" / "streamlit"
+    skill = _plant_skill(real_pkg)
+
+    def fake_run(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            ["python"], 0, stdout=f"STREAMLIT_PKG={real_pkg}\n", stderr=""
+        )
+
+    monkeypatch.setattr(discover_mod.subprocess, "run", fake_run)
+    code = discover_mod.main(["--project-dir", str(project)])
+    captured = capsys.readouterr()
+    assert code == 0
+    assert captured.out.strip() == str(skill.resolve())
 
 
 @pytest.mark.skipif(os.name != "nt", reason="Windows venv layout smoke")

--- a/lib/tests/streamlit/web/skills_test.py
+++ b/lib/tests/streamlit/web/skills_test.py
@@ -3447,20 +3447,18 @@ class TestVendoredMetaSkillDiscovery:
                 "vendored meta-skill or bundled content not present in this install"
             )
 
-        # Pin discover.py's interpreter detection to this test's own interpreter
-        # (which has Streamlit) by pointing VIRTUAL_ENV at its venv root. discover.py
-        # re-detects the project interpreter from VIRTUAL_ENV/PATH rather than
-        # reusing the launching sys.executable, so without this the test would fail
-        # (not skip) whenever the first python on PATH lacks Streamlit — e.g. when
-        # run outside ``uv``.
-        venv_root = os.path.dirname(os.path.dirname(sys.executable))
+        # ``sys.executable`` is a candidate (this test interpreter has Streamlit).
+        # Drop inherited VIRTUAL_ENV / CONDA_PREFIX so those tags cannot mask it.
+        env = os.environ.copy()
+        env.pop("VIRTUAL_ENV", None)
+        env.pop("CONDA_PREFIX", None)
         result = subprocess.run(
             [sys.executable, str(discover_py), "--project-dir", str(tmp_path)],
             capture_output=True,
             text=True,
             timeout=60,
             check=False,
-            env={**os.environ, "VIRTUAL_ENV": venv_root},
+            env=env,
         )
 
         assert result.returncode == 0, result.stderr

--- a/lib/tests/streamlit/web/skills_test.py
+++ b/lib/tests/streamlit/web/skills_test.py
@@ -3452,6 +3452,8 @@ class TestVendoredMetaSkillDiscovery:
         env = os.environ.copy()
         env.pop("VIRTUAL_ENV", None)
         env.pop("CONDA_PREFIX", None)
+        env.pop("CLAUDE_PROJECT_DIR", None)
+        env.pop("CURSOR_PROJECT_DIR", None)
         result = subprocess.run(
             [sys.executable, str(discover_py), "--project-dir", str(tmp_path)],
             capture_output=True,

--- a/lib/tests/streamlit/web/skills_test.py
+++ b/lib/tests/streamlit/web/skills_test.py
@@ -3447,8 +3447,8 @@ class TestVendoredMetaSkillDiscovery:
                 "vendored meta-skill or bundled content not present in this install"
             )
 
-        # ``sys.executable`` is a candidate (this test interpreter has Streamlit).
-        # Drop inherited VIRTUAL_ENV / CONDA_PREFIX so those tags cannot mask it.
+        # Drop inherited VIRTUAL_ENV / CONDA_PREFIX so they cannot outrank
+        # this test interpreter, which has Streamlit and is itself a candidate.
         env = os.environ.copy()
         env.pop("VIRTUAL_ENV", None)
         env.pop("CONDA_PREFIX", None)

--- a/specs/2026-08-29-defensive-meta-skill-discovery/tech-spec.md
+++ b/specs/2026-08-29-defensive-meta-skill-discovery/tech-spec.md
@@ -1,0 +1,298 @@
+---
+author: lukasmasuch
+created: 2026-08-29
+---
+
+# Defensive Streamlit agent-skill discovery
+
+## Summary
+
+Harden the **meta-skill** that `streamlit skills` installs so agents find this
+**project's** bundled Streamlit skill
+(`<streamlit>/.agents/skills/developing-with-streamlit/SKILL.md`).
+Failures are unobservable, so discovery must not return a confidently wrong path.
+
+Scope is **`streamlit skills` only** (project default, `--global`, Windows no-symlink
+fallback). Third-party installers are out of band. No `st.*` API changes.
+
+## Problem
+
+`streamlit skills` copies from the **local wheel** (no GitHub fetch; see
+[#15933](https://github.com/streamlit/streamlit/issues/15933)):
+
+| Mode | Installed | `discover.py` |
+|---|---|---|
+| **Project** (default) | Symlinks to bundled **content** skills | Unused |
+| **Global** (`--global`) | Meta-skill → `~/.agents/skills/` (and `~/.claude/skills/` if present) | Required |
+| **Windows, no Developer Mode** | Same global copy | Required |
+
+Today the script picks **one** interpreter and stops. Known wrong answers: stale
+`$VIRTUAL_ENV` hides the project `.venv`; probe stdout banners become a fake path;
+Windows conda `%CONDA_PREFIX%\python.exe` is missed; `python3` is often a Store stub;
+`uv run` may sync; a local `streamlit.py` shadows `find_spec`; uncaught exceptions
+print a traceback. The only vendored test forces `VIRTUAL_ENV` because
+`sys.executable` is ignored. CI is Ubuntu-only.
+
+**Same name, two skills:** project content skill at `.agents/skills/developing-with-streamlit`
+vs global meta-skill at `~/.agents/skills/developing-with-streamlit`. Assumed:
+project-local wins. Not renaming here.
+
+## Goals
+
+1. Return a usable bundled `SKILL.md` for this **project** when one exists, without
+   importing Streamlit and without installing or synchronizing dependencies.
+2. Keep searching after a miss, old install, or failed probe; only a usable skill
+   short-circuits.
+3. On total failure: one error, attempt log, docs URL, manual ladder. Never execute
+   install advice unless the user asked.
+4. Validate Windows layouts in CI **in the same change** as the script (or earlier).
+
+## Out of scope
+
+- Hatch, pixi, pyenv-virtualenv, direnv, `UV_PROJECT_ENVIRONMENT` (`--python` or manual
+  ladder).
+- Changing symlink install / Windows global fallback in `skills.py`.
+- `npx skills` / GitHub `agent-skills` lockstep.
+- Cursor/Codex/Gemini-only frontmatter.
+- Full Windows Python matrix.
+- Renaming the meta-skill.
+- Content-skill POSIX `grep`/`lsof` — **follow-up PR**.
+- Distinguishing `TOO_OLD` vs `INCOMPLETE` via `dist-info` (v1: one “found Streamlit,
+  no usable skill” outcome).
+
+## Locked decisions
+
+| Topic | Decision |
+|---|---|
+| Probe order | **Per candidate:** filesystem then subprocess, then the next candidate. |
+| Project vs `$VIRTUAL_ENV` | **Project `.venv`/`venv` first.** Agent shells often have `$VIRTUAL_ENV` pointing at the *agent*, not the app. `--python` if the user really wants the activated env. `--verbose` prints the winner on stderr so a wrong pick is diagnosable. |
+| Unusable Streamlit | Recorded, not terminal. After all candidates, report the outcome of the **highest-priority candidate that was actually inspected** (severity only *within* that candidate). |
+| Dependency guarantee | **No dependency installation or synchronization.** Manager CLIs (`uv run --no-sync`, `poetry run`, …) may still *create* an empty env; they run only if no prefix worked. Direct `python -c` may run `.pth` / `sitecustomize`. |
+| `--project-dir` | Expand `~` / env vars; light MSYS `/c/...` → `C:\...`. Unexpanded `${...}` or a path that does not exist → **WARNING on stderr, use cwd**. Hard `ERROR[INVALID_ARGS]` only for a bad `--python` or unknown flags. |
+| `--python` | Keep. Exclusive. |
+| `--verbose` | Winning tag + interpreter on **stderr**. Stdout stays one path. |
+| `allowed-tools` | `Read`, `Glob`, plus launcher-anchored grants that **match the body** (`py -3` / `python3` / `python` + script path + `*`). Not `Bash(python *)`. Prompt is OK. |
+| Shadowing | Reject a lone `streamlit.py` (no `submodule_search_locations`, origin not `__init__.py`). **Do not** reject every path under `project_dir` (breaks in-tree / editable Streamlit). |
+| Child flags | **No `python -P`** (3.11+ only; Streamlit supports 3.10). Sanitize `sys.path` in the snippet. Drop inherited `PYTHONPATH` / `PYTHONHOME`. |
+| Store stubs | Only the App Execution Alias dir (`%LOCALAPPDATA%\Microsoft\WindowsApps\`). Do not reject every path containing `WindowsApps` (real Store Python lives elsewhere). |
+| Agent branching | Exit 0 → Read stdout path. Non-zero → manual ladder. |
+| Extra dirs | `.venv` always; `venv` only with `pyvenv.cfg`. Not `env/`. |
+| Git walk | Cap at **20** ancestors (same as `_MAX_REPO_ROOT_WALK_DEPTH` in `skills.py`). |
+| Frontmatter | `name`, `description`, `license`, `allowed-tools`. No `compatibility`, no unused `metadata`. |
+| Windows CI | **Same PR as the script** (or land first). PR1 is not behavior-only. |
+
+## Proposal
+
+### 1. Per-candidate discovery
+
+For each candidate: filesystem lookup, then subprocess if needed. Stop only on a
+**usable** `SKILL.md`, or when the subprocess-time budget is exhausted.
+
+1. `--python` — exclusive
+2. `<project>/.venv`, then `<project>/venv` if `pyvenv.cfg` exists
+3. Same on parent, then git root (≤20 levels, skip duplicates)
+4. `$VIRTUAL_ENV`
+5. `$CONDA_PREFIX`
+6. `sys.executable` if not already listed — **best-effort version** (often the agent’s
+   Python, not the app’s)
+7. `pipenv` / `poetry` / `pdm` / `uv run --no-sync --quiet python` only if the CLI is on
+   `PATH` and the lockfile/`Pipfile` exists at `project_dir` or an ancestor
+8. Windows: `py -3`
+9. System: Windows `python` then `python3`; POSIX `python3` then `python`
+
+`find_venv_python`: Windows `<root>\python.exe` (conda) and `<root>\Scripts\python.exe`;
+POSIX `<root>/bin/python` and `python3`.
+
+Filesystem: `<prefix>\Lib\site-packages\streamlit` (Windows),
+`<prefix>/lib/python*/site-packages/streamlit` (POSIX; if several, prefer one that
+already has the skill file). Editable installs are a filesystem miss.
+
+**Budget:** charge **subprocess time only** (filesystem is free). Global 60s.
+Direct probe timeout ~10s; manager wrappers ~30s. Attempt log marks the rest
+`not tried`.
+
+### 2. Subprocess probe
+
+Never `import streamlit`. No `-P` / `-I`. Child snippet (3.10-safe):
+
+- Remove `''` and any `sys.path` entry that resolves to cwd
+- `find_spec("streamlit")`
+- Accept only a package: `submodule_search_locations` set, origin file is
+  `streamlit/__init__.py`
+- Print `STREAMLIT_PKG=<package-dir>` (parent parses the **last** such line)
+
+Child env: `PYTHONIOENCODING=utf-8`, `PYTHONUTF8=1`, and **omit** `PYTHONPATH` /
+`PYTHONHOME`. Parent `encoding="utf-8"`; `errors="replace"` only as a decode guard.
+Reconfigure this process’s **stdout and stderr** to UTF-8 without replacing characters.
+
+Catch `TimeoutExpired`, `FileNotFoundError`, `PermissionError`, `OSError`,
+`ValueError`, `UnicodeError`. Anything else → `ERROR[INTERNAL]`. Custom argparse:
+invalid flags start with `ERROR[INVALID_ARGS]`.
+
+### 3. Outcomes
+
+Usable `SKILL.md` → **exactly one** path on stdout, exit 0. If `--verbose`, stderr
+also has `discovered via: <tag> <interpreter>`.
+
+Do not infer version from missing files. v1: Streamlit found but no usable bundled
+skill → one outcome (exit 2), message “upgrade or reinstall, or use the docs.”
+`.agents/skills/` present but the expected file missing → exit 4 (`LAYOUT_CHANGED`).
+
+| ID | Exit | When |
+|---|---|---|
+| (success) | 0 | Usable `SKILL.md` |
+| `ERROR[NO_STREAMLIT]` | 1 | At least one candidate was inspected; none had Streamlit |
+| `ERROR[NO_USABLE_SKILL]` | 2 | Highest-priority inspected candidate had Streamlit but no usable bundled skill |
+| `ERROR[NO_PROJECT_PYTHON]` | 3 | Nothing started |
+| `ERROR[SKILLS_LAYOUT_CHANGED]` | 4 | Highest-priority inspected candidate has `.agents/skills/` without the expected file |
+| `ERROR[INVALID_ARGS]` | 5 | Bad `--python` or unknown flag |
+| `ERROR[INTERNAL]` | 6 | Unexpected exception |
+| `ERROR[PROBE_FAILED]` | 7 | Candidates were attempted but **none** were successfully inspected (timeouts, stubs, garbage stdout). Message: could not inspect any interpreter — **not** “Streamlit is not installed.” |
+
+**Final error** = outcome of the **highest-priority inspected** candidate. Severity is
+not compared across candidates (a low-priority `LAYOUT_CHANGED` must not hide a
+project-venv `NO_STREAMLIT`). If nothing was inspected → `PROBE_FAILED` or
+`NO_PROJECT_PYTHON`.
+
+Every non-zero stderr block ends with
+https://docs.streamlit.io/llms-full.txt.
+
+Install advice is last, quoted, and **must not be run unless the user approves**.
+No `source activate`. Prefer `uv add` / `uv pip` when `uv.lock` is present.
+
+### 4. CLI
+
+```text
+python scripts/discover.py --project-dir <DIR> [--python <EXECUTABLE>] [--verbose]
+```
+
+### 5. Meta-skill `SKILL.md`
+
+```yaml
+allowed-tools: Read Glob Bash(py -3 ${CLAUDE_SKILL_DIR}/scripts/discover.py *) Bash(python3 ${CLAUDE_SKILL_DIR}/scripts/discover.py *) Bash(python ${CLAUDE_SKILL_DIR}/scripts/discover.py *)
+```
+
+These prefixes match the body (interpreter + script). They do not grant arbitrary
+`python -c`. A prompt is OK if substitution fails.
+
+Body — Windows first, POSIX second; quote paths; if `${CLAUDE_PROJECT_DIR}` is
+literal, use the project cwd (script warns and does the same):
+
+```text
+py -3 "${CLAUDE_SKILL_DIR}/scripts/discover.py" --project-dir "${CLAUDE_PROJECT_DIR}"
+python3 "${CLAUDE_SKILL_DIR}/scripts/discover.py" --project-dir "${CLAUDE_PROJECT_DIR}"
+```
+
+Exit 0 → Read the stdout path. Non-zero → §5.1.
+
+#### 5.1 Manual discovery
+
+Read-only. Stop at the first existing file. **One physical line** each.
+
+Windows PowerShell:
+
+```powershell
+& ".\.venv\Scripts\python.exe" -c "import importlib.util, pathlib, sys; sys.path=[p for p in sys.path if p and pathlib.Path(p).resolve()!=pathlib.Path('.').resolve()]; s=importlib.util.find_spec('streamlit'); p=(pathlib.Path(s.origin).resolve().parent/'.agents'/'skills'/'developing-with-streamlit'/'SKILL.md') if (s and s.origin and s.submodule_search_locations and pathlib.Path(s.origin).name=='__init__.py') else None; print(p if p is not None and p.is_file() else '')"
+```
+
+POSIX:
+
+```bash
+".venv/bin/python" -c "import importlib.util, pathlib, sys; sys.path=[p for p in sys.path if p and pathlib.Path(p).resolve()!=pathlib.Path('.').resolve()]; s=importlib.util.find_spec('streamlit'); p=(pathlib.Path(s.origin).resolve().parent/'.agents'/'skills'/'developing-with-streamlit'/'SKILL.md') if (s and s.origin and s.submodule_search_locations and pathlib.Path(s.origin).name=='__init__.py') else None; print(p if p is not None and p.is_file() else '')"
+```
+
+Empty print / missing venv → step 2. `py -3` only if the venv interpreter is missing.
+Optional: `"<that-python>" -m pip show streamlit` and append
+`/streamlit/.agents/skills/developing-with-streamlit/SKILL.md` to `Location:`.
+
+2. Glob **project and parent only** (not `$HOME` — slow, wrong install, and many
+   agent globs skip gitignored `.venv`):
+
+   - `**/site-packages/streamlit/.agents/skills/developing-with-streamlit/SKILL.md`
+   - `**/Lib/site-packages/streamlit/.agents/skills/developing-with-streamlit/SKILL.md`
+
+   Prefer a hit under the project `.venv`/`venv`. Search tools may need to include
+   ignored files.
+
+3. `https://docs.streamlit.io/llms-full.txt`. Do not change dependencies unless the
+   user asked.
+
+### 6. Tests and CI
+
+`lib/tests/streamlit/web/meta_skill_discover_test.py`. Required cases: per-candidate
+order; project `.venv` beats `$VIRTUAL_ENV`; non-terminal unusable skill; lone
+`streamlit.py` rejected **and** in-tree `lib/streamlit` accepted; success stdout is
+one line; sentinel last-wins; Store-alias skip; conda `python.exe`; unexpanded
+`--project-dir` → cwd + warning; `--python` exclusive; wall-clock `not tried`;
+overall `PROBE_FAILED` when every probe fails; fake `.venv` e2e.
+
+Vendored happy path: `sys.executable`, no forced `VIRTUAL_ENV`.
+
+**Windows job in this PR:** `windows-latest`, `actions/setup-python` (3.12), then
+`python -m pip install pytest` and `python -m pip install -e lib` (or the repo’s
+existing editable install if that already pulls pytest). Run
+`python -m pytest lib/tests/streamlit/web/meta_skill_discover_test.py`. No `make`,
+no frontend. Path filter: `.agents/**`, this test, `web/skills.py`, packaging
+files.
+
+Smokes:
+
+1. **Filesystem:** plant `Lib\site-packages\streamlit\.agents\...`.
+2. **Subprocess:** do **not** plant under `Lib\site-packages`. Add a `.pth` in the
+   venv that points at a directory containing only that interpreter’s Streamlit
+   tree. Stage 1 must miss; stage 2 must hit via `.venv\Scripts\python.exe`.
+
+Also: space in the project path; skip `py -3` if missing.
+
+### 7. PRs
+
+| PR | Work |
+|---|---|
+| **1** | `discover.py` + meta `SKILL.md` + Ubuntu tests + **Windows discovery job** |
+| **2** (optional) | Content-skill POSIX cleanup |
+
+## Files (PR1)
+
+| File | Change |
+|---|---|
+| `.../meta-skill/.../scripts/discover.py` | Per-candidate discovery |
+| `.../meta-skill/.../SKILL.md` | Launchers + manual ladder |
+| `lib/tests/streamlit/web/meta_skill_discover_test.py` | Guardrails |
+| `lib/tests/streamlit/web/skills_test.py` | Drop forced `VIRTUAL_ENV` |
+| `.github/workflows/` | Narrow `windows-latest` discovery job |
+
+## Alternatives considered
+
+**`python -P`.** Rejected: 3.11+ only. In-snippet `sys.path` cleanup covers 3.10.
+
+**Reject every path under `project_dir`.** Rejected: Streamlit’s own editable checkout
+is `lib/streamlit`. Structural package checks are enough.
+
+**`Bash(${CLAUDE_SKILL_DIR}/scripts/discover.py *)` alone.** Never matches
+`py -3 …/discover.py`. Grant the interpreter + script prefix instead.
+
+**Severity across candidates.** Rejected: a random conda `LAYOUT_CHANGED` must not
+outrank the project venv’s `NO_STREAMLIT`.
+
+**Hard-fail invalid `--project-dir`.** Too harsh when `${CLAUDE_PROJECT_DIR}` is
+literal. Warn + cwd; hard-fail only `--python`.
+
+**`TOO_OLD` vs `INCOMPLETE` + exit 7.** Deferred. Agent behavior is the same; no
+telemetry. v1 uses one “no usable skill” exit.
+
+**Filesystem-only auto discovery.** Editable / Poetry cache still need `find_spec`.
+
+**Glob `$HOME`.** Slow and picks the wrong install.
+
+## Checklist
+
+| Item | Notes |
+|---|---|
+| Works on SiS, Cloud, etc? | N/A |
+| No breaking API changes | Success stdout still one path |
+| No new dependencies | stdlib (CI installs pytest on the Windows runner) |
+| Metrics collected | No; `--verbose` is the debug hook |
+| Security/legal | No auto-install. No `Bash(python *)`. Install advice needs user approval |
+| Docs | Meta `SKILL.md` |
+| Dual-repo | Not required |
+| Windows CI | Required in PR1 |


### PR DESCRIPTION
## Describe your changes

Harden the globally installed meta-skill `discover.py` so coding agents keep searching after a miss and find this project's bundled Streamlit skill without importing Streamlit.

- Project `.venv`/`venv` is searched before `$VIRTUAL_ENV`, because agent shells often point that variable at the agent rather than the app.
- Unexpanded `${CLAUDE_PROJECT_DIR}` warns and uses the current working directory instead of hard-failing; `--python` stays exclusive.
- Failures print `ERROR[CODE]` and an attempt log. Exit codes 1–5 keep their previous meanings; 6 (`INTERNAL`) and 7 (`PROBE_FAILED`) are new so a timeout is not reported as "Streamlit is not installed."
- Install advice is quoted and must not be run unless the user asked. Every non-zero stderr block ends with https://docs.streamlit.io/llms-full.txt.
- Adds a path-filtered Windows pytest job. Windows App Execution Alias stubs under `%LOCALAPPDATA%\Microsoft\WindowsApps\` are skipped.
- Existing `streamlit skills --global` copies keep the previous `discover.py` until the user re-runs that command.

Tech spec (this PR): `specs/2026-08-29-defensive-meta-skill-discovery/tech-spec.md`. Related: [#15933](https://github.com/streamlit/streamlit/issues/15933).

## GitHub Issue Link (if applicable)

- Related to https://github.com/streamlit/streamlit/issues/15933

## Testing Plan

- [x] Unit Tests (JS and/or Python)
  - `lib/tests/streamlit/web/meta_skill_discover_test.py` — candidate order, project venv vs `$VIRTUAL_ENV`, probe outcomes, skip Windows App Execution Alias stubs, conda `python.exe`, `.pth` subprocess hit, planted-venv subprocess
  - `lib/tests/streamlit/web/skills_test.py` — vendored happy path uses `sys.executable` (no forced `VIRTUAL_ENV`)
- [ ] E2E Tests — CLI script only; no `st.*` UI surface
- Windows CI: `.github/workflows/windows-meta-skill-discovery.yml` (`windows-latest`, Python 3.12, this test file only)

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.