### PR TITLE
Enforce the uv version floor from outside `[tool.uv]`

### DIFF
--- a/.cursor/rules/overview.mdc
+++ b/.cursor/rules/overview.mdc
@@ -42,11 +42,12 @@ alwaysApply: true
 
 - Prefer `make` targets for all dev tasks (tests, lint, format, builds).
 - Always use `uv run` to run any Python command (e.g. `uv run streamlit`, `uv run pytest`, `uv run ruff`, `uv run mypy`, etc.).
-- Always use `uv run` for git commands that trigger hooks (e.g. `uv run git commit`, `uv run git push`). Pre-commit hooks require the uv environment to run linters and formatters.
+- Use `uv run --no-sync` for git commands that trigger hooks (e.g. `uv run --no-sync git commit`, `uv run --no-sync git push`). Pre-commit hooks need the uv environment on `PATH` to run linters and formatters, but they do not need it re-synced: a bare `uv run` re-resolves the project first and can leave `uv.lock` dirty at the exact moment you are committing.
 - The committed root `uv.lock` is the source of truth for normal development and CI. Do not hand-edit it.
 - For Python dependency changes, edit the relevant `pyproject.toml`, run `uv lock`, and commit both files. Also run `uv lock` after changing the package name or version. Use `uv lock --upgrade-package <package>` for a targeted upgrade, `uv lock --upgrade` for a full compatible upgrade, and `uv lock --check` to verify consistency.
 - The dev/CI `[dependency-groups]` in the root `pyproject.toml` use bare package names because `uv.lock` owns the versions: do not add lower-bound floors, reserve exact `==` pins for tools we deliberately hold back, and add upper caps (`<`) only for versions known to break us (mirrored by `ignore` entries in `.github/dependabot.yml`); a `!=` exclusion of a single known-broken release needs no `ignore` entry. This does NOT apply to `lib/pyproject.toml`, whose version ranges are the published package's contract with users. See the comment above `[dependency-groups]` in the root `pyproject.toml` for details.
 - If `uv.lock` conflicts during a merge, restore it with `git checkout origin/develop -- uv.lock`, then run `uv lock`; never hand-merge it.
+- If `uv.lock` shows up modified when you did not touch any dependency, do not just restore it: your `uv` is below `[tool.uv] required-version` and is silently re-resolving the lock. uv reports this as a `Failed to parse pyproject.toml during settings discovery` warning, not an error, because the floor it violates is in the table it failed to parse. Run `./scripts/check_uv_version.py` to confirm, then `uv self update`.
 - For Python unit tests: `uv run pytest` commands are allowed and encouraged for running specific tests during development.
 - For E2E tests: `uv run pytest` commands targeting `e2e_playwright/` files are blocked by policy.
   Use `make run-e2e-test <filename>` instead.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -36,11 +36,12 @@
 
 - Prefer `make` targets for all dev tasks (tests, lint, format, builds).
 - Always use `uv run` to run any Python command (e.g. `uv run streamlit`, `uv run pytest`, `uv run ruff`, `uv run mypy`, etc.).
-- Always use `uv run` for git commands that trigger hooks (e.g. `uv run git commit`, `uv run git push`). Pre-commit hooks require the uv environment to run linters and formatters.
+- Use `uv run --no-sync` for git commands that trigger hooks (e.g. `uv run --no-sync git commit`, `uv run --no-sync git push`). Pre-commit hooks need the uv environment on `PATH` to run linters and formatters, but they do not need it re-synced: a bare `uv run` re-resolves the project first and can leave `uv.lock` dirty at the exact moment you are committing.
 - The committed root `uv.lock` is the source of truth for normal development and CI. Do not hand-edit it.
 - For Python dependency changes, edit the relevant `pyproject.toml`, run `uv lock`, and commit both files. Also run `uv lock` after changing the package name or version. Use `uv lock --upgrade-package <package>` for a targeted upgrade, `uv lock --upgrade` for a full compatible upgrade, and `uv lock --check` to verify consistency.
 - The dev/CI `[dependency-groups]` in the root `pyproject.toml` use bare package names because `uv.lock` owns the versions: do not add lower-bound floors, reserve exact `==` pins for tools we deliberately hold back, and add upper caps (`<`) only for versions known to break us (mirrored by `ignore` entries in `.github/dependabot.yml`); a `!=` exclusion of a single known-broken release needs no `ignore` entry. This does NOT apply to `lib/pyproject.toml`, whose version ranges are the published package's contract with users. See the comment above `[dependency-groups]` in the root `pyproject.toml` for details.
 - If `uv.lock` conflicts during a merge, restore it with `git checkout origin/develop -- uv.lock`, then run `uv lock`; never hand-merge it.
+- If `uv.lock` shows up modified when you did not touch any dependency, do not just restore it: your `uv` is below `[tool.uv] required-version` and is silently re-resolving the lock. uv reports this as a `Failed to parse pyproject.toml during settings discovery` warning, not an error, because the floor it violates is in the table it failed to parse. Run `./scripts/check_uv_version.py` to confirm, then `uv self update`.
 - For Python unit tests: `uv run pytest` commands are allowed and encouraged for running specific tests during development.
 - For E2E tests: `uv run pytest` commands targeting `e2e_playwright/` files are blocked by policy.
   Use `make run-e2e-test <filename>` instead.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,17 @@
 # the second commit should pass,
 # because the files were linted after trying to do the first commit.
 repos:
+  # Runs first, and on every commit: an older uv silently drops the whole
+  # `[tool.uv]` table (see scripts/check_uv_version.py) and rewrites `uv.lock`,
+  # which surfaces as the `uv-lock` hook below failing for no visible reason.
+  - repo: local
+    hooks:
+      - id: check-uv-version
+        name: Check uv version
+        entry: ./scripts/check_uv_version.py
+        language: system
+        always_run: true
+        pass_filenames: false
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # We fix ruff to a version to be in sync with pyproject.toml:
     rev: v0.16.5

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,11 +34,12 @@
 
 - Prefer `make` targets for all dev tasks (tests, lint, format, builds).
 - Always use `uv run` to run any Python command (e.g. `uv run streamlit`, `uv run pytest`, `uv run ruff`, `uv run mypy`, etc.).
-- Always use `uv run` for git commands that trigger hooks (e.g. `uv run git commit`, `uv run git push`). Pre-commit hooks require the uv environment to run linters and formatters.
+- Use `uv run --no-sync` for git commands that trigger hooks (e.g. `uv run --no-sync git commit`, `uv run --no-sync git push`). Pre-commit hooks need the uv environment on `PATH` to run linters and formatters, but they do not need it re-synced: a bare `uv run` re-resolves the project first and can leave `uv.lock` dirty at the exact moment you are committing.
 - The committed root `uv.lock` is the source of truth for normal development and CI. Do not hand-edit it.
 - For Python dependency changes, edit the relevant `pyproject.toml`, run `uv lock`, and commit both files. Also run `uv lock` after changing the package name or version. Use `uv lock --upgrade-package <package>` for a targeted upgrade, `uv lock --upgrade` for a full compatible upgrade, and `uv lock --check` to verify consistency.
 - The dev/CI `[dependency-groups]` in the root `pyproject.toml` use bare package names because `uv.lock` owns the versions: do not add lower-bound floors, reserve exact `==` pins for tools we deliberately hold back, and add upper caps (`<`) only for versions known to break us (mirrored by `ignore` entries in `.github/dependabot.yml`); a `!=` exclusion of a single known-broken release needs no `ignore` entry. This does NOT apply to `lib/pyproject.toml`, whose version ranges are the published package's contract with users. See the comment above `[dependency-groups]` in the root `pyproject.toml` for details.
 - If `uv.lock` conflicts during a merge, restore it with `git checkout origin/develop -- uv.lock`, then run `uv lock`; never hand-merge it.
+- If `uv.lock` shows up modified when you did not touch any dependency, do not just restore it: your `uv` is below `[tool.uv] required-version` and is silently re-resolving the lock. uv reports this as a `Failed to parse pyproject.toml during settings discovery` warning, not an error, because the floor it violates is in the table it failed to parse. Run `./scripts/check_uv_version.py` to confirm, then `uv self update`.
 - For Python unit tests: `uv run pytest` commands are allowed and encouraged for running specific tests during development.
 - For E2E tests: `uv run pytest` commands targeting `e2e_playwright/` files are blocked by policy.
   Use `make run-e2e-test <filename>` instead.

--- a/Makefile
+++ b/Makefile
@@ -159,6 +159,9 @@ python-init:
 		echo "Installing uv..."; \
 		pip install uv; \
 	fi
+	@# An older uv cannot parse `[tool.uv]` and silently discards all of it,
+	@# including the `required-version` floor meant to stop exactly that.
+	@./scripts/check_uv_version.py
 	@# Sync exactly one final dependency selection. uv otherwise includes dev by default.
 	@if [ "${PYTHON_DEPENDENCY_GROUP}" = "runtime" ]; then \
 		echo "Installing runtime dependencies..."; \
@@ -651,6 +654,9 @@ cli-smoke-tests:
 .PHONY: check
 # Run all checks (format, lint, types, unit tests) on changed files only. Useful to verify the current state of the codebase before committing.
 check:
+	@# Before any `uv run` below: an old uv rewrites `uv.lock` here, and the
+	@# `uv-lock` hook then fails on a file the user never touched.
+	@./scripts/check_uv_version.py
 	@echo "=== Checking changed files ==="
 	@CHANGED=$$(uv run python scripts/get_changed_files.py --all); \
 	if [ -z "$$CHANGED" ]; then \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,11 @@ dependencies = ["streamlit"]
 default-groups = ["dev"]
 # Keep this floor low enough for Dependabot's bundled uv.
 # Raise it when Dependabot ships a newer uv and we want a tighter floor.
+# NOTE: this floor cannot enforce itself. uv reads this whole table in one
+# settings-discovery pass, and `exclude-newer = "24 hours"` below is a form only
+# newer uv parses -- so an older uv discards this table entirely (warning, not
+# error) and re-resolves `uv.lock`. `scripts/check_uv_version.py` enforces the
+# floor from outside uv; keep them in sync.
 required-version = ">=0.11.8"
 # Resolve the development lock only for the currently supported Python range.
 environments = ["python_version < '3.15'"]

--- a/scripts/check_uv_version.py
+++ b/scripts/check_uv_version.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python
+
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Fail loudly when the local `uv` is older than the repo's `required-version`.
+
+`[tool.uv] required-version` cannot enforce itself. uv reads the whole
+`[tool.uv]` table in one "settings discovery" pass, and a value it does not
+understand takes the *entire table* down with a warning rather than an error.
+Our table contains `exclude-newer = "24 hours"`, a relative form only newer uv
+can parse, so on an older uv every setting is silently discarded --
+`required-version` included. uv then sees the lockfile's timestamp cutoff as
+removed, re-resolves from scratch, and rewrites `uv.lock`:
+
+    warning: Failed to parse `pyproject.toml` during settings discovery:
+      failed to parse year in date "24 hours": ...
+    Ignoring existing lockfile due to removal of timestamp cutoff
+
+The floor that exists to prevent this is disabled by the very key that needs
+it. This script closes that loop from outside uv, so the failure is an error
+with a fix in it instead of a warning nobody reads and a dirty `uv.lock`.
+
+Dropping the table also drops `environments` and `override-dependencies`, so
+the re-resolved lock is wrong on top of being noisy, and the 24h cooldown that
+`exclude-newer` exists to enforce is not applied at all.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+PRE_COMMIT_CONFIG = REPO_ROOT / ".pre-commit-config.yaml"
+
+# Bump instructions live next to `required-version` in pyproject.toml.
+INSTALL_HINT = (
+    "Fix it with:\n"
+    "    uv self update\n"
+    "or, if uv was not installed with the standalone installer:\n"
+    "    curl -LsSf https://astral.sh/uv/install.sh | sh"
+)
+
+
+def _release(version: str) -> tuple[int, ...]:
+    """Parse `0.11.8` into `(0, 11, 8)`, ignoring any pre-release suffix."""
+    match = re.match(r"\s*v?(\d+(?:\.\d+)*)", version)
+    if not match:
+        raise ValueError(f"cannot parse version: {version!r}")
+    return tuple(int(part) for part in match.group(1).split("."))
+
+
+def _pad(left: tuple[int, ...], right: tuple[int, ...]) -> tuple[tuple, tuple]:
+    width = max(len(left), len(right))
+    return (
+        left + (0,) * (width - len(left)),
+        right + (0,) * (width - len(right)),
+    )
+
+
+def _satisfies(version: str, specifier: str) -> bool:
+    """Evaluate a comma-separated PEP 440 style specifier without `packaging`.
+
+    `packaging` lives in the dev environment, and this check has to run *before*
+    that environment can be trusted -- an old uv is exactly how it gets built
+    wrong. Only the operators uv's `required-version` accepts are supported.
+    """
+    got = _release(version)
+    for raw_clause in specifier.split(","):
+        clause = raw_clause.strip()
+        if not clause:
+            continue
+        match = re.match(r"(>=|<=|==|!=|>|<)?\s*(.+)", clause)
+        if not match:
+            raise ValueError(f"cannot parse specifier clause: {clause!r}")
+        operator, want_raw = match.group(1) or "==", match.group(2)
+        want = _release(want_raw.rstrip(".*"))
+        left, right = _pad(got, want)
+        if operator == ">=" and not left >= right:
+            return False
+        if operator == ">" and not left > right:
+            return False
+        if operator == "<=" and not left <= right:
+            return False
+        if operator == "<" and not left < right:
+            return False
+        if operator == "==" and left != right:
+            return False
+        if operator == "!=" and left == right:
+            return False
+    return True
+
+
+def _required_version() -> str | None:
+    """Read `[tool.uv] required-version` from the root pyproject.toml.
+
+    tomllib is 3.11+; `make python-init` can run on an older interpreter, so
+    fall back to a line match rather than making the guard itself the thing
+    that breaks.
+    """
+    text = PYPROJECT.read_text(encoding="utf-8")
+    try:
+        import tomllib
+
+        return tomllib.loads(text).get("tool", {}).get("uv", {}).get("required-version")
+    except ImportError:
+        match = re.search(
+            r"^required-version\s*=\s*[\"'](.+?)[\"']", text, re.MULTILINE
+        )
+        return match.group(1) if match else None
+
+
+def _pre_commit_uv_rev() -> str | None:
+    """Read the pinned `astral-sh/uv-pre-commit` rev.
+
+    The `uv-lock` hook runs its own pinned uv, not the one on PATH, so it is a
+    second way an old uv can rewrite `uv.lock`.
+    """
+    text = PRE_COMMIT_CONFIG.read_text(encoding="utf-8")
+    match = re.search(
+        r"repo:\s*https://github\.com/astral-sh/uv-pre-commit\s*\n"
+        r"(?:\s*#.*\n)*"
+        r"\s*rev:\s*[\"']?v?([0-9][^\s\"']*)",
+        text,
+    )
+    return match.group(1) if match else None
+
+
+def _installed_version() -> str | None:
+    uv = shutil.which("uv")
+    if uv is None:
+        return None
+    result = subprocess.run(
+        [uv, "--version"], capture_output=True, text=True, check=False
+    )
+    match = re.search(r"(\d+\.\d+\.\d+)", result.stdout)
+    return match.group(1) if match else None
+
+
+def main() -> int:
+    required = _required_version()
+    if required is None:
+        print(
+            "error: could not find `[tool.uv] required-version` in pyproject.toml.\n"
+            "       If it was removed on purpose, drop this check too "
+            "(scripts/check_uv_version.py).",
+            file=sys.stderr,
+        )
+        return 1
+
+    installed = _installed_version()
+    if installed is None:
+        print(
+            "error: `uv` is not installed or did not report a version.\n"
+            + INSTALL_HINT,
+            file=sys.stderr,
+        )
+        return 1
+
+    failed = False
+
+    if not _satisfies(installed, required):
+        print(
+            f"error: uv {installed} does not satisfy the repo's required-version "
+            f"`{required}`.\n"
+            "\n"
+            "       uv will NOT tell you this itself. `required-version` lives in the\n"
+            '       same `[tool.uv]` table as `exclude-newer = "24 hours"`, which an\n'
+            "       older uv cannot parse -- so it discards the whole table (the\n"
+            "       version floor, `environments`, and `override-dependencies` with\n"
+            "       it), warns, then re-resolves and rewrites `uv.lock`.\n"
+            "\n"
+            "       Symptoms: a dirty `uv.lock` you did not touch, and the `uv-lock`\n"
+            '       pre-commit hook failing with "files were modified by this hook".\n'
+            "\n" + INSTALL_HINT,
+            file=sys.stderr,
+        )
+        failed = True
+
+    hook_rev = _pre_commit_uv_rev()
+    if hook_rev is None:
+        print(
+            "error: could not find the pinned `astral-sh/uv-pre-commit` rev in "
+            ".pre-commit-config.yaml.",
+            file=sys.stderr,
+        )
+        failed = True
+    elif not _satisfies(hook_rev, required):
+        print(
+            f"error: the `astral-sh/uv-pre-commit` rev pinned in "
+            f".pre-commit-config.yaml is {hook_rev}, which does not satisfy "
+            f"`{required}`.\n"
+            "       That hook owns `uv.lock`, and it runs its own pinned uv rather\n"
+            "       than the one on PATH -- so it would rewrite the lock on every\n"
+            "       commit. Raise the rev to a release that satisfies the floor.",
+            file=sys.stderr,
+        )
+        failed = True
+
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why

Agents and devs working in this repo keep hitting a dirty `uv.lock` they never touched, and the `uv-lock` pre-commit hook then fails with "files were modified by this hook". The standing workaround has been `git checkout origin/develop -- uv.lock`. Across my local agent transcripts that workaround shows up **732 times in 262 sessions**, alongside **506** uv settings-discovery warnings in 112 sessions.

The recurring explanation — "uv is under the repo's `>=0.11.8` floor" — has the causality backwards. The floor is not being violated and reported. **It is never evaluated.**

`[tool.uv] required-version` cannot enforce itself. uv reads the whole `[tool.uv]` table in a single settings-discovery pass, and `exclude-newer = "24 hours"` (the relative form added in #14581) is only parseable by newer uv. On an older uv the *entire table* is discarded — `required-version`, `environments`, and `override-dependencies` along with it — as a **warning, not an error**. uv then sees the lockfile's timestamp cutoff as removed, re-resolves from scratch, and rewrites `uv.lock`:

```
warning: Failed to parse `pyproject.toml` during settings discovery:
  failed to parse year in date "24 hours": failed to parse "24 h" as year ...
Ignoring existing lockfile due to removal of timestamp cutoff: `global: 0001-01-01T00:00:00Z`
```

The guard that exists to prevent this is disabled by the very key that requires it.

I reproduced it with a real uv 0.9.13 binary against current `develop`: 14 packages bumped, `uv.lock` **+713/−696**, and **exit 0**. Two consequences beyond the noise: the re-resolved lock is *wrong*, because `environments` and `override-dependencies` were dropped too; and the 24h supply-chain cooldown that `exclude-newer` exists to enforce is not applied at all, so the resolution pulls packages published inside the cooldown window.

Two things in the repo turned that latent breakage into commit-time pain, so this was not agents going off-script:

- `AGENTS.md` mandated `uv run git commit` / `uv run git push`. A bare `uv run` re-resolves the project first, so every commit and push ran a sync — surfacing the dirty lock at exactly the wrong moment.
- `make check` opens with `uv run python scripts/get_changed_files.py`, churning the lock before a single check runs. That is why `make check` reported `Changed files: uv.lock` and then failed the `uv-lock` hook on a file the author never edited.

## What

- **`scripts/check_uv_version.py`** — enforces the floor from outside uv, with the failure mode named in the error text so nobody has to re-derive it. Stdlib only (`tomllib` with a regex fallback for 3.10, and a small PEP 440 specifier evaluator instead of `packaging`), because this has to run *before* the dev environment can be trusted — an old uv is precisely how that environment gets built wrong. It reads the floor from `pyproject.toml` rather than hardcoding it, so the two cannot drift. It also checks the pinned `astral-sh/uv-pre-commit` rev, which owns `uv.lock` and runs its own uv rather than the one on `PATH`.
- **`.pre-commit-config.yaml`** — runs it as the first hook, `always_run`, ahead of the `uv-lock` hook it protects.
- **`Makefile`** — runs it in `python-init` (right after the existing `command -v uv` check) and at the top of `check`, before the opening `uv run` that used to churn the lock.
- **`AGENTS.md`** — `uv run --no-sync git commit` instead of a bare `uv run`. Hooks need the uv environment on `PATH`; they do not need it re-synced. This follows the precedent already in the Makefile at `python-integration-tests`, which documents the same `--no-sync` reasoning. Also replaces the "just restore the lock" reflex with the actual diagnosis, keeping the merge-conflict guidance intact.
- **`pyproject.toml`** — a note next to `required-version` explaining that it cannot self-enforce, so the next person to touch that table does not remove the external guard.

## Scope

No dependency, resolution, or `uv.lock` change. `pyproject.toml` gets a comment only; `exclude-newer = "24 hours"` is deliberately left alone, since reverting it to an absolute date would parse on old uv but throw away the rolling cooldown #14581 added on purpose. `.cursor/rules/overview.mdc` and `.github/copilot-instructions.md` are regenerated by `scripts/generate_agent_rules.py`.

I also considered moving `required-version` into a `uv.toml` so it parses independently of the broken key. That does not work: `uv.toml` *replaces* `[tool.uv]` wholesale rather than merging, so every setting would have to move and the unparseable key would take the new file down the same way.

## Testing

Verified against a real uv 0.9.13 standalone binary (downloaded to a scratch dir, kept off `PATH` except via an explicit shim) and uv 0.12.9:

- **Mechanism** — minimal repro and the real worktree both show the warning, the discarded table, and the rewritten lock at exit 0. Confirms `required-version` never fires.
- **`--no-sync`** — `uv run --no-sync git status` leaves `uv.lock` unchanged *even on the broken 0.9.13*, while bare `uv run git status` rewrites it. With no `.venv` present it degrades gracefully instead of erroring, so the new guidance is not a trap. This makes the AGENTS.md change a mitigation in its own right, independent of the version guard.
- **Preflight** — exit 0 on 0.12.9, exit 1 on 0.9.13. Nine evaluator cases covering minor and major rollover, comma-separated clauses, short forms, and pre-release suffixes. Both config parsers return the expected values (`>=0.11.8`, `0.12.6`).
- **`make check`** — with old uv on `PATH`: exit 2 at the preflight, before any `uv run`, with `uv.lock` still clean.
- **`pre-commit run check-uv-version`** — Failed on old uv, Passed on current. Full hook suite green on every changed file, including `uv-lock`, license headers, and the generated-agent-rules check.

Not verified: CI behavior on Linux runners, and Dependabot's bundled uv against the guard. Both should be unaffected, since the floor is unchanged and CI installs a modern uv, but I have not run either.
