### PR TITLE
[fix] Log all user-facing warnings to the console

### DIFF
--- a/.cursor/rules/python_lib.mdc
+++ b/.cursor/rules/python_lib.mdc
@@ -30,11 +30,15 @@ from streamlit.logger import get_logger
 _LOGGER: Final = get_logger(__name__)
 ```
 
-Always log diagnostics that help someone developing an app: API misuse,
-ignored parameters, degraded output, missing optional features, and unexpected
-fallbacks. Agents and CLI users only see the console; in-app
-`st.warning` / `st.error` / `st.exception` from library code are invisible to
-them unless they are also logged.
+Log diagnostics that a developer or coding agent needs to see: important API
+misuse, ignored parameters that change behavior, degraded or incomplete
+output, and unexpected fallbacks. Agents and CLI users only see the console;
+in-app `st.warning` / `st.error` / `st.exception` from library code are
+invisible to them unless they are also logged.
+
+Do not over-log. Console noise hides real issues. The library may handle
+potentially non-ideal API usage silently when it is not important enough to
+surface.
 
 Use `stack_info=True` when the user call site matters. Prefer
 `_LOGGER.warning("%s", message, stack_info=True)` when `message` may contain
@@ -46,9 +50,12 @@ uncaught-exception handler; do not double-log those.
 Do not use `st.warning`, `st.error`, or `st.exception` from library internals
 as the only signal. If you show one of those, also log the same message.
 
-- **Log only** when the command still works and the issue is a developer nit
-  (ignored parameter, format string that does not match the value type, empty
-  widget label).
+- **Stay silent** when a quirk can be handled without it mattering to the
+  developer or agent (benign coercion, unused optional kwargs that never
+  applied, other smart fallbacks).
+- **Log only** when the command still works but a developer or agent should
+  know (ignored `sample_rate` on non-numpy audio, number-input format that
+  does not match the value type).
 - **Log and show UI** when the app is actually misbehaving or data is
   incomplete (widget inside a cached function, display commands in
   `refresh_mode="background"`, JSON keys dropped, `st.echo` cannot read the
@@ -178,9 +185,10 @@ validation. Optional-dependency import failures may stay native
 (`st.connection` `ModuleNotFoundError`, `st.pyplot` matplotlib `ImportError`).
 
 Non-fatal library diagnostics (ignored parameters, degraded output, cached
-widget misuse) should not be raised. Log them, and add in-app
-`st.warning` / `st.error` / `st.exception` only when the app is actually
-wrong or data is incomplete — see Logging.
+widget misuse) should not be raised. Log them only when they are important
+for the developer or coding agent to see; otherwise handle them silently.
+Add in-app `st.warning` / `st.error` / `st.exception` only when the app is
+actually wrong or data is incomplete — see Logging.
 
 - `StreamlitAPIException`: base for malformed user interaction with the Streamlit
   API. Prefer a more specific subclass when one fits. When a bare

--- a/.cursor/rules/python_lib.mdc
+++ b/.cursor/rules/python_lib.mdc
@@ -22,14 +22,39 @@ not applicable to scripts and e2e tests.
 
 ## Logging
 
-If something needs to be logged, please use our logger - that returns a default
-Python logger - with an appropriate logging level:
+Use our logger (a standard Python logger) with an appropriate level:
 
 ```python
 from streamlit.logger import get_logger
 
 _LOGGER: Final = get_logger(__name__)
 ```
+
+Always log diagnostics that help someone developing an app: API misuse,
+ignored parameters, degraded output, missing optional features, and unexpected
+fallbacks. Agents and CLI users only see the console; in-app
+`st.warning` / `st.error` / `st.exception` from library code are invisible to
+them unless they are also logged.
+
+Use `stack_info=True` when the user call site matters. Prefer
+`_LOGGER.warning("%s", message, stack_info=True)` when `message` may contain
+`%`. Raised `StreamlitAPIException` subclasses are already logged by the
+uncaught-exception handler; do not double-log those.
+
+### In-app UI vs console-only
+
+Do not use `st.warning`, `st.error`, or `st.exception` from library internals
+as the only signal. If you show one of those, also log the same message.
+
+- **Log only** when the command still works and the issue is a developer nit
+  (ignored parameter, format string that does not match the value type, empty
+  widget label).
+- **Log and show UI** when the app is actually misbehaving or data is
+  incomplete (widget inside a cached function, display commands in
+  `refresh_mode="background"`, JSON keys dropped, `st.echo` cannot read the
+  source file). Use `st.exception(StreamlitAPIWarning)` when the in-app stack
+  should point at user code.
+- **Deprecations:** use `show_deprecation_warning()`, which already logs.
 
 ## Metrics
 
@@ -151,6 +176,11 @@ generic `StreamlitAPIException` with a one-off message. Do not raise native
 `ValueError`, `TypeError`, or `RuntimeError` for user-facing `st.*`
 validation. Optional-dependency import failures may stay native
 (`st.connection` `ModuleNotFoundError`, `st.pyplot` matplotlib `ImportError`).
+
+Non-fatal library diagnostics (ignored parameters, degraded output, cached
+widget misuse) should not be raised. Log them, and add in-app
+`st.warning` / `st.error` / `st.exception` only when the app is actually
+wrong or data is incomplete — see Logging.
 
 - `StreamlitAPIException`: base for malformed user interaction with the Streamlit
   API. Prefer a more specific subclass when one fits. When a bare

--- a/.cursor/rules/python_lib.mdc
+++ b/.cursor/rules/python_lib.mdc
@@ -54,8 +54,8 @@ as the only signal. If you show one of those, also log the same message.
   developer or agent (benign coercion, unused optional kwargs that never
   applied, other smart fallbacks).
 - **Log only** when the command still works but a developer or agent should
-  know (ignored `sample_rate` on non-numpy audio, number-input format that
-  does not match the value type).
+  know (explicitly provided `sample_rate` on non-numpy audio, number-input
+  format that does not match the value type).
 - **Log and show UI** when the app is actually misbehaving or data is
   incomplete (widget inside a cached function, display commands in
   `refresh_mode="background"`, JSON keys dropped, `st.echo` cannot read the

--- a/.github/instructions/python_lib.instructions.md
+++ b/.github/instructions/python_lib.instructions.md
@@ -52,8 +52,8 @@ as the only signal. If you show one of those, also log the same message.
   developer or agent (benign coercion, unused optional kwargs that never
   applied, other smart fallbacks).
 - **Log only** when the command still works but a developer or agent should
-  know (ignored `sample_rate` on non-numpy audio, number-input format that
-  does not match the value type).
+  know (explicitly provided `sample_rate` on non-numpy audio, number-input
+  format that does not match the value type).
 - **Log and show UI** when the app is actually misbehaving or data is
   incomplete (widget inside a cached function, display commands in
   `refresh_mode="background"`, JSON keys dropped, `st.echo` cannot read the

--- a/.github/instructions/python_lib.instructions.md
+++ b/.github/instructions/python_lib.instructions.md
@@ -28,11 +28,15 @@ from streamlit.logger import get_logger
 _LOGGER: Final = get_logger(__name__)
 ```
 
-Always log diagnostics that help someone developing an app: API misuse,
-ignored parameters, degraded output, missing optional features, and unexpected
-fallbacks. Agents and CLI users only see the console; in-app
-`st.warning` / `st.error` / `st.exception` from library code are invisible to
-them unless they are also logged.
+Log diagnostics that a developer or coding agent needs to see: important API
+misuse, ignored parameters that change behavior, degraded or incomplete
+output, and unexpected fallbacks. Agents and CLI users only see the console;
+in-app `st.warning` / `st.error` / `st.exception` from library code are
+invisible to them unless they are also logged.
+
+Do not over-log. Console noise hides real issues. The library may handle
+potentially non-ideal API usage silently when it is not important enough to
+surface.
 
 Use `stack_info=True` when the user call site matters. Prefer
 `_LOGGER.warning("%s", message, stack_info=True)` when `message` may contain
@@ -44,9 +48,12 @@ uncaught-exception handler; do not double-log those.
 Do not use `st.warning`, `st.error`, or `st.exception` from library internals
 as the only signal. If you show one of those, also log the same message.
 
-- **Log only** when the command still works and the issue is a developer nit
-  (ignored parameter, format string that does not match the value type, empty
-  widget label).
+- **Stay silent** when a quirk can be handled without it mattering to the
+  developer or agent (benign coercion, unused optional kwargs that never
+  applied, other smart fallbacks).
+- **Log only** when the command still works but a developer or agent should
+  know (ignored `sample_rate` on non-numpy audio, number-input format that
+  does not match the value type).
 - **Log and show UI** when the app is actually misbehaving or data is
   incomplete (widget inside a cached function, display commands in
   `refresh_mode="background"`, JSON keys dropped, `st.echo` cannot read the
@@ -176,9 +183,10 @@ validation. Optional-dependency import failures may stay native
 (`st.connection` `ModuleNotFoundError`, `st.pyplot` matplotlib `ImportError`).
 
 Non-fatal library diagnostics (ignored parameters, degraded output, cached
-widget misuse) should not be raised. Log them, and add in-app
-`st.warning` / `st.error` / `st.exception` only when the app is actually
-wrong or data is incomplete — see Logging.
+widget misuse) should not be raised. Log them only when they are important
+for the developer or coding agent to see; otherwise handle them silently.
+Add in-app `st.warning` / `st.error` / `st.exception` only when the app is
+actually wrong or data is incomplete — see Logging.
 
 - `StreamlitAPIException`: base for malformed user interaction with the Streamlit
   API. Prefer a more specific subclass when one fits. When a bare

--- a/.github/instructions/python_lib.instructions.md
+++ b/.github/instructions/python_lib.instructions.md
@@ -20,14 +20,39 @@ not applicable to scripts and e2e tests.
 
 ## Logging
 
-If something needs to be logged, please use our logger - that returns a default
-Python logger - with an appropriate logging level:
+Use our logger (a standard Python logger) with an appropriate level:
 
 ```python
 from streamlit.logger import get_logger
 
 _LOGGER: Final = get_logger(__name__)
 ```
+
+Always log diagnostics that help someone developing an app: API misuse,
+ignored parameters, degraded output, missing optional features, and unexpected
+fallbacks. Agents and CLI users only see the console; in-app
+`st.warning` / `st.error` / `st.exception` from library code are invisible to
+them unless they are also logged.
+
+Use `stack_info=True` when the user call site matters. Prefer
+`_LOGGER.warning("%s", message, stack_info=True)` when `message` may contain
+`%`. Raised `StreamlitAPIException` subclasses are already logged by the
+uncaught-exception handler; do not double-log those.
+
+### In-app UI vs console-only
+
+Do not use `st.warning`, `st.error`, or `st.exception` from library internals
+as the only signal. If you show one of those, also log the same message.
+
+- **Log only** when the command still works and the issue is a developer nit
+  (ignored parameter, format string that does not match the value type, empty
+  widget label).
+- **Log and show UI** when the app is actually misbehaving or data is
+  incomplete (widget inside a cached function, display commands in
+  `refresh_mode="background"`, JSON keys dropped, `st.echo` cannot read the
+  source file). Use `st.exception(StreamlitAPIWarning)` when the in-app stack
+  should point at user code.
+- **Deprecations:** use `show_deprecation_warning()`, which already logs.
 
 ## Metrics
 
@@ -149,6 +174,11 @@ generic `StreamlitAPIException` with a one-off message. Do not raise native
 `ValueError`, `TypeError`, or `RuntimeError` for user-facing `st.*`
 validation. Optional-dependency import failures may stay native
 (`st.connection` `ModuleNotFoundError`, `st.pyplot` matplotlib `ImportError`).
+
+Non-fatal library diagnostics (ignored parameters, degraded output, cached
+widget misuse) should not be raised. Log them, and add in-app
+`st.warning` / `st.error` / `st.exception` only when the app is actually
+wrong or data is incomplete — see Logging.
 
 - `StreamlitAPIException`: base for malformed user interaction with the Streamlit
   API. Prefer a more specific subclass when one fits. When a bare

--- a/lib/streamlit/AGENTS.md
+++ b/lib/streamlit/AGENTS.md
@@ -46,8 +46,8 @@ as the only signal. If you show one of those, also log the same message.
   developer or agent (benign coercion, unused optional kwargs that never
   applied, other smart fallbacks).
 - **Log only** when the command still works but a developer or agent should
-  know (ignored `sample_rate` on non-numpy audio, number-input format that
-  does not match the value type).
+  know (explicitly provided `sample_rate` on non-numpy audio, number-input
+  format that does not match the value type).
 - **Log and show UI** when the app is actually misbehaving or data is
   incomplete (widget inside a cached function, display commands in
   `refresh_mode="background"`, JSON keys dropped, `st.echo` cannot read the

--- a/lib/streamlit/AGENTS.md
+++ b/lib/streamlit/AGENTS.md
@@ -22,11 +22,15 @@ from streamlit.logger import get_logger
 _LOGGER: Final = get_logger(__name__)
 ```
 
-Always log diagnostics that help someone developing an app: API misuse,
-ignored parameters, degraded output, missing optional features, and unexpected
-fallbacks. Agents and CLI users only see the console; in-app
-`st.warning` / `st.error` / `st.exception` from library code are invisible to
-them unless they are also logged.
+Log diagnostics that a developer or coding agent needs to see: important API
+misuse, ignored parameters that change behavior, degraded or incomplete
+output, and unexpected fallbacks. Agents and CLI users only see the console;
+in-app `st.warning` / `st.error` / `st.exception` from library code are
+invisible to them unless they are also logged.
+
+Do not over-log. Console noise hides real issues. The library may handle
+potentially non-ideal API usage silently when it is not important enough to
+surface.
 
 Use `stack_info=True` when the user call site matters. Prefer
 `_LOGGER.warning("%s", message, stack_info=True)` when `message` may contain
@@ -38,9 +42,12 @@ uncaught-exception handler; do not double-log those.
 Do not use `st.warning`, `st.error`, or `st.exception` from library internals
 as the only signal. If you show one of those, also log the same message.
 
-- **Log only** when the command still works and the issue is a developer nit
-  (ignored parameter, format string that does not match the value type, empty
-  widget label).
+- **Stay silent** when a quirk can be handled without it mattering to the
+  developer or agent (benign coercion, unused optional kwargs that never
+  applied, other smart fallbacks).
+- **Log only** when the command still works but a developer or agent should
+  know (ignored `sample_rate` on non-numpy audio, number-input format that
+  does not match the value type).
 - **Log and show UI** when the app is actually misbehaving or data is
   incomplete (widget inside a cached function, display commands in
   `refresh_mode="background"`, JSON keys dropped, `st.echo` cannot read the
@@ -170,9 +177,10 @@ validation. Optional-dependency import failures may stay native
 (`st.connection` `ModuleNotFoundError`, `st.pyplot` matplotlib `ImportError`).
 
 Non-fatal library diagnostics (ignored parameters, degraded output, cached
-widget misuse) should not be raised. Log them, and add in-app
-`st.warning` / `st.error` / `st.exception` only when the app is actually
-wrong or data is incomplete — see Logging.
+widget misuse) should not be raised. Log them only when they are important
+for the developer or coding agent to see; otherwise handle them silently.
+Add in-app `st.warning` / `st.error` / `st.exception` only when the app is
+actually wrong or data is incomplete — see Logging.
 
 - `StreamlitAPIException`: base for malformed user interaction with the Streamlit
   API. Prefer a more specific subclass when one fits. When a bare

--- a/lib/streamlit/AGENTS.md
+++ b/lib/streamlit/AGENTS.md
@@ -14,14 +14,39 @@ not applicable to scripts and e2e tests.
 
 ## Logging
 
-If something needs to be logged, please use our logger - that returns a default
-Python logger - with an appropriate logging level:
+Use our logger (a standard Python logger) with an appropriate level:
 
 ```python
 from streamlit.logger import get_logger
 
 _LOGGER: Final = get_logger(__name__)
 ```
+
+Always log diagnostics that help someone developing an app: API misuse,
+ignored parameters, degraded output, missing optional features, and unexpected
+fallbacks. Agents and CLI users only see the console; in-app
+`st.warning` / `st.error` / `st.exception` from library code are invisible to
+them unless they are also logged.
+
+Use `stack_info=True` when the user call site matters. Prefer
+`_LOGGER.warning("%s", message, stack_info=True)` when `message` may contain
+`%`. Raised `StreamlitAPIException` subclasses are already logged by the
+uncaught-exception handler; do not double-log those.
+
+### In-app UI vs console-only
+
+Do not use `st.warning`, `st.error`, or `st.exception` from library internals
+as the only signal. If you show one of those, also log the same message.
+
+- **Log only** when the command still works and the issue is a developer nit
+  (ignored parameter, format string that does not match the value type, empty
+  widget label).
+- **Log and show UI** when the app is actually misbehaving or data is
+  incomplete (widget inside a cached function, display commands in
+  `refresh_mode="background"`, JSON keys dropped, `st.echo` cannot read the
+  source file). Use `st.exception(StreamlitAPIWarning)` when the in-app stack
+  should point at user code.
+- **Deprecations:** use `show_deprecation_warning()`, which already logs.
 
 ## Metrics
 
@@ -143,6 +168,11 @@ generic `StreamlitAPIException` with a one-off message. Do not raise native
 `ValueError`, `TypeError`, or `RuntimeError` for user-facing `st.*`
 validation. Optional-dependency import failures may stay native
 (`st.connection` `ModuleNotFoundError`, `st.pyplot` matplotlib `ImportError`).
+
+Non-fatal library diagnostics (ignored parameters, degraded output, cached
+widget misuse) should not be raised. Log them, and add in-app
+`st.warning` / `st.error` / `st.exception` only when the app is actually
+wrong or data is incomplete — see Logging.
 
 - `StreamlitAPIException`: base for malformed user interaction with the Streamlit
   API. Prefer a more specific subclass when one fits. When a bare

--- a/lib/streamlit/commands/echo.py
+++ b/lib/streamlit/commands/echo.py
@@ -110,8 +110,8 @@ def echo(
         error_message = f"Unable to display code. {err}"
         _LOGGER.warning("%s", error_message, stack_info=True)
 
-    # Run the echoed block even when the source file is missing, so echo
-    # never skips the user's code.
+    # Execute the echoed block even when the source file is missing, so a
+    # missing file does not skip the user's code.
     yield
 
     if code_string is not None:

--- a/lib/streamlit/commands/echo.py
+++ b/lib/streamlit/commands/echo.py
@@ -19,13 +19,15 @@ import contextlib
 import re
 import textwrap
 import traceback
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Final, Literal, cast
 
+from streamlit.logger import get_logger
 from streamlit.runtime.metrics_util import gather_metrics
 
 if TYPE_CHECKING:
     from collections.abc import Generator, Iterable
 
+_LOGGER: Final = get_logger(__name__)
 _SPACES_RE = re.compile(r"\s*")
 _EMPTY_LINE_RE = re.compile(r"\s*\n")
 
@@ -61,6 +63,8 @@ def echo(
         show_code = placeholder.code
         show_warning = placeholder.warning
 
+    code_string: str | None = None
+    error_message: str | None = None
     try:
         # Get stack frame *before* running the echoed code. The frame's
         # line number will point to the `st.echo` statement we're running.
@@ -102,15 +106,18 @@ def echo(
         lines_to_display = source_lines[echo_block_start_line:echo_block_end_line]
 
         code_string = textwrap.dedent("".join(lines_to_display))
-
-        # Run the echoed code...
-        yield
-
-        # And draw the code string to the app!
-        show_code(code_string, "python")
-
     except FileNotFoundError as err:
-        show_warning(f"Unable to display code. {err}")
+        error_message = f"Unable to display code. {err}"
+        _LOGGER.warning("%s", error_message, stack_info=True)
+
+    # Run the echoed block even when the source file is missing, so echo
+    # never skips the user's code.
+    yield
+
+    if code_string is not None:
+        show_code(code_string, "python")
+    elif error_message is not None:
+        show_warning(error_message)
 
 
 def _get_initial_indent(lines: Iterable[str]) -> int:

--- a/lib/streamlit/commands/echo.py
+++ b/lib/streamlit/commands/echo.py
@@ -106,12 +106,12 @@ def echo(
         lines_to_display = source_lines[echo_block_start_line:echo_block_end_line]
 
         code_string = textwrap.dedent("".join(lines_to_display))
-    except FileNotFoundError as err:
+    except OSError as err:
         error_message = f"Unable to display code. {err}"
         _LOGGER.warning("%s", error_message, stack_info=True)
 
-    # Execute the echoed block even when the source file is missing, so a
-    # missing file does not skip the user's code.
+    # Run the echoed block even when the source could not be read, so a
+    # missing or unreadable file does not skip the user's code.
     yield
 
     if code_string is not None:

--- a/lib/streamlit/elements/json.py
+++ b/lib/streamlit/elements/json.py
@@ -145,11 +145,11 @@ class JsonMixin:
                 # with a stack trace so CLI and agent users can find the call
                 # site.
                 warning_message = (
-                    "Warning: this data structure was not fully serializable as "
+                    "this data structure was not fully serializable as "
                     f"JSON due to one or more unexpected keys.  (Error was: {err})"
                 )
                 _LOGGER.warning("%s", warning_message, stack_info=True)
-                self.dg.warning(warning_message)
+                self.dg.warning(f"Warning: {warning_message}")
                 body = json.dumps(body, skipkeys=True, default=_ensure_serialization)
 
         json_proto = JsonProto()

--- a/lib/streamlit/elements/json.py
+++ b/lib/streamlit/elements/json.py
@@ -141,8 +141,9 @@ class JsonMixin:
                 # Serialize body to string and try to interpret sets as lists
                 body = json.dumps(body, default=_ensure_serialization)
             except TypeError as err:
-                # Keys were omitted, so keep the in-app warning and also log it
-                # with a stack trace.
+                # Incomplete JSON still gets an in-app warning; also log it
+                # with a stack trace so CLI and agent users can find the call
+                # site.
                 warning_message = (
                     "Warning: this data structure was not fully serializable as "
                     f"JSON due to one or more unexpected keys.  (Error was: {err})"

--- a/lib/streamlit/elements/json.py
+++ b/lib/streamlit/elements/json.py
@@ -17,10 +17,11 @@ from __future__ import annotations
 import json
 import types
 from collections import ChainMap, UserDict
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Final, cast
 
 from streamlit.elements.lib.layout_utils import create_layout_config
 from streamlit.errors import StreamlitInvalidParameterTypeError
+from streamlit.logger import get_logger
 from streamlit.proto.Json_pb2 import Json as JsonProto
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.type_util import (
@@ -36,6 +37,8 @@ from streamlit.user_info import UserInfoProxy
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
     from streamlit.elements.lib.layout_utils import WidthWithoutContent
+
+_LOGGER: Final = get_logger(__name__)
 
 
 def _ensure_serialization(o: object) -> str | list[Any]:
@@ -138,10 +141,14 @@ class JsonMixin:
                 # Serialize body to string and try to interpret sets as lists
                 body = json.dumps(body, default=_ensure_serialization)
             except TypeError as err:
-                self.dg.warning(
+                # Keys were omitted, so keep the in-app warning and also log it
+                # with a stack trace.
+                warning_message = (
                     "Warning: this data structure was not fully serializable as "
                     f"JSON due to one or more unexpected keys.  (Error was: {err})"
                 )
+                _LOGGER.warning("%s", warning_message, stack_info=True)
+                self.dg.warning(warning_message)
                 body = json.dumps(body, skipkeys=True, default=_ensure_serialization)
 
         json_proto = JsonProto()

--- a/lib/streamlit/elements/lib/policies.py
+++ b/lib/streamlit/elements/lib/policies.py
@@ -121,9 +121,11 @@ def check_cache_replay_rules() -> None:
     if in_cached_function.get():
         from streamlit import exception
 
-        # We use an exception here to show a proper stack trace
-        # that indicates to the user where the issue is.
-        exception(CachedWidgetWarning())
+        # Log the warning with a stack trace, and pass it to st.exception so
+        # the app still shows it at the widget call.
+        warning = CachedWidgetWarning()
+        _LOGGER.warning("%s", warning, stack_info=True)
+        exception(warning)
 
 
 def check_widget_policies(

--- a/lib/streamlit/elements/lib/policies.py
+++ b/lib/streamlit/elements/lib/policies.py
@@ -121,8 +121,8 @@ def check_cache_replay_rules() -> None:
     if in_cached_function.get():
         from streamlit import exception
 
-        # Log the warning with a stack trace, and pass it to st.exception so
-        # the app still shows it at the widget call.
+        # st.exception renders the warning at the widget call site; the log
+        # makes it visible to CLI users and agents.
         warning = CachedWidgetWarning()
         _LOGGER.warning("%s", warning, stack_info=True)
         exception(warning)

--- a/lib/streamlit/elements/media.py
+++ b/lib/streamlit/elements/media.py
@@ -213,8 +213,8 @@ class MediaMixin:
                 detail="Must be specified when `data` is a numpy array.",
             )
         if not is_data_numpy_array and sample_rate is not None:
-            # `sample_rate` does nothing for non-NumPy data; log it instead of
-            # drawing an in-app warning.
+            # `sample_rate` only applies to NumPy data, so it is dropped here
+            # and surfaced to the developer via the console.
             _LOGGER.warning(
                 "`sample_rate` will be ignored since data is not a numpy array.",
                 stack_info=True,

--- a/lib/streamlit/elements/media.py
+++ b/lib/streamlit/elements/media.py
@@ -31,6 +31,7 @@ from streamlit.errors import (
     StreamlitInvalidParameterTypeError,
     StreamlitMissingRequiredParameterError,
 )
+from streamlit.logger import get_logger
 from streamlit.proto.Audio_pb2 import Audio as AudioProto
 from streamlit.proto.Video_pb2 import Video as VideoProto
 from streamlit.proto.WidthConfig_pb2 import WidthConfig
@@ -44,6 +45,8 @@ if TYPE_CHECKING:
     from numpy import typing as npt
 
     from streamlit.delta_generator import DeltaGenerator
+
+_LOGGER: Final = get_logger(__name__)
 
 
 MediaData: TypeAlias = Union[
@@ -210,9 +213,11 @@ class MediaMixin:
                 detail="Must be specified when `data` is a numpy array.",
             )
         if not is_data_numpy_array and sample_rate is not None:
-            self.dg.warning(
-                "Warning: `sample_rate` will be ignored since data is not a numpy "
-                "array."
+            # `sample_rate` does nothing for non-NumPy data; log it instead of
+            # drawing an in-app warning.
+            _LOGGER.warning(
+                "`sample_rate` will be ignored since data is not a numpy array.",
+                stack_info=True,
             )
         coordinates = self.dg._get_delta_path_str()
         marshall_audio(

--- a/lib/streamlit/elements/widgets/number_input.py
+++ b/lib/streamlit/elements/widgets/number_input.py
@@ -686,8 +686,8 @@ class NumberInputMixin:
         # Use default format depending on value type if format was not provided:
         number_format = ("%d" if int_value else "%0.2f") if format is None else format
 
-        # Log a type/format mismatch instead of drawing an in-app warning; the
-        # widget still works.
+        # A type/format mismatch only affects how the value is displayed, so it
+        # is reported to the developer via the console rather than the app.
         if number_format in {"%d", "%u", "%i"} and float_value:
             _LOGGER.warning(
                 "NumberInput value has type float, but format %s displays as integer.",

--- a/lib/streamlit/elements/widgets/number_input.py
+++ b/lib/streamlit/elements/widgets/number_input.py
@@ -690,13 +690,13 @@ class NumberInputMixin:
         # is reported to the developer via the console rather than the app.
         if number_format in {"%d", "%u", "%i"} and float_value:
             _LOGGER.warning(
-                "NumberInput value has type float, but format %s displays as integer.",
+                "st.number_input value has type float, but format %s displays as integer.",
                 number_format,
                 stack_info=True,
             )
         elif number_format[-1] == "f" and int_value:
             _LOGGER.warning(
-                "NumberInput value has type int so is displayed as int despite "
+                "st.number_input value has type int so is displayed as int despite "
                 "format string %s.",
                 number_format,
                 stack_info=True,

--- a/lib/streamlit/elements/widgets/number_input.py
+++ b/lib/streamlit/elements/widgets/number_input.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import math
 import numbers
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Literal, TypeAlias, cast, overload
+from typing import TYPE_CHECKING, Final, Literal, TypeAlias, cast, overload
 
 from streamlit.elements.lib.form_utils import current_form_id
 from streamlit.elements.lib.js_number import JSNumber, JSNumberBoundsException
@@ -43,6 +43,7 @@ from streamlit.errors import (
     StreamlitValueAboveMaxError,
     StreamlitValueBelowMinError,
 )
+from streamlit.logger import get_logger
 from streamlit.proto.NumberInput_pb2 import NumberInput as NumberInputProto
 from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
@@ -59,6 +60,8 @@ from streamlit.string_util import to_help_str, validate_icon_or_emoji
 
 if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
+
+_LOGGER: Final = get_logger(__name__)
 
 Number: TypeAlias = int | float
 
@@ -683,20 +686,20 @@ class NumberInputMixin:
         # Use default format depending on value type if format was not provided:
         number_format = ("%d" if int_value else "%0.2f") if format is None else format
 
-        # Warn user if they format an int type as a float or vice versa.
+        # Log a type/format mismatch instead of drawing an in-app warning; the
+        # widget still works.
         if number_format in {"%d", "%u", "%i"} and float_value:
-            import streamlit as st
-
-            st.warning(
-                "Warning: NumberInput value below has type float,"
-                f" but format {number_format} displays as integer."
+            _LOGGER.warning(
+                "NumberInput value has type float, but format %s displays as integer.",
+                number_format,
+                stack_info=True,
             )
         elif number_format[-1] == "f" and int_value:
-            import streamlit as st
-
-            st.warning(
-                "Warning: NumberInput value below has type int so is"
-                f" displayed as int despite format string {number_format}."
+            _LOGGER.warning(
+                "NumberInput value has type int so is displayed as int despite "
+                "format string %s.",
+                number_format,
+                stack_info=True,
             )
 
         if step is None:

--- a/lib/streamlit/runtime/caching/cache_utils.py
+++ b/lib/streamlit/runtime/caching/cache_utils.py
@@ -842,13 +842,13 @@ class CachedFunc(Generic[P, R]):
         """Warn that display output won't replay on hits in background mode."""
         from streamlit import exception
 
-        # We use an exception here to show a proper stack trace pointing at the user's
-        # cached function (same channel as the cached-widget warning).
-        exception(
-            CachedStFunctionInBackgroundModeWarning(
-                self._info.cache_type, self._info.func
-            )
+        # Log the warning with a stack trace and show it via st.exception, same
+        # as the cached-widget warning.
+        warning = CachedStFunctionInBackgroundModeWarning(
+            self._info.cache_type, self._info.func
         )
+        _LOGGER.warning("%s", warning, stack_info=True)
+        exception(warning)
 
     @overload
     def clear(self) -> None: ...

--- a/lib/streamlit/runtime/caching/cache_utils.py
+++ b/lib/streamlit/runtime/caching/cache_utils.py
@@ -842,8 +842,8 @@ class CachedFunc(Generic[P, R]):
         """Warn that display output won't replay on hits in background mode."""
         from streamlit import exception
 
-        # Log the warning with a stack trace and show it via st.exception, same
-        # as the cached-widget warning.
+        # Mirrors the cached-widget warning: st.exception surfaces it in the
+        # app, the log surfaces it in the console.
         warning = CachedStFunctionInBackgroundModeWarning(
             self._info.cache_type, self._info.func
         )

--- a/lib/tests/streamlit/elements/audio_test.py
+++ b/lib/tests/streamlit/elements/audio_test.py
@@ -23,6 +23,7 @@ from parameterized import parameterized
 
 import streamlit as st
 from streamlit.elements.media import (
+    _LOGGER,
     _maybe_convert_to_wav_bytes,
     _parse_start_time_end_time,
 )
@@ -30,7 +31,6 @@ from streamlit.errors import (
     StreamlitAPIException,
     StreamlitMissingRequiredParameterError,
 )
-from streamlit.proto.Alert_pb2 import Alert as AlertProto
 from streamlit.runtime.media_file_storage import MediaFileStorageError
 from streamlit.runtime.memory_media_file_storage import _calculate_file_id
 from streamlit.web.server.server import MEDIA_ENDPOINT
@@ -126,21 +126,27 @@ class AudioTest(DeltaGeneratorTestCase):
 
         assert "sample_rate" in str(e.value)
 
-    def test_st_audio_sample_rate_raises_warning(self):
-        """Test st.audio raises streamlit warning when sample_rate parameter provided,
-        but data is not a numpy array."""
+    def test_st_audio_sample_rate_logs_warning(self):
+        """Test st.audio logs a warning when sample_rate is provided but data
+        is not a numpy array.
+        """
 
         fake_audio_data = b"\x11\x22\x33\x44\x55\x66"
         sample_rate = 44100
 
-        st.audio(fake_audio_data, sample_rate=sample_rate)
+        with self.assertLogs(_LOGGER) as logs:
+            st.audio(fake_audio_data, sample_rate=sample_rate)
 
-        c = self.get_delta_from_queue(-2).new_element.alert
-        assert c.format == AlertProto.WARNING
         assert (
-            c.body
-            == "Warning: `sample_rate` will be ignored since data is not a numpy array."
+            "`sample_rate` will be ignored since data is not a numpy array."
+            in logs.records[0].getMessage()
         )
+        assert logs.records[0].stack_info is not None
+        assert not any(
+            delta.new_element.WhichOneof("type") == "alert"
+            for delta in self.get_all_deltas_from_queue()
+        )
+        assert self.get_delta_from_queue().new_element.WhichOneof("type") == "audio"
 
     def test_maybe_convert_to_wave_numpy_arr_empty(self):
         """Test _maybe_convert_to_wave_bytes works correctly with empty numpy array."""

--- a/lib/tests/streamlit/elements/echo_test.py
+++ b/lib/tests/streamlit/elements/echo_test.py
@@ -12,10 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from unittest.mock import patch
+
+import pytest
 from parameterized import parameterized
 
 import streamlit as st
-from streamlit.commands.echo import _get_indent, _get_initial_indent
+from streamlit.commands.echo import _LOGGER, _get_indent, _get_initial_indent
+from streamlit.proto.Alert_pb2 import Alert as AlertProto
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 
 
@@ -195,6 +199,32 @@ class MultiDecorated:
 
         element = self.get_delta_from_queue(0).new_element
         assert echo_str == element.code.code_text
+
+    def test_echo_missing_source_file_warns_and_logs(self):
+        """If the source file can't be read, echo still runs the block, shows a
+        warning, and logs it with a stack trace.
+        """
+        with patch(
+            "streamlit.source_util.open_python_file",
+            side_effect=FileNotFoundError("missing.py"),
+        ):
+            with self.assertLogs(_LOGGER) as logs:
+                with st.echo():
+                    st.write("Hello")
+
+        assert "Unable to display code. missing.py" in logs.records[0].getMessage()
+        assert logs.records[0].stack_info is not None
+
+        warning_el = self.get_delta_from_queue(0).new_element.alert
+        assert warning_el.format == AlertProto.WARNING
+        assert "Unable to display code. missing.py" in warning_el.body
+        assert self.get_delta_from_queue(1).new_element.markdown.body == "Hello"
+
+    def test_echo_propagates_file_not_found_from_block(self):
+        """FileNotFoundError raised inside the echoed block is not swallowed."""
+        with pytest.raises(FileNotFoundError, match="from the block"):
+            with st.echo():
+                raise FileNotFoundError("from the block")
 
 
 class EchoUtilsTest(DeltaGeneratorTestCase):

--- a/lib/tests/streamlit/elements/echo_test.py
+++ b/lib/tests/streamlit/elements/echo_test.py
@@ -219,6 +219,10 @@ class MultiDecorated:
         assert warning_el.format == AlertProto.WARNING
         assert "Unable to display code. missing.py" in warning_el.body
         assert self.get_delta_from_queue(1).new_element.markdown.body == "Hello"
+        assert not any(
+            delta.new_element.WhichOneof("type") == "code"
+            for delta in self.get_all_deltas_from_queue()
+        )
 
     def test_echo_propagates_file_not_found_from_block(self):
         """FileNotFoundError raised inside the echoed block is not swallowed."""

--- a/lib/tests/streamlit/elements/echo_test.py
+++ b/lib/tests/streamlit/elements/echo_test.py
@@ -200,24 +200,30 @@ class MultiDecorated:
         element = self.get_delta_from_queue(0).new_element
         assert echo_str == element.code.code_text
 
-    def test_echo_missing_source_file_warns_and_logs(self):
-        """If the source file can't be read, echo still runs the block, shows a
+    @parameterized.expand(
+        [
+            (FileNotFoundError, "missing.py"),
+            (PermissionError, "denied.py"),
+        ]
+    )
+    def test_echo_unreadable_source_file_warns_and_logs(self, error_cls, err_text):
+        """If the source file cannot be opened, echo still runs the block, shows a
         warning, and logs it with a stack trace.
         """
         with patch(
             "streamlit.source_util.open_python_file",
-            side_effect=FileNotFoundError("missing.py"),
+            side_effect=error_cls(err_text),
         ):
             with self.assertLogs(_LOGGER) as logs:
                 with st.echo():
                     st.write("Hello")
 
-        assert "Unable to display code. missing.py" in logs.records[0].getMessage()
+        assert f"Unable to display code. {err_text}" in logs.records[0].getMessage()
         assert logs.records[0].stack_info is not None
 
         warning_el = self.get_delta_from_queue(0).new_element.alert
         assert warning_el.format == AlertProto.WARNING
-        assert "Unable to display code. missing.py" in warning_el.body
+        assert f"Unable to display code. {err_text}" in warning_el.body
         assert self.get_delta_from_queue(1).new_element.markdown.body == "Hello"
         assert not any(
             delta.new_element.WhichOneof("type") == "code"

--- a/lib/tests/streamlit/elements/element_policies_test.py
+++ b/lib/tests/streamlit/elements/element_policies_test.py
@@ -185,10 +185,14 @@ class CheckCacheReplayTest(ElementPoliciesTest):
         patched_st_exception.assert_not_called()
 
     @patch("streamlit.exception")
-    def test_cache_replay_rules_fails(self, patched_st_exception):
+    @patch("streamlit.elements.lib.policies._LOGGER")
+    def test_cache_replay_rules_fails(self, patched_logger, patched_st_exception):
         in_cached_function.set(True)
         check_cache_replay_rules()
         patched_st_exception.assert_called()
+        patched_logger.warning.assert_called_once()
+        _, kwargs = patched_logger.warning.call_args
+        assert kwargs.get("stack_info") is True
         # Reset the global flag to avoid affecting other tests
         in_cached_function.set(False)
 

--- a/lib/tests/streamlit/elements/json_test.py
+++ b/lib/tests/streamlit/elements/json_test.py
@@ -54,13 +54,16 @@ class StJsonAPITest(DeltaGeneratorTestCase):
         with self.assertLogs(_LOGGER) as logs:
             st.json(data)
 
-        assert "not fully serializable as JSON" in logs.records[0].getMessage()
+        log_message = logs.records[0].getMessage()
+        assert "not fully serializable as JSON" in log_message
+        assert not log_message.startswith("Warning:")
         assert logs.records[0].stack_info is not None
 
         json_el = self.get_delta_from_queue().new_element
         # Warning is enqueued first; JSON is last.
         warning_el = self.get_delta_from_queue(-2).new_element
         assert json_el.json.body == '{"array": "array([1, 2, 3, 4, 5])"}'
+        assert warning_el.alert.body.startswith("Warning:")
         assert "not fully serializable as JSON" in warning_el.alert.body
 
     def test_expanded_param(self):

--- a/lib/tests/streamlit/elements/json_test.py
+++ b/lib/tests/streamlit/elements/json_test.py
@@ -20,6 +20,7 @@ import pytest
 from parameterized import parameterized
 
 import streamlit as st
+from streamlit.elements.json import _LOGGER
 from streamlit.errors import (
     StreamlitInvalidParameterTypeError,
     StreamlitInvalidWidthError,
@@ -46,20 +47,20 @@ class StJsonAPITest(DeltaGeneratorTestCase):
         )
         assert el.width_config.use_stretch is True
 
-        # Test that an object containing non-json-friendly keys can still
-        # be displayed.  Resultant json body will be missing those keys.
-
+    def test_st_json_unserializable_keys_warns_and_logs(self):
+        """Non-JSON keys are omitted, logged, and shown as a warning."""
         n = np.array([1, 2, 3, 4, 5])
         data = {n[0]: "this key will not render as JSON", "array": n}
-        st.json(data)
+        with self.assertLogs(_LOGGER) as logs:
+            st.json(data)
 
-        el = self.get_delta_from_queue().new_element
-        assert el.json.body == '{"array": "array([1, 2, 3, 4, 5])"}'
-        assert (
-            el.width_config.WhichOneof("width_spec")
-            == WidthConfigFields.USE_STRETCH.value
-        )
-        assert el.width_config.use_stretch is True
+        assert "not fully serializable as JSON" in logs.records[0].getMessage()
+        assert logs.records[0].stack_info is not None
+
+        json_el = self.get_delta_from_queue().new_element
+        warning_el = self.get_delta_from_queue(-2).new_element
+        assert json_el.json.body == '{"array": "array([1, 2, 3, 4, 5])"}'
+        assert "not fully serializable as JSON" in warning_el.alert.body
 
     def test_expanded_param(self):
         """Test expanded parameter for `st.json`"""

--- a/lib/tests/streamlit/elements/json_test.py
+++ b/lib/tests/streamlit/elements/json_test.py
@@ -47,7 +47,7 @@ class StJsonAPITest(DeltaGeneratorTestCase):
         )
         assert el.width_config.use_stretch is True
 
-    def test_st_json_unserializable_keys_warns_and_logs(self):
+    def test_st_json_warns_and_logs_for_unserializable_keys(self):
         """Non-JSON keys are omitted, logged, and shown as a warning."""
         n = np.array([1, 2, 3, 4, 5])
         data = {n[0]: "this key will not render as JSON", "array": n}
@@ -58,6 +58,7 @@ class StJsonAPITest(DeltaGeneratorTestCase):
         assert logs.records[0].stack_info is not None
 
         json_el = self.get_delta_from_queue().new_element
+        # Warning is enqueued first; JSON is last.
         warning_el = self.get_delta_from_queue(-2).new_element
         assert json_el.json.body == '{"array": "array([1, 2, 3, 4, 5])"}'
         assert "not fully serializable as JSON" in warning_el.alert.body

--- a/lib/tests/streamlit/elements/number_input_test.py
+++ b/lib/tests/streamlit/elements/number_input_test.py
@@ -21,7 +21,7 @@ from parameterized import parameterized
 
 import streamlit as st
 from streamlit.elements.lib.js_number import JSNumber
-from streamlit.elements.widgets.number_input import NumberInputSerde
+from streamlit.elements.widgets.number_input import _LOGGER, NumberInputSerde
 from streamlit.errors import (
     StreamlitAPIException,
     StreamlitInvalidWidthError,
@@ -29,7 +29,6 @@ from streamlit.errors import (
     StreamlitValueAboveMaxError,
     StreamlitValueError,
 )
-from streamlit.proto.Alert_pb2 import Alert as AlertProto
 from streamlit.proto.LabelVisibility_pb2 import LabelVisibility
 from streamlit.proto.NumberInput_pb2 import NumberInput
 from streamlit.proto.WidgetStates_pb2 import WidgetState
@@ -219,25 +218,39 @@ class NumberInputTest(DeltaGeneratorTestCase):
             c = self.get_delta_from_queue().new_element.number_input
             assert c.format == "%" + char
 
-    def test_warns_on_float_type_with_int_format(self):
-        st.number_input("the label", value=5.0, format="%d")
+    def test_logs_warning_on_float_type_with_int_format(self):
+        """Integer format with a float value logs a warning and still uses that format."""
+        with self.assertLogs(_LOGGER) as logs:
+            st.number_input("the label", value=5.0, format="%d")
 
-        c = self.get_delta_from_queue(-2).new_element.alert
-        assert c.format == AlertProto.WARNING
         assert (
-            c.body
-            == "Warning: NumberInput value below has type float, but format %d displays as integer."
+            "NumberInput value has type float, but format %d displays as integer."
+            in logs.records[0].getMessage()
         )
+        assert logs.records[0].stack_info is not None
+        assert not any(
+            delta.new_element.WhichOneof("type") == "alert"
+            for delta in self.get_all_deltas_from_queue()
+        )
+        c = self.get_delta_from_queue().new_element.number_input
+        assert c.format == "%d"
 
-    def test_warns_on_int_type_with_float_format(self):
-        st.number_input("the label", value=5, format="%0.2f")
+    def test_logs_warning_on_int_type_with_float_format(self):
+        """Float format with an int value logs a warning and still uses that format."""
+        with self.assertLogs(_LOGGER) as logs:
+            st.number_input("the label", value=5, format="%0.2f")
 
-        c = self.get_delta_from_queue(-2).new_element.alert
-        assert c.format == AlertProto.WARNING
         assert (
-            c.body
-            == "Warning: NumberInput value below has type int so is displayed as int despite format string %0.2f."
+            "NumberInput value has type int so is displayed as int despite "
+            "format string %0.2f." in logs.records[0].getMessage()
         )
+        assert logs.records[0].stack_info is not None
+        assert not any(
+            delta.new_element.WhichOneof("type") == "alert"
+            for delta in self.get_all_deltas_from_queue()
+        )
+        c = self.get_delta_from_queue().new_element.number_input
+        assert c.format == "%0.2f"
 
     def test_error_on_unsupported_formatters(self):
         UNSUPPORTED = "pAn"

--- a/lib/tests/streamlit/elements/number_input_test.py
+++ b/lib/tests/streamlit/elements/number_input_test.py
@@ -224,7 +224,7 @@ class NumberInputTest(DeltaGeneratorTestCase):
             st.number_input("the label", value=5.0, format="%d")
 
         assert (
-            "NumberInput value has type float, but format %d displays as integer."
+            "st.number_input value has type float, but format %d displays as integer."
             in logs.records[0].getMessage()
         )
         assert logs.records[0].stack_info is not None
@@ -241,7 +241,7 @@ class NumberInputTest(DeltaGeneratorTestCase):
             st.number_input("the label", value=5, format="%0.2f")
 
         assert (
-            "NumberInput value has type int so is displayed as int despite "
+            "st.number_input value has type int so is displayed as int despite "
             "format string %0.2f." in logs.records[0].getMessage()
         )
         assert logs.records[0].stack_info is not None

--- a/lib/tests/streamlit/runtime/caching/common_cache_test.py
+++ b/lib/tests/streamlit/runtime/caching/common_cache_test.py
@@ -42,7 +42,7 @@ from streamlit.runtime.caching.cache_errors import (
     CachedStFunctionInBackgroundModeWarning,
     CacheReplayClosureError,
 )
-from streamlit.runtime.caching.cache_utils import CachedResult
+from streamlit.runtime.caching.cache_utils import _LOGGER, CachedResult
 from streamlit.runtime.caching.storage.dummy_cache_storage import (
     MemoryCacheStorageManager,
 )
@@ -1570,7 +1570,8 @@ class CommonCacheBackgroundRefreshTest(DeltaGeneratorTestCase):
 
         with patch.object(st, "exception") as mock_exception:
             timer_patch.return_value = 0
-            assert foo() == 1
+            with self.assertLogs(_LOGGER) as logs:
+                assert foo() == 1
             # Display output renders live during the actual miss.
             assert self._text_deltas() == ["hello"]
             # A warning is emitted about background-mode display commands.
@@ -1579,6 +1580,8 @@ class CommonCacheBackgroundRefreshTest(DeltaGeneratorTestCase):
                 mock_exception.call_args[0][0],
                 CachedStFunctionInBackgroundModeWarning,
             )
+            assert 'refresh_mode="background"' in logs.records[0].getMessage()
+            assert logs.records[0].stack_info is not None
 
             mock_exception.reset_mock()
             self.clear_queue()


### PR DESCRIPTION
## Describe your changes

Library diagnostics that previously appeared only as in-app alerts now go to the server console (with a stack trace) so CLI users and agents can see them. Display quirks are console-only; cases that change app output keep the in-app warning and add a log. `st.echo` still runs the block when the source file is missing (previously `contextlib` raised `RuntimeError: generator didn't yield` and the user's code never executed) and no longer swallows `FileNotFoundError` raised inside the block.

- Console-only for ignored-parameter / display-quirk cases (`st.number_input` format mismatch, `st.audio` ignored `sample_rate`). Those alerts are removed from the app, not copied.
- Keep in-app UI and add a console log for cases that affect app behavior (cached widgets, background-cache display, incomplete `st.json`, `st.echo` missing source)
- `st.echo` still runs the block when the source file cannot be read

## GitHub Issue Link (if applicable)

## Testing Plan

- [x] Unit Tests (JS and/or Python)

- `lib/tests/streamlit/elements/number_input_test.py`, `audio_test.py` — console-only warnings, no in-app alert
- `lib/tests/streamlit/elements/json_test.py`, `echo_test.py` — UI warning plus log; echo still runs the block
- `lib/tests/streamlit/elements/element_policies_test.py`, `common_cache_test.py` — cache warnings log with a stack trace
- E2E Tests: Not needed; the change is limited to backend console logging and unit-level element-delta behavior.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.