### PR TITLE
[chore] De-flake the directory-upload e2e tests

### DIFF
--- a/e2e_playwright/st_file_uploader_test.py
+++ b/e2e_playwright/st_file_uploader_test.py
@@ -17,7 +17,8 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
-from playwright.sync_api import FilePayload, Page, Route, expect
+from playwright.sync_api import FileChooser, FilePayload, Page, Route, expect
+from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
 from e2e_playwright.conftest import (
     ImageCompareFunction,
@@ -98,6 +99,27 @@ def verify_uploaded_files_in_widget(
                 f'[data-testid="stFileChipName"][title*="{expected_file}"]'
             ).first
         ).to_be_visible()
+
+
+def choose_directory(file_chooser: FileChooser, directory: str) -> None:
+    """Point a file chooser at a directory, tolerating a lost acknowledgement.
+
+    For a directory, Playwright hands the path to the browser to enumerate.
+    The browser sometimes delivers the files without ever answering the
+    protocol call, so `set_files` sits until its timeout even though the upload
+    already finished: in CI the upload requests complete within ~20ms of the
+    call and the app renders the files, and the call then fails 30s later. Seen
+    on webkit and firefox, never chromium, in roughly 5% of runs.
+
+    Waiting on that acknowledgement therefore tells us nothing the callers do
+    not already assert, so a timeout here is ignored. Callers must verify the
+    upload themselves, which they do via auto-retrying expectations - a genuinely
+    failed upload still fails those.
+    """
+    try:
+        file_chooser.set_files(files=[directory], timeout=10000)
+    except PlaywrightTimeoutError:
+        pass
 
 
 def test_file_uploader_render_correctly(
@@ -373,8 +395,7 @@ def test_uploads_directory_with_multiple_files(app: Page):
     with app.expect_file_chooser() as fc_info:
         file_uploader_dropzone.click()
 
-    file_chooser = fc_info.value
-    file_chooser.set_files(files=[temp_dir])
+    choose_directory(fc_info.value, temp_dir)
 
     wait_for_app_run(app, wait_delay=1000)
 
@@ -421,8 +442,7 @@ def test_directory_upload_with_file_type_filtering(app: Page):
     with app.expect_file_chooser() as fc_info:
         file_dropzone.click()
 
-    file_chooser = fc_info.value
-    file_chooser.set_files(files=[temp_dir])
+    choose_directory(fc_info.value, temp_dir)
 
     wait_for_app_run(app, wait_delay=1000)
 

--- a/e2e_playwright/st_file_uploader_test.py
+++ b/e2e_playwright/st_file_uploader_test.py
@@ -12,11 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import tempfile
-from pathlib import Path
 from typing import Any
 
+import pytest
 from playwright.sync_api import FileChooser, FilePayload, Page, Route, expect
 from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
@@ -39,12 +37,19 @@ from e2e_playwright.shared.app_utils import (
 NUM_FILE_UPLOADERS = 21
 
 
-def create_temp_directory_with_files(file_data: list[dict[str, Any]]) -> str:
+def create_temp_directory_with_files(
+    tmp_path_factory: pytest.TempPathFactory, file_data: list[dict[str, Any]]
+) -> str:
     """
     Create a temporary directory with files for directory upload testing.
 
     Parameters
     ----------
+    tmp_path_factory : pytest.TempPathFactory
+        Supplies a base directory that is unique per call, so that callers
+        running concurrently in separate xdist workers cannot clobber each
+        other's files. Also lets pytest garbage-collect the trees.
+
     file_data : list[dict[str, Any]]
         List of dict with 'path' and 'content' keys
 
@@ -53,16 +58,9 @@ def create_temp_directory_with_files(file_data: list[dict[str, Any]]) -> str:
     str
         Path to the temporary directory
     """
-    # The base directory must be unique per call. Callers can run concurrently in
-    # separate xdist workers, and a shared base made each one delete and rebuild
-    # the other's directory mid-test, so a single upload picked up both sets of
-    # files. The uploaded directory itself stays named "upload_dir" so that
-    # webkitRelativePath, and the chip titles asserted against it, are unchanged.
-    test_base_dir = tempfile.mkdtemp(prefix="streamlit_e2e_upload_")
-    temp_dir = os.path.join(test_base_dir, "upload_dir")
-    temp_path = Path(temp_dir)
-
-    # Create a nested structure so the uploaded directory preserves relative paths
+    # Nested as "upload_dir" so that webkitRelativePath, and the chip titles
+    # asserted against it, carry that prefix.
+    temp_path = tmp_path_factory.mktemp("streamlit_e2e_upload") / "upload_dir"
     temp_path.mkdir(parents=True, exist_ok=True)
 
     for file_info in file_data:
@@ -70,7 +68,7 @@ def create_temp_directory_with_files(file_data: list[dict[str, Any]]) -> str:
         file_path.parent.mkdir(parents=True, exist_ok=True)
         file_path.write_bytes(file_info["content"])
 
-    return str(temp_dir)
+    return str(temp_path)
 
 
 def verify_uploaded_files_in_widget(
@@ -369,7 +367,9 @@ def test_compact_uploader_with_files_snapshot(
     assert_snapshot(file_uploader, name="st_file_uploader-compact_with_files")
 
 
-def test_uploads_directory_with_multiple_files(app: Page):
+def test_uploads_directory_with_multiple_files(
+    app: Page, tmp_path_factory: pytest.TempPathFactory
+):
     """Test that directory upload works correctly with multiple files.
 
     Note: We don't test the visual order of files in the widget because
@@ -383,7 +383,7 @@ def test_uploads_directory_with_multiple_files(app: Page):
         {"path": "folder/subfolder/file3.md", "content": b"# Markdown"},
     ]
 
-    temp_dir = create_temp_directory_with_files(directory_data)
+    temp_dir = create_temp_directory_with_files(tmp_path_factory, directory_data)
 
     uploader_index = 3  # Directory uploader index
 
@@ -418,7 +418,9 @@ def test_uploads_directory_with_multiple_files(app: Page):
     expect(uploader_text).to_contain_text("Directory contains 2 files:")
 
 
-def test_directory_upload_with_file_type_filtering(app: Page):
+def test_directory_upload_with_file_type_filtering(
+    app: Page, tmp_path_factory: pytest.TempPathFactory
+):
     """Test that directory upload correctly filters files by type.
 
     Note: We don't test the visual order of files in the widget because
@@ -435,7 +437,7 @@ def test_directory_upload_with_file_type_filtering(app: Page):
         {"path": "nested/deep/file.txt", "content": b"nested file"},
     ]
 
-    temp_dir = create_temp_directory_with_files(directory_data)
+    temp_dir = create_temp_directory_with_files(tmp_path_factory, directory_data)
     file_dropzone = app.get_by_test_id("stFileUploaderDropzone").nth(uploader_index)
     expect(file_dropzone).to_be_visible()
 

--- a/e2e_playwright/st_file_uploader_test.py
+++ b/e2e_playwright/st_file_uploader_test.py
@@ -58,8 +58,8 @@ def create_temp_directory_with_files(
     str
         Path to the temporary directory
     """
-    # Nested as "upload_dir" so that webkitRelativePath, and the chip titles
-    # asserted against it, carry that prefix.
+    # Nest the files under "upload_dir": the browser reports that name in
+    # webkitRelativePath, and the chip-title assertions expect the prefix.
     temp_path = tmp_path_factory.mktemp("streamlit_e2e_upload") / "upload_dir"
     temp_path.mkdir(parents=True, exist_ok=True)
 
@@ -100,26 +100,20 @@ def verify_uploaded_files_in_widget(
 
 
 def choose_directory(file_chooser: FileChooser, directory: str) -> None:
-    """Point a file chooser at a directory, tolerating a lost acknowledgement.
+    """Select a directory in a file chooser, ignoring a lost Playwright acknowledgement.
 
-    For a directory, Playwright hands the path to the browser to enumerate.
-    The browser sometimes delivers the files without ever answering the
-    protocol call, so `set_files` sits until its timeout even though the upload
-    already finished: in CI the upload requests complete within ~20ms of the
-    call and the app renders the files, and the call then fails 30s later. Seen
-    on webkit and firefox, never chromium, in roughly 5% of runs.
-
-    Waiting on that acknowledgement therefore tells us nothing the callers do
-    not already assert, so a timeout here is ignored. Callers must verify the
-    upload themselves, which they do via auto-retrying expectations - a genuinely
-    failed upload still fails those.
+    Playwright sometimes applies the directory files but never answers
+    `set_files`, so the call times out even though the upload already finished.
+    Ignore that timeout; callers must still assert that the upload succeeded.
+    Drop this helper once Playwright's directory `setInputFiles` reliably
+    resolves (see #16772 for the evidence).
     """
     try:
         file_chooser.set_files(files=[directory], timeout=10000)
     except PlaywrightTimeoutError:
-        # A timeout here is not necessarily the lost acknowledgement, so say so.
-        # pytest only surfaces this if a later assertion fails, which is exactly
-        # when someone needs to know set_files was involved.
+        # Print instead of failing: the timeout may have some other cause, and
+        # pytest surfaces this output only when a later assertion fails, which
+        # is exactly when someone needs to know set_files was involved.
         print(f"set_files timed out for {directory}; continuing to the assertions")
 
 

--- a/e2e_playwright/st_file_uploader_test.py
+++ b/e2e_playwright/st_file_uploader_test.py
@@ -117,7 +117,10 @@ def choose_directory(file_chooser: FileChooser, directory: str) -> None:
     try:
         file_chooser.set_files(files=[directory], timeout=10000)
     except PlaywrightTimeoutError:
-        pass
+        # A timeout here is not necessarily the lost acknowledgement, so say so.
+        # pytest only surfaces this if a later assertion fails, which is exactly
+        # when someone needs to know set_files was involved.
+        print(f"set_files timed out for {directory}; continuing to the assertions")
 
 
 def test_file_uploader_render_correctly(

--- a/e2e_playwright/st_file_uploader_test.py
+++ b/e2e_playwright/st_file_uploader_test.py
@@ -13,12 +13,10 @@
 # limitations under the License.
 
 import os
-import shutil
 import tempfile
 from pathlib import Path
 from typing import Any
 
-import pytest
 from playwright.sync_api import FilePayload, Page, Route, expect
 
 from e2e_playwright.conftest import (
@@ -54,19 +52,16 @@ def create_temp_directory_with_files(file_data: list[dict[str, Any]]) -> str:
     str
         Path to the temporary directory
     """
-    # Use a deterministic directory name for consistent test results
-    temp_base = tempfile.gettempdir()
-    # Create a nested structure so the uploaded directory preserves relative paths
-    test_base_dir = os.path.join(temp_base, "streamlit_e2e_test_base")
+    # The base directory must be unique per call. Callers can run concurrently in
+    # separate xdist workers, and a shared base made each one delete and rebuild
+    # the other's directory mid-test, so a single upload picked up both sets of
+    # files. The uploaded directory itself stays named "upload_dir" so that
+    # webkitRelativePath, and the chip titles asserted against it, are unchanged.
+    test_base_dir = tempfile.mkdtemp(prefix="streamlit_e2e_upload_")
     temp_dir = os.path.join(test_base_dir, "upload_dir")
     temp_path = Path(temp_dir)
 
-    # Clean up any existing directory
-    base_path = Path(test_base_dir)
-    if base_path.exists():
-        shutil.rmtree(base_path)
-
-    # Create the directory
+    # Create a nested structure so the uploaded directory preserves relative paths
     temp_path.mkdir(parents=True, exist_ok=True)
 
     for file_info in file_data:
@@ -352,7 +347,6 @@ def test_compact_uploader_with_files_snapshot(
     assert_snapshot(file_uploader, name="st_file_uploader-compact_with_files")
 
 
-@pytest.mark.flaky(reruns=3)
 def test_uploads_directory_with_multiple_files(app: Page):
     """Test that directory upload works correctly with multiple files.
 
@@ -403,7 +397,6 @@ def test_uploads_directory_with_multiple_files(app: Page):
     expect(uploader_text).to_contain_text("Directory contains 2 files:")
 
 
-@pytest.mark.flaky(reruns=3)
 def test_directory_upload_with_file_type_filtering(app: Page):
     """Test that directory upload correctly filters files by type.
 


### PR DESCRIPTION
## Describe your changes

Fixes two separate problems in the two directory-upload e2e tests. The investigation corrected its own diagnosis partway through, so both are described.

### 1. The observed CI flake: a lost `set_files` acknowledgement

This is what was actually making these tests the top two flakes.

For a directory, Playwright hands the path to the browser to enumerate. The browser delivers the files but sometimes never answers the protocol call, so `set_files` sits until its timeout even though the upload already finished. From the failing run's trace and network log:

| event | time |
| --- | --- |
| 3 PUT uploads, all 204 | within **~20ms** of the call |
| `setInputFiles` finally errors | **30s** later |

The failure screenshots show the upload fully succeeded - correct chips, and the app rendering `Directory contains 3 files:` with the right `upload_dir/...` relative paths. Only the acknowledgement is lost.

Measured across the 322 develop runs from Aug 28 - Sep 1: **15 instances**, all recovered on rerun. 13 webkit, 2 firefox, 0 chromium.

This looks like an upstream Playwright/browser bug rather than ours:

- Playwright's contract is broken - the files *were* set, the call never resolved. The hang is in `_channel.send("setInputFiles", ...)`.
- The browser split is a transport signature, not an app signature: the Streamlit code is identical across browsers and only the non-CDP ones are affected.
- It is not a Streamlit bug. The `<input>` is the unconditional first child of the dropzone and the subtree that changes on upload is a *sibling after it*, so React keeps the same DOM node throughout. `useFsAccessApi={false}` already handles the known app-side picker pitfall.

No matching upstream issue was found, so there is no fixed version to upgrade to. Worth reporting upstream separately; the trace and network timeline are good evidence.

The mitigation is to stop waiting on a signal that carries no information: bound the wait and let the callers' existing auto-retrying assertions be the gate. A swallowed timeout is printed, which pytest surfaces only if a later assertion fails, so the cause is not a mystery if `set_files` ever times out for some other reason.

### 2. A latent cross-worker collision (real, but not what CI was hitting)

`create_temp_directory_with_files` used to `rmtree` and recreate a hard-coded `/tmp/streamlit_e2e_test_base/upload_dir`. CI runs `-n auto` with xdist's default `--dist load`, which schedules individual tests, so the two callers can run concurrently in separate worker processes and destroy each other's upload directory mid-test.

Running just those two tests under `-n 4` flaked **8/8**, with `to_have_count` expected 3 got **7** and expected 4 got **7** - 7 being test 1's 3 files plus test 2's 4 files merged into one directory.

This is severe in the changed-files workflow, where only this file runs so the two tests are almost certainly co-scheduled. It is rare in the full 32-worker suite, where they seldom land together - which is why main CI was not hitting it, and why attributing the observed flake to it was wrong.

The base now comes from pytest's `tmp_path_factory`, which is unique per call, xdist-safe, and garbage-collected by pytest. The uploaded directory is still named `upload_dir`, so `webkitRelativePath` and every chip title assertion are unchanged.

## Testing Plan

- **E2E Tests:** no new tests. Both changes are to the existing tests and their shared helpers; the assertions they make are unchanged.
- **Collision fix:** verified by before/after under load - 8/8 flaking beforehand, then 10/10 clean, and the full 69-test file clean 3/3 on all three browsers under `-n 4`. Sequentially both versions are 25/25 clean, which is why this never reproduced in single-worker local runs.
- **Mitigation, end to end:** a 100-iteration `flaky-test-verification` run on this branch came back **0 failures** ([run 33670418686](https://github.com/streamlit/streamlit/actions/runs/33670418686)), against a pre-mitigation baseline of **2 failures in 50** iterations on the same tests. Every iteration ran the full 69 tests (23 x three browsers) at `--reruns 0`, confirmed from the per-iteration stats artifacts rather than the job tally. At the measured ~4.7% rate, P(zero failures across 100 iterations if the mitigation did nothing) is ~0.8%.
- **Mitigation, safety:** verified. Forcing an early timeout so the files never arrive makes the assertions fail, so swallowing the timeout does **not** mask a broken upload.
- **Mitigation, recovery:** not demonstrated directly. In a real hang the page state matches a successful run, so the assertions should pass, but the "work completes, ack lost" window is too narrow to trigger deliberately and ~100 local iterations never produced the real hang. The tests now continue into steps never observed executing after a hang.
- **Manual testing:** none needed - test-only change, no product code touched.

Two caveats on the verification. The baseline was taken on the commit with only the temp-directory change, so a clean result strictly credits the whole delta rather than the acknowledgement mitigation in isolation - though that mitigation is the only change that plausibly affects the hang. And this mitigates an upstream bug rather than fixing it: the hang presumably still happens, we have just stopped waiting on an answer that carries no information. If Playwright's directory `setInputFiles` is fixed upstream, the `try`/`except` becomes dead code and can go.

### Note on the flaky markers

`@pytest.mark.flaky(reruns=3)` is deliberately **removed** and stays removed.

It is not needed to keep CI green: main CI's `--reruns 1` already absorbs a single hang, so going red would need the same test to hang twice in a row (~0.2%). It is not needed to measure the mitigation either, since `rerun_count` is recorded whether or not the marker is present - that is how these flakes were found in the first place. The only place the marker changes an outcome is `--reruns 0` workflows, which is precisely where we want a failure to be visible if the mitigation turns out incomplete.

They were originally added in #12441 as an undiagnosed bulk mitigation ("A couple more fixes to reduces e2e flakiness", 8 files, no issue link) for a since-fixed snapshot-ordering problem.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to e2e helpers and directory-upload flows; no application or runtime behavior is modified.
> 
> **Overview**
> Stabilizes the two Playwright directory-upload e2e tests without changing product code or their assertions.
> 
> **Temp directories** — `create_temp_directory_with_files` now builds trees via pytest `tmp_path_factory` (still under an `upload_dir` folder for `webkitRelativePath` expectations) instead of a shared fixed path under `/tmp` that parallel xdist workers could delete or overwrite.
> 
> **Playwright hang** — New `choose_directory` calls `set_files` with a 10s cap and continues if Playwright times out after the browser already applied the directory upload; success is still gated by the existing chip/count assertions. Both directory tests use this helper instead of blocking on `set_files` indefinitely.
> 
> **Flaky markers** — `@pytest.mark.flaky(reruns=3)` is removed from those two tests so `--reruns 0` runs surface real failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5882d3864d5dcb2f0da39d78a11d5982e3bf26c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->