### PR TITLE
[fix] Keep do-not-merge after QA PASS

### DIFF
--- a/.github/workflows/ai-qa-testing.yml
+++ b/.github/workflows/ai-qa-testing.yml
@@ -278,9 +278,9 @@ jobs:
               gh pr edit "$PR_NUMBER_ENV" --add-label "do-not-merge" --repo "$REPOSITORY"
               ;;
             PASS)
-              # Only the AI review job may remove do-not-merge (e.g. after an
-              # approved review). A QA PASS must not clear a review hold.
-              echo "QA PASS does not remove 'do-not-merge'; only the AI review job may remove it"
+              # A QA PASS must not lift a review hold. Only the AI review job
+              # removes do-not-merge, including holds this job added on FAIL.
+              echo "QA PASS does not remove 'do-not-merge'; re-add 'ai-review' or remove the label manually"
               ;;
             *)
               echo "Verdict is $VERDICT - no label changes"

--- a/.github/workflows/ai-qa-testing.yml
+++ b/.github/workflows/ai-qa-testing.yml
@@ -278,8 +278,9 @@ jobs:
               gh pr edit "$PR_NUMBER_ENV" --add-label "do-not-merge" --repo "$REPOSITORY"
               ;;
             PASS)
-              echo "Removing 'do-not-merge' label if present"
-              gh pr edit "$PR_NUMBER_ENV" --remove-label "do-not-merge" --repo "$REPOSITORY" || true
+              # Only the AI review job may remove do-not-merge (e.g. after an
+              # approved review). A QA PASS must not clear a review hold.
+              echo "QA PASS does not remove 'do-not-merge'; only the AI review job may remove it"
               ;;
             *)
               echo "Verdict is $VERDICT - no label changes"

--- a/.github/workflows/ai-qa-testing.yml
+++ b/.github/workflows/ai-qa-testing.yml
@@ -278,8 +278,8 @@ jobs:
               gh pr edit "$PR_NUMBER_ENV" --add-label "do-not-merge" --repo "$REPOSITORY"
               ;;
             PASS)
-              # A QA PASS must not lift a review hold. Only the AI review job
-              # removes do-not-merge, including holds this job added on FAIL.
+              # A QA PASS must not lift a review hold. Only ai-pr-review.yml
+              # or a human may remove do-not-merge, including a hold this job added on FAIL.
               echo "QA PASS does not remove 'do-not-merge'; re-add 'ai-review' or remove the label manually"
               ;;
             *)


### PR DESCRIPTION
## Describe your changes

AI QA testing no longer removes `do-not-merge` on a PASS verdict. Only the AI review job may clear that label, so a QA pass cannot lift a review hold.

QA FAIL still adds `do-not-merge`.

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- Workflow YAML only; no product code or tests to update
- `make check` passed (pre-commit / YAML hooks on the workflow file)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

Made with [Cursor](https://cursor.com)

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | checking-changes | 1 |
| skill | finalizing-pr | 1 |
| skill | reviewing-pr-description | 1 |
| subagent | fixing-pr | 2 |
| subagent | shell | 1 |

</details>
<!-- agent-metrics-end -->