### PR TITLE
[fix] Remove expired mapbox.token config option

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -1406,28 +1406,6 @@ _create_option(
 )
 
 
-# Config Section: Mapbox #
-
-_create_section("mapbox", "Mapbox configuration that is being used by DeckGL.")
-
-_create_option(
-    "mapbox.token",
-    description="""
-        If you'd like to show maps using Mapbox rather than Carto, use this
-        to pass the Mapbox API token.
-    """,
-    default_val="",
-    type_=str,
-    sensitive=True,
-    deprecated=True,
-    deprecation_text="""
-        Instead of this, you should use either the MAPBOX_API_KEY environment
-        variable or PyDeck's `api_keys` argument.
-    """,
-    expiration_date="2026-05-01",
-)
-
-
 # Config Section: Magic #
 
 _create_section("magic", "Settings for how Streamlit pre-processes your script")

--- a/lib/streamlit/config_option.py
+++ b/lib/streamlit/config_option.py
@@ -27,6 +27,32 @@ from streamlit.util import repr_
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+# Dedent at definition time so interpolating a multi-line deprecation_text
+# (already flush-left from __init__) cannot make textwrap.dedent() a no-op.
+_UNSUPPORTED_OPTION_BANNER = textwrap.dedent(
+    """
+    ════════════════════════════════════════════════
+    {key} IS NO LONGER SUPPORTED.
+
+    {deprecation_text}
+
+    Please update {where_defined}.
+    ════════════════════════════════════════════════
+    """
+)
+_DEPRECATED_OPTION_BANNER = textwrap.dedent(
+    """
+    ════════════════════════════════════════════════
+    {key} IS DEPRECATED.
+    {deprecation_text}
+
+    This option will be removed on or after {expiration_date}.
+
+    Please update {where_defined}.
+    ════════════════════════════════════════════════
+    """
+)
+
 
 class ConfigOption:
     '''Stores a Streamlit configuration option.
@@ -260,39 +286,25 @@ class ConfigOption:
         self.is_default = value == self.default_val
 
         if self.deprecated and self.where_defined != ConfigOption.DEFAULT_DEFINITION:
+            # Import here to avoid circular imports
+            from streamlit.logger import get_logger
+
+            logger = get_logger(__name__)
             if self.is_expired():
-                # Import here to avoid circular imports
-                from streamlit.logger import get_logger
-
-                get_logger(__name__).error(
-                    textwrap.dedent(
-                        f"""
-                    ════════════════════════════════════════════════
-                    {self.key} IS NO LONGER SUPPORTED.
-
-                    {self.deprecation_text}
-
-                    Please update {self.where_defined}.
-                    ════════════════════════════════════════════════
-                    """
+                logger.error(
+                    _UNSUPPORTED_OPTION_BANNER.format(
+                        key=self.key,
+                        deprecation_text=self.deprecation_text,
+                        where_defined=self.where_defined,
                     )
                 )
             else:
-                # Import here to avoid circular imports
-                from streamlit.logger import get_logger
-
-                get_logger(__name__).warning(
-                    textwrap.dedent(
-                        f"""
-                    ════════════════════════════════════════════════
-                    {self.key} IS DEPRECATED.
-                    {self.deprecation_text}
-
-                    This option will be removed on or after {self.expiration_date}.
-
-                    Please update {self.where_defined}.
-                    ════════════════════════════════════════════════
-                    """
+                logger.warning(
+                    _DEPRECATED_OPTION_BANNER.format(
+                        key=self.key,
+                        deprecation_text=self.deprecation_text,
+                        expiration_date=self.expiration_date,
+                        where_defined=self.where_defined,
                     )
                 )
 

--- a/lib/streamlit/config_option.py
+++ b/lib/streamlit/config_option.py
@@ -283,7 +283,7 @@ class ConfigOption:
 
                 get_logger(__name__).warning(
                     textwrap.dedent(
-                        f"""s
+                        f"""
                     ════════════════════════════════════════════════
                     {self.key} IS DEPRECATED.
                     {self.deprecation_text}

--- a/lib/streamlit/elements/deck_gl_json_chart.py
+++ b/lib/streamlit/elements/deck_gl_json_chart.py
@@ -29,7 +29,6 @@ from typing import (
     overload,
 )
 
-from streamlit import config
 from streamlit.deprecation_util import (
     make_deprecated_name_warning,
     show_deprecation_warning,
@@ -578,13 +577,7 @@ class PydeckMixin:
         if tooltip:
             pydeck_proto.tooltip = json.dumps(tooltip)
 
-        # Get the Mapbox key from the PyDeck object first, and then fallback to the
-        # old mapbox.token config option.
-
         mapbox_token = getattr(pydeck_obj, "mapbox_key", None)
-        if mapbox_token is None or mapbox_token == "":
-            mapbox_token = config.get_option("mapbox.token")
-
         if mapbox_token:
             pydeck_proto.mapbox_token = mapbox_token
 

--- a/lib/streamlit/elements/map.py
+++ b/lib/streamlit/elements/map.py
@@ -521,10 +521,9 @@ def marshall(
     pydeck_proto.json = pydeck_json
     pydeck_proto.id = ""
 
-    # st.map builds Deck JSON itself and has no Deck.mapbox_key. Copy
-    # MAPBOX_API_KEY onto the proto for parity with the former mapbox.token
-    # path. Default st.map styles are Carto, so the frontend only uses this
-    # token if a Mapbox style is set.
+    # st.map builds Deck JSON itself and never constructs a PyDeck Deck, so
+    # copy MAPBOX_API_KEY onto the proto. Default styles are Carto; the
+    # frontend uses this token only if the spec selects a Mapbox style.
     mapbox_token = os.environ.get("MAPBOX_API_KEY")
     if mapbox_token:
         pydeck_proto.mapbox_token = mapbox_token

--- a/lib/streamlit/elements/map.py
+++ b/lib/streamlit/elements/map.py
@@ -18,9 +18,10 @@ from __future__ import annotations
 
 import copy
 import json
+import os
 from typing import TYPE_CHECKING, Any, Final, cast
 
-from streamlit import config, dataframe_util
+from streamlit import dataframe_util
 from streamlit.deprecation_util import (
     make_deprecated_name_warning,
     show_deprecation_warning,
@@ -520,6 +521,8 @@ def marshall(
     pydeck_proto.json = pydeck_json
     pydeck_proto.id = ""
 
-    mapbox_token = config.get_option("mapbox.token")
+    # st.map builds Deck JSON itself and has no Deck.mapbox_key; copy
+    # MAPBOX_API_KEY onto the proto so the frontend can use Mapbox styles.
+    mapbox_token = os.environ.get("MAPBOX_API_KEY")
     if mapbox_token:
         pydeck_proto.mapbox_token = mapbox_token

--- a/lib/streamlit/elements/map.py
+++ b/lib/streamlit/elements/map.py
@@ -521,8 +521,10 @@ def marshall(
     pydeck_proto.json = pydeck_json
     pydeck_proto.id = ""
 
-    # st.map builds Deck JSON itself and has no Deck.mapbox_key; copy
-    # MAPBOX_API_KEY onto the proto so the frontend can use Mapbox styles.
+    # st.map builds Deck JSON itself and has no Deck.mapbox_key. Copy
+    # MAPBOX_API_KEY onto the proto for parity with the former mapbox.token
+    # path. Default st.map styles are Carto, so the frontend only uses this
+    # token if a Mapbox style is set.
     mapbox_token = os.environ.get("MAPBOX_API_KEY")
     if mapbox_token:
         pydeck_proto.mapbox_token = mapbox_token

--- a/lib/streamlit/web/bootstrap.py
+++ b/lib/streamlit/web/bootstrap.py
@@ -197,12 +197,12 @@ def _on_server_start(server: Server) -> None:
 
 
 def _fix_pydeck_mapbox_api_warning() -> None:
-    """Sets MAPBOX_API_KEY environment variable needed for PyDeck otherwise it
-    will throw an exception.
-    """
+    """Prevent PyDeck from throwing when MAPBOX_API_KEY is unset.
 
-    if "MAPBOX_API_KEY" not in os.environ:
-        os.environ["MAPBOX_API_KEY"] = config.get_option("mapbox.token")
+    PyDeck requires the environment variable to exist; an empty default is
+    enough when the user has not provided a token.
+    """
+    os.environ.setdefault("MAPBOX_API_KEY", "")
 
 
 def _initialize_mimetypes() -> None:

--- a/lib/tests/streamlit/config_option_test.py
+++ b/lib/tests/streamlit/config_option_test.py
@@ -114,8 +114,9 @@ class ConfigOptionTest(unittest.TestCase):
     def _assert_deprecation_banner_is_flush_left(self, message: str) -> None:
         """Logged deprecation banners must be flush left.
 
-        If the first non-empty line has no indent, textwrap.dedent() is a
-        no-op and later lines keep their source indent.
+        A zero-indent line anywhere in the template (e.g. a stray character on
+        the first line) makes textwrap.dedent() a no-op, so the rest of the
+        banner keeps its source indentation.
         """
         non_empty = [line for line in message.splitlines() if line]
         assert non_empty[0].startswith("═"), (
@@ -124,7 +125,19 @@ class ConfigOptionTest(unittest.TestCase):
         for line in non_empty:
             assert not line.startswith(" "), f"line still indented: {line!r}"
 
-    def test_deprecated_expired(self):
+    @parameterized.expand(
+        [
+            ("single_line", "dep text"),
+            (
+                "multi_line",
+                """
+                Instead of this, you should use either the MAPBOX_API_KEY environment
+                variable or PyDeck's `api_keys` argument.
+                """,
+            ),
+        ]
+    )
+    def test_deprecated_expired(self, _case: str, deprecation_text: str) -> None:
         """Expired options log a flush-left error that the option is unsupported."""
         my_value = "myValue"
         where_defined = "im defined here"
@@ -134,7 +147,7 @@ class ConfigOptionTest(unittest.TestCase):
         c = ConfigOption(
             key,
             deprecated=True,
-            deprecation_text="dep text",
+            deprecation_text=deprecation_text,
             expiration_date="2000-01-01",
         )
 
@@ -144,11 +157,25 @@ class ConfigOptionTest(unittest.TestCase):
         message = logs.records[0].getMessage()
         self._assert_deprecation_banner_is_flush_left(message)
         assert "mysection.myName IS NO LONGER SUPPORTED." in message
-        assert "dep text" in message
         assert "Please update im defined here." in message
+        for snippet in c.deprecation_text.splitlines():
+            if snippet:
+                assert snippet in message
         assert c.is_expired()
 
-    def test_deprecated_unexpired(self):
+    @parameterized.expand(
+        [
+            ("single_line", "dep text"),
+            (
+                "multi_line",
+                """
+                Instead of this, you should use either the MAPBOX_API_KEY environment
+                variable or PyDeck's `api_keys` argument.
+                """,
+            ),
+        ]
+    )
+    def test_deprecated_unexpired(self, _case: str, deprecation_text: str) -> None:
         """Unexpired options log a flush-left warning that the option is deprecated."""
         my_value = "myValue"
         where_defined = "im defined here"
@@ -158,7 +185,7 @@ class ConfigOptionTest(unittest.TestCase):
         c = ConfigOption(
             key,
             deprecated=True,
-            deprecation_text="dep text",
+            deprecation_text=deprecation_text,
             expiration_date="2100-01-01",
         )
 
@@ -168,9 +195,11 @@ class ConfigOptionTest(unittest.TestCase):
         message = logs.records[0].getMessage()
         self._assert_deprecation_banner_is_flush_left(message)
         assert "mysection.myName IS DEPRECATED." in message
-        assert "dep text" in message
         assert "This option will be removed on or after 2100-01-01." in message
         assert "Please update im defined here." in message
+        for snippet in c.deprecation_text.splitlines():
+            if snippet:
+                assert snippet in message
         assert not c.is_expired()
 
     def test_replaced_by_unexpired(self):

--- a/lib/tests/streamlit/config_option_test.py
+++ b/lib/tests/streamlit/config_option_test.py
@@ -111,7 +111,21 @@ class ConfigOptionTest(unittest.TestCase):
         assert my_value == c.value
         assert where_defined == c.where_defined
 
+    def _assert_deprecation_banner_is_flush_left(self, message: str) -> None:
+        """Logged deprecation banners must be flush left.
+
+        If the first non-empty line has no indent, textwrap.dedent() is a
+        no-op and later lines keep their source indent.
+        """
+        non_empty = [line for line in message.splitlines() if line]
+        assert non_empty[0].startswith("═"), (
+            f"banner should start at column 0, got {non_empty[0][:40]!r}"
+        )
+        for line in non_empty:
+            assert not line.startswith(" "), f"line still indented: {line!r}"
+
     def test_deprecated_expired(self):
+        """Expired options log a flush-left error that the option is unsupported."""
         my_value = "myValue"
         where_defined = "im defined here"
 
@@ -124,13 +138,18 @@ class ConfigOptionTest(unittest.TestCase):
             expiration_date="2000-01-01",
         )
 
-        # Expired options behave like deprecated options
-        # just a slightly different text.
-        c.set_value(my_value, where_defined)
+        with self.assertLogs("streamlit.config_option", level="ERROR") as logs:
+            c.set_value(my_value, where_defined)
 
+        message = logs.records[0].getMessage()
+        self._assert_deprecation_banner_is_flush_left(message)
+        assert "mysection.myName IS NO LONGER SUPPORTED." in message
+        assert "dep text" in message
+        assert "Please update im defined here." in message
         assert c.is_expired()
 
     def test_deprecated_unexpired(self):
+        """Unexpired options log a flush-left warning that the option is deprecated."""
         my_value = "myValue"
         where_defined = "im defined here"
 
@@ -143,8 +162,15 @@ class ConfigOptionTest(unittest.TestCase):
             expiration_date="2100-01-01",
         )
 
-        c.set_value(my_value, where_defined)
+        with self.assertLogs("streamlit.config_option", level="WARNING") as logs:
+            c.set_value(my_value, where_defined)
 
+        message = logs.records[0].getMessage()
+        self._assert_deprecation_banner_is_flush_left(message)
+        assert "mysection.myName IS DEPRECATED." in message
+        assert "dep text" in message
+        assert "This option will be removed on or after 2100-01-01." in message
+        assert "Please update im defined here." in message
         assert not c.is_expired()
 
     def test_replaced_by_unexpired(self):

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -831,7 +831,7 @@ class ConfigTest(unittest.TestCase):
         keys = sorted(config._config_options.keys())
         assert config_options == keys
 
-    def test_no_expired_deprecated_config_options(self):
+    def test_no_expired_deprecated_config_options(self) -> None:
         """Deprecated config options must be removed once expiration_date has passed."""
         expired = [
             opt.key

--- a/lib/tests/streamlit/config_test.py
+++ b/lib/tests/streamlit/config_test.py
@@ -723,7 +723,6 @@ class ConfigTest(unittest.TestCase):
                 "global",
                 "logger",
                 "magic",
-                "mapbox",
                 "runner",
                 "secrets",
                 "server",
@@ -795,7 +794,6 @@ class ConfigTest(unittest.TestCase):
                 "runner.enumCoercion",
                 "magic.displayRootDocString",
                 "magic.displayLastExprIfNoSemicolon",
-                "mapbox.token",
                 "secrets.files",
                 "server.address",
                 "server.allowedHosts",
@@ -832,6 +830,18 @@ class ConfigTest(unittest.TestCase):
         )
         keys = sorted(config._config_options.keys())
         assert config_options == keys
+
+    def test_no_expired_deprecated_config_options(self):
+        """Deprecated config options must be removed once expiration_date has passed."""
+        expired = [
+            opt.key
+            for opt in config._config_options_template.values()
+            if opt.deprecated and opt.is_expired()
+        ]
+        assert expired == [], (
+            "Deprecated config options whose expiration_date has passed "
+            f"must be removed: {expired}"
+        )
 
     def test_check_conflicts_server_port(self):
         config._set_option("global.developmentMode", True, "test")

--- a/lib/tests/streamlit/config_util_test.py
+++ b/lib/tests/streamlit/config_util_test.py
@@ -161,11 +161,11 @@ class ConfigUtilTest(unittest.TestCase):
             # Nothing changed.
             (
                 {
-                    "mapbox.token": "shhhhhhh",
+                    "browser.gatherUsageStats": True,
                     "server.address": "localhost",
                 },
                 {
-                    "mapbox.token": "shhhhhhh",
+                    "browser.gatherUsageStats": True,
                     "server.address": "localhost",
                 },
                 False,
@@ -173,11 +173,11 @@ class ConfigUtilTest(unittest.TestCase):
             # A non-server config option changed.
             (
                 {
-                    "mapbox.token": "shhhhhhh",
+                    "browser.gatherUsageStats": True,
                     "server.address": "localhost",
                 },
                 {
-                    "mapbox.token": "SHHHHHHH!!!!!! >:(",
+                    "browser.gatherUsageStats": False,
                     "server.address": "localhost",
                 },
                 False,
@@ -185,11 +185,11 @@ class ConfigUtilTest(unittest.TestCase):
             # A server config option changed.
             (
                 {
-                    "mapbox.token": "shhhhhhh",
+                    "browser.gatherUsageStats": True,
                     "server.address": "localhost",
                 },
                 {
-                    "mapbox.token": "shhhhhhh",
+                    "browser.gatherUsageStats": True,
                     "server.address": "streamlit.io",
                 },
                 True,

--- a/lib/tests/streamlit/elements/map_test.py
+++ b/lib/tests/streamlit/elements/map_test.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import itertools
 import json
+import os
 import re
 import warnings
 from unittest import mock
@@ -30,7 +31,6 @@ from parameterized import parameterized
 import streamlit as st
 from streamlit.elements.map import _DEFAULT_MAP, _DEFAULT_ZOOM_LEVEL
 from streamlit.errors import StreamlitAPIException
-from streamlit.testing.v1.util import patch_config_options
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 
 mock_df = pd.DataFrame({"lat": [1, 2, 3, 4], "lon": [10, 20, 30, 40]})
@@ -366,12 +366,19 @@ class StMapTest(DeltaGeneratorTestCase):
             st.map(df)
 
     def test_mapbox_token_is_set_in_proto(self):
-        """Test that mapbox token is set in proto if configured."""
-
-        with patch_config_options({"mapbox.token": "test_mapbox_token"}):
+        """Test that mapbox token is set in proto from MAPBOX_API_KEY."""
+        with mock.patch.dict(os.environ, {"MAPBOX_API_KEY": "test_mapbox_token"}):
             st.map(mock_df)
             c = self.get_delta_from_queue().new_element.deck_gl_json_chart
             assert c.mapbox_token == "test_mapbox_token"
+
+    def test_mapbox_token_not_set_without_env_var(self):
+        """Test that mapbox token is empty when MAPBOX_API_KEY is unset."""
+        with mock.patch.dict(os.environ):
+            os.environ.pop("MAPBOX_API_KEY", None)
+            st.map(mock_df)
+            c = self.get_delta_from_queue().new_element.deck_gl_json_chart
+            assert c.mapbox_token == ""
 
 
 class StMapWidthHeightTest(DeltaGeneratorTestCase):

--- a/lib/tests/streamlit/elements/map_test.py
+++ b/lib/tests/streamlit/elements/map_test.py
@@ -365,14 +365,14 @@ class StMapTest(DeltaGeneratorTestCase):
         ):
             st.map(df)
 
-    def test_mapbox_token_is_set_in_proto(self):
+    def test_mapbox_token_is_set_in_proto(self) -> None:
         """Test that mapbox token is set in proto from MAPBOX_API_KEY."""
         with mock.patch.dict(os.environ, {"MAPBOX_API_KEY": "test_mapbox_token"}):
             st.map(mock_df)
             c = self.get_delta_from_queue().new_element.deck_gl_json_chart
             assert c.mapbox_token == "test_mapbox_token"
 
-    def test_mapbox_token_not_set_without_env_var(self):
+    def test_mapbox_token_not_set_without_env_var(self) -> None:
         """Test that mapbox token is empty when MAPBOX_API_KEY is unset."""
         with mock.patch.dict(os.environ):
             os.environ.pop("MAPBOX_API_KEY", None)

--- a/lib/tests/streamlit/elements/pydeck_test.py
+++ b/lib/tests/streamlit/elements/pydeck_test.py
@@ -41,7 +41,6 @@ from streamlit.errors import (
     StreamlitValueError,
 )
 from streamlit.proto.DeckGlJsonChart_pb2 import DeckGlJsonChart as PydeckProto
-from streamlit.testing.v1.util import patch_config_options
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 
 df1 = pd.DataFrame({"lat": [1, 2, 3, 4], "lon": [10, 20, 30, 40]})
@@ -242,28 +241,6 @@ class PyDeckTest(DeltaGeneratorTestCase):
 
         assert "Invalid `selection_mode` type" in str(e.value)
 
-    @patch_config_options({"mapbox.token": "MOCK_CONFIG_KEY"})
-    def test_mapbox_token_config(self):
-        """Test a Mapbox token is passed in proto when provided in config."""
-
-        old_value = getattr(os.environ, "MAPBOX_API_KEY", None)
-        if old_value:
-            del os.environ["MAPBOX_API_KEY"]
-
-        st.pydeck_chart(
-            pdk.Deck(
-                layers=[
-                    pdk.Layer("ScatterplotLayer", data=df1),
-                ]
-            )
-        )
-
-        el = self.get_delta_from_queue().new_element
-        assert el.deck_gl_json_chart.mapbox_token == "MOCK_CONFIG_KEY"
-
-        if old_value:
-            os.environ["MAPBOX_API_KEY"] = old_value
-
 
 class PyDeckChartWidthTest(DeltaGeneratorTestCase):
     """Test pydeck_chart width parameter functionality."""
@@ -405,30 +382,6 @@ class PyDeckChartWidthTest(DeltaGeneratorTestCase):
 
     def test_mapbox_token_direct(self):
         """Test a Mapbox token is passed in proto when provided directly."""
-
-        old_value = getattr(os.environ, "MAPBOX_API_KEY", None)
-        if old_value:
-            del os.environ["MAPBOX_API_KEY"]
-
-        st.pydeck_chart(
-            pdk.Deck(
-                api_keys={"mapbox": "MOCK_API_KEY"},
-                map_provider="mapbox",
-                layers=[
-                    pdk.Layer("ScatterplotLayer", data=df1),
-                ],
-            )
-        )
-
-        el = self.get_delta_from_queue().new_element
-        assert el.deck_gl_json_chart.mapbox_token == "MOCK_API_KEY"
-
-        if old_value:
-            os.environ["MAPBOX_API_KEY"] = old_value
-
-    @patch_config_options({"mapbox.token": "MOCK_CONFIG_KEY"})
-    def test_native_mapbox_token_wins(self):
-        """Test that PyDecks' native Mapbox token wins against out config."""
 
         old_value = getattr(os.environ, "MAPBOX_API_KEY", None)
         if old_value:

--- a/lib/tests/streamlit/web/bootstrap_test.py
+++ b/lib/tests/streamlit/web/bootstrap_test.py
@@ -861,29 +861,17 @@ class BootstrapPydeckMapboxTest(TestCase):
     """Tests for _fix_pydeck_mapbox_api_warning."""
 
     def test_sets_mapbox_env_var_when_missing(self):
-        """Sets MAPBOX_API_KEY from config when env var is absent."""
-        env_without_key = {k: v for k, v in os.environ.items() if k != "MAPBOX_API_KEY"}
-        with (
-            patch.dict(os.environ, env_without_key, clear=True),
-            patch.object(
-                bootstrap.config, "get_option", return_value="cfg-token"
-            ) as mock_get_option,
-        ):
+        """Sets MAPBOX_API_KEY to empty when it is unset."""
+        with patch.dict(os.environ):
+            os.environ.pop("MAPBOX_API_KEY", None)
             bootstrap._fix_pydeck_mapbox_api_warning()
-            assert os.environ["MAPBOX_API_KEY"] == "cfg-token"
-
-        mock_get_option.assert_called_once_with("mapbox.token")
+            assert os.environ["MAPBOX_API_KEY"] == ""
 
     def test_does_not_overwrite_existing_mapbox_env_var(self):
         """Preserves an externally-set MAPBOX_API_KEY value."""
-        with (
-            patch.dict(os.environ, {"MAPBOX_API_KEY": "external"}, clear=False),
-            patch.object(bootstrap.config, "get_option") as mock_get_option,
-        ):
+        with patch.dict(os.environ, {"MAPBOX_API_KEY": "external"}):
             bootstrap._fix_pydeck_mapbox_api_warning()
             assert os.environ["MAPBOX_API_KEY"] == "external"
-
-        mock_get_option.assert_not_called()
 
 
 @patch("streamlit.web.bootstrap.prepare_streamlit_environment", Mock())

--- a/lib/tests/streamlit/web/cli_test.py
+++ b/lib/tests/streamlit/web/cli_test.py
@@ -263,14 +263,23 @@ class CliTest(unittest.TestCase):
         )
         assert result.exit_code == 0
 
-    def test_run_command_with_sensitive_options_as_flag(self):
+    @parameterized.expand(
+        [
+            (key,)
+            for key, opt in config._config_options_template.items()
+            if opt.sensitive
+        ]
+    )
+    def test_run_command_with_sensitive_option_as_flag(
+        self, sensitive_option: str
+    ) -> None:
         with (
             patch("streamlit.url_util.is_url", return_value=False),
             patch("streamlit.web.cli._main_run"),
             patch("pathlib.Path.exists", return_value=True),
         ):
             result = self.runner.invoke(
-                cli, ["run", "file_name.py", "--server.cookieSecret=TESTSECRET"]
+                cli, ["run", "file_name.py", f"--{sensitive_option}=TESTSECRET"]
             )
 
         assert "option using the CLI flag is not allowed" in result.output

--- a/lib/tests/streamlit/web/cli_test.py
+++ b/lib/tests/streamlit/web/cli_test.py
@@ -42,6 +42,10 @@ from streamlit.web import cli
 from streamlit.web.cli import _convert_config_option_to_click_option
 from tests import testutil
 
+_SENSITIVE_CONFIG_OPTIONS = [
+    key for key, opt in config._config_options_template.items() if opt.sensitive
+]
+
 
 class CliTest(unittest.TestCase):
     """Unit tests for the cli."""
@@ -263,13 +267,11 @@ class CliTest(unittest.TestCase):
         )
         assert result.exit_code == 0
 
-    @parameterized.expand(
-        [
-            (key,)
-            for key, opt in config._config_options_template.items()
-            if opt.sensitive
-        ]
-    )
+    def test_sensitive_config_options_are_registered(self) -> None:
+        """Fail if parameterization of sensitive CLI flags would expand to no cases."""
+        assert _SENSITIVE_CONFIG_OPTIONS
+
+    @parameterized.expand([(key,) for key in _SENSITIVE_CONFIG_OPTIONS])
     def test_run_command_with_sensitive_option_as_flag(
         self, sensitive_option: str
     ) -> None:

--- a/lib/tests/streamlit/web/cli_test.py
+++ b/lib/tests/streamlit/web/cli_test.py
@@ -263,15 +263,14 @@ class CliTest(unittest.TestCase):
         )
         assert result.exit_code == 0
 
-    @parameterized.expand(["mapbox.token", "server.cookieSecret"])
-    def test_run_command_with_sensitive_options_as_flag(self, sensitive_option):
+    def test_run_command_with_sensitive_options_as_flag(self):
         with (
             patch("streamlit.url_util.is_url", return_value=False),
             patch("streamlit.web.cli._main_run"),
             patch("pathlib.Path.exists", return_value=True),
         ):
             result = self.runner.invoke(
-                cli, ["run", "file_name.py", f"--{sensitive_option}=TESTSECRET"]
+                cli, ["run", "file_name.py", "--server.cookieSecret=TESTSECRET"]
             )
 
         assert "option using the CLI flag is not allowed" in result.output


### PR DESCRIPTION
## Describe your changes

Remove the expired `mapbox.token` config option. Mapbox tokens now come from `MAPBOX_API_KEY` or PyDeck `api_keys`. Leftover `[mapbox]` in `config.toml` logs the generic unknown-option warning and is ignored. `STREAMLIT_MAPBOX_TOKEN` is ignored with no warning, because sensitive env vars are only read for options that still exist.

- Fix the stray `s` in unexpired config deprecation warnings that disabled `textwrap.dedent()`, and dedent banner templates before interpolating so multi-line `deprecation_text` stays flush left
- Fail CI if a deprecated config option is past its `expiration_date`

## GitHub Issue Link (if applicable)

- Closes #16678
- Closes #16676

## Testing Plan

- [x] Unit Tests (JS and/or Python)
  - `lib/tests/streamlit/config_test.py` — option inventory and expired-deprecation CI guard
  - `lib/tests/streamlit/config_option_test.py` — flush-left deprecation banners, including multi-line `deprecation_text`
  - `lib/tests/streamlit/elements/map_test.py` — `MAPBOX_API_KEY` proto wiring
  - `lib/tests/streamlit/elements/pydeck_test.py` — env var and PyDeck `api_keys`
  - `lib/tests/streamlit/web/bootstrap_test.py`, `cli_test.py` — env default and remaining sensitive CLI flags
- E2E Tests: none added (no frontend or e2e files changed; host-config `mapboxToken` is unchanged)
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

Made with [Cursor](https://cursor.com)