### PR TITLE
[feature] Add `on_change="ignore"` mode to st.select_slider

### DIFF
--- a/e2e_playwright/st_select_slider.py
+++ b/e2e_playwright/st_select_slider.py
@@ -271,3 +271,17 @@ bound_formatted = st.select_slider(
     bind="query-params",
 )
 st.write("Bound formatted:", bound_formatted)
+
+# --- on_change="ignore" select slider ---
+ignore_select_slider = st.select_slider(
+    "Ignore change select slider",
+    options=["red", "orange", "yellow", "green", "blue", "indigo", "violet"],
+    value="red",
+    key="ignore_select_slider",
+    on_change="ignore",
+    bind="query-params",
+)
+st.write("Ignore select slider value:", ignore_select_slider)
+
+if st.button("Apply ignore select slider", key="apply_ignore_select_slider"):
+    st.write("Applied ignore select slider value:", ignore_select_slider)

--- a/e2e_playwright/st_select_slider_test.py
+++ b/e2e_playwright/st_select_slider_test.py
@@ -431,7 +431,7 @@ def test_select_slider_query_param_empty_value_rejected(page: Page, app_base_url
     expect(page).not_to_have_url(re.compile(r"[?&]bound_color="))
 
 
-def test_select_slider_on_change_ignore(app: Page):
+def test_select_slider_on_change_ignore(app: Page) -> None:
     """Test that on_change='ignore' suppresses rerun and sends value on next rerun."""
     expect(app.get_by_text("Runs: 1", exact=True)).to_be_visible()
     expect_prefixed_markdown(app, "Ignore select slider value:", "red")

--- a/e2e_playwright/st_select_slider_test.py
+++ b/e2e_playwright/st_select_slider_test.py
@@ -35,7 +35,7 @@ from e2e_playwright.shared.app_utils import (
     reset_hovering,
 )
 
-NUM_SELECT_SLIDERS = 20
+NUM_SELECT_SLIDERS = 21
 
 
 def test_select_slider_rendering(
@@ -429,3 +429,53 @@ def test_select_slider_query_param_empty_value_rejected(page: Page, app_base_url
     # Should use default ("green")
     expect_prefixed_markdown(page, "Bound color:", "green")
     expect(page).not_to_have_url(re.compile(r"[?&]bound_color="))
+
+
+def test_select_slider_on_change_ignore(app: Page):
+    """Test that on_change='ignore' suppresses rerun and sends value on next rerun."""
+    expect(app.get_by_text("Runs: 1", exact=True)).to_be_visible()
+    expect_prefixed_markdown(app, "Ignore select slider value:", "red")
+    # Default is omitted from the URL.
+    expect(app).not_to_have_url(re.compile(r"[?&]ignore_select_slider="))
+
+    slider = get_element_by_key(app, "ignore_select_slider")
+    slider_role = slider.get_by_role("slider")
+
+    # Commit with ArrowRight - should NOT trigger a rerun, but should update the URL
+    slider_role.press("ArrowRight")
+
+    # Wait for any potential rerun to complete. If on_change="ignore" is working
+    # correctly, no rerun will occur, but this ensures that if a bug causes
+    # a rerun, we wait for it before checking.
+    wait_for_app_run(app)
+
+    expect(app.get_by_text("Runs: 1", exact=True)).to_be_visible()
+    expect(app.get_by_text("Runs: 2", exact=True)).not_to_be_visible()
+    expect_prefixed_markdown(app, "Ignore select slider value:", "red")
+    expect(app).to_have_url(re.compile(r"[?&]ignore_select_slider=orange"))
+
+    # Extra ArrowRight commits accumulate without a rerun.
+    for _ in range(4):
+        slider_role.press("ArrowRight")
+
+    expect(slider).to_contain_text("indigo")
+    expect_prefixed_markdown(app, "Ignore select slider value:", "red")
+    expect(app).to_have_url(re.compile(r"[?&]ignore_select_slider=indigo"))
+    expect(app.get_by_text("Runs: 1", exact=True)).to_be_visible()
+
+    # Click button to trigger a rerun - accumulated value should be sent
+    app.get_by_role("button", name="Apply ignore select slider", exact=True).click()
+    wait_for_app_run(app)
+
+    expect(
+        app.get_by_text("Ignore select slider value: indigo", exact=True)
+    ).to_be_visible()
+    expect(
+        app.get_by_text("Applied ignore select slider value: indigo", exact=True)
+    ).to_be_visible()
+
+    # Bound ignore-mode values persist across reload via the URL.
+    app.reload()
+    wait_for_app_loaded(app)
+    expect(get_element_by_key(app, "ignore_select_slider")).to_contain_text("indigo")
+    expect_prefixed_markdown(app, "Ignore select slider value:", "indigo")

--- a/frontend/lib/src/components/widgets/Slider/Slider.test.tsx
+++ b/frontend/lib/src/components/widgets/Slider/Slider.test.tsx
@@ -794,4 +794,41 @@ describe("on_change='ignore' mode", () => {
       }
     )
   })
+
+  it("passes triggerRerun: false for select_slider with setStringArrayValue", async () => {
+    const props = getProps({
+      ignoreRerun: true,
+      default: [1],
+      min: 0,
+      max: 6,
+      format: "%s",
+      type: SliderProto.Type.SELECT_SLIDER,
+      options: [
+        "red",
+        "orange",
+        "yellow",
+        "green",
+        "blue",
+        "indigo",
+        "violet",
+      ],
+    })
+    vi.spyOn(props.widgetMgr, "setStringArrayValue")
+
+    render(<Slider {...props} />)
+
+    const slider = screen.getByRole("slider")
+    await triggerChangeEvent(slider, "ArrowRight")
+
+    expect(props.widgetMgr.setStringArrayValue).toHaveBeenCalledWith(
+      props.element.id,
+      ["yellow"],
+      {
+        formId: props.element.formId,
+        fragmentId: undefined,
+        fromUser: true,
+        triggerRerun: false,
+      }
+    )
+  })
 })

--- a/lib/streamlit/elements/widgets/select_slider.py
+++ b/lib/streamlit/elements/widgets/select_slider.py
@@ -53,11 +53,13 @@ from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
 from streamlit.runtime.state import (
     BindOption,
+    OnChangeMode,
     PersistStateOption,
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,
     register_widget,
+    validate_on_change_mode,
 )
 from streamlit.string_util import to_help_str
 from streamlit.type_util import check_python_comparable
@@ -167,7 +169,7 @@ class SelectSliderMixin:
         format_func: Callable[[Any], Any] = str,
         key: Key | None = None,
         help: str | None = None,
-        on_change: WidgetCallback | None = None,
+        on_change: WidgetCallback | OnChangeMode | None = "rerun",
         args: WidgetArgs | None = None,
         kwargs: WidgetKwargs | None = None,
         *,  # keyword-only arguments:
@@ -187,7 +189,7 @@ class SelectSliderMixin:
         format_func: Callable[[Any], Any] = str,
         key: Key | None = None,
         help: str | None = None,
-        on_change: WidgetCallback | None = None,
+        on_change: WidgetCallback | OnChangeMode | None = "rerun",
         args: WidgetArgs | None = None,
         kwargs: WidgetKwargs | None = None,
         *,  # keyword-only arguments:
@@ -207,7 +209,7 @@ class SelectSliderMixin:
         format_func: Callable[[Any], Any] = str,
         key: Key | None = None,
         help: str | None = None,
-        on_change: WidgetCallback | None = None,
+        on_change: WidgetCallback | OnChangeMode | None = "rerun",
         args: WidgetArgs | None = None,
         kwargs: WidgetKwargs | None = None,
         *,  # keyword-only arguments:
@@ -298,8 +300,29 @@ class SelectSliderMixin:
             including the Markdown directives described in the ``body``
             parameter of ``st.markdown``.
 
-        on_change : callable
-            An optional callback invoked when this select_slider's value changes.
+        on_change : callable, "rerun", "ignore", or None
+            How the select slider should respond to value changes. This controls
+            whether or not Streamlit reruns the app when the user interacts
+            with the select slider. ``on_change`` can be one of the following:
+
+            - ``"rerun"`` (default): Streamlit will rerun the app when the
+              user commits a new value (releasing a drag, clicking the
+              track, or using the arrow keys).
+
+            - ``"ignore"``: Streamlit will not rerun the app when the user
+              commits a new value. The select slider still updates in the UI.
+              The new value is available on the next rerun triggered by
+              something else, such as another widget interaction. Ignored
+              commits are held in the browser and are lost if the page is
+              refreshed before that rerun, unless ``bind="query-params"``
+              is set (see ``bind``). Inside ``st.form``, this has no
+              effect: the form already defers all commits until submit.
+
+            - A ``callable``: Streamlit will rerun the app and execute the
+              ``callable`` as a callback function before the rest of the app.
+
+            - ``None``: This is the same as ``on_change="rerun"``. This value
+              exists for backwards compatibility and shouldn't be used.
 
         args : list or tuple
             An optional list or tuple of args to pass to the callback.
@@ -346,6 +369,11 @@ class SelectSliderMixin:
             Invalid query parameter values are ignored and removed
             from the URL. Range select sliders use repeated parameters
             (e.g., ``?color=red&color=blue``).
+
+            When ``on_change="ignore"``, select slider interactions still update
+            the URL immediately, the same as widgets inside a form. Python
+            receives the new value on the next rerun. A page load or share
+            uses the updated URL value.
 
         persist_state : "page", "session", or None
             How long to preserve the widget's value when it isn't rendered.
@@ -439,7 +467,7 @@ class SelectSliderMixin:
         format_func: Callable[[Any], Any] = str,
         key: Key | None = None,
         help: str | None = None,
-        on_change: WidgetCallback | None = None,
+        on_change: WidgetCallback | OnChangeMode | None = "rerun",
         args: WidgetArgs | None = None,
         kwargs: WidgetKwargs | None = None,
         disabled: bool = False,
@@ -451,10 +479,16 @@ class SelectSliderMixin:
     ) -> T | tuple[T, T]:
         key = to_key(key)
 
+        validate_on_change_mode(on_change)
+
+        on_change_callback: WidgetCallback | None = (
+            on_change if callable(on_change) else None
+        )
+
         check_widget_policies(
             self.dg,
             key,
-            on_change,
+            on_change_callback,
             default_value=value,
         )
         label = maybe_raise_label_warnings(label, label_visibility)
@@ -525,6 +559,9 @@ class SelectSliderMixin:
         if bind and key:
             slider_proto.query_param_key = str(key)
 
+        if isinstance(on_change, str) and on_change == "ignore":
+            slider_proto.ignore_rerun = True
+
         layout_config = create_layout_config(width=width)
 
         serde = SelectSliderSerde(
@@ -536,7 +573,7 @@ class SelectSliderMixin:
 
         widget_state = register_widget(
             slider_proto.id,
-            on_change_handler=on_change,
+            on_change_handler=on_change_callback,
             args=args,
             kwargs=kwargs,
             deserializer=serde.deserialize,

--- a/lib/tests/streamlit/elements/select_slider_test.py
+++ b/lib/tests/streamlit/elements/select_slider_test.py
@@ -880,14 +880,14 @@ class SelectSliderOnChangeModeTest(DeltaGeneratorTestCase):
     )
     def test_on_change_mode_sets_ignore_rerun_proto_field(
         self, _name: str, on_change: Any, expected_ignore_rerun: bool
-    ):
+    ) -> None:
         """Test that on_change modes correctly set the ignore_rerun proto field."""
         st.select_slider("the label", options=["a", "b", "c"], on_change=on_change)
 
         c = self.get_delta_from_queue().new_element.slider
         assert c.ignore_rerun is expected_ignore_rerun
 
-    def test_on_change_invalid_mode_raises_exception(self):
+    def test_on_change_invalid_mode_raises_exception(self) -> None:
         """Test that invalid on_change mode raises StreamlitValueError."""
         with pytest.raises(st.errors.StreamlitValueError) as exc_info:
             st.select_slider("the label", options=["a", "b", "c"], on_change="invalid")
@@ -897,7 +897,7 @@ class SelectSliderOnChangeModeTest(DeltaGeneratorTestCase):
         assert "'ignore'" in str(exc_info.value)
         assert "a callback function" in str(exc_info.value)
 
-    def test_on_change_non_string_value_raises_exception(self):
+    def test_on_change_non_string_value_raises_exception(self) -> None:
         """Test that a non-string, non-callable on_change raises StreamlitValueError."""
         with pytest.raises(st.errors.StreamlitValueError) as exc_info:
             st.select_slider("the label", options=["a", "b", "c"], on_change=[])  # type: ignore[arg-type]
@@ -905,7 +905,7 @@ class SelectSliderOnChangeModeTest(DeltaGeneratorTestCase):
         assert "on_change" in str(exc_info.value)
 
     @patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
-    def test_on_change_ignore_allowed_inside_form(self):
+    def test_on_change_ignore_allowed_inside_form(self) -> None:
         """Test that on_change='ignore' inside a form does not raise."""
         with st.form("form"):
             st.select_slider("the label", options=["a", "b", "c"], on_change="ignore")

--- a/lib/tests/streamlit/elements/select_slider_test.py
+++ b/lib/tests/streamlit/elements/select_slider_test.py
@@ -865,3 +865,50 @@ def test_select_slider_serde_deserialize_range_sorts_ascending() -> None:
     )
     # Values arrive as (high, low); the result is swapped back to ascending order.
     assert serde.deserialize(["d", "b"]) == ("b", "d")
+
+
+class SelectSliderOnChangeModeTest(DeltaGeneratorTestCase):
+    """Test on_change mode functionality (rerun, ignore, callable)."""
+
+    @parameterized.expand(
+        [
+            ("ignore", "ignore", True),
+            ("rerun", "rerun", False),
+            ("none", None, False),
+            ("callback", lambda: None, False),
+        ]
+    )
+    def test_on_change_mode_sets_ignore_rerun_proto_field(
+        self, _name: str, on_change: Any, expected_ignore_rerun: bool
+    ):
+        """Test that on_change modes correctly set the ignore_rerun proto field."""
+        st.select_slider("the label", options=["a", "b", "c"], on_change=on_change)
+
+        c = self.get_delta_from_queue().new_element.slider
+        assert c.ignore_rerun is expected_ignore_rerun
+
+    def test_on_change_invalid_mode_raises_exception(self):
+        """Test that invalid on_change mode raises StreamlitValueError."""
+        with pytest.raises(st.errors.StreamlitValueError) as exc_info:
+            st.select_slider("the label", options=["a", "b", "c"], on_change="invalid")
+
+        assert "on_change" in str(exc_info.value)
+        assert "'rerun'" in str(exc_info.value)
+        assert "'ignore'" in str(exc_info.value)
+        assert "a callback function" in str(exc_info.value)
+
+    def test_on_change_non_string_value_raises_exception(self):
+        """Test that a non-string, non-callable on_change raises StreamlitValueError."""
+        with pytest.raises(st.errors.StreamlitValueError) as exc_info:
+            st.select_slider("the label", options=["a", "b", "c"], on_change=[])  # type: ignore[arg-type]
+
+        assert "on_change" in str(exc_info.value)
+
+    @patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
+    def test_on_change_ignore_allowed_inside_form(self):
+        """Test that on_change='ignore' inside a form does not raise."""
+        with st.form("form"):
+            st.select_slider("the label", options=["a", "b", "c"], on_change="ignore")
+
+        c = self.get_delta_from_queue(1).new_element.slider
+        assert c.ignore_rerun is True

--- a/lib/tests/streamlit/elements/select_slider_test.py
+++ b/lib/tests/streamlit/elements/select_slider_test.py
@@ -889,7 +889,7 @@ class SelectSliderOnChangeModeTest(DeltaGeneratorTestCase):
 
     def test_on_change_invalid_mode_raises_exception(self) -> None:
         """Test that invalid on_change mode raises StreamlitValueError."""
-        with pytest.raises(st.errors.StreamlitValueError) as exc_info:
+        with pytest.raises(StreamlitValueError) as exc_info:
             st.select_slider("the label", options=["a", "b", "c"], on_change="invalid")
 
         assert "on_change" in str(exc_info.value)
@@ -897,9 +897,9 @@ class SelectSliderOnChangeModeTest(DeltaGeneratorTestCase):
         assert "'ignore'" in str(exc_info.value)
         assert "a callback function" in str(exc_info.value)
 
-    def test_on_change_non_string_value_raises_exception(self) -> None:
+    def test_on_change_list_value_raises_exception(self) -> None:
         """Test that a non-string, non-callable on_change raises StreamlitValueError."""
-        with pytest.raises(st.errors.StreamlitValueError) as exc_info:
+        with pytest.raises(StreamlitValueError) as exc_info:
             st.select_slider("the label", options=["a", "b", "c"], on_change=[])  # type: ignore[arg-type]
 
         assert "on_change" in str(exc_info.value)

--- a/lib/tests/streamlit/typing/select_slider_types.py
+++ b/lib/tests/streamlit/typing/select_slider_types.py
@@ -74,6 +74,16 @@ if TYPE_CHECKING:
         tuple[int, int],
     )
 
+    # Check on_change parameter modes
+    assert_type(select_slider("foo", [1, 2, 3], on_change=None), int)
+    assert_type(select_slider("foo", [1, 2, 3], on_change="rerun"), int)
+    assert_type(select_slider("foo", [1, 2, 3], on_change="ignore"), int)
+    assert_type(select_slider("foo", [1, 2, 3], on_change=lambda: None), int)
+    assert_type(
+        select_slider("foo", [1, 2, 3], value=(1, 3), on_change="ignore"),
+        tuple[int, int],
+    )
+
     def on_select_slider_change(prefix: str) -> None: ...
 
     # Common parameters combined


### PR DESCRIPTION
## Describe your changes

Adds `on_change="ignore"` to `st.select_slider`. Releasing a drag, clicking the track, or using the arrow keys updates the widget and any bound query parameter without rerunning the app. Python receives the value on the next rerun, for example after a button click.

`Slider.proto` and `Slider.tsx` already implement `ignore_rerun`; this PR wires the select-slider backend and tests.

- Follows the `on_change` modes already on `st.slider`, `st.number_input`, and `st.text_input` (#14828, #16649, #16605)

## GitHub Issue Link (if applicable)

- Implements `st.select_slider` support from the on-change modes spec (`specs/2026-04-14-on-change-modes`, #14787)
- Related: #5827

## Testing Plan

- [x] Unit Tests (JS and/or Python)
- [x] E2E Tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

Made with [Cursor](https://cursor.com)

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | assessing-external-test-risk | 1 |
| skill | checking-changes | 2 |
| skill | debugging-streamlit | 1 |
| skill | finalizing-pr | 1 |
| skill | implementing-on-change-ignore | 1 |
| skill | qa-testing-feature | 1 |
| skill | reviewing-pr-description | 1 |
| skill | reviewing-readability | 1 |
| skill | sharing-pr-agent-artifacts | 1 |
| skill | updating-internal-docs | 1 |
| subagent | fixing-pr | 2 |
| subagent | generalPurpose | 5 |
| subagent | qa-testing-feature | 1 |
| subagent | reviewing-local-changes | 1 |
| subagent | shell | 2 |
| subagent | simplifying-local-changes | 1 |

</details>
<!-- agent-metrics-end -->