### PR TITLE
[chore] Restore Testing Library ESLint rules

### DIFF
--- a/frontend/app/src/components/StatusWidget/StatusWidget.test.tsx
+++ b/frontend/app/src/components/StatusWidget/StatusWidget.test.tsx
@@ -298,10 +298,12 @@ describe("Running Icon", () => {
     })
 
     await waitFor(() => {
-      const icon = screen.getByTestId("stStatusWidgetNewYearsIcon")
-      expect(icon).toBeVisible()
-      expect(icon).toHaveAttribute("src", "/src/assets/img/fireworks.gif")
+      expect(screen.getByTestId("stStatusWidgetNewYearsIcon")).toBeVisible()
     })
+    expect(screen.getByTestId("stStatusWidgetNewYearsIcon")).toHaveAttribute(
+      "src",
+      "/src/assets/img/fireworks.gif"
+    )
   })
 
   it("renders firework gif on Jan 6th", async () => {
@@ -319,10 +321,12 @@ describe("Running Icon", () => {
     })
 
     await waitFor(() => {
-      const icon = screen.getByTestId("stStatusWidgetNewYearsIcon")
-      expect(icon).toBeVisible()
-      expect(icon).toHaveAttribute("src", "/src/assets/img/fireworks.gif")
+      expect(screen.getByTestId("stStatusWidgetNewYearsIcon")).toBeVisible()
     })
+    expect(screen.getByTestId("stStatusWidgetNewYearsIcon")).toHaveAttribute(
+      "src",
+      "/src/assets/img/fireworks.gif"
+    )
   })
 
   it("renders regular running gif after New Years", async () => {

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -474,14 +474,26 @@ export default defineConfig([
       vitest,
     },
     rules: {
-      // Recommended vitest configuration to enforce good testing practices
+      // Recommended Testing Library + vitest configuration. The preset must be
+      // spread *inside* `rules` — replacing `rules` after spreading the config
+      // object discards every recommended testing-library rule.
+      ...testingLibrary.configs["flat/react"].rules,
       ...vitest.configs.recommended.rules,
       // Allow hardcoded styles in test files
       "streamlit-custom/no-hardcoded-theme-values": "off",
       // Allow force reflow access in test files
       "streamlit-custom/no-force-reflow-access": "off",
 
-      // Testing library rules
+      // Recommended rules with large existing debt; enable in later cleanups.
+      "testing-library/no-node-access": "off",
+      "testing-library/no-container": "off",
+      "testing-library/prefer-implicit-assert": "off",
+      "testing-library/prefer-presence-queries": "off",
+      "testing-library/no-unnecessary-act": "off",
+      "testing-library/no-manual-cleanup": "off",
+      "testing-library/render-result-naming-convention": "off",
+
+      // Testing library overrides
       "testing-library/prefer-user-event": "error",
       // Prefer screen.getBy* over destructured queries for consistency
       "testing-library/prefer-screen-queries": "warn",

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -467,16 +467,15 @@ export default defineConfig([
   // Test files specific configuration
   {
     files: ["**/*.test.ts", "**/*.test.tsx"],
-    ...testingLibrary.configs["flat/react"],
     plugins: {
       ...testingLibrary.configs["flat/react"].plugins,
       "testing-library": testingLibrary,
       vitest,
     },
     rules: {
-      // Recommended Testing Library + vitest configuration. The preset must be
-      // spread *inside* `rules` — replacing `rules` after spreading the config
-      // object discards every recommended testing-library rule.
+      // Spread Testing Library recommended rules inside `rules`. A sibling
+      // `rules` key replaces the preset's own and silently drops every
+      // recommended testing-library rule.
       ...testingLibrary.configs["flat/react"].rules,
       ...vitest.configs.recommended.rules,
       // Allow hardcoded styles in test files
@@ -487,7 +486,6 @@ export default defineConfig([
       // Recommended rules with large existing debt; enable in later cleanups.
       "testing-library/no-node-access": "off",
       "testing-library/no-container": "off",
-      "testing-library/prefer-implicit-assert": "off",
       "testing-library/prefer-presence-queries": "off",
       "testing-library/no-unnecessary-act": "off",
       "testing-library/no-manual-cleanup": "off",

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -468,14 +468,13 @@ export default defineConfig([
   {
     files: ["**/*.test.ts", "**/*.test.tsx"],
     plugins: {
-      ...testingLibrary.configs["flat/react"].plugins,
       "testing-library": testingLibrary,
       vitest,
     },
     rules: {
-      // Spread Testing Library recommended rules inside `rules`. A sibling
-      // `rules` key replaces the preset's own and silently drops every
-      // recommended testing-library rule.
+      // Merge the Testing Library preset into this `rules` object. Spreading the
+      // whole preset at this config root would let this `rules` key replace it
+      // and drop every recommended testing-library rule.
       ...testingLibrary.configs["flat/react"].rules,
       ...vitest.configs.recommended.rules,
       // Allow hardcoded styles in test files
@@ -484,6 +483,7 @@ export default defineConfig([
       "streamlit-custom/no-force-reflow-access": "off",
 
       // Recommended rules with large existing debt; enable in later cleanups.
+      // Plan: https://github.com/streamlit/streamlit/wiki/2026-09-03-improving-frontend-linting
       "testing-library/no-node-access": "off",
       "testing-library/no-container": "off",
       "testing-library/prefer-presence-queries": "off",

--- a/frontend/lib/src/WidgetStateManager.test.ts
+++ b/frontend/lib/src/WidgetStateManager.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { waitFor } from "@testing-library/dom"
+import { waitFor } from "@testing-library/react"
 import { enableMapSet, enablePatches } from "immer"
 import { getLogger } from "loglevel"
 import { Mock } from "vitest"
@@ -113,7 +113,6 @@ describe("Widget State Manager", () => {
       expect(sendBackMsg).not.toHaveBeenCalled()
     } else {
       await waitFor(() => {
-        expect(sendBackMsg).toHaveBeenCalledTimes(1)
         expect(sendBackMsg).toHaveBeenCalledWith(
           expect.anything(),
           undefined, // fragmentId
@@ -121,6 +120,7 @@ describe("Widget State Manager", () => {
           undefined
         )
       })
+      expect(sendBackMsg).toHaveBeenCalledTimes(1)
     }
   }
 

--- a/frontend/lib/src/components/elements/PlotlyChart/utils.test.ts
+++ b/frontend/lib/src/components/elements/PlotlyChart/utils.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { waitFor } from "@testing-library/dom"
+import { waitFor } from "@testing-library/react"
 import Plotly from "plotly.js"
 
 import { PlotlyChart as PlotlyChartProto } from "@streamlit/protobuf"

--- a/frontend/lib/src/components/elements/Tabs/Tabs.test.tsx
+++ b/frontend/lib/src/components/elements/Tabs/Tabs.test.tsx
@@ -559,10 +559,12 @@ describe("st.tabs", () => {
       rerender(<Tabs {...getProps({ node: replacement, widgetMgr })} />)
 
       await waitFor(() => {
-        const tabs = screen.getAllByRole("tab")
-        expect(tabs[0]).toHaveAttribute("aria-selected", "true")
-        expect(tabs[0]).toHaveTextContent("Alpha")
+        expect(screen.getAllByRole("tab")[0]).toHaveAttribute(
+          "aria-selected",
+          "true"
+        )
       })
+      expect(screen.getAllByRole("tab")[0]).toHaveTextContent("Alpha")
       expect(widgetMgr.getElementState(blockId, "activeTabLabel")).toBe(
         "Alpha"
       )
@@ -622,10 +624,12 @@ describe("st.tabs", () => {
       rerender(<Tabs {...getProps({ node: longerList, widgetMgr })} />)
 
       await waitFor(() => {
-        const tabs = screen.getAllByRole("tab")
-        expect(tabs[1]).toHaveAttribute("aria-selected", "true")
-        expect(tabs[1]).toHaveTextContent("B")
+        expect(screen.getAllByRole("tab")[1]).toHaveAttribute(
+          "aria-selected",
+          "true"
+        )
       })
+      expect(screen.getAllByRole("tab")[1]).toHaveTextContent("B")
       expect(screen.getAllByRole("tab")[0]).toHaveAttribute(
         "aria-selected",
         "false"

--- a/frontend/lib/src/components/shared/BaseButton/BaseButtonTooltip.test.tsx
+++ b/frontend/lib/src/components/shared/BaseButton/BaseButtonTooltip.test.tsx
@@ -57,6 +57,7 @@ describe("BaseButtonTooltip", () => {
     beforeAll(() => {
       // Register React Aria's document pointer listener so hover counts as
       // pointer modality. See Tooltip.test.tsx for the full setup.
+      // eslint-disable-next-line testing-library/no-render-in-lifecycle -- useFocusVisible must run once so React Aria registers the document pointer listener that hover tests depend on.
       renderHook(() => useFocusVisible())
     })
 

--- a/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
+++ b/frontend/lib/src/components/shared/Dropdown/Selectbox.test.tsx
@@ -232,9 +232,9 @@ describe("Selectbox widget", () => {
     await user.keyboard("{ArrowDown}{Enter}")
 
     await waitFor(() => {
-      expect(props.onChange).toHaveBeenCalledTimes(1)
       expect(props.onChange).toHaveBeenCalledWith("b")
     })
+    expect(props.onChange).toHaveBeenCalledTimes(1)
     expect(screen.getByDisplayValue("b")).toBeVisible()
   })
 

--- a/frontend/lib/src/components/shared/Tooltip/Tooltip.test.tsx
+++ b/frontend/lib/src/components/shared/Tooltip/Tooltip.test.tsx
@@ -64,9 +64,7 @@ const renderTooltip = (props: Partial<TooltipProps> = {}): RenderResult => {
 
 describe("Tooltip element", () => {
   beforeAll(() => {
-    // Register React Aria's global pointermove listener so interaction
-    // modality tracking works during hover tests.
-    // eslint-disable-next-line testing-library/no-render-in-lifecycle -- useFocusVisible must run once so React Aria registers its document pointer listener.
+    // eslint-disable-next-line testing-library/no-render-in-lifecycle -- useFocusVisible must run once so React Aria registers the document pointer listener that hover tests depend on.
     renderHook(() => useFocusVisible())
   })
 

--- a/frontend/lib/src/components/shared/Tooltip/Tooltip.test.tsx
+++ b/frontend/lib/src/components/shared/Tooltip/Tooltip.test.tsx
@@ -66,7 +66,7 @@ describe("Tooltip element", () => {
   beforeAll(() => {
     // Register React Aria's global pointermove listener so interaction
     // modality tracking works during hover tests.
-    // eslint-disable-next-line testing-library/no-render-in-lifecycle -- setupGlobalFocusEvents must run once; the document listener is module-level.
+    // eslint-disable-next-line testing-library/no-render-in-lifecycle -- useFocusVisible must run once so React Aria registers its document pointer listener.
     renderHook(() => useFocusVisible())
   })
 

--- a/frontend/lib/src/components/shared/Tooltip/Tooltip.test.tsx
+++ b/frontend/lib/src/components/shared/Tooltip/Tooltip.test.tsx
@@ -66,6 +66,7 @@ describe("Tooltip element", () => {
   beforeAll(() => {
     // Register React Aria's global pointermove listener so interaction
     // modality tracking works during hover tests.
+    // eslint-disable-next-line testing-library/no-render-in-lifecycle -- setupGlobalFocusEvents must run once; the document listener is module-level.
     renderHook(() => useFocusVisible())
   })
 

--- a/frontend/lib/src/components/shared/TooltipIcon/TooltipIcon.test.tsx
+++ b/frontend/lib/src/components/shared/TooltipIcon/TooltipIcon.test.tsx
@@ -33,6 +33,7 @@ describe("TooltipIcon element", () => {
   // hover-triggered tooltip tests can work.  See Tooltip.test.tsx for a full
   // explanation of this setup.
   beforeAll(() => {
+    // eslint-disable-next-line testing-library/no-render-in-lifecycle -- setupGlobalFocusEvents must run once; the document listener is module-level.
     renderHook(() => useFocusVisible())
   })
   it("renders a TooltipIcon", () => {

--- a/frontend/lib/src/components/shared/TooltipIcon/TooltipIcon.test.tsx
+++ b/frontend/lib/src/components/shared/TooltipIcon/TooltipIcon.test.tsx
@@ -33,7 +33,7 @@ describe("TooltipIcon element", () => {
   // hover-triggered tooltip tests can work.  See Tooltip.test.tsx for a full
   // explanation of this setup.
   beforeAll(() => {
-    // eslint-disable-next-line testing-library/no-render-in-lifecycle -- setupGlobalFocusEvents must run once; the document listener is module-level.
+    // eslint-disable-next-line testing-library/no-render-in-lifecycle -- useFocusVisible must run once so React Aria registers its document pointer listener.
     renderHook(() => useFocusVisible())
   })
   it("renders a TooltipIcon", () => {

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.test.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.test.tsx
@@ -806,15 +806,13 @@ describe("ChatInput widget", () => {
 
     // Wait for files to be displayed (order-agnostic check)
     await waitFor(() => {
-      const fileNames = screen.getAllByTestId("stFileChipName")
-      expect(fileNames).toHaveLength(2)
-
-      // Check that both files are present using title attribute (full filename)
-      const fileTitles = Array.from(fileNames).map(el =>
-        el.getAttribute("title")
-      )
-      expect(fileTitles).toContain("folder/file1.txt")
-      expect(fileTitles).toContain("folder/file2.txt")
+      expect(
+        new Set(
+          screen
+            .getAllByTestId("stFileChipName")
+            .map(el => el.getAttribute("title"))
+        )
+      ).toEqual(new Set(["folder/file1.txt", "folder/file2.txt"]))
     })
 
     // Find and delete file1

--- a/frontend/lib/src/components/widgets/ChatInput/ChatInput.test.tsx
+++ b/frontend/lib/src/components/widgets/ChatInput/ChatInput.test.tsx
@@ -807,12 +807,11 @@ describe("ChatInput widget", () => {
     // Wait for files to be displayed (order-agnostic check)
     await waitFor(() => {
       expect(
-        new Set(
-          screen
-            .getAllByTestId("stFileChipName")
-            .map(el => el.getAttribute("title"))
-        )
-      ).toEqual(new Set(["folder/file1.txt", "folder/file2.txt"]))
+        screen
+          .getAllByTestId("stFileChipName")
+          .map(el => el.getAttribute("title"))
+          .sort()
+      ).toEqual(["folder/file1.txt", "folder/file2.txt"])
     })
 
     // Find and delete file1

--- a/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
+++ b/frontend/lib/src/components/widgets/DateInput/DateInput.test.tsx
@@ -1950,12 +1950,15 @@ describe("DateInput single-mode active calendar (Alt+ArrowDown)", () => {
     await waitFor(() => {
       const calendar = screen.getByTestId("stDateInputCalendar")
       expect(calendar).toHaveAttribute("role", "dialog")
-      expect(calendar).toHaveAttribute("aria-modal", "true")
       // Focus should be inside the calendar grid
       const focused = document.activeElement
       expect(calendar.contains(focused)).toBe(true)
       expect(focused?.getAttribute("tabindex")).toBe("0")
     })
+    expect(screen.getByTestId("stDateInputCalendar")).toHaveAttribute(
+      "aria-modal",
+      "true"
+    )
   })
 
   it("Alt+ArrowDown opens calendar even if popover was closed", async () => {
@@ -2184,10 +2187,15 @@ describe("DateInput range-mode active calendar (Alt+ArrowDown)", () => {
     await user.keyboard("{Alt>}{ArrowDown}{/Alt}")
 
     await waitFor(() => {
-      const calendar = screen.getByTestId("stDateInputCalendar")
-      expect(calendar).toHaveAttribute("role", "dialog")
-      expect(calendar).toHaveAttribute("aria-modal", "true")
+      expect(screen.getByTestId("stDateInputCalendar")).toHaveAttribute(
+        "role",
+        "dialog"
+      )
     })
+    expect(screen.getByTestId("stDateInputCalendar")).toHaveAttribute(
+      "aria-modal",
+      "true"
+    )
   })
 
   it("Alt+ArrowDown from end field segment enters active calendar", async () => {

--- a/frontend/lib/src/components/widgets/DateTimeInput/DateTimeInput.test.tsx
+++ b/frontend/lib/src/components/widgets/DateTimeInput/DateTimeInput.test.tsx
@@ -1664,12 +1664,15 @@ describe("DateTimeInput widget", () => {
       await waitFor(() => {
         const calendar = screen.getByTestId("stDateTimeInputCalendar")
         expect(calendar).toHaveAttribute("role", "dialog")
-        expect(calendar).toHaveAttribute("aria-modal", "true")
         // Focus should be inside the calendar grid
         const focused = document.activeElement
         expect(calendar.contains(focused)).toBe(true)
         expect(focused?.getAttribute("tabindex")).toBe("0")
       })
+      expect(screen.getByTestId("stDateTimeInputCalendar")).toHaveAttribute(
+        "aria-modal",
+        "true"
+      )
     })
 
     it("Escape from active calendar closes it and returns focus to the field", async () => {
@@ -1724,10 +1727,15 @@ describe("DateTimeInput widget", () => {
       await user.keyboard("{Alt>}{ArrowDown}{/Alt}")
 
       await waitFor(() => {
-        const calendar = screen.getByTestId("stDateTimeInputCalendar")
-        expect(calendar).toHaveAttribute("role", "dialog")
-        expect(calendar).toHaveAttribute("aria-modal", "true")
+        expect(screen.getByTestId("stDateTimeInputCalendar")).toHaveAttribute(
+          "role",
+          "dialog"
+        )
       })
+      expect(screen.getByTestId("stDateTimeInputCalendar")).toHaveAttribute(
+        "aria-modal",
+        "true"
+      )
     })
   })
 

--- a/frontend/lib/src/render-tree/AppRoot.test.ts
+++ b/frontend/lib/src/render-tree/AppRoot.test.ts
@@ -1510,6 +1510,7 @@ describe("AppRoot", () => {
 
   describe("AppRoot.debug", () => {
     it("prints labeled child sections with tree output", () => {
+      // eslint-disable-next-line testing-library/no-debugging-utils -- AppRoot.debug() is a tree printer, not Testing Library's screen.debug().
       const out = ROOT.debug()
       // Header
       expect(out.startsWith("AppRoot\n")).toBe(true)

--- a/frontend/lib/src/render-tree/TransientNode.test.ts
+++ b/frontend/lib/src/render-tree/TransientNode.test.ts
@@ -106,6 +106,7 @@ describe("TransientNode", () => {
       const t2 = text("t2")
       const node = new TransientNode("run-xyz", anchor, [t1, t2], 5)
 
+      // eslint-disable-next-line testing-library/no-debugging-utils -- TransientNode.debug() is a tree printer, not Testing Library's screen.debug().
       const debug = node.debug()
 
       expect(debug.split("\n")[0]).toBe(


### PR DESCRIPTION
## Describe your changes

Restores recommended Testing Library ESLint rules that the test-file `rules`
object was overwriting. `waitFor` callbacks now keep one assertion per async
subject so timeouts name the failing condition.

High-count recommended rules stay off until later cleanups: `no-node-access`,
`no-container`, `prefer-presence-queries`, `no-unnecessary-act`,
`no-manual-cleanup`, and `render-result-naming-convention`.

Implements P0.1 of the frontend linting cleanup:
https://github.com/streamlit/streamlit/wiki/2026-09-03-improving-frontend-linting

## GitHub Issue Link (if applicable)

## Testing Plan

- [x] No new tests: existing unit tests were restructured for
  `no-wait-for-multiple-assertions` and related restored rules
- No e2e or manual testing: lint config and assertion structure only

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

Made with [Cursor](https://cursor.com)