### PR TITLE
[refactor] Move checkbox/toggle to React Aria Field + Button

### DIFF
--- a/e2e_playwright/st_columns.py
+++ b/e2e_playwright/st_columns.py
@@ -135,6 +135,22 @@ with st.expander("Vertical alignment - bottom", expanded=True):
     col3.checkbox("Checkbox 1 (bottom)")
     col3.checkbox("Checkbox 2 (bottom)")
 
+# Fixture for the toggle half of the column vertical-alignment selector.
+# Two toggles per column so `:first-of-type` and `:last-of-type` land on
+# different elements.
+with st.expander("Vertical alignment - toggle", expanded=True):
+    top_col1, top_col2, top_col3 = st.columns(3, vertical_alignment="top")
+    top_col1.text_input("Text input (top toggle)")
+    top_col2.button("Button (top toggle)", width="stretch")
+    top_col3.toggle("Toggle 1 (top)")
+    top_col3.toggle("Toggle 2 (top)")
+
+    bottom_col1, bottom_col2, bottom_col3 = st.columns(3, vertical_alignment="bottom")
+    bottom_col1.text_input("Text input (bottom toggle)")
+    bottom_col2.button("Button (bottom toggle)", width="stretch")
+    bottom_col3.toggle("Toggle 1 (bottom)")
+    bottom_col3.toggle("Toggle 2 (bottom)")
+
 if st.button("Nested columns - two levels"):
     col1, col2 = st.columns(2)
     with col1:
@@ -185,21 +201,3 @@ with st.container(key="columns_wrap_true"):
     wrap_true_cols = st.columns(3, wrap=True, border=True)
     for i, col in enumerate(wrap_true_cols):
         col.write(f"Wrap true {i + 1}")
-
-# Toggles and checkboxes render separate wrapper elements, so the column
-# vertical-alignment margins have to be asserted against a toggle as well —
-# a checkbox-only assertion cannot catch the toggle wrapper being dropped from
-# the alignment selector. Two toggles per column so that the first-of-type and
-# last-of-type halves of that selector are told apart.
-with st.expander("Vertical alignment - toggle", expanded=True):
-    top_col1, top_col2, top_col3 = st.columns(3, vertical_alignment="top")
-    top_col1.text_input("Text input (top toggle)")
-    top_col2.button("Button (top toggle)", width="stretch")
-    top_col3.toggle("Toggle 1 (top)")
-    top_col3.toggle("Toggle 2 (top)")
-
-    bottom_col1, bottom_col2, bottom_col3 = st.columns(3, vertical_alignment="bottom")
-    bottom_col1.text_input("Text input (bottom toggle)")
-    bottom_col2.button("Button (bottom toggle)", width="stretch")
-    bottom_col3.toggle("Toggle 1 (bottom)")
-    bottom_col3.toggle("Toggle 2 (bottom)")

--- a/e2e_playwright/st_columns.py
+++ b/e2e_playwright/st_columns.py
@@ -136,8 +136,8 @@ with st.expander("Vertical alignment - bottom", expanded=True):
     col3.checkbox("Checkbox 2 (bottom)")
 
 # Toggle counterpart to the checkbox vertical-alignment fixtures above.
-# Two toggles per column so the first and last element-container rules apply to
-# different widgets.
+# Two toggles per column so the :first-of-type and :last-of-type alignment rules
+# land on different widgets.
 with st.expander("Vertical alignment - toggle", expanded=True):
     with st.container(key="vertical_alignment_toggle_top"):
         top_col1, top_col2, top_col3 = st.columns(3, vertical_alignment="top")

--- a/e2e_playwright/st_columns.py
+++ b/e2e_playwright/st_columns.py
@@ -135,21 +135,25 @@ with st.expander("Vertical alignment - bottom", expanded=True):
     col3.checkbox("Checkbox 1 (bottom)")
     col3.checkbox("Checkbox 2 (bottom)")
 
-# Fixture for the toggle half of the column vertical-alignment selector.
-# Two toggles per column so `:first-of-type` and `:last-of-type` land on
-# different elements.
+# Toggle counterpart to the checkbox vertical-alignment fixtures above.
+# Two toggles per column so the first and last element-container rules apply to
+# different widgets.
 with st.expander("Vertical alignment - toggle", expanded=True):
-    top_col1, top_col2, top_col3 = st.columns(3, vertical_alignment="top")
-    top_col1.text_input("Text input (top toggle)")
-    top_col2.button("Button (top toggle)", width="stretch")
-    top_col3.toggle("Toggle 1 (top)")
-    top_col3.toggle("Toggle 2 (top)")
+    with st.container(key="vertical_alignment_toggle_top"):
+        top_col1, top_col2, top_col3 = st.columns(3, vertical_alignment="top")
+        top_col1.text_input("Text input (top toggle)")
+        top_col2.button("Button (top toggle)", width="stretch")
+        top_col3.toggle("Toggle 1 (top)")
+        top_col3.toggle("Toggle 2 (top)")
 
-    bottom_col1, bottom_col2, bottom_col3 = st.columns(3, vertical_alignment="bottom")
-    bottom_col1.text_input("Text input (bottom toggle)")
-    bottom_col2.button("Button (bottom toggle)", width="stretch")
-    bottom_col3.toggle("Toggle 1 (bottom)")
-    bottom_col3.toggle("Toggle 2 (bottom)")
+    with st.container(key="vertical_alignment_toggle_bottom"):
+        bottom_col1, bottom_col2, bottom_col3 = st.columns(
+            3, vertical_alignment="bottom"
+        )
+        bottom_col1.text_input("Text input (bottom toggle)")
+        bottom_col2.button("Button (bottom toggle)", width="stretch")
+        bottom_col3.toggle("Toggle 1 (bottom)")
+        bottom_col3.toggle("Toggle 2 (bottom)")
 
 if st.button("Nested columns - two levels"):
     col1, col2 = st.columns(2)

--- a/e2e_playwright/st_columns.py
+++ b/e2e_playwright/st_columns.py
@@ -185,3 +185,21 @@ with st.container(key="columns_wrap_true"):
     wrap_true_cols = st.columns(3, wrap=True, border=True)
     for i, col in enumerate(wrap_true_cols):
         col.write(f"Wrap true {i + 1}")
+
+# Toggles and checkboxes render separate wrapper elements, so the column
+# vertical-alignment margins have to be asserted against a toggle as well —
+# a checkbox-only assertion cannot catch the toggle wrapper being dropped from
+# the alignment selector. Two toggles per column so that the first-of-type and
+# last-of-type halves of that selector are told apart.
+with st.expander("Vertical alignment - toggle", expanded=True):
+    top_col1, top_col2, top_col3 = st.columns(3, vertical_alignment="top")
+    top_col1.text_input("Text input (top toggle)")
+    top_col2.button("Button (top toggle)", width="stretch")
+    top_col3.toggle("Toggle 1 (top)")
+    top_col3.toggle("Toggle 2 (top)")
+
+    bottom_col1, bottom_col2, bottom_col3 = st.columns(3, vertical_alignment="bottom")
+    bottom_col1.text_input("Text input (bottom toggle)")
+    bottom_col2.button("Button (bottom toggle)", width="stretch")
+    bottom_col3.toggle("Toggle 1 (bottom)")
+    bottom_col3.toggle("Toggle 2 (bottom)")

--- a/e2e_playwright/st_columns_test.py
+++ b/e2e_playwright/st_columns_test.py
@@ -231,20 +231,21 @@ def test_column_vertical_alignment_applies_to_toggles(app: Page):
     """Test that toggles get the same alignment margins as checkboxes.
 
     Toggles and checkboxes render separate wrapper elements, so the alignment
-    selector has to name both. The checkbox-only assertions above cannot catch
-    the toggle wrapper being dropped from it.
+    selector has to name both. `test_column_vertical_alignment_top` and
+    `test_column_vertical_alignment_bottom` assert only on checkboxes, so they
+    cannot catch the toggle wrapper being dropped from it.
     """
     expander = get_expander(app, "Vertical alignment - toggle")
 
-    top_column = expander.get_by_test_id("stHorizontalBlock").nth(0)
-    top_toggles = top_column.get_by_test_id("stCheckbox")
+    top_row = expander.get_by_test_id("stHorizontalBlock").nth(0)
+    top_toggles = top_row.get_by_test_id("stCheckbox")
     expect(top_toggles).to_have_count(2)
     expect(top_toggles.first).to_have_css("margin-top", "8px")
     # The top rule must not also apply a bottom margin.
     expect(top_toggles.last).to_have_css("margin-bottom", "0px")
 
-    bottom_column = expander.get_by_test_id("stHorizontalBlock").nth(1)
-    bottom_toggles = bottom_column.get_by_test_id("stCheckbox")
+    bottom_row = expander.get_by_test_id("stHorizontalBlock").nth(1)
+    bottom_toggles = bottom_row.get_by_test_id("stCheckbox")
     expect(bottom_toggles).to_have_count(2)
     expect(bottom_toggles.last).to_have_css("margin-bottom", "8px")
     # The bottom rule must not also apply a top margin.

--- a/e2e_playwright/st_columns_test.py
+++ b/e2e_playwright/st_columns_test.py
@@ -235,16 +235,14 @@ def test_column_vertical_alignment_applies_to_toggles(app: Page):
     `test_column_vertical_alignment_bottom` assert only on checkboxes, so they
     cannot catch the toggle wrapper being dropped from it.
     """
-    expander = get_expander(app, "Vertical alignment - toggle")
-
-    top_row = expander.get_by_test_id("stHorizontalBlock").nth(0)
+    top_row = get_element_by_key(app, "vertical_alignment_toggle_top")
     top_toggles = top_row.get_by_test_id("stCheckbox")
     expect(top_toggles).to_have_count(2)
     expect(top_toggles.first).to_have_css("margin-top", "8px")
     # The top rule must not also apply a bottom margin.
     expect(top_toggles.last).to_have_css("margin-bottom", "0px")
 
-    bottom_row = expander.get_by_test_id("stHorizontalBlock").nth(1)
+    bottom_row = get_element_by_key(app, "vertical_alignment_toggle_bottom")
     bottom_toggles = bottom_row.get_by_test_id("stCheckbox")
     expect(bottom_toggles).to_have_count(2)
     expect(bottom_toggles.last).to_have_css("margin-bottom", "8px")

--- a/e2e_playwright/st_columns_test.py
+++ b/e2e_playwright/st_columns_test.py
@@ -227,6 +227,30 @@ def test_column_vertical_alignment_bottom(
     )
 
 
+def test_column_vertical_alignment_applies_to_toggles(app: Page):
+    """Test that toggles get the same alignment margins as checkboxes.
+
+    Toggles and checkboxes render separate wrapper elements, so the alignment
+    selector has to name both. The checkbox-only assertions above cannot catch
+    the toggle wrapper being dropped from it.
+    """
+    expander = get_expander(app, "Vertical alignment - toggle")
+
+    top_column = expander.get_by_test_id("stHorizontalBlock").nth(0)
+    top_toggles = top_column.get_by_test_id("stCheckbox")
+    expect(top_toggles).to_have_count(2)
+    expect(top_toggles.first).to_have_css("margin-top", "8px")
+    # The top rule must not also apply a bottom margin.
+    expect(top_toggles.last).to_have_css("margin-bottom", "0px")
+
+    bottom_column = expander.get_by_test_id("stHorizontalBlock").nth(1)
+    bottom_toggles = bottom_column.get_by_test_id("stCheckbox")
+    expect(bottom_toggles).to_have_count(2)
+    expect(bottom_toggles.last).to_have_css("margin-bottom", "8px")
+    # The bottom rule must not also apply a top margin.
+    expect(bottom_toggles.first).to_have_css("margin-top", "0px")
+
+
 def test_nesting_columns_is_allowed(app: Page):
     """Checks that nesting columns is allowed."""
 

--- a/e2e_playwright/st_columns_test.py
+++ b/e2e_playwright/st_columns_test.py
@@ -228,12 +228,10 @@ def test_column_vertical_alignment_bottom(
 
 
 def test_column_vertical_alignment_applies_to_toggles(app: Page):
-    """Test that toggles get the same alignment margins as checkboxes.
+    """Protect the toggle side of the column-alignment CSS.
 
-    Toggles and checkboxes render separate wrapper elements, so the alignment
-    selector has to name both. `test_column_vertical_alignment_top` and
-    `test_column_vertical_alignment_bottom` assert only on checkboxes, so they
-    cannot catch the toggle wrapper being dropped from it.
+    `test_column_vertical_alignment_top` and `test_column_vertical_alignment_bottom`
+    assert only on checkboxes, so neither would catch toggles losing the margin.
     """
     top_row = get_element_by_key(app, "vertical_alignment_toggle_top")
     top_toggles = top_row.get_by_test_id("stCheckbox")

--- a/frontend/lib/src/components/core/Block/styled-components.ts
+++ b/frontend/lib/src/components/core/Block/styled-components.ts
@@ -25,7 +25,10 @@ import {
   STEP_FOLLOWED_BY_STEP_SELECTOR,
 } from "~lib/components/core/Layout/stepConnector"
 import { Direction } from "~lib/components/core/Layout/utils"
-import { StyledCheckbox } from "~lib/components/widgets/Checkbox/styled-components"
+import {
+  StyledCheckboxField,
+  StyledSwitchField,
+} from "~lib/components/widgets/Checkbox/styled-components"
 import { STALE_STYLES } from "~lib/theme/consts"
 import type { EmotionTheme } from "~lib/theme/types"
 import { assertNever } from "~lib/util/assertNever"
@@ -193,7 +196,7 @@ export const StyledColumn = styled.div<StyledColumnProps>(
         // Scoped to the column's own stVerticalBlock so nested containers
         // (e.g. horizontal containers of checkboxes) do not also get matched
         // (issue #13162).
-        [`& > .stVerticalBlock > ${StyledElementContainer}:last-of-type > ${StyledCheckbox}`]:
+        [`& > .stVerticalBlock > ${StyledElementContainer}:last-of-type > :is(${StyledCheckboxField}, ${StyledSwitchField})`]:
           {
             marginBottom: theme.spacing.sm,
           },
@@ -203,7 +206,7 @@ export const StyledColumn = styled.div<StyledColumnProps>(
         // widgets. Scoped to the column's own stVerticalBlock so nested
         // containers (e.g. horizontal containers of checkboxes) do not also
         // get matched (issue #13162).
-        [`& > .stVerticalBlock > ${StyledElementContainer}:first-of-type > ${StyledCheckbox}`]:
+        [`& > .stVerticalBlock > ${StyledElementContainer}:first-of-type > :is(${StyledCheckboxField}, ${StyledSwitchField})`]:
           {
             marginTop: theme.spacing.sm,
           },

--- a/frontend/lib/src/components/core/Block/styled-components.ts
+++ b/frontend/lib/src/components/core/Block/styled-components.ts
@@ -25,13 +25,18 @@ import {
   STEP_FOLLOWED_BY_STEP_SELECTOR,
 } from "~lib/components/core/Layout/stepConnector"
 import { Direction } from "~lib/components/core/Layout/utils"
-import {
-  StyledCheckboxField,
-  StyledSwitchField,
-} from "~lib/components/widgets/Checkbox/styled-components"
 import { STALE_STYLES } from "~lib/theme/consts"
 import type { EmotionTheme } from "~lib/theme/types"
 import { assertNever } from "~lib/util/assertNever"
+
+/**
+ * Class that `st.checkbox` and `st.toggle` both set on their outer React Aria
+ * field wrapper (see `Checkbox.tsx`). The column vertical-alignment rules below
+ * target this class rather than the two field styled-components so that `Block`
+ * does not import widget internals, and so the rules keep covering both widgets
+ * if their internal composition changes again.
+ */
+const CHECKBOX_WRAPPER_SELECTOR = ".stCheckbox"
 
 function translateGapWidth(
   gap: streamlit.GapConfig.$Properties | undefined,
@@ -196,7 +201,7 @@ export const StyledColumn = styled.div<StyledColumnProps>(
         // Scoped to the column's own stVerticalBlock so nested containers
         // (e.g. horizontal containers of checkboxes) do not also get matched
         // (issue #13162).
-        [`& > .stVerticalBlock > ${StyledElementContainer}:last-of-type > :is(${StyledCheckboxField}, ${StyledSwitchField})`]:
+        [`& > .stVerticalBlock > ${StyledElementContainer}:last-of-type > ${CHECKBOX_WRAPPER_SELECTOR}`]:
           {
             marginBottom: theme.spacing.sm,
           },
@@ -206,7 +211,7 @@ export const StyledColumn = styled.div<StyledColumnProps>(
         // widgets. Scoped to the column's own stVerticalBlock so nested
         // containers (e.g. horizontal containers of checkboxes) do not also
         // get matched (issue #13162).
-        [`& > .stVerticalBlock > ${StyledElementContainer}:first-of-type > :is(${StyledCheckboxField}, ${StyledSwitchField})`]:
+        [`& > .stVerticalBlock > ${StyledElementContainer}:first-of-type > ${CHECKBOX_WRAPPER_SELECTOR}`]:
           {
             marginTop: theme.spacing.sm,
           },

--- a/frontend/lib/src/components/core/Block/styled-components.ts
+++ b/frontend/lib/src/components/core/Block/styled-components.ts
@@ -32,9 +32,9 @@ import { assertNever } from "~lib/util/assertNever"
 /**
  * Class that `st.checkbox` and `st.toggle` both set on their outer React Aria
  * field wrapper (see `Checkbox.tsx`). The column vertical-alignment rules below
- * target this class rather than the two field styled-components so that `Block`
- * does not import widget internals, and so the rules keep covering both widgets
- * if their internal composition changes again.
+ * target this class rather than the widgets' field styled-components, so `Block`
+ * does not import widget internals and the rules cover both widgets regardless
+ * of how each composes React Aria internally.
  */
 const CHECKBOX_WRAPPER_SELECTOR = ".stCheckbox"
 

--- a/frontend/lib/src/components/core/Block/styled-components.ts
+++ b/frontend/lib/src/components/core/Block/styled-components.ts
@@ -30,11 +30,9 @@ import type { EmotionTheme } from "~lib/theme/types"
 import { assertNever } from "~lib/util/assertNever"
 
 /**
- * Class that `st.checkbox` and `st.toggle` both set on their outer React Aria
- * field wrapper (see `Checkbox.tsx`). The column vertical-alignment rules below
- * target this class rather than the widgets' field styled-components, so `Block`
- * does not import widget internals and the rules cover both widgets regardless
- * of how each composes React Aria internally.
+ * Column vertical-alignment rules target the wrapper class rather than the two
+ * field styled-components, so both widgets stay covered if their inner React
+ * Aria composition changes.
  */
 const CHECKBOX_WRAPPER_SELECTOR = ".stCheckbox"
 

--- a/frontend/lib/src/components/widgets/Checkbox/Checkbox.test.tsx
+++ b/frontend/lib/src/components/widgets/Checkbox/Checkbox.test.tsx
@@ -134,6 +134,21 @@ describe("Checkbox widget", () => {
     ).toBeVisible()
   })
 
+  // The visible label is removed from the accessibility tree in both of these
+  // cases, so `aria-label` on the field is the only remaining source of the
+  // accessible name.
+  it.each([
+    ["hidden", LabelVisibilityProto.LabelVisibilityOptions.HIDDEN],
+    ["collapsed", LabelVisibilityProto.LabelVisibilityOptions.COLLAPSED],
+  ])("keeps an accessible name when the label is %s", (_, visibility) => {
+    const props = getProps({ labelVisibility: { value: visibility } })
+    render(<Checkbox {...props} />)
+
+    expect(
+      screen.getByRole("checkbox", { name: props.element.label })
+    ).toBeVisible()
+  })
+
   it("toggles via keyboard Space key", async () => {
     const user = userEvent.setup()
     const props = getProps()
@@ -266,6 +281,21 @@ describe("Checkbox TOGGLE type", () => {
 
   it("has an accessible name matching the label", () => {
     const props = getToggleProps()
+    render(<Checkbox {...props} />)
+
+    expect(
+      screen.getByRole("switch", { name: props.element.label })
+    ).toBeVisible()
+  })
+
+  // The visible label is removed from the accessibility tree in both of these
+  // cases, so `aria-label` on the field is the only remaining source of the
+  // accessible name.
+  it.each([
+    ["hidden", LabelVisibilityProto.LabelVisibilityOptions.HIDDEN],
+    ["collapsed", LabelVisibilityProto.LabelVisibilityOptions.COLLAPSED],
+  ])("keeps an accessible name when the label is %s", (_, visibility) => {
+    const props = getToggleProps({ labelVisibility: { value: visibility } })
     render(<Checkbox {...props} />)
 
     expect(

--- a/frontend/lib/src/components/widgets/Checkbox/Checkbox.test.tsx
+++ b/frontend/lib/src/components/widgets/Checkbox/Checkbox.test.tsx
@@ -457,7 +457,7 @@ describe("Checkbox wrap", () => {
 
   // Both checkbox and toggle share the same truncation/title wiring, so the
   // wrap behavior is exercised over both style types to catch a regression in
-  // either root (StyledCheckboxRoot / StyledSwitchRoot).
+  // either button (StyledCheckboxButton / StyledSwitchButton).
   const STYLE_TYPES = [
     ["checkbox", CheckboxProto.StyleType.DEFAULT],
     ["toggle", CheckboxProto.StyleType.TOGGLE],

--- a/frontend/lib/src/components/widgets/Checkbox/Checkbox.test.tsx
+++ b/frontend/lib/src/components/widgets/Checkbox/Checkbox.test.tsx
@@ -487,7 +487,7 @@ describe("Checkbox wrap", () => {
 
   // Both checkbox and toggle share the same truncation/title wiring, so the
   // wrap behavior is exercised over both style types to catch a regression in
-  // either button (StyledCheckboxButton / StyledSwitchButton).
+  // either variant's button wrapper (StyledCheckboxButton / StyledSwitchButton).
   const STYLE_TYPES = [
     ["checkbox", CheckboxProto.StyleType.DEFAULT],
     ["toggle", CheckboxProto.StyleType.TOGGLE],

--- a/frontend/lib/src/components/widgets/Checkbox/Checkbox.test.tsx
+++ b/frontend/lib/src/components/widgets/Checkbox/Checkbox.test.tsx
@@ -134,9 +134,8 @@ describe("Checkbox widget", () => {
     ).toBeVisible()
   })
 
-  // The visible label is removed from the accessibility tree in both of these
-  // cases, so `aria-label` on the field is the only remaining source of the
-  // accessible name.
+  // Both cases remove the visible label from the accessibility tree, leaving the
+  // field's aria-label as the only source of the accessible name.
   it.each([
     ["hidden", LabelVisibilityProto.LabelVisibilityOptions.HIDDEN],
     ["collapsed", LabelVisibilityProto.LabelVisibilityOptions.COLLAPSED],
@@ -288,9 +287,8 @@ describe("Checkbox TOGGLE type", () => {
     ).toBeVisible()
   })
 
-  // The visible label is removed from the accessibility tree in both of these
-  // cases, so `aria-label` on the field is the only remaining source of the
-  // accessible name.
+  // Both cases remove the visible label from the accessibility tree, leaving the
+  // field's aria-label as the only source of the accessible name.
   it.each([
     ["hidden", LabelVisibilityProto.LabelVisibilityOptions.HIDDEN],
     ["collapsed", LabelVisibilityProto.LabelVisibilityOptions.COLLAPSED],

--- a/frontend/lib/src/components/widgets/Checkbox/Checkbox.tsx
+++ b/frontend/lib/src/components/widgets/Checkbox/Checkbox.tsx
@@ -31,11 +31,12 @@ import { labelVisibilityProtoValueToEnum } from "~lib/util/utils"
 import { WidgetStateManager } from "~lib/WidgetStateManager"
 
 import {
-  StyledCheckbox,
+  StyledCheckboxField,
   StyledCheckboxIndicator,
   StyledCheckboxRoot,
   StyledContent,
   StyledLabelText,
+  StyledSwitchField,
   StyledSwitchRoot,
   StyledToggleThumb,
   StyledToggleTrack,
@@ -132,17 +133,15 @@ function Checkbox({
 
   if (isToggle) {
     return (
-      <StyledCheckbox
+      <StyledSwitchField
         className="row-widget stCheckbox"
         data-testid="stCheckbox"
+        isSelected={value}
+        isDisabled={disabled}
+        onChange={handleChange}
+        aria-label={element.label}
       >
-        <StyledSwitchRoot
-          isSelected={value}
-          isDisabled={disabled}
-          onChange={handleChange}
-          aria-label={element.label}
-          $truncate={truncate}
-        >
+        <StyledSwitchRoot $truncate={truncate}>
           {({ isSelected, isHovered, isDisabled: isDisab }) => (
             <>
               <StyledToggleTrack
@@ -159,19 +158,20 @@ function Checkbox({
             </>
           )}
         </StyledSwitchRoot>
-      </StyledCheckbox>
+      </StyledSwitchField>
     )
   }
 
   return (
-    <StyledCheckbox className="row-widget stCheckbox" data-testid="stCheckbox">
-      <StyledCheckboxRoot
-        isSelected={value}
-        isDisabled={disabled}
-        onChange={handleChange}
-        aria-label={element.label}
-        $truncate={truncate}
-      >
+    <StyledCheckboxField
+      className="row-widget stCheckbox"
+      data-testid="stCheckbox"
+      isSelected={value}
+      isDisabled={disabled}
+      onChange={handleChange}
+      aria-label={element.label}
+    >
+      <StyledCheckboxRoot $truncate={truncate}>
         {({ isSelected, isFocusVisible, isDisabled: isDisab }) => (
           <>
             <StyledCheckboxIndicator
@@ -189,7 +189,7 @@ function Checkbox({
           </>
         )}
       </StyledCheckboxRoot>
-    </StyledCheckbox>
+    </StyledCheckboxField>
   )
 }
 

--- a/frontend/lib/src/components/widgets/Checkbox/Checkbox.tsx
+++ b/frontend/lib/src/components/widgets/Checkbox/Checkbox.tsx
@@ -31,13 +31,13 @@ import { labelVisibilityProtoValueToEnum } from "~lib/util/utils"
 import { WidgetStateManager } from "~lib/WidgetStateManager"
 
 import {
+  StyledCheckboxButton,
   StyledCheckboxField,
   StyledCheckboxIndicator,
-  StyledCheckboxRoot,
   StyledContent,
   StyledLabelText,
+  StyledSwitchButton,
   StyledSwitchField,
-  StyledSwitchRoot,
   StyledToggleThumb,
   StyledToggleTrack,
 } from "./styled-components"
@@ -141,7 +141,7 @@ function Checkbox({
         onChange={handleChange}
         aria-label={element.label}
       >
-        <StyledSwitchRoot $truncate={truncate}>
+        <StyledSwitchButton $truncate={truncate}>
           {({ isSelected, isHovered, isDisabled: isDisab }) => (
             <>
               <StyledToggleTrack
@@ -157,7 +157,7 @@ function Checkbox({
               {labelContent}
             </>
           )}
-        </StyledSwitchRoot>
+        </StyledSwitchButton>
       </StyledSwitchField>
     )
   }
@@ -171,7 +171,7 @@ function Checkbox({
       onChange={handleChange}
       aria-label={element.label}
     >
-      <StyledCheckboxRoot $truncate={truncate}>
+      <StyledCheckboxButton $truncate={truncate}>
         {({ isSelected, isFocusVisible, isDisabled: isDisab }) => (
           <>
             <StyledCheckboxIndicator
@@ -188,7 +188,7 @@ function Checkbox({
             {labelContent}
           </>
         )}
-      </StyledCheckboxRoot>
+      </StyledCheckboxButton>
     </StyledCheckboxField>
   )
 }

--- a/frontend/lib/src/components/widgets/Checkbox/styled-components.tsx
+++ b/frontend/lib/src/components/widgets/Checkbox/styled-components.tsx
@@ -39,7 +39,8 @@ export const StyledCheckboxField = styled(RACheckboxField)(({ theme }) => ({
 /**
  * Outer wrapper for the toggle variant. Kept separate from `StyledCheckboxField`
  * because `SwitchButton` reads its state from a `SwitchField`, not from a
- * `CheckboxField`.
+ * `CheckboxField`. Layout matches `StyledCheckboxField` so checkbox and toggle
+ * align identically.
  */
 export const StyledSwitchField = styled(RASwitchField)(({ theme }) => ({
   display: "flex",
@@ -85,15 +86,15 @@ export const StyledLabelText = styled.div<StyledLabelTextProps>(
       : { display: "contents" }
 )
 
-interface StyledRootProps {
+interface StyledButtonProps {
   /** When true, the control can shrink within its container so the label can ellipsize. */
   $truncate?: boolean
 }
 
 /** Wrapper around React Aria CheckboxButton — handles layout and keyboard-focus background. */
-export const StyledCheckboxRoot = styled(RACheckboxButton, {
+export const StyledCheckboxButton = styled(RACheckboxButton, {
   shouldForwardProp: (prop: string) => !prop.startsWith("$"),
-})<StyledRootProps>(({ theme, $truncate }) => ({
+})<StyledButtonProps>(({ theme, $truncate }) => ({
   display: "flex",
   alignItems: "flex-start",
   gap: theme.spacing.sm,
@@ -176,9 +177,9 @@ export const StyledCheckboxIndicator =
   )
 
 /** Wrapper around React Aria SwitchButton — handles layout for the toggle variant. */
-export const StyledSwitchRoot = styled(RASwitchButton, {
+export const StyledSwitchButton = styled(RASwitchButton, {
   shouldForwardProp: (prop: string) => !prop.startsWith("$"),
-})<StyledRootProps>(({ theme, $truncate }) => ({
+})<StyledButtonProps>(({ theme, $truncate }) => ({
   display: "flex",
   alignItems: "flex-start",
   gap: theme.spacing.sm,

--- a/frontend/lib/src/components/widgets/Checkbox/styled-components.tsx
+++ b/frontend/lib/src/components/widgets/Checkbox/styled-components.tsx
@@ -46,9 +46,8 @@ export const StyledCheckboxField = styled(RACheckboxField)(fieldStyles)
 /**
  * The toggle's equivalent of `StyledCheckboxField`, kept separate because
  * `SwitchButton` reads its state from a `SwitchField`, not from a
- * `CheckboxField`. Column alignment CSS, `data-testid="stCheckbox"` and the
- * `stCheckbox` class target this element too — the toggle silently dropping out
- * of that alignment CSS is the regression this pairing exists to avoid.
+ * `CheckboxField`. Column alignment CSS and `data-testid="stCheckbox"` target
+ * this element too, so checkbox and toggle stay aligned identically.
  */
 export const StyledSwitchField = styled(RASwitchField)(fieldStyles)
 
@@ -180,7 +179,10 @@ export const StyledCheckboxIndicator =
     }
   )
 
-/** The toggle's equivalent of `StyledCheckboxButton`: truncation and keyboard-focus background apply here, not on the Field wrapper. */
+/**
+ * The toggle's equivalent of `StyledCheckboxButton`: truncation and
+ * keyboard-focus background apply here, not on the Field wrapper.
+ */
 export const StyledSwitchButton = styled(RASwitchButton, {
   shouldForwardProp: (prop: string) => !prop.startsWith("$"),
 })<StyledButtonProps>(({ theme, $truncate }) => ({

--- a/frontend/lib/src/components/widgets/Checkbox/styled-components.tsx
+++ b/frontend/lib/src/components/widgets/Checkbox/styled-components.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import styled from "@emotion/styled"
+import styled, { CSSObject } from "@emotion/styled"
 import {
   CheckboxButton as RACheckboxButton,
   CheckboxField as RACheckboxField,
@@ -23,30 +23,34 @@ import {
 } from "react-aria-components"
 
 import { hasLightBackgroundColor } from "~lib/theme/getColors"
+import type { EmotionTheme } from "~lib/theme/types"
 import { LabelVisibilityOptions } from "~lib/util/utils"
+
+/**
+ * Shared by both field wrappers so checkbox and toggle cannot drift out of
+ * alignment with each other.
+ */
+const fieldStyles = ({ theme }: { theme: EmotionTheme }): CSSObject => ({
+  display: "flex",
+  alignItems: "center",
+  minHeight: theme.sizes.smallElementHeight,
+})
 
 /**
  * React Aria field that passes the controlled selection state to
  * `CheckboxButton` and renders the outer wrapper `<div>`. Column alignment CSS,
  * `data-testid="stCheckbox"` and the `stCheckbox` class all target this element.
  */
-export const StyledCheckboxField = styled(RACheckboxField)(({ theme }) => ({
-  display: "flex",
-  alignItems: "center",
-  minHeight: theme.sizes.smallElementHeight,
-}))
+export const StyledCheckboxField = styled(RACheckboxField)(fieldStyles)
 
 /**
- * Outer wrapper for the toggle variant. Kept separate from `StyledCheckboxField`
- * because `SwitchButton` reads its state from a `SwitchField`, not from a
- * `CheckboxField`. Layout matches `StyledCheckboxField` so checkbox and toggle
- * align identically.
+ * The toggle's equivalent of `StyledCheckboxField`, kept separate because
+ * `SwitchButton` reads its state from a `SwitchField`, not from a
+ * `CheckboxField`. Column alignment CSS, `data-testid="stCheckbox"` and the
+ * `stCheckbox` class target this element too — the toggle silently dropping out
+ * of that alignment CSS is the regression this pairing exists to avoid.
  */
-export const StyledSwitchField = styled(RASwitchField)(({ theme }) => ({
-  display: "flex",
-  alignItems: "center",
-  minHeight: theme.sizes.smallElementHeight,
-}))
+export const StyledSwitchField = styled(RASwitchField)(fieldStyles)
 
 interface StyledContentProps {
   visibility?: LabelVisibilityOptions
@@ -91,7 +95,7 @@ interface StyledButtonProps {
   $truncate?: boolean
 }
 
-/** Wrapper around React Aria CheckboxButton — handles layout and keyboard-focus background. */
+/** Truncation and keyboard-focus background apply here, not on the Field wrapper. */
 export const StyledCheckboxButton = styled(RACheckboxButton, {
   shouldForwardProp: (prop: string) => !prop.startsWith("$"),
 })<StyledButtonProps>(({ theme, $truncate }) => ({
@@ -176,7 +180,7 @@ export const StyledCheckboxIndicator =
     }
   )
 
-/** Wrapper around React Aria SwitchButton — handles layout for the toggle variant. */
+/** The toggle's equivalent of `StyledCheckboxButton`: truncation and keyboard-focus background apply here, not on the Field wrapper. */
 export const StyledSwitchButton = styled(RASwitchButton, {
   shouldForwardProp: (prop: string) => !prop.startsWith("$"),
 })<StyledButtonProps>(({ theme, $truncate }) => ({

--- a/frontend/lib/src/components/widgets/Checkbox/styled-components.tsx
+++ b/frontend/lib/src/components/widgets/Checkbox/styled-components.tsx
@@ -26,9 +26,9 @@ import { hasLightBackgroundColor } from "~lib/theme/getColors"
 import { LabelVisibilityOptions } from "~lib/util/utils"
 
 /**
- * Outer wrapper for the checkbox variant. React Aria's `CheckboxField` owns the
- * widget state (`isSelected`, `isDisabled`, `onChange`) and renders the `<div>`
- * that wraps the clickable `CheckboxButton` label.
+ * React Aria field that passes the controlled selection state to
+ * `CheckboxButton` and renders the outer wrapper `<div>`. Column alignment CSS,
+ * `data-testid="stCheckbox"` and the `stCheckbox` class all target this element.
  */
 export const StyledCheckboxField = styled(RACheckboxField)(({ theme }) => ({
   display: "flex",

--- a/frontend/lib/src/components/widgets/Checkbox/styled-components.tsx
+++ b/frontend/lib/src/components/widgets/Checkbox/styled-components.tsx
@@ -37,17 +37,15 @@ const fieldStyles = ({ theme }: { theme: EmotionTheme }): CSSObject => ({
 })
 
 /**
- * React Aria field that passes the controlled selection state to
- * `CheckboxButton` and renders the outer wrapper `<div>`. Column alignment CSS,
- * `data-testid="stCheckbox"` and the `stCheckbox` class all target this element.
+ * Outer wrapper `<div>` for the checkbox. Column-alignment CSS,
+ * `data-testid="stCheckbox"`, and the `stCheckbox` class all target this
+ * element. Passes controlled selection state to `CheckboxButton`.
  */
 export const StyledCheckboxField = styled(RACheckboxField)(fieldStyles)
 
 /**
- * The toggle's equivalent of `StyledCheckboxField`, kept separate because
- * `SwitchButton` reads its state from a `SwitchField`, not from a
- * `CheckboxField`. Column alignment CSS and `data-testid="stCheckbox"` target
- * this element too, so checkbox and toggle stay aligned identically.
+ * Toggle counterpart to `StyledCheckboxField`. `SwitchButton` reads state from a
+ * `SwitchField`, so this cannot share the checkbox Field component.
  */
 export const StyledSwitchField = styled(RASwitchField)(fieldStyles)
 
@@ -94,10 +92,14 @@ interface StyledButtonProps {
   $truncate?: boolean
 }
 
-/** Truncation and keyboard-focus background apply here, not on the Field wrapper. */
-export const StyledCheckboxButton = styled(RACheckboxButton, {
-  shouldForwardProp: (prop: string) => !prop.startsWith("$"),
-})<StyledButtonProps>(({ theme, $truncate }) => ({
+/**
+ * Shared by both button labels so truncation and the keyboard-focus background
+ * cannot drift between checkbox and toggle.
+ */
+const buttonStyles = ({
+  theme,
+  $truncate,
+}: { theme: EmotionTheme } & StyledButtonProps): CSSObject => ({
   display: "flex",
   alignItems: "flex-start",
   gap: theme.spacing.sm,
@@ -118,7 +120,12 @@ export const StyledCheckboxButton = styled(RACheckboxButton, {
   "&[data-focus-visible]": {
     backgroundColor: theme.colors.darkenedBgMix25,
   },
-}))
+})
+
+/** React Aria's `<label>` for the checkbox. Truncation and the keyboard-focus background belong here, not on the field wrapper. */
+export const StyledCheckboxButton = styled(RACheckboxButton, {
+  shouldForwardProp: (prop: string) => !prop.startsWith("$"),
+})<StyledButtonProps>(buttonStyles)
 
 interface StyledCheckboxIndicatorProps {
   $isSelected: boolean
@@ -179,34 +186,10 @@ export const StyledCheckboxIndicator =
     }
   )
 
-/**
- * The toggle's equivalent of `StyledCheckboxButton`: truncation and
- * keyboard-focus background apply here, not on the Field wrapper.
- */
+/** Toggle counterpart to `StyledCheckboxButton`, sharing its styles. */
 export const StyledSwitchButton = styled(RASwitchButton, {
   shouldForwardProp: (prop: string) => !prop.startsWith("$"),
-})<StyledButtonProps>(({ theme, $truncate }) => ({
-  display: "flex",
-  alignItems: "flex-start",
-  gap: theme.spacing.sm,
-  marginBottom: 0,
-  marginTop: 0,
-  cursor: "pointer",
-  position: "relative",
-  // Bound the control to its container (without expanding a short label to full
-  // width) and let it shrink so an overflowing label can ellipsize instead of
-  // widening the control past its container.
-  ...($truncate && { minWidth: 0, maxWidth: "100%" }),
-
-  "&[data-disabled]": {
-    cursor: "not-allowed",
-    color: theme.colors.fadedText40,
-  },
-
-  "&[data-focus-visible]": {
-    backgroundColor: theme.colors.darkenedBgMix25,
-  },
-}))
+})<StyledButtonProps>(buttonStyles)
 
 interface StyledToggleTrackProps {
   $isSelected: boolean

--- a/frontend/lib/src/components/widgets/Checkbox/styled-components.tsx
+++ b/frontend/lib/src/components/widgets/Checkbox/styled-components.tsx
@@ -16,14 +16,32 @@
 
 import styled from "@emotion/styled"
 import {
-  Checkbox as RACheckbox,
-  Switch as RASwitch,
+  CheckboxButton as RACheckboxButton,
+  CheckboxField as RACheckboxField,
+  SwitchButton as RASwitchButton,
+  SwitchField as RASwitchField,
 } from "react-aria-components"
 
 import { hasLightBackgroundColor } from "~lib/theme/getColors"
 import { LabelVisibilityOptions } from "~lib/util/utils"
 
-export const StyledCheckbox = styled.div(({ theme }) => ({
+/**
+ * Outer wrapper for the checkbox variant. React Aria's `CheckboxField` owns the
+ * widget state (`isSelected`, `isDisabled`, `onChange`) and renders the `<div>`
+ * that wraps the clickable `CheckboxButton` label.
+ */
+export const StyledCheckboxField = styled(RACheckboxField)(({ theme }) => ({
+  display: "flex",
+  alignItems: "center",
+  minHeight: theme.sizes.smallElementHeight,
+}))
+
+/**
+ * Outer wrapper for the toggle variant. Kept separate from `StyledCheckboxField`
+ * because `SwitchButton` reads its state from a `SwitchField`, not from a
+ * `CheckboxField`.
+ */
+export const StyledSwitchField = styled(RASwitchField)(({ theme }) => ({
   display: "flex",
   alignItems: "center",
   minHeight: theme.sizes.smallElementHeight,
@@ -72,13 +90,8 @@ interface StyledRootProps {
   $truncate?: boolean
 }
 
-/**
- * Wrapper around React Aria Checkbox — handles layout and keyboard-focus background.
- * Checkbox is deprecated in favor of CheckboxField + CheckboxButton. Keep the
- * current composition until that migration is done as its own a11y/DOM change.
- */
-// eslint-disable-next-line @typescript-eslint/no-deprecated
-export const StyledCheckboxRoot = styled(RACheckbox, {
+/** Wrapper around React Aria CheckboxButton — handles layout and keyboard-focus background. */
+export const StyledCheckboxRoot = styled(RACheckboxButton, {
   shouldForwardProp: (prop: string) => !prop.startsWith("$"),
 })<StyledRootProps>(({ theme, $truncate }) => ({
   display: "flex",
@@ -162,13 +175,8 @@ export const StyledCheckboxIndicator =
     }
   )
 
-/**
- * Wrapper around React Aria Switch — handles layout for the toggle variant.
- * Switch is deprecated in favor of SwitchField + SwitchButton. Keep the
- * current composition until that migration is done as its own a11y/DOM change.
- */
-// eslint-disable-next-line @typescript-eslint/no-deprecated
-export const StyledSwitchRoot = styled(RASwitch, {
+/** Wrapper around React Aria SwitchButton — handles layout for the toggle variant. */
+export const StyledSwitchRoot = styled(RASwitchButton, {
   shouldForwardProp: (prop: string) => !prop.startsWith("$"),
 })<StyledRootProps>(({ theme, $truncate }) => ({
   display: "flex",


### PR DESCRIPTION
## Describe your changes

Migrates `st.checkbox` and `st.toggle` off react-aria-components' deprecated `Checkbox` and `Switch` onto the `Field` + `Button` split (adobe/react-spectrum#9877), preserving the wrapper DOM, classes, test ID, widget behaviour, accessibility and column alignment. Worth doing now rather than at the next major, where upstream intends to reuse the `Checkbox` name for the Field — a rename that would silently change what our import renders instead of failing the build.

- The `Field` takes over the plain wrapper `div` the widget already rendered, so node count and tree shape are unchanged, and `data-testid`, `row-widget` and `stCheckbox` stay on the same element. `StyledCheckboxRoot` / `StyledSwitchRoot` are renamed to `*Button` to match what they now wrap.
- `Block`'s column vertical-alignment CSS targets the `.stCheckbox` class that both wrappers carry, instead of importing the two field styled-components. That keeps `Block` free of widget internals and keeps the rules covering both widgets if the internal composition changes again — which is what went wrong here: the one wrapper that served both variants split in two, and the selector silently stopped covering toggles.
- The new e2e test restores that toggle coverage. It went into a new expander rather than the existing `Vertical alignment - top` / `bottom` ones, so committed linux snapshots don't need regenerating.

## Testing Plan

- Frontend Unit Tests: existing `Block` and `Checkbox` tests pass unmodified, so the migration is behaviour-neutral. The 4 added tests pin the accessible name under `label_visibility="hidden"` / `"collapsed"`, which nothing covered before: with a visible label the `<label>` supplies the name, so moving `aria-label` onto the Field could have broken silently. Mutation-tested — removing `aria-label` from both Fields fails exactly those 4 and nothing else.
- E2E Tests: `test_column_vertical_alignment_applies_to_toggles` covers both halves of the alignment CSS. Mutation-tested — dropping toggles from the selector fails it on `margin-bottom: expected 8px, actual 0px`, so both its assertions are live. The `#13162` nested-container leak test guards the other direction.
- Snapshot parity checked with a two-pass comparison: darwin baselines generated from `develop`, then re-run on this branch. 27 checkbox, 27 toggle and 22 column snapshots identical. Only `linux` baselines are committed, so this is the only way to verify locally on macOS.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared checkbox/toggle DOM, a11y naming, and column layout CSS; changes are covered by new and existing tests but affect widely used widgets.
> 
> **Overview**
> Migrates **`st.checkbox`** and **`st.toggle`** from react-aria-components’ deprecated monolithic **`Checkbox`** / **`Switch`** to the **`Field` + `Button`** pattern, with controlled state and **`aria-label`** on the field wrapper while **`stCheckbox`**, **`data-testid`**, and outer DOM shape stay the same.
> 
> **Column vertical alignment** in **`Block`** now targets the **`.stCheckbox`** wrapper class instead of a checkbox-only styled import, so top/bottom margin rules apply to **toggles** as well as checkboxes after the internal split into separate field components.
> 
> Adds **Playwright** coverage for toggle alignment margins and **unit tests** that the accessible name still comes from **`aria-label`** when labels are **hidden** or **collapsed**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 663f7bc1c633940af0d85ff3a66aa128a6aefed7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

