### PR TITLE
[feature] Add browser.command to choose which browser opens

### DIFF
--- a/lib/streamlit/cli_util.py
+++ b/lib/streamlit/cli_util.py
@@ -17,6 +17,8 @@
 from __future__ import annotations
 
 import os
+import shlex
+import shutil
 from typing import Any
 
 from streamlit import env_util, errors
@@ -73,39 +75,97 @@ def _open_browser_with_command(command: str, url: str) -> None:
 
 
 def _nonblocking_webbrowser_command(browser_command: str) -> str:
-    """If the command contains ``%s`` and does not already end with ``&``,
-    append ``&`` so ``webbrowser.get()`` uses ``BackgroundBrowser`` instead of
-    ``GenericBrowser`` (which waits for the subprocess and would block the server).
+    """If the command contains ``%s``, ensure it ends with a standalone ``&``.
+
+    ``webbrowser.get()`` uses ``BackgroundBrowser`` only when the last shlex
+    token is ``&``. ``GenericBrowser`` waits for the subprocess and would
+    block the server event loop. A trailing ``&`` glued to ``%s`` (``%s&``)
+    is split off so the URL placeholder stays intact.
     """
-    if "%s" in browser_command and not browser_command.rstrip().endswith("&"):
-        return f"{browser_command} &"
-    return browser_command
+    if "%s" not in browser_command:
+        return browser_command
+    try:
+        parts = shlex.split(browser_command)
+    except ValueError:
+        return browser_command
+    if not parts or parts[-1] == "&":
+        return browser_command
+    stripped = browser_command.rstrip()
+    if stripped.endswith("&"):
+        return f"{stripped[:-1].rstrip()} &"
+    return f"{stripped} &"
+
+
+def _executable_from_browser_command(browser_command: str) -> str | None:
+    """Return the program token from a webbrowser command, or None if unparsable."""
+    try:
+        parts = shlex.split(browser_command)
+    except ValueError:
+        return None
+    if parts and parts[-1] == "&":
+        parts = parts[:-1]
+    if not parts:
+        return None
+    return parts[0]
+
+
+def _browser_command_refers_to_existing_executable(browser_command: str) -> bool:
+    """Return whether ``browser.command`` points at a program we can launch.
+
+    Bare paths are checked as a whole so paths with spaces are not split.
+    Command templates use the first shlex token (the program).
+    """
+    if os.path.isfile(browser_command) or shutil.which(browser_command) is not None:
+        return True
+    if "%s" not in browser_command:
+        return False
+    executable = _executable_from_browser_command(browser_command)
+    if executable is None:
+        return False
+    return os.path.isfile(executable) or shutil.which(executable) is not None
 
 
 def _open_browser_with_configured_command(browser_command: str, url: str) -> bool:
     """Try to open ``url`` with ``browser.command`` via ``webbrowser.get()``.
 
     Return True if a controller was constructed and ``open()`` was invoked
-    without raising. Return False only if the command cannot be resolved or
-    ``open()`` raises ``OSError``, so the caller can fall back.
+    without raising. Return False if the command cannot be resolved, the
+    executable does not exist, the controller would block the server
+    (``GenericBrowser``), or ``open()`` raises ``OSError``, so the caller
+    can fall back.
 
     Do not treat ``open()``'s boolean as success. ``BackgroundBrowser``
     returns False when the helper exits immediately (for example ``open -a``
     or a browser that is already running), which is not a launch failure.
     """
-    import shlex
     import webbrowser
 
     try:
-        controller = webbrowser.get(_nonblocking_webbrowser_command(browser_command))
-    except webbrowser.Error:
-        try:
-            # webbrowser.get() only synthesizes a controller from a path when
-            # the string contains "%s". Keep this Error handler in case that
-            # contract changes.
-            controller = webbrowser.get(f"{shlex.quote(browser_command)} %s &")
-        except webbrowser.Error:
+        using = _nonblocking_webbrowser_command(browser_command)
+        if "%s" in using and not _browser_command_refers_to_existing_executable(using):
             return False
+        controller = webbrowser.get(using)
+    except (webbrowser.Error, ValueError, IndexError):
+        # webbrowser.get() only resolves a bare path when its basename matches a
+        # registered browser, and it splits on whitespace, so quoted paths and
+        # paths with spaces fail. Retry as an explicit "%s &" command template
+        # only when that path exists.
+        if (
+            "%s" in browser_command
+            or not _browser_command_refers_to_existing_executable(browser_command)
+        ):
+            return False
+        try:
+            controller = webbrowser.get(f"{shlex.quote(browser_command)} %s &")
+        except (webbrowser.Error, ValueError, IndexError):
+            return False
+
+    # GenericBrowser.open() calls Popen.wait() and would block the server.
+    if isinstance(controller, webbrowser.GenericBrowser) and not isinstance(
+        controller, webbrowser.BackgroundBrowser
+    ):
+        return False
+
     try:
         controller.open(url)
     except OSError:

--- a/lib/streamlit/cli_util.py
+++ b/lib/streamlit/cli_util.py
@@ -51,6 +51,13 @@ def style_for_cli(message: str, **kwargs: Any) -> str:
         return message
 
 
+def _get_logger() -> Any:
+    """Return this module's logger. Load it lazily to avoid a config import cycle."""
+    from streamlit.logger import get_logger
+
+    return get_logger(__name__)
+
+
 def _open_browser_with_webbrowser(url: str) -> None:
     import webbrowser
 
@@ -65,18 +72,48 @@ def _open_browser_with_command(command: str, url: str) -> None:
         subprocess.Popen(cmd_line, stdout=devnull, stderr=subprocess.STDOUT)  # noqa: S603
 
 
-def open_browser(url: str) -> None:
-    """Open a web browser pointing to a given URL.
-
-    We use this function instead of Python's `webbrowser` module because this
-    way we can capture stdout/stderr to avoid polluting the terminal with the
-    browser's messages. For example, Chrome always prints things like "Created
-    new window in existing browser session", and those get on the user's way.
-
-    url : str
-        The URL. Must include the protocol.
-
+def _nonblocking_webbrowser_command(browser_command: str) -> str:
+    """If the command contains ``%s`` and does not already end with ``&``,
+    append ``&`` so ``webbrowser.get()`` uses ``BackgroundBrowser`` instead of
+    ``GenericBrowser`` (which waits for the subprocess and would block the server).
     """
+    if "%s" in browser_command and not browser_command.rstrip().endswith("&"):
+        return f"{browser_command} &"
+    return browser_command
+
+
+def _open_browser_with_configured_command(browser_command: str, url: str) -> bool:
+    """Try to open ``url`` with ``browser.command`` via ``webbrowser.get()``.
+
+    Return True if a controller was constructed and ``open()`` was invoked
+    without raising. Return False only if the command cannot be resolved or
+    ``open()`` raises ``OSError``, so the caller can fall back.
+
+    Do not treat ``open()``'s boolean as success. ``BackgroundBrowser``
+    returns False when the helper exits immediately (for example ``open -a``
+    or a browser that is already running), which is not a launch failure.
+    """
+    import shlex
+    import webbrowser
+
+    try:
+        controller = webbrowser.get(_nonblocking_webbrowser_command(browser_command))
+    except webbrowser.Error:
+        try:
+            # webbrowser.get() only synthesizes a controller from a path when
+            # the string contains "%s". Keep this Error handler in case that
+            # contract changes.
+            controller = webbrowser.get(f"{shlex.quote(browser_command)} %s &")
+        except webbrowser.Error:
+            return False
+    try:
+        controller.open(url)
+    except OSError:
+        return False
+    return True
+
+
+def _open_browser_with_os_default(url: str) -> None:
     # Treat Windows separately because:
     # 1. /dev/null doesn't exist.
     # 2. subprocess.Popen(['start', url]) doesn't actually pop up the
@@ -106,3 +143,26 @@ def open_browser(url: str) -> None:
     import platform  # pragma: no cover - unsupported platform
 
     raise errors.Error(f'Cannot open browser in platform "{platform.system()}"')  # ty: ignore[unresolved-attribute]  # pragma: no cover - unsupported platform
+
+
+def open_browser(url: str) -> None:
+    """Open a web browser pointing to a given URL.
+
+    If ``browser.command`` is set, try that browser via ``webbrowser.get()``.
+    If it is unset or opening fails, use the operating system's default handler.
+
+    url : str
+        The URL. Must include the protocol.
+    """
+    from streamlit import config
+
+    browser_command = str(config.get_option("browser.command") or "").strip()
+    if browser_command and _open_browser_with_configured_command(browser_command, url):
+        return
+    if browser_command:
+        _get_logger().warning(
+            "Could not open the browser configured by browser.command=%r. "
+            "Falling back to the system default.",
+            browser_command,
+        )
+    _open_browser_with_os_default(url)

--- a/lib/streamlit/cli_util.py
+++ b/lib/streamlit/cli_util.py
@@ -54,7 +54,13 @@ def style_for_cli(message: str, **kwargs: Any) -> str:
 
 
 def _get_logger() -> Any:
-    """Return this module's logger. Load it lazily to avoid a config import cycle."""
+    """Return this module's logger.
+
+    Load it lazily: ``get_logger()`` calls ``setup_formatter()``, which imports
+    ``streamlit.config``. This module is imported by ``config_util`` during
+    config load (``config`` → ``config_util`` → ``cli_util``), so a module-level
+    ``_LOGGER = get_logger(__name__)`` would cycle.
+    """
     from streamlit.logger import get_logger
 
     return get_logger(__name__)
@@ -75,12 +81,12 @@ def _open_browser_with_command(command: str, url: str) -> None:
 
 
 def _nonblocking_webbrowser_command(browser_command: str) -> str:
-    """If the command contains ``%s``, ensure it ends with a standalone ``&``.
+    """Keep ``%s`` command templates from blocking the server.
 
-    ``webbrowser.get()`` uses ``BackgroundBrowser`` only when the last shlex
-    token is ``&``. ``GenericBrowser`` waits for the subprocess and would
-    block the server event loop. A trailing ``&`` glued to ``%s`` (``%s&``)
-    is split off so the URL placeholder stays intact.
+    ``webbrowser.get()`` uses ``GenericBrowser``, which waits for the
+    subprocess, unless the command ends with a standalone ``&``. A trailing
+    ``&`` glued to ``%s`` (``%s&``) is split off so the URL placeholder stays
+    intact.
     """
     if "%s" not in browser_command:
         return browser_command
@@ -112,44 +118,49 @@ def _executable_from_browser_command(browser_command: str) -> str | None:
 def _browser_command_refers_to_existing_executable(browser_command: str) -> bool:
     """Return whether ``browser.command`` points at a program we can launch.
 
-    Bare paths are checked as a whole so paths with spaces are not split.
-    Command templates use the first shlex token (the program).
+    Uses ``shutil.which`` so a non-executable regular file is not treated as
+    a valid browser. Bare paths are checked as a whole so paths with spaces
+    are not split. Command templates use the first shlex token (the program).
     """
-    if os.path.isfile(browser_command) or shutil.which(browser_command) is not None:
+    if shutil.which(browser_command) is not None:
         return True
     if "%s" not in browser_command:
         return False
     executable = _executable_from_browser_command(browser_command)
     if executable is None:
         return False
-    return os.path.isfile(executable) or shutil.which(executable) is not None
+    return shutil.which(executable) is not None
 
 
 def _open_browser_with_configured_command(browser_command: str, url: str) -> bool:
-    """Try to open ``url`` with ``browser.command`` via ``webbrowser.get()``.
+    """Launch ``url`` with ``browser.command`` without blocking forever.
 
-    Return True if a controller was constructed and ``open()`` was invoked
-    without raising. Return False if the command cannot be resolved, the
-    executable does not exist, the controller would block the server
-    (``GenericBrowser``), or ``open()`` raises ``OSError``, so the caller
-    can fall back.
+    Ignore a falsey ``open()`` only for ``BackgroundBrowser`` (the helper
+    often exits after a successful launch). Other controllers treat False as
+    a failed launch. Return False so the caller can fall back if the command
+    cannot be resolved, the executable does not exist, the controller is a
+    blocking ``GenericBrowser``, ``open()`` raises ``OSError``, or a
+    non-background ``open()`` returns False.
 
-    Do not treat ``open()``'s boolean as success. ``BackgroundBrowser``
-    returns False when the helper exits immediately (for example ``open -a``
-    or a browser that is already running), which is not a launch failure.
+    Named GUI controllers (``UnixBrowser``, ``MacOSXOSAScript``) may
+    ``wait()`` for a few seconds. Callers on the asyncio loop must run this
+    function off the loop.
     """
     import webbrowser
 
     try:
-        using = _nonblocking_webbrowser_command(browser_command)
-        if "%s" in using and not _browser_command_refers_to_existing_executable(using):
+        webbrowser_spec = _nonblocking_webbrowser_command(browser_command)
+        if (
+            "%s" in webbrowser_spec
+            and not _browser_command_refers_to_existing_executable(webbrowser_spec)
+        ):
             return False
-        controller = webbrowser.get(using)
+        controller = webbrowser.get(webbrowser_spec)
     except (webbrowser.Error, ValueError, IndexError):
-        # webbrowser.get() only resolves a bare path when its basename matches a
-        # registered browser, and it splits on whitespace, so quoted paths and
-        # paths with spaces fail. Retry as an explicit "%s &" command template
-        # only when that path exists.
+        # webbrowser.get() does not take a raw path when:
+        # - the basename is not a registered browser, or
+        # - the path contains spaces (it splits on whitespace).
+        # Retry as a quoted "%s &" template only when that path exists.
         if (
             "%s" in browser_command
             or not _browser_command_refers_to_existing_executable(browser_command)
@@ -160,17 +171,20 @@ def _open_browser_with_configured_command(browser_command: str, url: str) -> boo
         except (webbrowser.Error, ValueError, IndexError):
             return False
 
-    # GenericBrowser.open() calls Popen.wait() and would block the server.
+    # GenericBrowser.open() calls Popen.wait() until the process exits
+    # (console browsers such as lynx). Do not use those. UnixBrowser and
+    # MacOSXOSAScript are not GenericBrowser subclasses; they may still
+    # wait briefly and must be invoked off the asyncio loop.
     if isinstance(controller, webbrowser.GenericBrowser) and not isinstance(
         controller, webbrowser.BackgroundBrowser
     ):
         return False
 
     try:
-        controller.open(url)
+        opened = controller.open(url)
     except OSError:
         return False
-    return True
+    return bool(opened) or isinstance(controller, webbrowser.BackgroundBrowser)
 
 
 def _open_browser_with_os_default(url: str) -> None:
@@ -216,7 +230,7 @@ def open_browser(url: str) -> None:
     """
     from streamlit import config
 
-    browser_command = str(config.get_option("browser.command") or "").strip()
+    browser_command = config.get_option("browser.command").strip()
     if browser_command and _open_browser_with_configured_command(browser_command, url):
         return
     if browser_command:

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -1357,6 +1357,27 @@ def _browser_server_port() -> int:
     return int(get_option("server.port"))
 
 
+_create_option(
+    "browser.command",
+    description="""
+        Browser or command used to open the app when Streamlit starts.
+
+        If empty (default), Streamlit uses the operating system's default
+        handler. This option has no effect when server.headless is true.
+        If the value cannot be resolved, Streamlit logs a warning and
+        falls back to the default handler.
+
+        Examples:
+        - A browser name such as "chrome", "firefox", or "safari".
+        - A command with "%s" as the URL placeholder, for example
+          'open -a Firefox %s'.
+        - An executable path, including paths with spaces.
+    """,
+    default_val="",
+    type_=str,
+)
+
+
 _SSL_PRODUCTION_WARNING = [
     (
         "DO NOT USE THIS OPTION IN A PRODUCTION ENVIRONMENT. It has not gone through "

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -1360,7 +1360,8 @@ def _browser_server_port() -> int:
 _create_option(
     "browser.command",
     description="""
-        Browser or command used to open the app when Streamlit starts.
+        Browser or command Streamlit uses when it opens a URL (for example,
+        streamlit run and streamlit docs).
 
         If empty (default), Streamlit uses the operating system's default
         handler. This option has no effect when server.headless is true.

--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -1364,15 +1364,19 @@ _create_option(
         streamlit run and streamlit docs).
 
         If empty (default), Streamlit uses the operating system's default
-        handler. This option has no effect when server.headless is true.
-        If the value cannot be resolved, Streamlit logs a warning and
-        falls back to the default handler.
+        handler. For streamlit run, this option has no effect when
+        server.headless is true. If the value cannot be resolved, Streamlit
+        logs a warning and falls back to the default handler.
 
         Examples:
-        - A browser name such as "chrome", "firefox", or "safari".
+        - A registered name such as "firefox", "safari", or "google-chrome"
+          when that name is registered on your OS.
         - A command with "%s" as the URL placeholder, for example
-          'open -a Firefox %s'.
-        - An executable path, including paths with spaces.
+          'open -a "Google Chrome" %s' or 'open -a Firefox %s' on macOS.
+          webbrowser parses "%s" templates with POSIX shlex, so a Windows
+          path that contains backslashes should omit "%s".
+        - An executable path, including paths with spaces (for example WSL
+          Chrome). On Windows, use the path without "%s".
     """,
     default_val="",
     type_=str,

--- a/lib/streamlit/web/bootstrap.py
+++ b/lib/streamlit/web/bootstrap.py
@@ -19,6 +19,7 @@ import mimetypes
 import os
 import signal
 import sys
+import threading
 from typing import TYPE_CHECKING, Any, Final, Literal
 
 from streamlit import cli_util, config, env_util, file_util, net_util, secrets
@@ -192,8 +193,13 @@ def _on_server_start(server: Server) -> None:
 
         cli_util.open_browser(server_util.get_url(addr))
 
-    # Schedule the browser to open on the main thread.
-    asyncio.get_running_loop().call_soon(maybe_open_browser)
+    # Named webbrowser controllers (UnixBrowser, MacOSXOSAScript) can
+    # Popen.wait() for several seconds. Do not run that on the event loop.
+    threading.Thread(
+        target=maybe_open_browser,
+        daemon=True,
+        name="streamlit-open-browser",
+    ).start()
 
 
 def _fix_pydeck_mapbox_api_warning() -> None:

--- a/lib/tests/streamlit/cli_util_test.py
+++ b/lib/tests/streamlit/cli_util_test.py
@@ -24,7 +24,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from streamlit import env_util
-from streamlit.cli_util import open_browser
+from streamlit.cli_util import _nonblocking_webbrowser_command, open_browser
 from tests.testutil import patch_config_options
 
 if TYPE_CHECKING:
@@ -111,8 +111,14 @@ def test_open_browser_linux_no_xdg() -> None:
         ("firefox", "firefox"),
         ("/usr/bin/firefox %s", "/usr/bin/firefox %s &"),
         ("firefox %s &", "firefox %s &"),
+        ("firefox %s&", "firefox %s &"),
     ],
-    ids=["registered_name", "percent_s_appends_ampersand", "template_keeps_ampersand"],
+    ids=[
+        "registered_name",
+        "percent_s_appends_ampersand",
+        "template_keeps_ampersand",
+        "glued_ampersand_is_split",
+    ],
 )
 def test_configured_command_passed_to_webbrowser_get(
     browser_command: str, expected_get_arg: str
@@ -122,6 +128,10 @@ def test_configured_command_passed_to_webbrowser_get(
     with (
         _platform(darwin=True),
         patch_config_options({"browser.command": browser_command}),
+        patch(
+            "streamlit.cli_util._browser_command_refers_to_existing_executable",
+            return_value=True,
+        ),
         patch("webbrowser.get", return_value=controller) as webbrowser_get,
         patch("webbrowser.open") as webbrowser_open,
         patch("subprocess.Popen") as subprocess_popen,
@@ -142,6 +152,10 @@ def test_configured_command_retries_bare_path_as_quoted_template() -> None:
         _platform(darwin=True),
         patch_config_options({"browser.command": path}),
         patch(
+            "streamlit.cli_util._browser_command_refers_to_existing_executable",
+            return_value=True,
+        ),
+        patch(
             "webbrowser.get",
             side_effect=[webbrowser.Error("unknown"), controller],
         ) as webbrowser_get,
@@ -161,23 +175,75 @@ def test_configured_command_falls_back_for_unknown_name() -> None:
     """An unresolvable command logs a warning and uses the OS default."""
     with (
         _platform(darwin=True),
-        patch_config_options({"browser.command": "not-a-browser"}),
-        patch(
-            "webbrowser.get", side_effect=webbrowser.Error("unknown")
-        ) as webbrowser_get,
-        patch("webbrowser.open") as webbrowser_open,
-        patch("subprocess.Popen") as subprocess_popen,
+        patch_config_options({"browser.command": "definitely-not-a-browser-xyz"}),
+        patch("streamlit.cli_util._open_browser_with_os_default") as os_default,
         patch("streamlit.cli_util._get_logger") as mock_get_logger,
     ):
         open_browser(_URL)
 
-        assert webbrowser_get.call_count == 2
         mock_get_logger.return_value.warning.assert_called_once()
         warning_args = mock_get_logger.return_value.warning.call_args.args
         assert "browser.command=%r" in warning_args[0]
-        assert warning_args[1] == "not-a-browser"
-        subprocess_popen.assert_called_once()
-        webbrowser_open.assert_not_called()
+        assert warning_args[1] == "definitely-not-a-browser-xyz"
+        os_default.assert_called_once_with(_URL)
+
+
+def test_configured_command_falls_back_for_missing_path() -> None:
+    """A missing executable path logs a warning and uses the OS default."""
+    path = "/definitely/not/a/browser/that/exists"
+    with (
+        _platform(darwin=True),
+        patch_config_options({"browser.command": path}),
+        patch("streamlit.cli_util._open_browser_with_os_default") as os_default,
+        patch("streamlit.cli_util._get_logger") as mock_get_logger,
+    ):
+        open_browser(_URL)
+
+        mock_get_logger.return_value.warning.assert_called_once()
+        os_default.assert_called_once_with(_URL)
+
+
+def test_configured_command_falls_back_for_missing_template_executable() -> None:
+    """A %s template whose program does not exist warns and uses the OS default."""
+    with (
+        _platform(darwin=True),
+        patch_config_options({"browser.command": "definitely-not-a-browser-xyz %s"}),
+        patch("streamlit.cli_util._open_browser_with_os_default") as os_default,
+        patch("streamlit.cli_util._get_logger") as mock_get_logger,
+    ):
+        open_browser(_URL)
+
+        mock_get_logger.return_value.warning.assert_called_once()
+        os_default.assert_called_once_with(_URL)
+
+
+def test_configured_command_falls_back_for_malformed_template() -> None:
+    """Unmatched quotes in a %s template must not skip the OS-default fallback."""
+    with (
+        _platform(darwin=True),
+        patch_config_options({"browser.command": 'firefox "profile %s'}),
+        patch("streamlit.cli_util._open_browser_with_os_default") as os_default,
+        patch("streamlit.cli_util._get_logger") as mock_get_logger,
+    ):
+        open_browser(_URL)
+
+        mock_get_logger.return_value.warning.assert_called_once()
+        os_default.assert_called_once_with(_URL)
+
+
+def test_configured_command_falls_back_for_generic_browser() -> None:
+    """GenericBrowser.open() waits for the process; fall back instead of blocking."""
+    with (
+        _platform(darwin=True),
+        patch_config_options({"browser.command": "lynx"}),
+        patch("webbrowser.get", return_value=webbrowser.GenericBrowser("lynx")),
+        patch("streamlit.cli_util._open_browser_with_os_default") as os_default,
+        patch("streamlit.cli_util._get_logger") as mock_get_logger,
+    ):
+        open_browser(_URL)
+
+        mock_get_logger.return_value.warning.assert_called_once()
+        os_default.assert_called_once_with(_URL)
 
 
 def test_configured_command_does_not_fall_back_when_open_returns_false() -> None:
@@ -272,3 +338,25 @@ def test_open_browser_ignores_server_headless() -> None:
         controller.open.assert_called_once_with(_URL)
         webbrowser_open.assert_not_called()
         subprocess_popen.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("command", "expected"),
+    [
+        ("firefox", "firefox"),
+        ("firefox %s", "firefox %s &"),
+        ("firefox %s &", "firefox %s &"),
+        ("firefox %s&", "firefox %s &"),
+        ("open -a Firefox %s", "open -a Firefox %s &"),
+    ],
+    ids=[
+        "name_unchanged",
+        "appends_ampersand",
+        "keeps_ampersand",
+        "splits_glued_ampersand",
+        "open_a_template",
+    ],
+)
+def test_nonblocking_webbrowser_command(command: str, expected: str) -> None:
+    """Normalize %s templates so webbrowser.get() uses BackgroundBrowser."""
+    assert _nonblocking_webbrowser_command(command) == expected

--- a/lib/tests/streamlit/cli_util_test.py
+++ b/lib/tests/streamlit/cli_util_test.py
@@ -14,42 +14,261 @@
 
 from __future__ import annotations
 
-import unittest
-from unittest.mock import patch
+import shlex
+import shutil
+import webbrowser
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
 
-from parameterized import parameterized
+import pytest
 
+from streamlit import env_util
 from streamlit.cli_util import open_browser
+from tests.testutil import patch_config_options
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+_URL = "http://some-url"
 
 
-class CliUtilTest(unittest.TestCase):
-    @parameterized.expand(
-        [("Linux", False, True), ("Windows", True, False), ("Darwin", False, True)]
-    )
-    def test_open_browser(self, os_type, webbrowser_expect, popen_expect):
-        """Test web browser opening scenarios."""
-        from streamlit import env_util
+@contextmanager
+def _platform(
+    *, windows: bool = False, darwin: bool = False, linux: bool = False
+) -> Iterator[None]:
+    """Pin env_util OS flags without leaking globals across tests."""
+    with (
+        patch.object(env_util, "IS_WINDOWS", windows),
+        patch.object(env_util, "IS_DARWIN", darwin),
+        patch.object(env_util, "IS_LINUX_OR_BSD", linux),
+    ):
+        yield
 
-        env_util.IS_WINDOWS = os_type == "Windows"
-        env_util.IS_DARWIN = os_type == "Darwin"
-        env_util.IS_LINUX_OR_BSD = os_type == "Linux"
 
-        with patch("streamlit.env_util.is_executable_in_path", return_value=True):
-            with patch("webbrowser.open") as webbrowser_open:
-                with patch("subprocess.Popen") as subprocess_popen:
-                    open_browser("http://some-url")
-                    assert webbrowser_expect == webbrowser_open.called
-                    assert popen_expect == subprocess_popen.called
+def _successful_controller() -> MagicMock:
+    controller = MagicMock()
+    controller.open.return_value = True
+    return controller
 
-    def test_open_browser_linux_no_xdg(self):
-        """Test opening the browser on Linux with no xdg installed"""
-        from streamlit import env_util
 
-        env_util.IS_LINUX_OR_BSD = True
+@pytest.mark.parametrize(
+    ("os_name", "expect_webbrowser_open", "expect_popen_command"),
+    [
+        ("Linux", False, "xdg-open"),
+        ("Windows", True, None),
+        ("Darwin", False, "open"),
+    ],
+    ids=["linux_xdg_open", "windows_webbrowser", "darwin_open"],
+)
+def test_open_browser_os_default(
+    os_name: str, expect_webbrowser_open: bool, expect_popen_command: str | None
+) -> None:
+    """With an empty browser.command, each OS uses its default handler."""
+    with (
+        _platform(
+            windows=os_name == "Windows",
+            darwin=os_name == "Darwin",
+            linux=os_name == "Linux",
+        ),
+        patch_config_options({"browser.command": ""}),
+        patch("streamlit.env_util.is_executable_in_path", return_value=True),
+        patch("webbrowser.get") as webbrowser_get,
+        patch("webbrowser.open") as webbrowser_open,
+        patch("subprocess.Popen") as subprocess_popen,
+    ):
+        open_browser(_URL)
 
-        with patch("streamlit.env_util.is_executable_in_path", return_value=False):
-            with patch("webbrowser.open") as webbrowser_open:
-                with patch("subprocess.Popen") as subprocess_popen:
-                    open_browser("http://some-url")
-                    assert webbrowser_open.called
-                    assert not subprocess_popen.called
+        webbrowser_get.assert_not_called()
+        assert webbrowser_open.called is expect_webbrowser_open
+        if expect_popen_command is None:
+            subprocess_popen.assert_not_called()
+        else:
+            subprocess_popen.assert_called_once()
+            assert subprocess_popen.call_args.args[0] == [expect_popen_command, _URL]
+
+
+def test_open_browser_linux_no_xdg() -> None:
+    """Linux without xdg-open falls back to webbrowser.open."""
+    with (
+        _platform(linux=True),
+        patch_config_options({"browser.command": ""}),
+        patch("streamlit.env_util.is_executable_in_path", return_value=False),
+        patch("webbrowser.get") as webbrowser_get,
+        patch("webbrowser.open") as webbrowser_open,
+        patch("subprocess.Popen") as subprocess_popen,
+    ):
+        open_browser(_URL)
+
+        webbrowser_get.assert_not_called()
+        webbrowser_open.assert_called_once_with(_URL)
+        subprocess_popen.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("browser_command", "expected_get_arg"),
+    [
+        ("firefox", "firefox"),
+        ("/usr/bin/firefox %s", "/usr/bin/firefox %s &"),
+        ("firefox %s &", "firefox %s &"),
+    ],
+    ids=["registered_name", "percent_s_appends_ampersand", "template_keeps_ampersand"],
+)
+def test_configured_command_passed_to_webbrowser_get(
+    browser_command: str, expected_get_arg: str
+) -> None:
+    """Pass browser.command to webbrowser.get(), appending & to %s templates."""
+    controller = _successful_controller()
+    with (
+        _platform(darwin=True),
+        patch_config_options({"browser.command": browser_command}),
+        patch("webbrowser.get", return_value=controller) as webbrowser_get,
+        patch("webbrowser.open") as webbrowser_open,
+        patch("subprocess.Popen") as subprocess_popen,
+    ):
+        open_browser(_URL)
+
+        webbrowser_get.assert_called_once_with(expected_get_arg)
+        controller.open.assert_called_once_with(_URL)
+        webbrowser_open.assert_not_called()
+        subprocess_popen.assert_not_called()
+
+
+def test_configured_command_retries_bare_path_as_quoted_template() -> None:
+    """If get() fails, retry with a quoted executable path plus '%s &'."""
+    path = "/mnt/c/Program Files (x86)/Google/Chrome/Application/chrome.exe"
+    controller = _successful_controller()
+    with (
+        _platform(darwin=True),
+        patch_config_options({"browser.command": path}),
+        patch(
+            "webbrowser.get",
+            side_effect=[webbrowser.Error("unknown"), controller],
+        ) as webbrowser_get,
+        patch("webbrowser.open") as webbrowser_open,
+        patch("subprocess.Popen") as subprocess_popen,
+    ):
+        open_browser(_URL)
+
+        assert webbrowser_get.call_args_list[0].args == (path,)
+        assert webbrowser_get.call_args_list[1].args == (f"{shlex.quote(path)} %s &",)
+        controller.open.assert_called_once_with(_URL)
+        webbrowser_open.assert_not_called()
+        subprocess_popen.assert_not_called()
+
+
+def test_configured_command_falls_back_for_unknown_name() -> None:
+    """An unresolvable command logs a warning and uses the OS default."""
+    with (
+        _platform(darwin=True),
+        patch_config_options({"browser.command": "not-a-browser"}),
+        patch(
+            "webbrowser.get", side_effect=webbrowser.Error("unknown")
+        ) as webbrowser_get,
+        patch("webbrowser.open") as webbrowser_open,
+        patch("subprocess.Popen") as subprocess_popen,
+        patch("streamlit.cli_util._get_logger") as mock_get_logger,
+    ):
+        open_browser(_URL)
+
+        assert webbrowser_get.call_count == 2
+        mock_get_logger.return_value.warning.assert_called_once()
+        warning_args = mock_get_logger.return_value.warning.call_args.args
+        assert "browser.command=%r" in warning_args[0]
+        assert warning_args[1] == "not-a-browser"
+        subprocess_popen.assert_called_once()
+        webbrowser_open.assert_not_called()
+
+
+def test_configured_command_does_not_fall_back_when_open_returns_false() -> None:
+    """A falsey controller.open() result must not open a second (OS default) browser.
+
+    BackgroundBrowser returns False when the helper exits immediately, which
+    is normal for ``open -a`` and for a browser that is already running.
+    """
+    controller = MagicMock()
+    controller.open.return_value = False
+    with (
+        _platform(darwin=True),
+        patch_config_options({"browser.command": "firefox"}),
+        patch("webbrowser.get", return_value=controller),
+        patch("streamlit.cli_util._open_browser_with_os_default") as os_default,
+        patch("streamlit.cli_util._get_logger") as mock_get_logger,
+    ):
+        open_browser(_URL)
+
+        controller.open.assert_called_once_with(_URL)
+        mock_get_logger.assert_not_called()
+        os_default.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "error",
+    [OSError("boom"), FileNotFoundError("missing")],
+    ids=["raises_os_error", "raises_file_not_found"],
+)
+def test_configured_command_falls_back_when_open_raises(error: OSError) -> None:
+    """If controller.open() raises OSError, log a warning and use the OS default."""
+    controller = MagicMock()
+    controller.open.side_effect = error
+    with (
+        _platform(darwin=True),
+        patch_config_options({"browser.command": "firefox"}),
+        patch("webbrowser.get", return_value=controller),
+        patch("subprocess.Popen") as subprocess_popen,
+        patch("streamlit.cli_util._get_logger") as mock_get_logger,
+    ):
+        open_browser(_URL)
+
+        controller.open.assert_called_once_with(_URL)
+        mock_get_logger.return_value.warning.assert_called_once()
+        subprocess_popen.assert_called_once()
+
+
+@pytest.mark.skipif(shutil.which("true") is None, reason="true is not on PATH")
+def test_background_browser_false_does_not_fall_back() -> None:
+    """A %s template that exits immediately must not also open the OS default."""
+    with (
+        _platform(darwin=True),
+        patch_config_options({"browser.command": "true %s"}),
+        patch("streamlit.cli_util._open_browser_with_os_default") as os_default,
+    ):
+        open_browser(_URL)
+
+        os_default.assert_not_called()
+
+
+def test_whitespace_only_command_is_treated_as_unset() -> None:
+    """Whitespace-only browser.command uses the OS default with no warning."""
+    with (
+        _platform(darwin=True),
+        patch_config_options({"browser.command": "   "}),
+        patch("webbrowser.get") as webbrowser_get,
+        patch("webbrowser.open") as webbrowser_open,
+        patch("subprocess.Popen") as subprocess_popen,
+        patch("streamlit.cli_util._get_logger") as mock_get_logger,
+    ):
+        open_browser(_URL)
+
+        webbrowser_get.assert_not_called()
+        mock_get_logger.assert_not_called()
+        subprocess_popen.assert_called_once()
+        webbrowser_open.assert_not_called()
+
+
+def test_open_browser_ignores_server_headless() -> None:
+    """open_browser still opens when server.headless is true; headless is bootstrap's job."""
+    controller = _successful_controller()
+    with (
+        _platform(darwin=True),
+        patch_config_options({"browser.command": "chrome", "server.headless": True}),
+        patch("webbrowser.get", return_value=controller) as webbrowser_get,
+        patch("webbrowser.open") as webbrowser_open,
+        patch("subprocess.Popen") as subprocess_popen,
+    ):
+        open_browser(_URL)
+
+        webbrowser_get.assert_called_once_with("chrome")
+        controller.open.assert_called_once_with(_URL)
+        webbrowser_open.assert_not_called()
+        subprocess_popen.assert_not_called()

--- a/lib/tests/streamlit/cli_util_test.py
+++ b/lib/tests/streamlit/cli_util_test.py
@@ -262,16 +262,38 @@ def test_background_browser_false_does_not_fall_back() -> None:
 
 @pytest.mark.parametrize(
     "controller",
-    [webbrowser.Mozilla("firefox"), webbrowser.MacOSXOSAScript("chrome")],
-    ids=["mozilla", "macosx_osascript"],
+    [webbrowser.Mozilla("firefox"), webbrowser.Chrome("google-chrome")],
+    ids=["mozilla", "chrome"],
 )
 def test_non_background_controller_false_falls_back(
     controller: webbrowser.BaseBrowser,
 ) -> None:
-    """False from UnixBrowser or MacOSXOSAScript is a failed launch; fall back."""
+    """False from UnixBrowser is a failed launch; fall back to the OS default."""
     with (
         _platform(darwin=True),
         patch_config_options({"browser.command": "firefox"}),
+        patch("webbrowser.get", return_value=controller),
+        patch.object(controller, "open", return_value=False) as mock_open,
+        patch("streamlit.cli_util._open_browser_with_os_default") as os_default,
+        patch("streamlit.cli_util._get_logger") as mock_get_logger,
+    ):
+        open_browser(_URL)
+
+        mock_open.assert_called_once_with(_URL)
+        mock_get_logger.return_value.warning.assert_called_once()
+        os_default.assert_called_once_with(_URL)
+
+
+@pytest.mark.skipif(
+    not hasattr(webbrowser, "MacOSXOSAScript"),
+    reason="MacOSXOSAScript is only defined on macOS",
+)
+def test_macosx_osascript_false_falls_back() -> None:
+    """False from MacOSXOSAScript (macOS chrome/firefox names) is a failed launch."""
+    controller = webbrowser.MacOSXOSAScript("chrome")
+    with (
+        _platform(darwin=True),
+        patch_config_options({"browser.command": "chrome"}),
         patch("webbrowser.get", return_value=controller),
         patch.object(controller, "open", return_value=False) as mock_open,
         patch("streamlit.cli_util._open_browser_with_os_default") as os_default,

--- a/lib/tests/streamlit/cli_util_test.py
+++ b/lib/tests/streamlit/cli_util_test.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import os
 import shlex
 import shutil
 import webbrowser
@@ -29,6 +30,7 @@ from tests.testutil import patch_config_options
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+    from pathlib import Path
 
 _URL = "http://some-url"
 
@@ -128,10 +130,7 @@ def test_configured_command_passed_to_webbrowser_get(
     with (
         _platform(darwin=True),
         patch_config_options({"browser.command": browser_command}),
-        patch(
-            "streamlit.cli_util._browser_command_refers_to_existing_executable",
-            return_value=True,
-        ),
+        patch("streamlit.cli_util.shutil.which", return_value="/usr/bin/firefox"),
         patch("webbrowser.get", return_value=controller) as webbrowser_get,
         patch("webbrowser.open") as webbrowser_open,
         patch("subprocess.Popen") as subprocess_popen,
@@ -151,10 +150,7 @@ def test_configured_command_retries_bare_path_as_quoted_template() -> None:
     with (
         _platform(darwin=True),
         patch_config_options({"browser.command": path}),
-        patch(
-            "streamlit.cli_util._browser_command_refers_to_existing_executable",
-            return_value=True,
-        ),
+        patch("streamlit.cli_util.shutil.which", return_value=path),
         patch(
             "webbrowser.get",
             side_effect=[webbrowser.Error("unknown"), controller],
@@ -246,24 +242,62 @@ def test_configured_command_falls_back_for_generic_browser() -> None:
         os_default.assert_called_once_with(_URL)
 
 
-def test_configured_command_does_not_fall_back_when_open_returns_false() -> None:
-    """A falsey controller.open() result must not open a second (OS default) browser.
-
-    BackgroundBrowser returns False when the helper exits immediately, which
-    is normal for ``open -a`` and for a browser that is already running.
-    """
-    controller = MagicMock()
-    controller.open.return_value = False
+def test_background_browser_false_does_not_fall_back() -> None:
+    """BackgroundBrowser returning False is a successful launch, not a fallback."""
+    controller = webbrowser.BackgroundBrowser("true")
     with (
         _platform(darwin=True),
         patch_config_options({"browser.command": "firefox"}),
         patch("webbrowser.get", return_value=controller),
+        patch.object(controller, "open", return_value=False) as mock_open,
         patch("streamlit.cli_util._open_browser_with_os_default") as os_default,
         patch("streamlit.cli_util._get_logger") as mock_get_logger,
     ):
         open_browser(_URL)
 
-        controller.open.assert_called_once_with(_URL)
+        mock_open.assert_called_once_with(_URL)
+        mock_get_logger.assert_not_called()
+        os_default.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "controller",
+    [webbrowser.Mozilla("firefox"), webbrowser.MacOSXOSAScript("chrome")],
+    ids=["mozilla", "macosx_osascript"],
+)
+def test_non_background_controller_false_falls_back(
+    controller: webbrowser.BaseBrowser,
+) -> None:
+    """False from UnixBrowser or MacOSXOSAScript is a failed launch; fall back."""
+    with (
+        _platform(darwin=True),
+        patch_config_options({"browser.command": "firefox"}),
+        patch("webbrowser.get", return_value=controller),
+        patch.object(controller, "open", return_value=False) as mock_open,
+        patch("streamlit.cli_util._open_browser_with_os_default") as os_default,
+        patch("streamlit.cli_util._get_logger") as mock_get_logger,
+    ):
+        open_browser(_URL)
+
+        mock_open.assert_called_once_with(_URL)
+        mock_get_logger.return_value.warning.assert_called_once()
+        os_default.assert_called_once_with(_URL)
+
+
+def test_unix_browser_true_does_not_fall_back() -> None:
+    """Mozilla/Chrome controllers are invoked rather than rejected as GenericBrowser."""
+    controller = webbrowser.Mozilla("firefox")
+    with (
+        _platform(darwin=True),
+        patch_config_options({"browser.command": "firefox"}),
+        patch("webbrowser.get", return_value=controller),
+        patch.object(controller, "open", return_value=True) as mock_open,
+        patch("streamlit.cli_util._open_browser_with_os_default") as os_default,
+        patch("streamlit.cli_util._get_logger") as mock_get_logger,
+    ):
+        open_browser(_URL)
+
+        mock_open.assert_called_once_with(_URL)
         mock_get_logger.assert_not_called()
         os_default.assert_not_called()
 
@@ -291,8 +325,26 @@ def test_configured_command_falls_back_when_open_raises(error: OSError) -> None:
         subprocess_popen.assert_called_once()
 
 
+@pytest.mark.skipif(os.name == "nt", reason="Windows has no POSIX execute bit")
+def test_configured_command_falls_back_for_non_executable_file(tmp_path: Path) -> None:
+    """An existing non-executable file must not skip the OS-default fallback."""
+    path = tmp_path / "not-a-browser"
+    path.write_text("#!/bin/sh\n")
+    path.chmod(0o644)
+    with (
+        _platform(darwin=True),
+        patch_config_options({"browser.command": str(path)}),
+        patch("streamlit.cli_util._open_browser_with_os_default") as os_default,
+        patch("streamlit.cli_util._get_logger") as mock_get_logger,
+    ):
+        open_browser(_URL)
+
+        mock_get_logger.return_value.warning.assert_called_once()
+        os_default.assert_called_once_with(_URL)
+
+
 @pytest.mark.skipif(shutil.which("true") is None, reason="true is not on PATH")
-def test_background_browser_false_does_not_fall_back() -> None:
+def test_immediately_exiting_configured_template_does_not_fall_back() -> None:
     """A %s template that exits immediately must not also open the OS default."""
     with (
         _platform(darwin=True),

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -750,6 +750,7 @@ class ConfigTest(unittest.TestCase):
 
         config_options = sorted(
             [
+                "browser.command",
                 "browser.gatherUsageStats",
                 "browser.serverAddress",
                 "browser.serverPort",

--- a/lib/tests/streamlit/typing/markdown_types.py
+++ b/lib/tests/streamlit/typing/markdown_types.py
@@ -110,6 +110,68 @@ if TYPE_CHECKING:
     assert_type(caption("Note", wrap=False), DeltaGenerator)
     caption("Note", wrap="yes")  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
 
-    # st.badge does not take wrap
+    # =====================================================================
+    # st.badge return type tests
+    # =====================================================================
+
+    # Basic usage - returns DeltaGenerator
     assert_type(badge("New"), DeltaGenerator)
+
+    # icon parameter (keyword-only)
+    assert_type(badge("New", icon=":material/star:"), DeltaGenerator)
+    assert_type(badge("Alert", icon="🚨"), DeltaGenerator)
+    assert_type(badge("New", icon=None), DeltaGenerator)
+
+    # color parameter (keyword-only) - all supported literals
+    assert_type(badge("New", color="red"), DeltaGenerator)
+    assert_type(badge("New", color="orange"), DeltaGenerator)
+    assert_type(badge("New", color="yellow"), DeltaGenerator)
+    assert_type(badge("New", color="blue"), DeltaGenerator)
+    assert_type(badge("New", color="green"), DeltaGenerator)
+    assert_type(badge("New", color="violet"), DeltaGenerator)
+    assert_type(badge("New", color="gray"), DeltaGenerator)
+    assert_type(badge("New", color="grey"), DeltaGenerator)
+    assert_type(badge("New", color="primary"), DeltaGenerator)
+
+    # width parameter (keyword-only)
+    assert_type(badge("New", width="content"), DeltaGenerator)
+    assert_type(badge("New", width="stretch"), DeltaGenerator)
+    assert_type(badge("New", width=300), DeltaGenerator)
+
+    # help parameter (keyword-only)
+    assert_type(badge("New", help="Help text"), DeltaGenerator)
+    assert_type(badge("New", help=None), DeltaGenerator)
+
+    # All parameters combined
+    assert_type(
+        badge(
+            "Success",
+            icon=":material/check:",
+            color="green",
+            width="stretch",
+            help="Completed",
+        ),
+        DeltaGenerator,
+    )
+
+    # =====================================================================
+    # Invalid st.badge usages - should NOT type check
+    # =====================================================================
+
+    # label is str, not SupportsStr
+    badge(42)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+
+    # Invalid color value
+    badge("New", color="rainbow")  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+
+    # Invalid width value (not "stretch", "content", or int)
+    badge("New", width="auto")  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+
+    # Invalid icon type (not str or None)
+    badge("New", icon=123)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+
+    # Passing keyword-only parameters as positional
+    badge("New", ":material/star:")  # type: ignore[call-arg]  # ty: ignore[too-many-positional-arguments]
+
+    # st.badge does not take wrap
     badge("New", wrap=False)  # type: ignore[call-arg]  # ty: ignore[unknown-argument]

--- a/lib/tests/streamlit/typing/spinner_types.py
+++ b/lib/tests/streamlit/typing/spinner_types.py
@@ -70,15 +70,15 @@ if TYPE_CHECKING:
     # =====================================================================
 
     # Invalid text type (not str)
-    spinner(123)  # type: ignore[arg-type]
-    spinner(text=None)  # type: ignore[arg-type]
+    spinner(123)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+    spinner(text=None)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
 
     # Invalid show_time type (not bool)
-    spinner("Wait...", show_time="yes")  # type: ignore[arg-type]
+    spinner("Wait...", show_time="yes")  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
 
     # Passing show_time as positional argument (should be keyword-only)
-    spinner("Wait...", True)  # type: ignore[call-arg]
+    spinner("Wait...", True)  # type: ignore[call-arg]  # ty: ignore[too-many-positional-arguments]
 
     # Invalid width value (not "content", "stretch", or int)
-    spinner("Wait...", width="full")  # type: ignore[arg-type]
-    spinner("Wait...", width=None)  # type: ignore[arg-type]
+    spinner("Wait...", width="full")  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+    spinner("Wait...", width=None)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]

--- a/lib/tests/streamlit/web/bootstrap_test.py
+++ b/lib/tests/streamlit/web/bootstrap_test.py
@@ -939,11 +939,12 @@ class BootstrapOnServerStartBrowserTest(IsolatedAsyncioTestCase):
         ):
             bootstrap._on_server_start(Mock(is_running_hello=False))
 
-        mock_thread.assert_called_once()
-        kwargs = mock_thread.call_args.kwargs
-        assert kwargs["daemon"] is True
-        assert kwargs["name"] == "streamlit-open-browser"
-        kwargs["target"]()
+            mock_thread.assert_called_once()
+            kwargs = mock_thread.call_args.kwargs
+            assert kwargs["daemon"] is True
+            assert kwargs["name"] == "streamlit-open-browser"
+            kwargs["target"]()
+
         mock_open_browser.assert_called_once()
 
     async def test_does_not_open_browser_in_headless_mode(self, mock_open_browser):

--- a/lib/tests/streamlit/web/bootstrap_test.py
+++ b/lib/tests/streamlit/web/bootstrap_test.py
@@ -20,6 +20,7 @@ import os.path
 import sys
 import types
 from io import StringIO
+from typing import TYPE_CHECKING
 from unittest import IsolatedAsyncioTestCase, TestCase
 from unittest.mock import Mock, patch
 
@@ -30,6 +31,9 @@ from streamlit.runtime.runtime import Runtime
 from streamlit.web import bootstrap
 from tests import testutil
 from tests.testutil import patch_config_options
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 class BootstrapPrintTest(IsolatedAsyncioTestCase):
@@ -886,6 +890,23 @@ class BootstrapPydeckMapboxTest(TestCase):
         mock_get_option.assert_not_called()
 
 
+class _ImmediateThread:
+    """Stand-in for threading.Thread that runs target() on start()."""
+
+    def __init__(
+        self,
+        target: Callable[..., object],
+        daemon: bool = False,
+        name: str | None = None,
+    ) -> None:
+        self._target = target
+        self.daemon = daemon
+        self.name = name
+
+    def start(self) -> None:
+        self._target()
+
+
 @patch("streamlit.web.bootstrap.prepare_streamlit_environment", Mock())
 @patch("streamlit.web.bootstrap._print_url", Mock())
 @patch("streamlit.web.bootstrap._maybe_print_skills_recommendation", Mock())
@@ -897,9 +918,33 @@ class BootstrapOnServerStartBrowserTest(IsolatedAsyncioTestCase):
         # prepare_streamlit_environment is mocked at the class level to avoid
         # leaking changes to os.environ (MAPBOX_API_KEY) and the global
         # mimetypes registry across tests.
-        bootstrap._on_server_start(Mock(is_running_hello=False))
-        # Yield to the event loop so the call_soon callback runs.
-        await asyncio.sleep(0)
+        # Run the browser-open callback inline so tests do not wait on a thread.
+        with patch(
+            "streamlit.web.bootstrap.threading.Thread",
+            side_effect=_ImmediateThread,
+        ):
+            bootstrap._on_server_start(Mock(is_running_hello=False))
+
+    async def test_opens_browser_off_the_event_loop(self, mock_open_browser):
+        """maybe_open_browser runs on a daemon thread, not the asyncio loop."""
+        with (
+            testutil.patch_config_options(
+                {
+                    "server.headless": False,
+                    "server.port": 8501,
+                    "global.developmentMode": False,
+                }
+            ),
+            patch("streamlit.web.bootstrap.threading.Thread") as mock_thread,
+        ):
+            bootstrap._on_server_start(Mock(is_running_hello=False))
+
+        mock_thread.assert_called_once()
+        kwargs = mock_thread.call_args.kwargs
+        assert kwargs["daemon"] is True
+        assert kwargs["name"] == "streamlit-open-browser"
+        kwargs["target"]()
+        mock_open_browser.assert_called_once()
 
     async def test_does_not_open_browser_in_headless_mode(self, mock_open_browser):
         """The scheduled callback skips opening a browser when headless=True."""


### PR DESCRIPTION
## Describe your changes

Adds a `browser.command` config option so `streamlit run` can open a chosen browser instead of the OS default.

- Uses Python's `webbrowser.get()` (same approach as Jupyter) so names like `safari` and `chrome` work without OS-specific launching.
- Falls back to the OS default if the value is empty or cannot be resolved. `controller.open()` returning False is not treated as failure: `BackgroundBrowser` often exits immediately after a successful launch (for example `open -a Firefox`).

## GitHub Issue Link (if applicable)

- Closes #637

## Testing Plan

- [x] Unit Tests (Python)
- [ ] E2E Tests — not applicable; this launches an OS browser process at CLI startup

- `lib/tests/streamlit/cli_util_test.py` — OS default path, registered names, `%s` templates, path retry, unresolvable-name/missing-path fallback, and no double-open when `open()` returns False
- `lib/tests/streamlit/config_test.py` — config key inventory

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.