### PR TITLE
[chore] Pin transitive fflate to patched 0.7.5

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,6 +44,7 @@
     "d3-color": "^3.1.0",
     "dompurify": "^3.2.4",
     "prismjs": "^1.30.0",
+    "fflate@npm:0.7.4": "^0.7.5",
     "@swc/core": "^1.16.1",
     "@typescript-eslint/utils": "^8.58.2",
     "@typescript-eslint/scope-manager": "^8.58.2",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -8237,10 +8237,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fflate@npm:0.7.4":
-  version: 0.7.4
-  resolution: "fflate@npm:0.7.4"
-  checksum: 10c0/5e749eb3a6ed61a0f6c55756abf9f4258f06f60505db689e22d18503dd252ca5af656d32668e4b7b20714adf8b313febf695d23863a8352f23e325baee0f672d
+"fflate@npm:^0.7.5":
+  version: 0.7.5
+  resolution: "fflate@npm:0.7.5"
+  checksum: 10c0/dd49302136bbe63d5e26a1e2ce7f2c9ff73a2c7eb591af433a20a4fd840e4914c7cad863945162067ec87dd871baa9250b755d06650f59c86b2d72dde4042f58
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Describe your changes

Pins `fflate` 0.7.4 → 0.7.5, clearing [Dependabot alert #429](https://github.com/streamlit/streamlit/security/dependabot/429) (CVE-2026-45820 / GHSA-px8p-9vwx-vf98 — infinite loop in `unzipSync()` on a malformed ZIP64 archive).

Follows #16748: another transitive package Dependabot flagged but cannot open a PR for. `@loaders.gl/compression` (via `@deck.gl`) pins `fflate` to the exact string `0.7.4`, so no range can climb out of it, and the latest `@loaders.gl/compression` 4.4.5 still pins `0.7.4` — a yarn resolution is the only mechanism available.

- Stays inside the 0.7 line (`^0.7.5`) rather than jumping to `^0.8.3`: the patch is all that's needed, with no API-change risk in a package we don't control.
- Not exploitable here, so this is alert hygiene rather than an urgent fix. `@loaders.gl/compression` declares `fflate` but never imports it — its own `package.json` is the only reference anywhere in the package. Nothing else in the deck.gl / luma.gl stack or in Streamlit imports it, `unzipSync` is never called, and `fflate` does not appear in the built bundle.
- Pinned rather than dismissed as not-used (the route #16748 took for `image-size`) because a patched release exists here, making the pin cheaper than a dismissal someone has to re-justify later.

## GitHub Issue Link (if applicable)

Dependabot alert [#429](https://github.com/streamlit/streamlit/security/dependabot/429) (CVE-2026-45820 / GHSA-px8p-9vwx-vf98)

## Testing Plan

Lockfile-only Yarn resolution. No application code or tests changed.

Verified `yarn install --immutable` passes with a single `fflate@npm:^0.7.5` → `0.7.5` lock entry, `node_modules/fflate` reports `0.7.5`, `make frontend-fast` builds, and the `Check frontend yarn.lock dedupe` pre-commit hook passes.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

