### PR TITLE
[refactor] Move radio to React Aria Field + Button

### DIFF
--- a/frontend/lib/src/components/shared/Radio/Radio.test.tsx
+++ b/frontend/lib/src/components/shared/Radio/Radio.test.tsx
@@ -205,8 +205,8 @@ describe("Radio widget", () => {
 
     const optionItems = screen.getAllByTestId("stRadioOption")
     expect(optionItems).toHaveLength(3)
-    // Pin stRadioOption to the input's <label>. e2e helpers click this node
-    // (app_utils.get_radio_option); the Field wrapper is not a click target.
+    // e2e helpers click stRadioOption (app_utils.get_radio_option), so it
+    // must stay on the input's <label>, not the Field wrapper.
     const firstRadio = screen.getAllByRole("radio")[0]
     expect(firstRadio.closest("label")).toBe(optionItems[0])
   })
@@ -217,8 +217,8 @@ describe("Radio widget", () => {
     const props = getProps({ onChange, value: 0 })
     render(<Radio {...props} />)
 
-    // Click the e2e target (stRadioOption), not the hidden input the other tests use.
     const radioOptions = screen.getAllByRole("radio")
+    // Other tests click the hidden input; this one clicks the e2e helper target.
     await user.click(screen.getAllByTestId("stRadioOption")[1])
 
     expect(onChange).toHaveBeenCalledTimes(1)

--- a/frontend/lib/src/components/shared/Radio/Radio.test.tsx
+++ b/frontend/lib/src/components/shared/Radio/Radio.test.tsx
@@ -205,6 +205,25 @@ describe("Radio widget", () => {
 
     const optionItems = screen.getAllByTestId("stRadioOption")
     expect(optionItems).toHaveLength(3)
+    // Keep this test id on the <label> that wraps the input, not on
+    // RadioField's wrapper div: e2e helpers click this element
+    // (app_utils.get_radio_option), and clicking the label activates the input
+    // directly rather than relying on the wrapper's box overlapping it.
+    const firstRadio = screen.getAllByRole("radio")[0]
+    expect(firstRadio.closest("label")).toBe(optionItems[0])
+  })
+
+  it("selects an option when its stRadioOption element is clicked", async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    const props = getProps({ onChange, value: 0 })
+    render(<Radio {...props} />)
+
+    // Exercises the element the e2e helpers click, which the other click tests
+    // do not: they target the hidden input via its `radio` role.
+    await user.click(screen.getAllByTestId("stRadioOption")[1])
+
+    expect(onChange).toHaveBeenCalledWith(1)
   })
 
   it("forwards data-testid to the radio group element", () => {

--- a/frontend/lib/src/components/shared/Radio/Radio.test.tsx
+++ b/frontend/lib/src/components/shared/Radio/Radio.test.tsx
@@ -199,16 +199,14 @@ describe("Radio widget", () => {
     })
   })
 
-  it("renders each option with data-testid stRadioOption", () => {
+  it("puts the stRadioOption test id on each option's label", () => {
     const props = getProps()
     render(<Radio {...props} />)
 
     const optionItems = screen.getAllByTestId("stRadioOption")
     expect(optionItems).toHaveLength(3)
-    // Keep this test id on the <label> that wraps the input, not on
-    // RadioField's wrapper div: e2e helpers click this element
-    // (app_utils.get_radio_option), and clicking the label activates the input
-    // directly rather than relying on the wrapper's box overlapping it.
+    // Pin stRadioOption to the input's <label>. e2e helpers click this node
+    // (app_utils.get_radio_option); the Field wrapper is not a click target.
     const firstRadio = screen.getAllByRole("radio")[0]
     expect(firstRadio.closest("label")).toBe(optionItems[0])
   })
@@ -219,11 +217,14 @@ describe("Radio widget", () => {
     const props = getProps({ onChange, value: 0 })
     render(<Radio {...props} />)
 
-    // Exercises the element the e2e helpers click, which the other click tests
-    // do not: they target the hidden input via its `radio` role.
+    // Click the e2e target (stRadioOption), not the hidden input the other tests use.
+    const radioOptions = screen.getAllByRole("radio")
     await user.click(screen.getAllByTestId("stRadioOption")[1])
 
+    expect(onChange).toHaveBeenCalledTimes(1)
     expect(onChange).toHaveBeenCalledWith(1)
+    expect(radioOptions[1]).toBeChecked()
+    expect(radioOptions[0]).not.toBeChecked()
   })
 
   it("forwards data-testid to the radio group element", () => {

--- a/frontend/lib/src/components/shared/Radio/Radio.tsx
+++ b/frontend/lib/src/components/shared/Radio/Radio.tsx
@@ -23,11 +23,12 @@ import { WidgetLabelHelpIconInline } from "~lib/components/widgets/BaseWidget/Wi
 import { LabelVisibilityOptions } from "~lib/util/utils"
 
 import {
+  StyledRadioButton,
   StyledRadioCaption,
   StyledRadioContent,
+  StyledRadioField,
   StyledRadioGroup,
   StyledRadioInner,
-  StyledRadioItem,
   StyledRadioOuter,
   StyledRadioRow,
 } from "./styled-components"
@@ -117,40 +118,45 @@ function Radio({
         $hasCaptions={hasCaptions}
       >
         {cleanedOptions.map((option: string, index: number) => (
-          <StyledRadioItem
+          <StyledRadioField
             // eslint-disable-next-line @eslint-react/no-array-index-key
             key={index}
             value={index.toString()}
-            data-testid="stRadioOption"
           >
-            {({ isSelected, isDisabled }) => (
-              <StyledRadioContent $isDisabled={isDisabled}>
-                <StyledRadioRow>
-                  <StyledRadioOuter
-                    $isSelected={isSelected}
-                    $isDisabled={isDisabled}
-                  >
-                    <StyledRadioInner $isSelected={isSelected} />
-                  </StyledRadioOuter>
-                  <StreamlitMarkdown
-                    source={option}
-                    allowHTML={false}
-                    isLabel
-                  />
-                </StyledRadioRow>
-                {hasCaptions && (
-                  <StyledRadioCaption>
+            <StyledRadioButton data-testid="stRadioOption">
+              {({ isSelected, isDisabled }) => (
+                // Keep this render function on the button, not the field:
+                // RadioFieldRenderProps has no interaction states (hovered,
+                // pressed, focused, focus-visible), so only the button can
+                // drive the indicator from them.
+                <StyledRadioContent $isDisabled={isDisabled}>
+                  <StyledRadioRow>
+                    <StyledRadioOuter
+                      $isSelected={isSelected}
+                      $isDisabled={isDisabled}
+                    >
+                      <StyledRadioInner $isSelected={isSelected} />
+                    </StyledRadioOuter>
                     <StreamlitMarkdown
-                      source={spacerNeeded(captions[index])}
+                      source={option}
                       allowHTML={false}
-                      isCaption
                       isLabel
                     />
-                  </StyledRadioCaption>
-                )}
-              </StyledRadioContent>
-            )}
-          </StyledRadioItem>
+                  </StyledRadioRow>
+                  {hasCaptions && (
+                    <StyledRadioCaption>
+                      <StreamlitMarkdown
+                        source={spacerNeeded(captions[index])}
+                        allowHTML={false}
+                        isCaption
+                        isLabel
+                      />
+                    </StyledRadioCaption>
+                  )}
+                </StyledRadioContent>
+              )}
+            </StyledRadioButton>
+          </StyledRadioField>
         ))}
       </StyledRadioGroup>
     </div>

--- a/frontend/lib/src/components/shared/Radio/Radio.tsx
+++ b/frontend/lib/src/components/shared/Radio/Radio.tsx
@@ -125,10 +125,6 @@ function Radio({
           >
             <StyledRadioButton data-testid="stRadioOption">
               {({ isSelected, isDisabled }) => (
-                // Keep this render function on the button, not the field:
-                // RadioFieldRenderProps has no interaction states (hovered,
-                // pressed, focused, focus-visible), so only the button can
-                // drive the indicator from them.
                 <StyledRadioContent $isDisabled={isDisabled}>
                   <StyledRadioRow>
                     <StyledRadioOuter

--- a/frontend/lib/src/components/shared/Radio/styled-components.tsx
+++ b/frontend/lib/src/components/shared/Radio/styled-components.tsx
@@ -55,28 +55,29 @@ export const StyledRadioGroup = styled(RARadioGroup, {
 }))
 
 /**
- * Required `RadioField` wrapper around each option. `RadioButton` must nest
- * inside it: the field declares which option this is (`value`) and passes the
- * group's selection state to the button via context.
+ * Per-option wrapper: it declares the option's `value` and passes the group's
+ * selection state to its `RadioButton` child via context. `RadioButton` must
+ * nest inside this field.
  *
- * Unstyled so it shrink-wraps the label as a flex item, and `StyledRadioGroup`'s
- * `alignItems` and `gap` apply to the option's visible box. React Aria mirrors
- * `data-selected`/`data-disabled` onto this div, so keep state-driven styles on
- * the label's class to avoid matching both elements.
+ * It needs no styles of its own — as a block-level flex item it shrink-wraps the
+ * label, so `StyledRadioGroup`'s `alignItems` and `gap` still apply to the
+ * option's visible box.
+ *
+ * Keep state-driven styles on the label's class: React Aria also sets
+ * `data-selected`/`data-disabled` on this div, so styling both elements would
+ * apply those rules twice.
  */
 export const StyledRadioField = styled(RARadioField)()
 
 /**
- * Clickable `<label>` for each radio option — it wraps the hidden input, the
+ * Clickable `<label>` for each radio option. It wraps the hidden input, the
  * circle indicator (`StyledRadioOuter`/`StyledRadioInner`), and the option text,
- * so the whole row is a click target.
+ * so the whole row is a click target. It stays a plain block container: the
+ * children own the circle-and-text alignment so the caption can sit outside that
+ * row without manual offset calculations.
  *
- * React Aria sets `data-focus-visible`, `data-disabled`, `data-selected` etc.
- * as data attributes — we use those for state-driven styles.
- *
- * This element is intentionally a plain block container. Layout (circle + text
- * alignment) is handled by the children so that the caption can live outside
- * the circle/text row without requiring any manual offset calculations.
+ * React Aria sets `data-focus-visible`, `data-disabled`, `data-selected` and
+ * friends as data attributes — we use those for state-driven styles.
  */
 export const StyledRadioButton = styled(RARadioButton)(({ theme }) => ({
   display: "block",

--- a/frontend/lib/src/components/shared/Radio/styled-components.tsx
+++ b/frontend/lib/src/components/shared/Radio/styled-components.tsx
@@ -55,23 +55,21 @@ export const StyledRadioGroup = styled(RARadioGroup, {
 }))
 
 /**
- * `<div>` wrapper for each individual radio option. It exists because
- * `RadioButton` must be nested inside a `RadioField`: the field declares which
- * option this is (`value`) and passes the group's selection state down to the
- * button via context.
+ * Required `RadioField` wrapper around each option. `RadioButton` must nest
+ * inside it: the field declares which option this is (`value`) and passes the
+ * group's selection state to the button via context.
  *
- * Unstyled: as a flex item it shrink-wraps the label, so `StyledRadioGroup`'s
- * `alignItems` and `gap` apply to the option's visible box. React Aria also
- * mirrors `data-selected`/`data-disabled` onto this div, so scope any
- * state-driven style to the label's class to avoid matching both elements.
+ * Unstyled so it shrink-wraps the label as a flex item, and `StyledRadioGroup`'s
+ * `alignItems` and `gap` apply to the option's visible box. React Aria mirrors
+ * `data-selected`/`data-disabled` onto this div, so keep state-driven styles on
+ * the label's class to avoid matching both elements.
  */
 export const StyledRadioField = styled(RARadioField)()
 
 /**
  * Clickable `<label>` for each radio option — it wraps the hidden input, the
- * circle indicator, and the option text, so the whole row is a click target.
- * Despite the name this is the label, not the indicator: the visual circle is
- * `StyledRadioOuter`/`StyledRadioInner`.
+ * circle indicator (`StyledRadioOuter`/`StyledRadioInner`), and the option text,
+ * so the whole row is a click target.
  *
  * React Aria sets `data-focus-visible`, `data-disabled`, `data-selected` etc.
  * as data attributes — we use those for state-driven styles.

--- a/frontend/lib/src/components/shared/Radio/styled-components.tsx
+++ b/frontend/lib/src/components/shared/Radio/styled-components.tsx
@@ -16,7 +16,8 @@
 
 import styled from "@emotion/styled"
 import {
-  Radio as RARadio,
+  RadioButton as RARadioButton,
+  RadioField as RARadioField,
   RadioGroup as RARadioGroup,
 } from "react-aria-components"
 
@@ -54,19 +55,32 @@ export const StyledRadioGroup = styled(RARadioGroup, {
 }))
 
 /**
- * Outer `<label>` wrapper for each individual radio option.
+ * `<div>` wrapper for each individual radio option. It exists because
+ * `RadioButton` must be nested inside a `RadioField`: the field declares which
+ * option this is (`value`) and passes the group's selection state down to the
+ * button via context.
+ *
+ * Unstyled: as a flex item it shrink-wraps the label, so `StyledRadioGroup`'s
+ * `alignItems` and `gap` apply to the option's visible box. React Aria also
+ * mirrors `data-selected`/`data-disabled` onto this div, so scope any
+ * state-driven style to the label's class to avoid matching both elements.
+ */
+export const StyledRadioField = styled(RARadioField)()
+
+/**
+ * Clickable `<label>` for each radio option — it wraps the hidden input, the
+ * circle indicator, and the option text, so the whole row is a click target.
+ * Despite the name this is the label, not the indicator: the visual circle is
+ * `StyledRadioOuter`/`StyledRadioInner`.
+ *
  * React Aria sets `data-focus-visible`, `data-disabled`, `data-selected` etc.
  * as data attributes — we use those for state-driven styles.
  *
  * This element is intentionally a plain block container. Layout (circle + text
  * alignment) is handled by the children so that the caption can live outside
  * the circle/text row without requiring any manual offset calculations.
- *
- * Radio is deprecated in favor of RadioField + RadioButton. Keep the current
- * composition until that migration is done as its own a11y/DOM change.
  */
-// eslint-disable-next-line @typescript-eslint/no-deprecated
-export const StyledRadioItem = styled(RARadio)(({ theme }) => ({
+export const StyledRadioButton = styled(RARadioButton)(({ theme }) => ({
   display: "block",
   cursor: "pointer",
   userSelect: "none",


### PR DESCRIPTION
## Describe your changes

Migrates `st.radio` off react-aria-components' deprecated `Radio` onto `RadioField` + `RadioButton` (adobe/react-spectrum#9877), matching #16787. Upstream intends to reuse the `Radio` name for the Field at the next major, which would silently change what our import renders rather than failing the build. `RadioGroup` is not deprecated and is unchanged.

The migration preserves the clickable `stRadioOption` label, the visual layout, and the current caption accessibility. Moving captions into the Field `description` slot is follow-up work, because it changes what screen readers announce.

- Each option gains one wrapper `<div>`. Unlike #16787 there was no existing wrapper to absorb, because `StyledRadioContent` sits *inside* the label while the Field has to sit outside it. Verified layout-neutral: every emotion class hash is character-identical to `develop`, down to the label's `css-150d2nz`, and all 33 radio snapshots match.
- `data-testid="stRadioOption"` stays on the label rather than moving to the Field, because `app_utils.get_radio_option` clicks it. Now pinned by two unit assertions instead of only by convention.
- The render function stays on `RadioButton`, where the deprecated `Radio` also had it. Both values it reads (`isSelected`, `isDisabled`) exist on the field too, so this is placement rather than a constraint.
- `StyledRadioField` is deliberately style-free: `RadioField` is what provides the `description` slot, so it is the seam the caption follow-up needs rather than something to remove now.

## Testing Plan

- Frontend Unit Tests: `Radio.test.tsx` 28 and `widgets/Radio` 18 pass. The migration needed no edits to existing tests — one assertion was strengthened and one test added, both guarding the test id's placement on the label. Verified adversarially: moving it onto the Field fails both.
- Snapshot parity checked with a two-pass comparison: darwin baselines generated from `develop`, then re-run on this branch. 33 radio snapshots identical. Only `linux` baselines are committed, so this is the only way to verify locally on macOS.
- No new e2e: the split introduced no cross-module coupling to cover. Nothing outside `components/shared/Radio/` imports `StyledRadio*`, unlike #16787 where `Block`'s alignment selector had to name both wrappers.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped refactor inside `components/shared/Radio/` with snapshot parity and stronger tests; no auth or data-path changes.
> 
> **Overview**
> Migrates the shared **Radio** widget off react-aria-components’ deprecated **`Radio`** primitive to **`RadioField` + `RadioButton`**, avoiding a future major where the `Radio` import would silently change semantics.
> 
> Each option is now a **`StyledRadioField`** (value wrapper, no styles) around **`StyledRadioButton`** (clickable label; carries the former option styles). **`data-testid="stRadioOption"`** stays on the **label** (`RadioButton`), not the field wrapper, so e2e helpers that click that test id keep working.
> 
> Unit tests **pin** that test-id placement and add coverage that **clicking `stRadioOption`** selects the option and fires **`onChange`** with the right index.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6474133911b8bf385d60b156f48531d7089ac59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


