### PR TITLE
[chore] Fix click, uvloop, knip, and teardown test warnings

### DIFF
--- a/frontend/knip.json
+++ b/frontend/knip.json
@@ -2,21 +2,17 @@
   "$schema": "https://unpkg.com/knip@5/schema.json",
   "tags": ["-lintignore"],
   "ignoreBinaries": ["streamlit"],
-  "ignoreUnresolved": ["^\\./proto(?:\\.js)?$"],
   "ignoreIssues": {
     "component-lib/src/ArrowTable.ts": ["exports", "types"]
   },
   "ignoreDependencies": [
     "@bufbuild/buf",
-    "@deck.gl/extensions",
-    "@deck.gl/widgets",
     "@playwright/cli",
     "@swc/plugin-emotion",
     "eslint-plugin-streamlit-custom",
     "oxfmt",
     "protobufjs",
     "protobufjs-cli",
-    "react-responsive-carousel",
     "typescript-v7"
   ],
   "workspaces": {

--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -647,7 +647,9 @@ class AppSession:
         try:
             self._event_loop.call_soon_threadsafe(callback)
         except RuntimeError:
-            _LOGGER.debug("Dropped event-loop callback; event loop is closed")
+            if not self._event_loop.is_closed():
+                raise
+            _LOGGER.debug("Dropped event-loop callback", exc_info=True)
 
     def _handle_scriptrunner_event_on_event_loop(
         self,

--- a/lib/streamlit/runtime/app_session.py
+++ b/lib/streamlit/runtime/app_session.py
@@ -426,7 +426,7 @@ class AppSession:
         # this exception ForwardMsg *must* also be enqueued in a callback,
         # so that it will be enqueued *after* the various ForwardMsgs that
         # _on_scriptrunner_event sends.
-        self._event_loop.call_soon_threadsafe(
+        self._call_soon_on_event_loop(
             lambda: self._enqueue_forward_msg(self._create_exception_message(e))
         )
 
@@ -624,7 +624,7 @@ class AppSession:
         We forward the event on to _handle_scriptrunner_event_on_event_loop,
         which will be called on the main thread.
         """
-        self._event_loop.call_soon_threadsafe(
+        self._call_soon_on_event_loop(
             lambda: self._handle_scriptrunner_event_on_event_loop(
                 sender,
                 event,
@@ -636,6 +636,18 @@ class AppSession:
                 pages,
             )
         )
+
+    def _call_soon_on_event_loop(self, callback: Callable[[], None]) -> None:
+        """Schedule ``callback`` on the session event loop.
+
+        ScriptRunner events can arrive after the loop is closed (process
+        shutdown or test teardown). Drop them instead of raising
+        ``RuntimeError: Event loop is closed``.
+        """
+        try:
+            self._event_loop.call_soon_threadsafe(callback)
+        except RuntimeError:
+            _LOGGER.debug("Dropped event-loop callback; event loop is closed")
 
     def _handle_scriptrunner_event_on_event_loop(
         self,

--- a/lib/streamlit/web/bootstrap.py
+++ b/lib/streamlit/web/bootstrap.py
@@ -76,9 +76,8 @@ def _fix_sys_path(main_script_path: str) -> None:
 def _get_uvloop_loop_factory() -> Callable[[], asyncio.AbstractEventLoop] | None:
     """Return uvloop's event-loop factory, or None if it cannot be used.
 
-    ``uvloop.install()`` and event-loop policies are deprecated (removed in
-    Python 3.16). Prefer passing this factory to ``asyncio.Runner`` /
-    ``asyncio.run(..., loop_factory=...)``.
+    ``new_event_loop`` exists on our minimum uvloop (0.15.2). We still look it
+    up with ``getattr`` so an unexpected older build falls back to ``install()``.
     """
     if env_util.IS_WINDOWS:
         return None
@@ -88,35 +87,60 @@ def _get_uvloop_loop_factory() -> Callable[[], asyncio.AbstractEventLoop] | None
     except ModuleNotFoundError:
         return None
 
-    return uvloop.new_event_loop
+    factory = getattr(uvloop, "new_event_loop", None)
+    return factory if callable(factory) else None
+
+
+def _try_install_uvloop() -> None:
+    """Install uvloop as the process event-loop policy if that API exists.
+
+    Used on Python 3.10 (no ``asyncio.Runner``) and as a fallback when
+    ``uvloop.new_event_loop`` is missing. ``install()`` is deprecated from
+    Python 3.12 and removed in 3.16; those versions take the Runner path.
+    """
+    if env_util.IS_WINDOWS:
+        return
+
+    try:
+        import uvloop
+    except ModuleNotFoundError:
+        return
+
+    install = getattr(uvloop, "install", None)
+    if not callable(install):
+        return
+
+    try:
+        install()
+        _LOGGER.debug("uvloop installed as default event loop policy.")
+    except Exception:
+        _LOGGER.warning(
+            "Failed to install uvloop. Falling back to default loop.",
+            exc_info=True,
+        )
 
 
 def _run_server_loop(main: Coroutine[Any, Any, None]) -> None:
     """Run ``main`` on a new event loop, using uvloop when available.
 
-    On Python 3.11+ this uses ``asyncio.Runner(loop_factory=...)`` so we never
-    call the deprecated ``uvloop.install()`` / event-loop policy APIs. Python
-    3.10 still uses ``install()`` because ``asyncio.Runner`` was added in 3.11.
+    Preferred path (Python 3.11+ and uvloop with ``new_event_loop``):
+    ``asyncio.Runner(loop_factory=...)``. That avoids the deprecated
+    ``uvloop.install()`` / event-loop policy APIs.
+
+    Fallback (Python 3.10, or uvloop too old for ``new_event_loop``):
+    ``uvloop.install()`` when present, then ``asyncio.run()``.
     """
     loop_factory = _get_uvloop_loop_factory()
-    if loop_factory is not None and sys.version_info >= (3, 11):
+    # Runner was added in 3.11 and is the supported way to pick a loop
+    # implementation. getattr keeps this importable on 3.10.
+    runner_cls = getattr(asyncio, "Runner", None)
+    if loop_factory is not None and runner_cls is not None:
         _LOGGER.debug("Starting new uvloop event loop for server")
-        with asyncio.Runner(loop_factory=loop_factory) as runner:
+        with runner_cls(loop_factory=loop_factory) as runner:
             runner.run(main)
         return
 
-    if loop_factory is not None:
-        try:
-            import uvloop
-
-            uvloop.install()
-            _LOGGER.debug("uvloop installed as default event loop policy.")
-        except Exception:
-            _LOGGER.warning(
-                "Failed to install uvloop. Falling back to default loop.",
-                exc_info=True,
-            )
-
+    _try_install_uvloop()
     _LOGGER.debug("Starting new event loop for server")
     asyncio.run(main)
 

--- a/lib/streamlit/web/bootstrap.py
+++ b/lib/streamlit/web/bootstrap.py
@@ -95,8 +95,9 @@ def _try_install_uvloop() -> None:
     """Install uvloop as the process event-loop policy if that API exists.
 
     Used on Python 3.10 (no ``asyncio.Runner``) and as a fallback when
-    ``uvloop.new_event_loop`` is missing. ``install()`` is deprecated from
-    Python 3.12 and removed in 3.16; those versions take the Runner path.
+    ``uvloop.new_event_loop`` is missing. ``install()`` relies on the asyncio
+    policy APIs, which are deprecated from Python 3.14 and removed in 3.16.
+    Python 3.11+ takes the Runner path instead.
     """
     if env_util.IS_WINDOWS:
         return
@@ -135,10 +136,20 @@ def _run_server_loop(main: Coroutine[Any, Any, None]) -> None:
     # implementation. getattr keeps this importable on 3.10.
     runner_cls = getattr(asyncio, "Runner", None)
     if loop_factory is not None and runner_cls is not None:
-        _LOGGER.debug("Starting new uvloop event loop for server")
-        with runner_cls(loop_factory=loop_factory) as runner:
-            runner.run(main)
-        return
+        try:
+            # Create the loop before Runner.run so a factory failure can
+            # fall back without wrapping the server coroutine itself.
+            loop = loop_factory()
+        except Exception:
+            _LOGGER.warning(
+                "Failed to create uvloop event loop. Falling back to default loop.",
+                exc_info=True,
+            )
+        else:
+            _LOGGER.debug("Starting new uvloop event loop for server")
+            with runner_cls(loop_factory=lambda: loop) as runner:
+                runner.run(main)
+            return
 
     _try_install_uvloop()
     _LOGGER.debug("Starting new event loop for server")

--- a/lib/streamlit/web/bootstrap.py
+++ b/lib/streamlit/web/bootstrap.py
@@ -19,12 +19,15 @@ import mimetypes
 import os
 import signal
 import sys
-from typing import Any, Final, Literal
+from typing import TYPE_CHECKING, Any, Final, Literal
 
 from streamlit import cli_util, config, env_util, file_util, net_util, secrets
 from streamlit.logger import get_logger
 from streamlit.watcher import report_watchdog_availability, watch_file
 from streamlit.web.server import Server, server_address_is_unix_socket, server_util
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Coroutine
 
 _LOGGER: Final = get_logger(__name__)
 
@@ -70,27 +73,52 @@ def _fix_sys_path(main_script_path: str) -> None:
     sys.path.insert(0, os.path.dirname(main_script_path))
 
 
-def _maybe_install_uvloop(running_in_event_loop: bool) -> None:
-    """Install uvloop as the default event loop policy if available."""
+def _get_uvloop_loop_factory() -> Callable[[], asyncio.AbstractEventLoop] | None:
+    """Return uvloop's event-loop factory, or None if it cannot be used.
 
-    if running_in_event_loop:
-        return
-
+    ``uvloop.install()`` and event-loop policies are deprecated (removed in
+    Python 3.16). Prefer passing this factory to ``asyncio.Runner`` /
+    ``asyncio.run(..., loop_factory=...)``.
+    """
     if env_util.IS_WINDOWS:
-        return
+        return None
 
     try:
         import uvloop
     except ModuleNotFoundError:
+        return None
+
+    return uvloop.new_event_loop
+
+
+def _run_server_loop(main: Coroutine[Any, Any, None]) -> None:
+    """Run ``main`` on a new event loop, using uvloop when available.
+
+    On Python 3.11+ this uses ``asyncio.Runner(loop_factory=...)`` so we never
+    call the deprecated ``uvloop.install()`` / event-loop policy APIs. Python
+    3.10 still uses ``install()`` because ``asyncio.Runner`` was added in 3.11.
+    """
+    loop_factory = _get_uvloop_loop_factory()
+    if loop_factory is not None and sys.version_info >= (3, 11):
+        _LOGGER.debug("Starting new uvloop event loop for server")
+        with asyncio.Runner(loop_factory=loop_factory) as runner:
+            runner.run(main)
         return
 
-    try:
-        uvloop.install()
-        _LOGGER.debug("uvloop installed as default event loop policy.")
-    except Exception:
-        _LOGGER.warning(
-            "Failed to install uvloop. Falling back to default loop.", exc_info=True
-        )
+    if loop_factory is not None:
+        try:
+            import uvloop
+
+            uvloop.install()
+            _LOGGER.debug("uvloop installed as default event loop policy.")
+        except Exception:
+            _LOGGER.warning(
+                "Failed to install uvloop. Falling back to default loop.",
+                exc_info=True,
+            )
+
+    _LOGGER.debug("Starting new event loop for server")
+    asyncio.run(main)
 
 
 def _fix_sys_argv(main_script_path: str, args: list[str]) -> None:
@@ -470,8 +498,5 @@ def run(
         # This prevents the task from being garbage collected
         server._bootstrap_task = task
     else:
-        _maybe_install_uvloop(running_in_event_loop)
-        # No running event loop, so we can use asyncio.run
-        # This is the normal case when running streamlit from the command line
-        _LOGGER.debug("Starting new event loop for server")
-        asyncio.run(main())
+        # No running event loop. This is the normal CLI case.
+        _run_server_loop(main())

--- a/lib/streamlit/web/bootstrap.py
+++ b/lib/streamlit/web/bootstrap.py
@@ -129,7 +129,8 @@ def _run_server_loop(main: Coroutine[Any, Any, None]) -> None:
     ``uvloop.install()`` / event-loop policy APIs.
 
     Fallback (Python 3.10, or uvloop too old for ``new_event_loop``):
-    ``uvloop.install()`` when present, then ``asyncio.run()``.
+    ``uvloop.install()`` when present, then ``asyncio.run()``. If creating
+    the uvloop loop fails, skip ``install()`` and use the stdlib loop.
     """
     loop_factory = _get_uvloop_loop_factory()
     # Runner was added in 3.11 and is the supported way to pick a loop
@@ -141,6 +142,8 @@ def _run_server_loop(main: Coroutine[Any, Any, None]) -> None:
             # fall back without wrapping the server coroutine itself.
             loop = loop_factory()
         except Exception:
+            # Don't call install() here: that would retry the same uvloop
+            # implementation that just failed to create a loop.
             _LOGGER.warning(
                 "Failed to create uvloop event loop. Falling back to default loop.",
                 exc_info=True,
@@ -150,8 +153,9 @@ def _run_server_loop(main: Coroutine[Any, Any, None]) -> None:
             with runner_cls(loop_factory=lambda: loop) as runner:
                 runner.run(main)
             return
+    else:
+        _try_install_uvloop()
 
-    _try_install_uvloop()
     _LOGGER.debug("Starting new event loop for server")
     asyncio.run(main)
 

--- a/lib/tests/streamlit/dataframe_util_test.py
+++ b/lib/tests/streamlit/dataframe_util_test.py
@@ -19,6 +19,7 @@ import os
 import sqlite3
 import unittest
 from collections.abc import Iterator, Mapping
+from contextlib import closing
 from datetime import date
 from decimal import Decimal
 from typing import Any
@@ -747,28 +748,27 @@ class DataframeUtilTest(unittest.TestCase):
     def test_verify_sqlite3_integration(self):
         """Verify that sqlite3 cursor can be used as a data source."""
 
-        con = sqlite3.connect("file::memory:", uri=True)
-        cur = con.cursor()
-        cur.execute("CREATE TABLE movie(title, year, score)")
-        cur.execute("""
-            INSERT INTO movie VALUES
-                ('Monty Python and the Holy Grail', 1975, 8.2),
-                ('And Now for Something Completely Different', 1971, 7.5)
-        """)
-        con.commit()
-        db_cursor = cur.execute("SELECT * FROM movie")
-        assert dataframe_util.is_dbapi_cursor(db_cursor) is True
-        assert (
-            dataframe_util.determine_data_format(db_cursor)
-            is dataframe_util.DataFormat.DBAPI_CURSOR
-        )
-        converted_df = dataframe_util.convert_anything_to_pandas_df(db_cursor)
-        assert isinstance(
-            converted_df,
-            pd.DataFrame,
-        )
-        assert converted_df.shape == (2, 3)
-        con.close()
+        with closing(sqlite3.connect("file::memory:", uri=True)) as con:
+            cur = con.cursor()
+            cur.execute("CREATE TABLE movie(title, year, score)")
+            cur.execute("""
+                INSERT INTO movie VALUES
+                    ('Monty Python and the Holy Grail', 1975, 8.2),
+                    ('And Now for Something Completely Different', 1971, 7.5)
+            """)
+            con.commit()
+            db_cursor = cur.execute("SELECT * FROM movie")
+            assert dataframe_util.is_dbapi_cursor(db_cursor) is True
+            assert (
+                dataframe_util.determine_data_format(db_cursor)
+                is dataframe_util.DataFormat.DBAPI_CURSOR
+            )
+            converted_df = dataframe_util.convert_anything_to_pandas_df(db_cursor)
+            assert isinstance(
+                converted_df,
+                pd.DataFrame,
+            )
+            assert converted_df.shape == (2, 3)
 
     @pytest.mark.require_integration
     def test_verify_duckdb_db_api_integration(self):
@@ -1273,7 +1273,7 @@ def test_convert_duckdb_relation_row_cap_triggers_caption() -> None:
 
 def test_convert_dbapi_cursor_row_cap_triggers_caption() -> None:
     """DB-API cursors that return a full fetchmany batch may show a row-limit caption."""
-    with sqlite3.connect("file::memory:", uri=True) as con:
+    with closing(sqlite3.connect("file::memory:", uri=True)) as con:
         cur = con.cursor()
         cur.execute("CREATE TABLE t(x INTEGER)")
         cur.executemany("INSERT INTO t VALUES (?)", [(i,) for i in range(6)])

--- a/lib/tests/streamlit/runtime/app_session_test.py
+++ b/lib/tests/streamlit/runtime/app_session_test.py
@@ -1181,19 +1181,40 @@ class AppSessionScriptEventTest(unittest.IsolatedAsyncioTestCase):
         loop = asyncio.new_event_loop()
         loop.close()
         session = _create_test_session(loop)
+        handle_event = MagicMock()
+        session._handle_scriptrunner_event_on_event_loop = handle_event
 
         session._on_scriptrunner_event(
             sender=MagicMock(),
             event=ScriptRunnerEvent.SCRIPT_STOPPED_WITH_SUCCESS,
         )
 
+        handle_event.assert_not_called()
+
     def test_handle_backmsg_exception_when_event_loop_closed(self):
         """A late backmsg exception after the loop is closed is dropped."""
         loop = asyncio.new_event_loop()
         loop.close()
         session = _create_test_session(loop)
+        handle_event = MagicMock()
+        enqueue = MagicMock()
+        session._handle_scriptrunner_event_on_event_loop = handle_event
+        session._enqueue_forward_msg = enqueue
 
         session.handle_backmsg_exception(RuntimeError("late exception"))
+
+        handle_event.assert_not_called()
+        enqueue.assert_not_called()
+
+    def test_call_soon_on_event_loop_reraises_when_loop_open(self):
+        """Unexpected RuntimeError from call_soon_threadsafe is not swallowed."""
+        loop = MagicMock()
+        loop.is_closed.return_value = False
+        loop.call_soon_threadsafe.side_effect = RuntimeError("unexpected")
+        session = _create_test_session(loop)
+
+        with pytest.raises(RuntimeError, match="unexpected"):
+            session._call_soon_on_event_loop(lambda: None)
 
     async def test_event_handler_asserts_if_called_off_event_loop(self):
         """AppSession._handle_scriptrunner_event_on_event_loop will assert

--- a/lib/tests/streamlit/runtime/app_session_test.py
+++ b/lib/tests/streamlit/runtime/app_session_test.py
@@ -1176,6 +1176,25 @@ class AppSessionScriptEventTest(unittest.IsolatedAsyncioTestCase):
 
         handle_event_spy.assert_called_once()
 
+    def test_on_scriptrunner_event_when_event_loop_closed(self):
+        """A late ScriptRunner event after the loop is closed is dropped."""
+        loop = asyncio.new_event_loop()
+        loop.close()
+        session = _create_test_session(loop)
+
+        session._on_scriptrunner_event(
+            sender=MagicMock(),
+            event=ScriptRunnerEvent.SCRIPT_STOPPED_WITH_SUCCESS,
+        )
+
+    def test_handle_backmsg_exception_when_event_loop_closed(self):
+        """A late backmsg exception after the loop is closed is dropped."""
+        loop = asyncio.new_event_loop()
+        loop.close()
+        session = _create_test_session(loop)
+
+        session.handle_backmsg_exception(RuntimeError("late exception"))
+
     async def test_event_handler_asserts_if_called_off_event_loop(self):
         """AppSession._handle_scriptrunner_event_on_event_loop will assert
         if it's called from another event loop (or no event loop).

--- a/lib/tests/streamlit/web/bootstrap_test.py
+++ b/lib/tests/streamlit/web/bootstrap_test.py
@@ -605,7 +605,7 @@ class BootstrapUvloopTest(TestCase):
             assert bootstrap._get_uvloop_loop_factory() is None
 
     def test_returns_none_when_uvloop_missing(self):
-        """Missing uvloop does not raise."""
+        """Missing uvloop yields no loop factory."""
         with (
             patch.object(bootstrap.env_util, "IS_WINDOWS", False),
             patch.dict("sys.modules", {"uvloop": None}),
@@ -613,7 +613,7 @@ class BootstrapUvloopTest(TestCase):
             assert bootstrap._get_uvloop_loop_factory() is None
 
     def test_returns_none_when_new_event_loop_missing(self):
-        """Older uvloop without new_event_loop falls back to install()."""
+        """An older uvloop without ``new_event_loop`` yields no loop factory."""
         fake_uvloop = types.ModuleType("uvloop")
 
         with (
@@ -624,7 +624,8 @@ class BootstrapUvloopTest(TestCase):
 
     def test_run_server_loop_uses_runner_loop_factory(self):
         """When asyncio.Runner exists, the server uses loop_factory=uvloop."""
-        fake_factory = Mock(name="uvloop_factory")
+        fake_loop = Mock(name="uvloop")
+        fake_factory = Mock(name="uvloop_factory", return_value=fake_loop)
         mock_runner = Mock()
         mock_runner.__enter__ = Mock(return_value=mock_runner)
         mock_runner.__exit__ = Mock(return_value=False)
@@ -642,8 +643,34 @@ class BootstrapUvloopTest(TestCase):
         ):
             bootstrap._run_server_loop(coro)
 
-        mock_runner_cls.assert_called_once_with(loop_factory=fake_factory)
+        fake_factory.assert_called_once_with()
+        mock_runner_cls.assert_called_once()
+        assert mock_runner_cls.call_args.kwargs["loop_factory"]() is fake_loop
         mock_runner.run.assert_called_once_with(coro)
+
+    def test_run_server_loop_falls_back_when_factory_fails(self):
+        """A failing uvloop factory falls back to the default loop."""
+        coro = Mock(name="main_coro")
+        fake_factory = Mock(name="uvloop_factory", side_effect=RuntimeError("boom"))
+
+        with (
+            patch.object(
+                bootstrap, "_get_uvloop_loop_factory", return_value=fake_factory
+            ),
+            patch(
+                "streamlit.web.bootstrap.asyncio.Runner",
+                create=True,
+            ) as mock_runner_cls,
+            patch.object(bootstrap, "_try_install_uvloop") as mock_install,
+            patch("streamlit.web.bootstrap.asyncio.run") as mock_run,
+            patch.object(bootstrap._LOGGER, "warning") as mock_warning,
+        ):
+            bootstrap._run_server_loop(coro)
+
+        mock_runner_cls.assert_not_called()
+        mock_install.assert_called_once()
+        mock_run.assert_called_once_with(coro)
+        mock_warning.assert_called_once()
 
     def test_run_server_loop_uses_install_when_runner_unavailable(self):
         """Python 3.10 (no asyncio.Runner) falls back to uvloop.install()."""
@@ -678,14 +705,17 @@ class BootstrapUvloopTest(TestCase):
         mock_run.assert_called_once_with(coro)
 
     def test_try_install_uvloop_skips_when_install_missing(self):
-        """uvloop without install() does not raise."""
+        """uvloop without install() does not raise or warn."""
         fake_uvloop = types.ModuleType("uvloop")
 
         with (
             patch.object(bootstrap.env_util, "IS_WINDOWS", False),
             patch.dict("sys.modules", {"uvloop": fake_uvloop}),
+            patch.object(bootstrap._LOGGER, "warning") as mock_warning,
         ):
             bootstrap._try_install_uvloop()
+
+        mock_warning.assert_not_called()
 
 
 class BootstrapAsgiTest(IsolatedAsyncioTestCase):

--- a/lib/tests/streamlit/web/bootstrap_test.py
+++ b/lib/tests/streamlit/web/bootstrap_test.py
@@ -555,18 +555,19 @@ class BootstrapRunTest(IsolatedAsyncioTestCase):
         with testutil.patch_config_options({"server.headless": True}):
             bootstrap.run("", False, [], {}, stop_immediately_for_testing=True)
 
-    def test_bootstrap_run_in_existing_event_loop(self):
+    async def test_bootstrap_run_in_existing_event_loop(self):
         """Bootstrap run works within an existing event loop."""
-        import asyncio
-
-        event_loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(event_loop)
         with testutil.patch_config_options({"server.headless": True}):
-
-            async def _run():
-                bootstrap.run("", False, [], {}, stop_immediately_for_testing=True)
-
-            event_loop.run_until_complete(_run())
+            bootstrap.run("", False, [], {}, stop_immediately_for_testing=True)
+            # When a loop is already running, run() schedules the server and
+            # returns. Await that task so serve_with_signal is not leaked.
+            bootstrap_tasks = [
+                task
+                for task in asyncio.all_tasks()
+                if task.get_name() == "bootstrap.run_server"
+            ]
+            assert bootstrap_tasks
+            await asyncio.gather(*bootstrap_tasks)
 
     def test_bootstrap_run_without_existing_event_loop(self):
         """Bootstrap run creates event loop when none exists."""

--- a/lib/tests/streamlit/web/bootstrap_test.py
+++ b/lib/tests/streamlit/web/bootstrap_test.py
@@ -668,7 +668,7 @@ class BootstrapUvloopTest(TestCase):
             bootstrap._run_server_loop(coro)
 
         mock_runner_cls.assert_not_called()
-        mock_install.assert_called_once()
+        mock_install.assert_not_called()
         mock_run.assert_called_once_with(coro)
         mock_warning.assert_called_once()
 

--- a/lib/tests/streamlit/web/bootstrap_test.py
+++ b/lib/tests/streamlit/web/bootstrap_test.py
@@ -612,11 +612,18 @@ class BootstrapUvloopTest(TestCase):
         ):
             assert bootstrap._get_uvloop_loop_factory() is None
 
-    def test_run_server_loop_uses_runner_loop_factory(self):
-        """Python 3.11+ runs the server with asyncio.Runner(loop_factory=...)."""
-        if sys.version_info < (3, 11):
-            self.skipTest("asyncio.Runner requires Python 3.11+")
+    def test_returns_none_when_new_event_loop_missing(self):
+        """Older uvloop without new_event_loop falls back to install()."""
+        fake_uvloop = types.ModuleType("uvloop")
 
+        with (
+            patch.object(bootstrap.env_util, "IS_WINDOWS", False),
+            patch.dict("sys.modules", {"uvloop": fake_uvloop}),
+        ):
+            assert bootstrap._get_uvloop_loop_factory() is None
+
+    def test_run_server_loop_uses_runner_loop_factory(self):
+        """When asyncio.Runner exists, the server uses loop_factory=uvloop."""
         fake_factory = Mock(name="uvloop_factory")
         mock_runner = Mock()
         mock_runner.__enter__ = Mock(return_value=mock_runner)
@@ -628,7 +635,9 @@ class BootstrapUvloopTest(TestCase):
                 bootstrap, "_get_uvloop_loop_factory", return_value=fake_factory
             ),
             patch(
-                "streamlit.web.bootstrap.asyncio.Runner", return_value=mock_runner
+                "streamlit.web.bootstrap.asyncio.Runner",
+                return_value=mock_runner,
+                create=True,
             ) as mock_runner_cls,
         ):
             bootstrap._run_server_loop(coro)
@@ -636,17 +645,47 @@ class BootstrapUvloopTest(TestCase):
         mock_runner_cls.assert_called_once_with(loop_factory=fake_factory)
         mock_runner.run.assert_called_once_with(coro)
 
+    def test_run_server_loop_uses_install_when_runner_unavailable(self):
+        """Python 3.10 (no asyncio.Runner) falls back to uvloop.install()."""
+        fake_uvloop = types.ModuleType("uvloop")
+        fake_uvloop.new_event_loop = Mock(name="new_event_loop")
+        fake_uvloop.install = Mock(name="install")
+        coro = Mock(name="main_coro")
+
+        with (
+            patch.object(bootstrap.env_util, "IS_WINDOWS", False),
+            patch.dict("sys.modules", {"uvloop": fake_uvloop}),
+            patch.object(asyncio, "Runner", None, create=True),
+            patch("streamlit.web.bootstrap.asyncio.run") as mock_run,
+        ):
+            bootstrap._run_server_loop(coro)
+
+        fake_uvloop.install.assert_called_once()
+        mock_run.assert_called_once_with(coro)
+
     def test_run_server_loop_falls_back_to_asyncio_run(self):
         """Without uvloop, the server uses the stdlib event loop."""
         coro = Mock(name="main_coro")
 
         with (
             patch.object(bootstrap, "_get_uvloop_loop_factory", return_value=None),
+            patch.object(bootstrap, "_try_install_uvloop") as mock_install,
             patch("streamlit.web.bootstrap.asyncio.run") as mock_run,
         ):
             bootstrap._run_server_loop(coro)
 
+        mock_install.assert_called_once()
         mock_run.assert_called_once_with(coro)
+
+    def test_try_install_uvloop_skips_when_install_missing(self):
+        """uvloop without install() does not raise."""
+        fake_uvloop = types.ModuleType("uvloop")
+
+        with (
+            patch.object(bootstrap.env_util, "IS_WINDOWS", False),
+            patch.dict("sys.modules", {"uvloop": fake_uvloop}),
+        ):
+            bootstrap._try_install_uvloop()
 
 
 class BootstrapAsgiTest(IsolatedAsyncioTestCase):

--- a/lib/tests/streamlit/web/bootstrap_test.py
+++ b/lib/tests/streamlit/web/bootstrap_test.py
@@ -580,50 +580,73 @@ class BootstrapRunTest(IsolatedAsyncioTestCase):
 
 
 class BootstrapUvloopTest(TestCase):
-    def test_installs_uvloop_when_available(self):
-        """uvloop is installed as the default policy when present."""
+    def test_returns_uvloop_factory_when_available(self):
+        """uvloop's new_event_loop is used as the asyncio loop factory."""
         fake_uvloop = types.ModuleType("uvloop")
-        fake_uvloop.install = Mock()
+        fake_uvloop.new_event_loop = Mock(name="new_event_loop")
 
         with (
             patch.object(bootstrap.env_util, "IS_WINDOWS", False),
             patch.dict("sys.modules", {"uvloop": fake_uvloop}),
         ):
-            bootstrap._maybe_install_uvloop(running_in_event_loop=False)
+            factory = bootstrap._get_uvloop_loop_factory()
 
-        fake_uvloop.install.assert_called_once()
+        assert factory is fake_uvloop.new_event_loop
 
-    def test_skips_install_when_loop_running(self):
-        """uvloop installation is skipped if a loop is already running."""
+    def test_returns_none_on_windows(self):
+        """uvloop is not used on Windows."""
         fake_uvloop = types.ModuleType("uvloop")
-        fake_uvloop.install = Mock()
-
-        with (
-            patch.object(bootstrap.env_util, "IS_WINDOWS", False),
-            patch.dict("sys.modules", {"uvloop": fake_uvloop}),
-        ):
-            bootstrap._maybe_install_uvloop(running_in_event_loop=True)
-
-        fake_uvloop.install.assert_not_called()
-
-    def test_skips_install_on_windows(self):
-        """uvloop installation is skipped on Windows."""
-        fake_uvloop = types.ModuleType("uvloop")
-        fake_uvloop.install = Mock()
+        fake_uvloop.new_event_loop = Mock()
 
         with (
             patch.object(bootstrap.env_util, "IS_WINDOWS", True),
             patch.dict("sys.modules", {"uvloop": fake_uvloop}),
         ):
-            bootstrap._maybe_install_uvloop(running_in_event_loop=False)
+            assert bootstrap._get_uvloop_loop_factory() is None
 
-        fake_uvloop.install.assert_not_called()
-
-    def test_handles_missing_uvloop(self):
+    def test_returns_none_when_uvloop_missing(self):
         """Missing uvloop does not raise."""
-        with patch.object(bootstrap.env_util, "IS_WINDOWS", False):
-            with patch.dict("sys.modules", {"uvloop": None}):
-                bootstrap._maybe_install_uvloop(running_in_event_loop=False)
+        with (
+            patch.object(bootstrap.env_util, "IS_WINDOWS", False),
+            patch.dict("sys.modules", {"uvloop": None}),
+        ):
+            assert bootstrap._get_uvloop_loop_factory() is None
+
+    def test_run_server_loop_uses_runner_loop_factory(self):
+        """Python 3.11+ runs the server with asyncio.Runner(loop_factory=...)."""
+        if sys.version_info < (3, 11):
+            self.skipTest("asyncio.Runner requires Python 3.11+")
+
+        fake_factory = Mock(name="uvloop_factory")
+        mock_runner = Mock()
+        mock_runner.__enter__ = Mock(return_value=mock_runner)
+        mock_runner.__exit__ = Mock(return_value=False)
+        coro = Mock(name="main_coro")
+
+        with (
+            patch.object(
+                bootstrap, "_get_uvloop_loop_factory", return_value=fake_factory
+            ),
+            patch(
+                "streamlit.web.bootstrap.asyncio.Runner", return_value=mock_runner
+            ) as mock_runner_cls,
+        ):
+            bootstrap._run_server_loop(coro)
+
+        mock_runner_cls.assert_called_once_with(loop_factory=fake_factory)
+        mock_runner.run.assert_called_once_with(coro)
+
+    def test_run_server_loop_falls_back_to_asyncio_run(self):
+        """Without uvloop, the server uses the stdlib event loop."""
+        coro = Mock(name="main_coro")
+
+        with (
+            patch.object(bootstrap, "_get_uvloop_loop_factory", return_value=None),
+            patch("streamlit.web.bootstrap.asyncio.run") as mock_run,
+        ):
+            bootstrap._run_server_loop(coro)
+
+        mock_run.assert_called_once_with(coro)
 
 
 class BootstrapAsgiTest(IsolatedAsyncioTestCase):

--- a/lib/tests/streamlit/web/cli_test.py
+++ b/lib/tests/streamlit/web/cli_test.py
@@ -852,28 +852,22 @@ def test_main_run_handles_none_flag_options() -> None:
     assert flag_opts == {}
 
 
-def test_init_command_runs_app_when_user_confirms() -> None:
+def test_init_command_runs_app_when_user_confirms(tmp_path: Path) -> None:
     """``streamlit init`` invokes ``_main_run`` when the user confirms 'Run the app now?'."""
     runner = CliRunner()
-    with (
-        runner.isolated_filesystem(),
-        patch("streamlit.web.cli._main_run") as mock_main_run,
-    ):
-        result = runner.invoke(cli.main, ["init"], input="y\n")
+    with patch("streamlit.web.cli._main_run") as mock_main_run:
+        result = runner.invoke(cli.main, ["init", str(tmp_path)], input="y\n")
 
     assert result.exit_code == 0
     mock_main_run.assert_called_once()
     assert "streamlit_app.py" in mock_main_run.call_args.args[0]
 
 
-def test_init_command_raises_click_exception_on_oserror() -> None:
+def test_init_command_raises_click_exception_on_oserror(tmp_path: Path) -> None:
     """``streamlit init <dir>`` surfaces ``OSError`` as a Click exception."""
     runner = CliRunner()
-    with (
-        runner.isolated_filesystem(),
-        patch("pathlib.Path.mkdir", side_effect=OSError("disk full")),
-    ):
-        result = runner.invoke(cli.main, ["init", "some-dir"])
+    with patch("pathlib.Path.mkdir", side_effect=OSError("disk full")):
+        result = runner.invoke(cli.main, ["init", str(tmp_path / "some-dir")])
 
     assert result.exit_code != 0
     assert "Failed to create directory" in result.output


### PR DESCRIPTION
## Describe your changes

Clear CI and runtime warnings on Click 8 / Python 3.14 without breaking Python 3.10 or older uvloop.

- CLI init tests pass absolute paths via pytest `tmp_path` instead of Click's `isolated_filesystem()` (removed in Click 9)
- Server startup prefers `asyncio.Runner(loop_factory=uvloop.new_event_loop)` when that API exists; Python 3.10 and older uvloop still use `uvloop.install()`
- ScriptRunner events that arrive after the asyncio loop is closed are dropped instead of raising `RuntimeError: Event loop is closed`
- Sqlite dataframe tests use `contextlib.closing` because `with sqlite3.connect()` does not close the connection
- Unused Knip ignores for `./proto`, `react-responsive-carousel`, and `@deck.gl/{widgets,extensions}` are removed

## GitHub Issue Link (if applicable)

## Testing Plan

- [x] Unit Tests (JS and/or Python)
  - `lib/tests/streamlit/web/cli_test.py` — init command uses `tmp_path`
  - `lib/tests/streamlit/web/bootstrap_test.py` — uvloop Runner path and `install()` fallback
  - `lib/tests/streamlit/runtime/app_session_test.py` — closed-loop events are dropped
  - `lib/tests/streamlit/dataframe_util_test.py` — sqlite connections are closed
- Knip config-only: `yarn knip` is clean; no extra JS unit tests needed

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.