### PR TITLE
[chore] Add typing tests for st.badge

### DIFF
--- a/lib/tests/streamlit/typing/markdown_types.py
+++ b/lib/tests/streamlit/typing/markdown_types.py
@@ -110,6 +110,69 @@ if TYPE_CHECKING:
     assert_type(caption("Note", wrap=False), DeltaGenerator)
     caption("Note", wrap="yes")  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
 
-    # st.badge does not take wrap
+    # =====================================================================
+    # st.badge return type tests
+    # =====================================================================
+
+    # Basic usage - returns DeltaGenerator
     assert_type(badge("New"), DeltaGenerator)
+
+    # icon parameter (keyword-only)
+    assert_type(badge("New", icon=":material/star:"), DeltaGenerator)
+    assert_type(badge("Alert", icon="star"), DeltaGenerator)
+    assert_type(badge("New", icon=None), DeltaGenerator)
+
+    # color parameter (keyword-only) - all supported literals
+    assert_type(badge("New", color="red"), DeltaGenerator)
+    assert_type(badge("New", color="orange"), DeltaGenerator)
+    assert_type(badge("New", color="yellow"), DeltaGenerator)
+    assert_type(badge("New", color="blue"), DeltaGenerator)
+    assert_type(badge("New", color="green"), DeltaGenerator)
+    assert_type(badge("New", color="violet"), DeltaGenerator)
+    assert_type(badge("New", color="gray"), DeltaGenerator)
+    assert_type(badge("New", color="grey"), DeltaGenerator)
+    assert_type(badge("New", color="primary"), DeltaGenerator)
+
+    # width parameter (keyword-only)
+    assert_type(badge("New", width="content"), DeltaGenerator)
+    assert_type(badge("New", width="stretch"), DeltaGenerator)
+    assert_type(badge("New", width=300), DeltaGenerator)
+
+    # help parameter (keyword-only)
+    assert_type(badge("New", help="Help text"), DeltaGenerator)
+    assert_type(badge("New", help=None), DeltaGenerator)
+
+    # All parameters combined
+    assert_type(
+        badge(
+            "Success",
+            icon=":material/check:",
+            color="green",
+            width="stretch",
+            help="Completed",
+        ),
+        DeltaGenerator,
+    )
+
+    # =====================================================================
+    # Invalid st.badge usages - should NOT type check
+    # =====================================================================
+
+    # label is str, not SupportsStr
+    badge(42)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+
+    # Invalid color value
+    badge("New", color="rainbow")  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+
+    # Invalid width value (not "stretch", "content", or int)
+    badge("New", width="auto")  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+    badge("New", width="invalid")  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+
+    # Invalid icon type (not str or None)
+    badge("New", icon=123)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+
+    # Passing keyword-only parameters as positional
+    badge("New", ":material/star:")  # type: ignore[call-arg]  # ty: ignore[too-many-positional-arguments]
+
+    # st.badge does not take wrap
     badge("New", wrap=False)  # type: ignore[call-arg]  # ty: ignore[unknown-argument]

--- a/lib/tests/streamlit/typing/markdown_types.py
+++ b/lib/tests/streamlit/typing/markdown_types.py
@@ -119,7 +119,7 @@ if TYPE_CHECKING:
 
     # icon parameter (keyword-only)
     assert_type(badge("New", icon=":material/star:"), DeltaGenerator)
-    assert_type(badge("Alert", icon="star"), DeltaGenerator)
+    assert_type(badge("Alert", icon="🚨"), DeltaGenerator)
     assert_type(badge("New", icon=None), DeltaGenerator)
 
     # color parameter (keyword-only) - all supported literals
@@ -166,7 +166,6 @@ if TYPE_CHECKING:
 
     # Invalid width value (not "stretch", "content", or int)
     badge("New", width="auto")  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
-    badge("New", width="invalid")  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
 
     # Invalid icon type (not str or None)
     badge("New", icon=123)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]

--- a/lib/tests/streamlit/typing/spinner_types.py
+++ b/lib/tests/streamlit/typing/spinner_types.py
@@ -70,15 +70,15 @@ if TYPE_CHECKING:
     # =====================================================================
 
     # Invalid text type (not str)
-    spinner(123)  # type: ignore[arg-type]
-    spinner(text=None)  # type: ignore[arg-type]
+    spinner(123)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+    spinner(text=None)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
 
     # Invalid show_time type (not bool)
-    spinner("Wait...", show_time="yes")  # type: ignore[arg-type]
+    spinner("Wait...", show_time="yes")  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
 
     # Passing show_time as positional argument (should be keyword-only)
-    spinner("Wait...", True)  # type: ignore[call-arg]
+    spinner("Wait...", True)  # type: ignore[call-arg]  # ty: ignore[too-many-positional-arguments]
 
     # Invalid width value (not "content", "stretch", or int)
-    spinner("Wait...", width="full")  # type: ignore[arg-type]
-    spinner("Wait...", width=None)  # type: ignore[arg-type]
+    spinner("Wait...", width="full")  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+    spinner("Wait...", width=None)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]


### PR DESCRIPTION
## Describe your changes

Adds static type checks for `st.badge` with mypy and ty, covering its return type, public parameters, and invalid calls.

Adds `# ty: ignore[...]` on intentional invalid `st.spinner` calls so `make python-types` passes.

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- [x] Verified with `make python-types` (mypy + ty)
- [ ] E2E Tests — not needed (typing-only change)
- [ ] Manual testing — not needed

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.