### PR TITLE
[docs] Document script-thread event loop ownership

### DIFF
--- a/.claude/skills/understanding-streamlit-architecture/references/backend.md
+++ b/.claude/skills/understanding-streamlit-architecture/references/backend.md
@@ -54,6 +54,8 @@ Represents a single browser tab.
 
 **File watchers**: Monitors script, config.toml, secrets.toml, pages/ for changes.
 
+**Script event loop**: Owns one non-running asyncio loop for the script thread, reused across `ScriptRunner` instances and closed on session shutdown.
+
 ## Session bootstrap ordering
 
 Initial session creation and first script run are intentionally decoupled:
@@ -83,6 +85,7 @@ Executes user scripts in isolated thread.
 - `SCRIPT_STOPPED_WITH_COMPILE_ERROR`
 - `SCRIPT_STOPPED_FOR_RERUN` (st.rerun() called)
 - `FRAGMENT_STOPPED_WITH_SUCCESS`
+- `SHUTDOWN` (the ScriptRunner is exiting)
 
 **Interrupt points**: Most `st.*` commands check for stop/rerun requests and raise `RerunException` or `StopException`.
 


### PR DESCRIPTION
## Describe your changes

Updates the backend architecture reference to record the `AppSession`-owned script event loop and the terminal `ScriptRunner` shutdown event.

## GitHub Issue Link (if applicable)

- Follow-up to #16167

## Testing Plan

- Documentation-only change; `make check` passes.
- No additional tests are needed because runtime behavior is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API impact.
> 
> **Overview**
> Updates the backend architecture reference (`.claude/skills/understanding-streamlit-architecture/references/backend.md`) so it matches recent runtime behavior documented in follow-up to #16167.
> 
> Under **AppSession**, it now states that each session **owns one non-running asyncio event loop** for the script thread, that the loop is **reused across `ScriptRunner` instances**, and that it is **closed on session shutdown**.
> 
> Under **ScriptRunner** script events, it adds **`SHUTDOWN`** as the terminal signal when the runner is exiting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7874e2cc33421f10b219ed8673658433e33c5bef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->