### PR TITLE
[chore] De-flake container min-width reduced-viewport snapshots

### DIFF
--- a/e2e_playwright/st_layouts_container_min_width_test.py
+++ b/e2e_playwright/st_layouts_container_min_width_test.py
@@ -53,6 +53,8 @@ def test_container_reduced_viewport(
 ):
     """Test container layouts at the reduced mobile viewport."""
     app.set_viewport_size({"width": _REDUCED_VIEWPORT_WIDTH, "height": 844})
+    # Wait until the browser has applied the viewport so the React-stability
+    # wait does not start (and finish) before the resize.
     app.wait_for_function(f"() => window.innerWidth <= {_REDUCED_VIEWPORT_WIDTH}")
     # Snapshots must wait for the resize-driven rerender. The new width reaches
     # React through a ResizeObserver throttled to 100ms, and canvas-backed

--- a/e2e_playwright/st_layouts_container_min_width_test.py
+++ b/e2e_playwright/st_layouts_container_min_width_test.py
@@ -17,6 +17,9 @@ from playwright.sync_api import Page
 
 from e2e_playwright.conftest import ImageCompareFunction
 from e2e_playwright.shared.app_utils import get_element_by_key
+from e2e_playwright.shared.react18_utils import wait_for_react_stability
+
+REDUCED_VIEWPORT_WIDTH = 390
 
 CONTAINER_KEYS = [
     "layout-horizontal-markdown",
@@ -48,8 +51,19 @@ def test_container_regular_viewport(
 def test_container_reduced_viewport(
     app: Page, assert_snapshot: ImageCompareFunction, container_key: str
 ):
-    """Test container layouts at reduced viewport (390px)."""
-    app.set_viewport_size({"width": 390, "height": 844})
+    """Test container layouts at the reduced mobile viewport."""
+    app.set_viewport_size({"width": REDUCED_VIEWPORT_WIDTH, "height": 844})
+    app.wait_for_function(f"() => window.innerWidth <= {REDUCED_VIEWPORT_WIDTH}")
+    # The new width reaches React through a ResizeObserver throttled to 100ms.
+    # The throttle fires on the leading edge, so when the resize produces more
+    # than one notification the first (intermediate) width is rendered and the
+    # real one only arrives with the trailing call 100ms later. Canvas-backed
+    # elements repaint from that second render, and because their boxes are
+    # already at the final size throughout, Playwright's screenshot stability
+    # check cannot see the stale pixels. Without waiting for the re-render, the
+    # dataframe and chart containers intermittently snapshot columns and axes
+    # still sized for the wide viewport.
+    wait_for_react_stability(app)
     container_element = get_element_by_key(app, container_key)
     assert_snapshot(
         container_element,

--- a/e2e_playwright/st_layouts_container_min_width_test.py
+++ b/e2e_playwright/st_layouts_container_min_width_test.py
@@ -19,7 +19,7 @@ from e2e_playwright.conftest import ImageCompareFunction
 from e2e_playwright.shared.app_utils import get_element_by_key
 from e2e_playwright.shared.react18_utils import wait_for_react_stability
 
-REDUCED_VIEWPORT_WIDTH = 390
+_REDUCED_VIEWPORT_WIDTH = 390
 
 CONTAINER_KEYS = [
     "layout-horizontal-markdown",
@@ -52,17 +52,13 @@ def test_container_reduced_viewport(
     app: Page, assert_snapshot: ImageCompareFunction, container_key: str
 ):
     """Test container layouts at the reduced mobile viewport."""
-    app.set_viewport_size({"width": REDUCED_VIEWPORT_WIDTH, "height": 844})
-    app.wait_for_function(f"() => window.innerWidth <= {REDUCED_VIEWPORT_WIDTH}")
-    # The new width reaches React through a ResizeObserver throttled to 100ms.
-    # The throttle fires on the leading edge, so when the resize produces more
-    # than one notification the first (intermediate) width is rendered and the
-    # real one only arrives with the trailing call 100ms later. Canvas-backed
-    # elements repaint from that second render, and because their boxes are
-    # already at the final size throughout, Playwright's screenshot stability
-    # check cannot see the stale pixels. Without waiting for the re-render, the
-    # dataframe and chart containers intermittently snapshot columns and axes
-    # still sized for the wide viewport.
+    app.set_viewport_size({"width": _REDUCED_VIEWPORT_WIDTH, "height": 844})
+    app.wait_for_function(f"() => window.innerWidth <= {_REDUCED_VIEWPORT_WIDTH}")
+    # Snapshots must wait for the resize-driven rerender. The new width reaches
+    # React through a ResizeObserver throttled to 100ms, and canvas-backed
+    # elements repaint only after that. Their boxes are already at the final
+    # size meanwhile, so Playwright's screenshot stability check cannot detect
+    # the stale pixels.
     wait_for_react_stability(app)
     container_element = get_element_by_key(app, container_key)
     assert_snapshot(


### PR DESCRIPTION
Waits for the post-resize re-render before snapshotting `test_container_reduced_viewport`, which failed intermittently on webkit in CI with a 0.29% mismatch against a 0.2% budget.

`useCalculatedDimensions` feeds the new width to React through a ResizeObserver throttled to 100ms, and the throttle fires on the **leading** edge. When the resize produces more than one notification, the first (intermediate) width is rendered immediately and the real one only arrives with the trailing call 100ms later. Canvas-backed elements repaint from that second render — so for ~200ms the dataframe grid still shows columns sized for the wide viewport, while its DOM box is already narrow. Playwright's screenshot stability check watches geometry, so it cannot see the stale pixels.

## Evidence

The diff images from the failing CI run were gone (a passing rerun deletes them), so the diagnosis came from the failed attempt's `video.webm`: frame 57 is the resize, frames 59–63 show 2 clipped columns instead of 3, frame 64 onward matches the golden.

Reproduced locally by forcing two notifications inside the cooldown with a stepped resize. Without the wait the capture differs from the settled render by 0.68–0.82% — 3–4x over budget — and with it, 0 pixels, across 3 runs.

The goldens are unchanged. The test passes against a baseline generated before this change, confirming the settled render was always correct and only the sampling was early.

## Notes for reviewers

- An earlier version added a `wait_for_canvas_pixels_stable` helper that sampled canvas pixels directly. The repro showed `wait_for_react_stability` alone is sufficient, so the helper was dropped rather than carried for insurance.
- The local repro is on chromium; webkit's `set_viewport_size` round-trip is too slow locally to land two notifications inside the 100ms cooldown. The throttle is Streamlit's own JS, so the mechanism is browser-independent.
- Adds ~350ms per case (10 cases x 3 browsers), spread across CI workers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Playwright test-only timing changes with no production or snapshot baseline updates.
> 
> **Overview**
> **De-flakes** reduced-viewport container layout snapshot tests that intermittently failed on WebKit when screenshots were taken before canvas-backed widgets finished repainting after a resize.
> 
> `test_container_reduced_viewport` now waits until `window.innerWidth` reflects the **390px** mobile width, then calls **`wait_for_react_stability`** so captures happen after the throttled ResizeObserver-driven rerender (not when DOM geometry is already narrow but dataframe/chart pixels are still from the wide layout). The viewport width is extracted to **`_REDUCED_VIEWPORT_WIDTH`**; golden images are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 989e254924f4dc2747fac0af894290228b539dbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->