### PR TITLE
[fix] Delay button help tooltips on hover

### DIFF
--- a/e2e_playwright/st_button_test.py
+++ b/e2e_playwright/st_button_test.py
@@ -238,9 +238,10 @@ def test_button_hover(themed_app: Page, assert_snapshot: ImageCompareFunction):
     help_button = get_element_by_key(help_button_container, "help_button_key")
     # Prime the interaction modality to 'pointer' before hovering.
     reset_hovering(themed_app)
-    help_button.hover()
-    # Not open immediately after hover; unit tests lock the 500ms delay.
+    # Tooltip must not already be attached before hover. The exact 500ms
+    # delay is covered by BaseButtonTooltip unit tests.
     expect(themed_app.get_by_test_id("stTooltipContent")).not_to_be_attached()
+    help_button.hover()
     expect(themed_app.get_by_text("help text")).to_be_visible()
     assert_snapshot(help_button_container, name="st_button-help_button")
 

--- a/e2e_playwright/st_button_test.py
+++ b/e2e_playwright/st_button_test.py
@@ -239,6 +239,8 @@ def test_button_hover(themed_app: Page, assert_snapshot: ImageCompareFunction):
     # Prime the interaction modality to 'pointer' before hovering.
     reset_hovering(themed_app)
     help_button.hover()
+    # Not open immediately after hover; unit tests lock the 500ms delay.
+    expect(themed_app.get_by_test_id("stTooltipContent")).not_to_be_attached()
     expect(themed_app.get_by_text("help text")).to_be_visible()
     assert_snapshot(help_button_container, name="st_button-help_button")
 

--- a/frontend/lib/src/components/shared/BaseButton/BaseButtonTooltip.test.tsx
+++ b/frontend/lib/src/components/shared/BaseButton/BaseButtonTooltip.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, cleanup, renderHook, screen } from "@testing-library/react"
+import { userEvent } from "@testing-library/user-event"
+import { useFocusVisible } from "react-aria"
+
+import { render } from "~lib/test_util"
+
+import {
+  BaseButtonTooltip,
+  HELP_TOOLTIP_HOVER_DELAY_MS,
+} from "./BaseButtonTooltip"
+
+function renderHelpButton(): void {
+  render(
+    <BaseButtonTooltip help="Button help" containerWidth={false}>
+      <button type="button">Click me</button>
+    </BaseButtonTooltip>
+  )
+}
+
+describe("BaseButtonTooltip", () => {
+  it("renders children only when help is omitted", () => {
+    render(
+      <BaseButtonTooltip containerWidth={false}>
+        <button type="button">Click me</button>
+      </BaseButtonTooltip>
+    )
+
+    expect(screen.getByRole("button", { name: "Click me" })).toBeVisible()
+    expect(
+      screen.queryByTestId("stTooltipHoverTarget")
+    ).not.toBeInTheDocument()
+  })
+
+  describe("help tooltip hover delay", () => {
+    let user: ReturnType<typeof userEvent.setup>
+
+    beforeAll(() => {
+      // See Tooltip.test.tsx for why hover tests need this React Aria setup.
+      renderHook(() => useFocusVisible())
+    })
+
+    beforeEach(() => {
+      vi.useFakeTimers()
+      document.dispatchEvent(new MouseEvent("mousemove", { bubbles: true }))
+      user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    })
+
+    afterEach(async () => {
+      // Unhover first so React Aria starts its cooldown. Unmounting while
+      // warmup is still armed would skip the delay on the next hover.
+      const tooltipTarget = screen.queryByTestId("stTooltipHoverTarget")
+      if (tooltipTarget) {
+        await user.unhover(tooltipTarget)
+      }
+      act(() => {
+        // Expire React Aria's global tooltip cooldown (not
+        // HELP_TOOLTIP_HOVER_DELAY_MS) so the next test still honors the
+        // open delay.
+        vi.advanceTimersByTime(500)
+        cleanup()
+      })
+      vi.useRealTimers()
+    })
+
+    it("shows the tooltip only after the hover delay", async () => {
+      renderHelpButton()
+
+      const tooltipTarget = screen.getByTestId("stTooltipHoverTarget")
+      await user.hover(tooltipTarget)
+      expect(screen.queryByTestId("stTooltipContent")).not.toBeInTheDocument()
+
+      act(() => {
+        vi.advanceTimersByTime(HELP_TOOLTIP_HOVER_DELAY_MS - 1)
+      })
+      expect(screen.queryByTestId("stTooltipContent")).not.toBeInTheDocument()
+
+      act(() => {
+        vi.advanceTimersByTime(1)
+      })
+      expect(screen.getByTestId("stTooltipContent")).toHaveTextContent(
+        "Button help"
+      )
+    })
+
+    it("does not show the tooltip if the pointer leaves before the delay", async () => {
+      renderHelpButton()
+
+      const tooltipTarget = screen.getByTestId("stTooltipHoverTarget")
+      await user.hover(tooltipTarget)
+      expect(screen.queryByTestId("stTooltipContent")).not.toBeInTheDocument()
+
+      await user.unhover(tooltipTarget)
+      act(() => {
+        vi.advanceTimersByTime(HELP_TOOLTIP_HOVER_DELAY_MS + 100)
+      })
+      expect(screen.queryByTestId("stTooltipContent")).not.toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/lib/src/components/shared/BaseButton/BaseButtonTooltip.test.tsx
+++ b/frontend/lib/src/components/shared/BaseButton/BaseButtonTooltip.test.tsx
@@ -67,8 +67,13 @@ describe("BaseButtonTooltip", () => {
     })
 
     afterEach(async () => {
-      // Unhover before unmount. If a tooltip is still in React Aria's warmup
-      // window, the next hover skips the open delay.
+      // Drop focus before unhover: pointer leave does not close while focus is
+      // inside the trigger, and an open tooltip keeps React Aria warmed up.
+      act(() => {
+        if (document.activeElement instanceof HTMLElement) {
+          document.activeElement.blur()
+        }
+      })
       const tooltipTarget = screen.queryByTestId("stTooltipHoverTarget")
       if (tooltipTarget) {
         await user.unhover(tooltipTarget)

--- a/frontend/lib/src/components/shared/BaseButton/BaseButtonTooltip.test.tsx
+++ b/frontend/lib/src/components/shared/BaseButton/BaseButtonTooltip.test.tsx
@@ -25,6 +25,10 @@ import {
   HELP_TOOLTIP_HOVER_DELAY_MS,
 } from "./BaseButtonTooltip"
 
+// React Aria's shared tooltip cooldown (independent of
+// HELP_TOOLTIP_HOVER_DELAY_MS even when the values match).
+const REACT_ARIA_TOOLTIP_COOLDOWN_MS = 500
+
 function renderHelpButton(): void {
   render(
     <BaseButtonTooltip help="Button help" containerWidth={false}>
@@ -51,7 +55,8 @@ describe("BaseButtonTooltip", () => {
     let user: ReturnType<typeof userEvent.setup>
 
     beforeAll(() => {
-      // See Tooltip.test.tsx for why hover tests need this React Aria setup.
+      // Register React Aria's document pointer listener so hover counts as
+      // pointer modality. See Tooltip.test.tsx for the full setup.
       renderHook(() => useFocusVisible())
     })
 
@@ -62,17 +67,14 @@ describe("BaseButtonTooltip", () => {
     })
 
     afterEach(async () => {
-      // Unhover first so React Aria starts its cooldown. Unmounting while
-      // warmup is still armed would skip the delay on the next hover.
+      // Unhover before unmount. If a tooltip is still in React Aria's warmup
+      // window, the next hover skips the open delay.
       const tooltipTarget = screen.queryByTestId("stTooltipHoverTarget")
       if (tooltipTarget) {
         await user.unhover(tooltipTarget)
       }
       act(() => {
-        // Expire React Aria's global tooltip cooldown (not
-        // HELP_TOOLTIP_HOVER_DELAY_MS) so the next test still honors the
-        // open delay.
-        vi.advanceTimersByTime(500)
+        vi.advanceTimersByTime(REACT_ARIA_TOOLTIP_COOLDOWN_MS)
         cleanup()
       })
       vi.useRealTimers()
@@ -86,7 +88,8 @@ describe("BaseButtonTooltip", () => {
       expect(screen.queryByTestId("stTooltipContent")).not.toBeInTheDocument()
 
       act(() => {
-        vi.advanceTimersByTime(HELP_TOOLTIP_HOVER_DELAY_MS - 1)
+        // Literal 499ms locks the 500ms contract; the next 1ms step opens it.
+        vi.advanceTimersByTime(499)
       })
       expect(screen.queryByTestId("stTooltipContent")).not.toBeInTheDocument()
 
@@ -110,6 +113,16 @@ describe("BaseButtonTooltip", () => {
         vi.advanceTimersByTime(HELP_TOOLTIP_HOVER_DELAY_MS + 100)
       })
       expect(screen.queryByTestId("stTooltipContent")).not.toBeInTheDocument()
+    })
+
+    it("shows the tooltip immediately on keyboard focus", async () => {
+      renderHelpButton()
+
+      await user.tab()
+      expect(screen.getByRole("button", { name: "Click me" })).toHaveFocus()
+      expect(screen.getByTestId("stTooltipContent")).toHaveTextContent(
+        "Button help"
+      )
     })
   })
 })

--- a/frontend/lib/src/components/shared/BaseButton/BaseButtonTooltip.tsx
+++ b/frontend/lib/src/components/shared/BaseButton/BaseButtonTooltip.tsx
@@ -22,8 +22,9 @@ import TooltipIcon from "~lib/components/shared/TooltipIcon/TooltipIcon"
 import { StyledTooltipMobile, StyledTooltipNormal } from "./styled-components"
 
 /**
- * Hover delay for help that wraps a control. The Tooltip default (200ms) is
- * too fast: accidental hover while aiming to click would cover nearby widgets.
+ * Hover delay for help attached to a whole element (button, popover, badge)
+ * so a pass toward a click does not cover nearby widgets. The Tooltip
+ * default (200ms) is too fast here.
  */
 export const HELP_TOOLTIP_HOVER_DELAY_MS = 500
 

--- a/frontend/lib/src/components/shared/BaseButton/BaseButtonTooltip.tsx
+++ b/frontend/lib/src/components/shared/BaseButton/BaseButtonTooltip.tsx
@@ -21,6 +21,12 @@ import TooltipIcon from "~lib/components/shared/TooltipIcon/TooltipIcon"
 
 import { StyledTooltipMobile, StyledTooltipNormal } from "./styled-components"
 
+/**
+ * Hover delay for help that wraps a control. The Tooltip default (200ms) is
+ * too fast: accidental hover while aiming to click would cover nearby widgets.
+ */
+export const HELP_TOOLTIP_HOVER_DELAY_MS = 500
+
 interface Props {
   children: ReactElement
   // TODO(lawilby): Probably remove this once width is implemented on Popover.
@@ -49,6 +55,7 @@ export function BaseButtonTooltip({
           placement={placement || Placement.TOP}
           containerWidth={containerWidth}
           constrainWidth={constrainWidth}
+          onMouseEnterDelay={HELP_TOOLTIP_HOVER_DELAY_MS}
         >
           {children}
         </TooltipIcon>

--- a/frontend/lib/src/components/widgets/Button/Button.test.tsx
+++ b/frontend/lib/src/components/widgets/Button/Button.test.tsx
@@ -137,7 +137,6 @@ describe("Button widget", () => {
 
   it("renders with help properly", async () => {
     const user = userEvent.setup()
-    // Hover to see tooltip content
     render(<Button {...getProps({ help: "mockHelpText" })} />)
 
     // Ensure both the button and the tooltip target have the correct width.
@@ -148,7 +147,6 @@ describe("Button widget", () => {
     const tooltipTarget = screen.getByTestId("stTooltipHoverTarget")
     expect(tooltipTarget).toHaveStyle("width: 100%")
 
-    // Ensure the tooltip content is visible and has the correct text
     await user.hover(tooltipTarget)
 
     const tooltipContent = await screen.findByTestId("stTooltipContent")


### PR DESCRIPTION
## Describe your changes

Button help tooltips wait 500ms on hover (previously 200ms) so moving the pointer across a control on the way to another one no longer pops a tooltip over nearby widgets. Keyboard focus is unaffected — the tooltip still opens immediately on focus.

- Applies to `st.button` and other controls that wrap help around the whole widget (download, link, page link, form submit, popover, menu button, badges). Widget help icons stay at the existing 200ms delay.
- No new delay parameter; 500ms matches the chat file-upload button tooltip.

## GitHub Issue Link (if applicable)

- Closes #8686

## Testing Plan

- [x] Unit Tests (JS and/or Python)
- [x] E2E Tests

- `frontend/lib/src/components/shared/BaseButton/BaseButtonTooltip.test.tsx` — tooltip stays hidden until 500ms; leaving earlier never shows it; keyboard focus opens immediately
- `e2e_playwright/st_button_test.py` — the existing hover flow still renders and snapshots help; the exact delay is covered by the frontend unit test

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

Made with [Cursor](https://cursor.com)