### PR TITLE
[fix] Use a static form field name for file uploads

### DIFF
--- a/frontend/connection/src/DefaultStreamlitEndpoints.test.ts
+++ b/frontend/connection/src/DefaultStreamlitEndpoints.test.ts
@@ -416,9 +416,9 @@ describe("DefaultStreamlitEndpoints", () => {
       expect(actualRequestConfig.onUploadProgress).toBe(mockOnUploadProgress)
     })
 
-    // axios-mock-adapter intercepts before the request reaches XHR, so these
-    // cases pin the FormData entry key, not the Content-Disposition line a
-    // browser would write from it.
+    // Assert the FormData entry key is static. axios-mock-adapter never
+    // serializes Content-Disposition, so this does not cover the on-the-wire
+    // header.
     it.each([
       {
         description: "a regular file",

--- a/frontend/connection/src/DefaultStreamlitEndpoints.test.ts
+++ b/frontend/connection/src/DefaultStreamlitEndpoints.test.ts
@@ -333,7 +333,7 @@ describe("DefaultStreamlitEndpoints", () => {
       const actualRequestConfig = axiosMock.history.put[0]
 
       const expectedData = new FormData()
-      expectedData.append(MOCK_FILE.name, MOCK_FILE)
+      expectedData.append("file", MOCK_FILE)
 
       expect(actualRequestConfig.url).toBe(
         "http://streamlit.mock:80/mock/base/path/_stcore/upload_file/file_1"
@@ -368,7 +368,7 @@ describe("DefaultStreamlitEndpoints", () => {
       const actualRequestConfig = axiosMock.history.put[0]
 
       const expectedData = new FormData()
-      expectedData.append(MOCK_FILE.name, MOCK_FILE)
+      expectedData.append("file", MOCK_FILE)
 
       expect(actualRequestConfig.url).toBe(
         "http://example.com/upload_file/file_2"
@@ -409,7 +409,7 @@ describe("DefaultStreamlitEndpoints", () => {
       const actualRequestConfig = axiosMock.history.put[0]
 
       const expectedData = new FormData()
-      expectedData.append(MOCK_FILE.name, MOCK_FILE)
+      expectedData.append("file", MOCK_FILE)
 
       expect(actualRequestConfig.url).toBe(
         "http://example.com/someprefix/upload_file/file_2"
@@ -427,6 +427,50 @@ describe("DefaultStreamlitEndpoints", () => {
       expect(actualRequestConfig.signal).toBe(mockAbortController.signal)
       expect(actualRequestConfig.onUploadProgress).toBe(mockOnUploadProgress)
     })
+
+    it.each([
+      {
+        description: "a regular file",
+        file: MOCK_FILE,
+        expectedFileName: "file1.txt",
+      },
+      {
+        description: "a file with a hostile name",
+        file: new File(["file1"], 'evil"; name="injected'),
+        expectedFileName: 'evil"; name="injected',
+      },
+      {
+        description: "a directory upload",
+        file: Object.assign(new File(["file1"], "photo.jpg"), {
+          webkitRelativePath: "album/photo.jpg",
+        }),
+        expectedFileName: "album/photo.jpg",
+      },
+    ])(
+      "sends $description under a static form field name",
+      async ({ file, expectedFileName }) => {
+        axiosMock
+          .onPut("http://streamlit.mock:80/mock/base/path/_stcore/upload_file")
+          .reply(() => [200, 1])
+
+        await expect(
+          endpoints.uploadFileUploaderFile(
+            "/_stcore/upload_file",
+            file,
+            "mockSessionId"
+          )
+        ).resolves.toBeUndefined()
+
+        const formData = axiosMock.history.put[0].data as FormData
+        const entries = Array.from(formData.entries())
+
+        expect(entries).toHaveLength(1)
+        const [fieldName, uploadedFile] = entries[0]
+        expect(fieldName).toBe("file")
+        expect(fieldName).not.toBe(file.name)
+        expect((uploadedFile as File).name).toBe(expectedFileName)
+      }
+    )
 
     it("errors on bad status", async () => {
       axiosMock

--- a/frontend/connection/src/DefaultStreamlitEndpoints.test.ts
+++ b/frontend/connection/src/DefaultStreamlitEndpoints.test.ts
@@ -332,16 +332,12 @@ describe("DefaultStreamlitEndpoints", () => {
       expect(axiosMock.history.put.length).toBe(1)
       const actualRequestConfig = axiosMock.history.put[0]
 
-      const expectedData = new FormData()
-      expectedData.append("file", MOCK_FILE)
-
       expect(actualRequestConfig.url).toBe(
         "http://streamlit.mock:80/mock/base/path/_stcore/upload_file/file_1"
       )
       // method is implied by history.put, but can be checked if present in config
       // expect(actualRequestConfig.method?.toUpperCase()).toBe("PUT");
       expect(actualRequestConfig.responseType).toBe("text")
-      expect(actualRequestConfig.data).toEqual(expectedData)
       expect(actualRequestConfig.signal).toBe(mockAbortController.signal)
       expect(actualRequestConfig.onUploadProgress).toBe(mockOnUploadProgress)
     })
@@ -367,14 +363,10 @@ describe("DefaultStreamlitEndpoints", () => {
       expect(axiosMock.history.put.length).toBe(1)
       const actualRequestConfig = axiosMock.history.put[0]
 
-      const expectedData = new FormData()
-      expectedData.append("file", MOCK_FILE)
-
       expect(actualRequestConfig.url).toBe(
         "http://example.com/upload_file/file_2"
       )
       expect(actualRequestConfig.responseType).toBe("text")
-      expect(actualRequestConfig.data).toEqual(expectedData)
       expect(actualRequestConfig.signal).toBe(mockAbortController.signal)
       expect(actualRequestConfig.onUploadProgress).toBe(mockOnUploadProgress)
     })
@@ -408,14 +400,10 @@ describe("DefaultStreamlitEndpoints", () => {
       expect(axiosMock.history.put.length).toBe(1)
       const actualRequestConfig = axiosMock.history.put[0]
 
-      const expectedData = new FormData()
-      expectedData.append("file", MOCK_FILE)
-
       expect(actualRequestConfig.url).toBe(
         "http://example.com/someprefix/upload_file/file_2"
       )
       expect(actualRequestConfig.responseType).toBe("text")
-      expect(actualRequestConfig.data).toEqual(expectedData)
       expect(actualRequestConfig.headers).toEqual(
         new AxiosHeaders({
           Accept: "application/json, text/plain, */*",
@@ -428,6 +416,9 @@ describe("DefaultStreamlitEndpoints", () => {
       expect(actualRequestConfig.onUploadProgress).toBe(mockOnUploadProgress)
     })
 
+    // axios-mock-adapter intercepts before the request reaches XHR, so these
+    // cases pin the FormData entry key, not the Content-Disposition line a
+    // browser would write from it.
     it.each([
       {
         description: "a regular file",
@@ -461,13 +452,14 @@ describe("DefaultStreamlitEndpoints", () => {
           )
         ).resolves.toBeUndefined()
 
+        expect(axiosMock.history.put.length).toBe(1)
         const formData = axiosMock.history.put[0].data as FormData
         const entries = Array.from(formData.entries())
 
         expect(entries).toHaveLength(1)
         const [fieldName, uploadedFile] = entries[0]
         expect(fieldName).toBe("file")
-        expect(fieldName).not.toBe(file.name)
+        expect(uploadedFile).toBeInstanceOf(File)
         expect((uploadedFile as File).name).toBe(expectedFileName)
       }
     )

--- a/frontend/connection/src/DefaultStreamlitEndpoints.ts
+++ b/frontend/connection/src/DefaultStreamlitEndpoints.ts
@@ -280,8 +280,7 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
     // For directory uploads, use the relative path as fileName to preserve directory structure
     const fileName = webkitRelativePath || name
     // Keep the user-controlled filename out of the Content-Disposition `name`
-    // parameter; it still travels in `filename`. Upload endpoints read the file
-    // from whichever part the body carries, not from the field name.
+    // parameter; it still travels in `filename`.
     form.append(UPLOAD_FORM_FIELD_NAME, file, fileName)
 
     const headers: Record<string, string> = this.getAdditionalHeaders()

--- a/frontend/connection/src/DefaultStreamlitEndpoints.ts
+++ b/frontend/connection/src/DefaultStreamlitEndpoints.ts
@@ -55,7 +55,6 @@ const UPLOAD_FILE_ENDPOINT = "/_stcore/upload_file"
 const COMPONENT_ENDPOINT_BASE = "/component"
 const BIDI_COMPONENT_ENDPOINT_BASE = "/_stcore/bidi-components"
 
-/** Multipart form-data field name used for file uploads. */
 const UPLOAD_FORM_FIELD_NAME = "file"
 
 /** Default Streamlit server implementation of the StreamlitEndpoints interface. */
@@ -280,10 +279,9 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
     const { name, webkitRelativePath } = file
     // For directory uploads, use the relative path as fileName to preserve directory structure
     const fileName = webkitRelativePath || name
-    // The field name is intentionally static: the server reads the file from
-    // whichever form entry is present and only uses the filename, so keeping
-    // user-controlled input out of the field name avoids putting arbitrary
-    // strings into the multipart Content-Disposition header.
+    // Keep the user-controlled filename out of the Content-Disposition `name`
+    // parameter; it still travels in `filename`. Upload endpoints read the file
+    // from whichever part the body carries, not from the field name.
     form.append(UPLOAD_FORM_FIELD_NAME, file, fileName)
 
     const headers: Record<string, string> = this.getAdditionalHeaders()

--- a/frontend/connection/src/DefaultStreamlitEndpoints.ts
+++ b/frontend/connection/src/DefaultStreamlitEndpoints.ts
@@ -55,6 +55,9 @@ const UPLOAD_FILE_ENDPOINT = "/_stcore/upload_file"
 const COMPONENT_ENDPOINT_BASE = "/component"
 const BIDI_COMPONENT_ENDPOINT_BASE = "/_stcore/bidi-components"
 
+/** Multipart form-data field name used for file uploads. */
+const UPLOAD_FORM_FIELD_NAME = "file"
+
 /** Default Streamlit server implementation of the StreamlitEndpoints interface. */
 export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
   private readonly getServerUri: () => URL | undefined
@@ -277,7 +280,11 @@ export class DefaultStreamlitEndpoints implements StreamlitEndpoints {
     const { name, webkitRelativePath } = file
     // For directory uploads, use the relative path as fileName to preserve directory structure
     const fileName = webkitRelativePath || name
-    form.append(name, file, fileName)
+    // The field name is intentionally static: the server reads the file from
+    // whichever form entry is present and only uses the filename, so keeping
+    // user-controlled input out of the field name avoids putting arbitrary
+    // strings into the multipart Content-Disposition header.
+    form.append(UPLOAD_FORM_FIELD_NAME, file, fileName)
 
     const headers: Record<string, string> = this.getAdditionalHeaders()
 

--- a/lib/tests/streamlit/web/server/starlette/starlette_routes_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_routes_test.py
@@ -986,9 +986,9 @@ def test_upload_put_stores_file_and_returns_204() -> None:
     [
         pytest.param("file", id="static_field_name"),
         pytest.param("foo.txt", id="field_name_matching_filename"),
-        # A duplicated `name` parameter resolves last-wins, so the handler sees
-        # `injected`. This pins that the injected parameter cannot displace
-        # `filename`, not that the handler receives the raw quoted string.
+        # Pins that a second `name` parameter cannot replace `filename`.
+        # Browsers escape quotes in field names, so this models a hand-built
+        # request.
         pytest.param(
             'evil"; name="injected', id="field_name_injecting_extra_name_param"
         ),
@@ -997,15 +997,9 @@ def test_upload_put_stores_file_and_returns_204() -> None:
 def test_upload_put_ignores_form_field_name(field_name: str) -> None:
     """The upload is stored regardless of the multipart form field name.
 
-    The handler takes whichever file part the body carries and reads the name
-    from the part's ``filename``, so the field name carries no meaning. The
-    frontend relies on this to send a static field name instead of repeating the
-    user-controlled filename in ``Content-Disposition``'s ``name``.
-
-    The cases cover the field name the frontend now sends, the filename it used
-    to send (older frontends and host proxies must keep working), and a
-    non-browser client injecting an extra ``name`` parameter -- browsers escape
-    quotes in field names, so the last case models a hand-built request.
+    The handler reads the name from the part's ``filename``, so older frontends
+    that used the filename as the field name, and hand-built requests that
+    inject an extra ``name`` parameter, must keep working.
     """
     runtime = MagicMock()
     runtime.is_active_session.return_value = True

--- a/lib/tests/streamlit/web/server/starlette/starlette_routes_test.py
+++ b/lib/tests/streamlit/web/server/starlette/starlette_routes_test.py
@@ -981,6 +981,54 @@ def test_upload_put_stores_file_and_returns_204() -> None:
     assert stored[0].name == "foo.txt"
 
 
+@pytest.mark.parametrize(
+    "field_name",
+    [
+        pytest.param("file", id="static_field_name"),
+        pytest.param("foo.txt", id="field_name_matching_filename"),
+        # A duplicated `name` parameter resolves last-wins, so the handler sees
+        # `injected`. This pins that the injected parameter cannot displace
+        # `filename`, not that the handler receives the raw quoted string.
+        pytest.param(
+            'evil"; name="injected', id="field_name_injecting_extra_name_param"
+        ),
+    ],
+)
+def test_upload_put_ignores_form_field_name(field_name: str) -> None:
+    """The upload is stored regardless of the multipart form field name.
+
+    The handler takes whichever file part the body carries and reads the name
+    from the part's ``filename``, so the field name carries no meaning. The
+    frontend relies on this to send a static field name instead of repeating the
+    user-controlled filename in ``Content-Disposition``'s ``name``.
+
+    The cases cover the field name the frontend now sends, the filename it used
+    to send (older frontends and host proxies must keep working), and a
+    non-browser client injecting an extra ``name`` parameter -- browsers escape
+    quotes in field names, so the last case models a hand-built request.
+    """
+    runtime = MagicMock()
+    runtime.is_active_session.return_value = True
+    upload_mgr = MemoryUploadedFileManager("/_stcore/upload_file")
+    endpoint = _endpoint_for(create_upload_routes(runtime, upload_mgr, ""), "PUT")
+
+    body, boundary = _multipart_body(b"hello world", field_name=field_name)
+    request = _make_upload_request(
+        [{"type": "http.request", "body": body, "more_body": False}],
+        boundary=boundary,
+    )
+
+    with patch_config_options({"server.enableXsrfProtection": False}):
+        response = asyncio.run(endpoint(request))
+
+    assert response.status_code == 204
+    stored = upload_mgr.get_files("session123", ["fileid"])
+    assert len(stored) == 1
+    assert stored[0].data == b"hello world"
+    # The name comes from `filename`, never from the field name.
+    assert stored[0].name == "foo.txt"
+
+
 def test_upload_put_max_size_file_succeeds() -> None:
     """A file of exactly ``maxUploadSize`` is accepted, not rejected by the cap.
 


### PR DESCRIPTION
## Describe your changes

Uploads now send the file under a static `"file"` field name instead of the file's own name, keeping user-controlled input out of the multipart `Content-Disposition` `name` parameter. The filename/path still travels in `filename`, unchanged.

The server never used the field name — `_upload_put` takes whichever `UploadFile` the form carries and reads `upload.filename` — so this is a no-op server-side, and it covers `st.file_uploader`, `st.chat_input`, `st.camera_input`, and `st.audio_input`, which share the upload path. Nothing pinned that behavior, so a server-side test now does.

This is hardening, not a vulnerability fix: browsers percent-encode `"`, CR, and LF in both parameters, so no filename could inject header structure. Measured in Chromium with the filename `ev"il\r\n.txt`:

```
before: name="ev%22il%0D%0A.txt"; filename="ev%22il%0D%0A.txt"
after:  name="file";              filename="ev%22il%0D%0A.txt"
```

That also settles uploads redirected to a host endpoint via `fileUploadClientConfig`. The old field name was already an escaped arbitrary string, so no receiver could have matched a literal name, and one reading `name` as the filename was already getting the escaped form — and the basename rather than the path for directory uploads. Anything working today reads `filename` or iterates parts, both identical before and after.

## GitHub Issue Link (if applicable)

Closes #16691

## Testing Plan

- Unit tests on both sides of the contract: the server stores the upload and takes its name from `filename` whatever the field name is, and the client sends a single `file` entry with the filename preserved.
- No E2E: Chromium won't expose a multipart body containing a `File` over CDP (`post_data` and `post_data_buffer` are both `None`), so the serialized bytes can't be asserted from Playwright — hence the measurement above. Existing upload E2E covers the round trip.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only multipart shaping with server compatibility tests; stored filenames and upload semantics stay the same.
> 
> **Overview**
> **File uploads now use a fixed `"file"` multipart field name** instead of the user-controlled filename, so the `Content-Disposition` `name` parameter is no longer derived from the chosen file name. The display/path name is unchanged and still sent via the third argument to `form.append` (`webkitRelativePath` or `name`).
> 
> This hardens the shared upload path used by `st.file_uploader`, chat/camera/audio inputs, and optional `fileUploadClientConfig` redirects. **Server behavior is unchanged** — the Starlette handler already persisted `upload.filename` — and a new parametrized test locks that contract for static, legacy filename-as-field, and adversarial field names.
> 
> Frontend tests drop brittle full-`FormData` equality on URL/header cases and add `it.each` coverage for regular files, hostile names, and directory uploads asserting a single `"file"` entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f34d37e285d373b4fcb458d2d3c864014a27311. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->