### PR TITLE
[fix] Stop mypy treating macOS skip as unreachable

### DIFF
--- a/e2e_playwright/load_testing/test_load.py
+++ b/e2e_playwright/load_testing/test_load.py
@@ -75,6 +75,10 @@ _SCENARIOS: Final[list[ScenarioConfig]] = [
 ]
 
 
+@pytest.mark.skipif(
+    sys.platform == "darwin",
+    reason="macOS SO_REUSEADDR allows binding over live client ephemeral ports",
+)
 def test_port_availability_check_rejects_active_client_port() -> None:
     """Ensure active ephemeral client ports aren't selected for a server.
 
@@ -82,11 +86,6 @@ def test_port_availability_check_rejects_active_client_port() -> None:
     cannot bind over a live client ephemeral port. On macOS/BSD, SO_REUSEADDR
     can, matching Streamlit's server socket options — so skip there.
     """
-    if sys.platform == "darwin":
-        pytest.skip(
-            "macOS SO_REUSEADDR allows binding over live client ephemeral ports"
-        )
-
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
         listener.bind(("localhost", 0))
         listener.listen()


### PR DESCRIPTION
## Describe your changes

Use `@pytest.mark.skipif` for the macOS-only load-test port check. A runtime `pytest.skip()` after `sys.platform == "darwin"` is treated as unreachable by mypy on Darwin, which fails `make python-types` locally but not on Linux CI.

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

No new tests — this only changes how an existing test is skipped. Linux CI still runs `test_port_availability_check_rejects_active_client_port`; macOS still skips it.

- [ ] Unit Tests (JS and/or Python)
- [ ] E2E Tests
- [ ] Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

Made with [Cursor](https://cursor.com)