### PR TITLE
[docs] Document that st.rerun() works in widget callbacks

### DIFF
--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/session-state.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/session-state.md
@@ -122,7 +122,7 @@ st.button("Add 5", on_click=increment, args=(5,))
 
 Access a widget's value in its own callback via `st.session_state.key`, not the return variable.
 
-Calling `st.rerun()` or `st.switch_page()` inside a callback works as expected — execution of the current callback stops at that point (statements after the call do not run), but any other callbacks from the same interaction still complete before the rerun is dispatched. The interaction's default full-app rerun is replaced by the callback-requested one.
+Calling `st.rerun()` or `st.switch_page()` inside a callback works as expected — execution of the current callback stops at that point (statements after the call do not run), but any other callbacks from the same interaction still complete before the rerun is dispatched. The interaction's default rerun—full-app for main-script interactions and fragment-scoped for fragment interactions—is replaced by the callback-requested one.
 
 ## Initialization patterns
 

--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/session-state.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/session-state.md
@@ -122,7 +122,7 @@ st.button("Add 5", on_click=increment, args=(5,))
 
 Access a widget's value in its own callback via `st.session_state.key`, not the return variable.
 
-Calling `st.rerun()` or `st.switch_page()` inside a callback works as expected — execution of the current callback stops at that point (statements after the call do not run), but any other callbacks from the same interaction still complete before the rerun is dispatched. The interaction's default rerun—full-app for main-script interactions and fragment-scoped for fragment interactions—is replaced by the callback-requested one.
+Calling `st.rerun()` or `st.switch_page()` inside a callback ends that callback immediately (statements after the call don't run). Streamlit still runs the interaction's other callbacks before performing the rerun or navigation.
 
 ## Initialization patterns
 

--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/session-state.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/session-state.md
@@ -122,7 +122,7 @@ st.button("Add 5", on_click=increment, args=(5,))
 
 Access a widget's value in its own callback via `st.session_state.key`, not the return variable.
 
-Calling `st.rerun()` or `st.switch_page()` inside a callback works as expected — it schedules a rerun after all callbacks for the current interaction have completed. The interaction's default full-app rerun is replaced by the callback-requested one.
+Calling `st.rerun()` or `st.switch_page()` inside a callback works as expected — execution of the current callback stops at that point (statements after the call do not run), but any other callbacks from the same interaction still complete before the rerun is dispatched. The interaction's default full-app rerun is replaced by the callback-requested one.
 
 ## Initialization patterns
 

--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/session-state.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/session-state.md
@@ -122,6 +122,8 @@ st.button("Add 5", on_click=increment, args=(5,))
 
 Access a widget's value in its own callback via `st.session_state.key`, not the return variable.
 
+Calling `st.rerun()` or `st.switch_page()` inside a callback works as expected — it schedules a rerun after all callbacks for the current interaction have completed. The interaction's default full-app rerun is replaced by the callback-requested one.
+
 ## Initialization patterns
 
 Initialize all state at the top of your app for clarity:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Describe your changes

The embedded `developing-with-streamlit` agent skill's `session-state.md` was missing guidance about `st.rerun()` behavior in widget callbacks. PR #16158 changed this behavior: calling `st.rerun()` or `st.switch_page()` from an `on_change`/`on_click` callback now works as expected, scheduling a rerun after all callbacks for the interaction complete. Previously, `st.rerun()` in a callback was silently discarded with a warning.

Adds one sentence to the Callbacks section to document this.

## GitHub Issue Link (if applicable)

Related: #16158

## Testing Plan

- No new tests needed — this is a documentation-only change to a Markdown skill file.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4550bb7b-b791-4ceb-817b-770cd2f484c2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4550bb7b-b791-4ceb-817b-770cd2f484c2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

