### PR TITLE
[fix] Expose st.radio captions as option descriptions

### DIFF
--- a/e2e_playwright/st_radio.py
+++ b/e2e_playwright/st_radio.py
@@ -23,7 +23,7 @@ markdown_options = (
     "*italics text*",
     "~strikethrough text~",
     "shortcode: :blush:",
-    # link should not work when used as an option label (it does work in a caption)
+    # Links in option labels are non-navigable; caption links can navigate.
     "[link text](www.example.com)",
     "`code text`",
     ":red[red] :blue[blue] :green[green] :violet[violet] :orange[orange]",

--- a/e2e_playwright/st_radio.py
+++ b/e2e_playwright/st_radio.py
@@ -23,7 +23,7 @@ markdown_options = (
     "*italics text*",
     "~strikethrough text~",
     "shortcode: :blush:",
-    # link should not work in radio options
+    # link should not work when used as an option label (it does work in a caption)
     "[link text](www.example.com)",
     "`code text`",
     ":red[red] :blue[blue] :green[green] :violet[violet] :orange[orange]",

--- a/e2e_playwright/st_radio_test.py
+++ b/e2e_playwright/st_radio_test.py
@@ -114,7 +114,7 @@ def test_help_tooltip_works(app: Page):
     expect_help_tooltip(app, element_with_help, "help text")
 
 
-def test_captions_describe_options_without_being_click_targets(app: Page):
+def test_captions_are_option_descriptions_not_labels(app: Page):
     """Captions reach assistive tech as descriptions, not as part of the name."""
     with_captions = get_radio(app, "radio 10 (with captions)")
 
@@ -135,34 +135,36 @@ def test_captions_describe_options_without_being_click_targets(app: Page):
     )
 
     # The caption is reachable instead through aria-describedby.
-    option_a = get_radio_option(with_captions, "A").locator("input")
+    option_a = get_radio_option(with_captions, "A").get_by_role("radio")
     caption_a = with_captions.get_by_test_id("stRadioCaption").filter(
         has_text="bold text"
     )
     expect(caption_a).to_have_text("bold text")
+    expect(caption_a).to_have_attribute("id", re.compile(r"\S"))
+    caption_id = caption_a.get_attribute("id")
+    assert caption_id is not None  # narrowed for the type checker
     # Match the caption's id as one entry rather than the whole value, so a
     # group-level description added later cannot break this.
-    caption_id = re.escape(caption_a.get_attribute("id") or "")
     expect(option_a).to_have_attribute(
-        "aria-describedby", re.compile(rf"(^|\s){caption_id}(\s|$)")
+        "aria-describedby", re.compile(rf"(^|\s){re.escape(caption_id)}(\s|$)")
     )
 
     # An empty caption must not point the description at blank content.
     horizontal = get_radio(app, "radio 11 (horizontal, captions)")
     # "maybe" is the option whose caption is "".
-    no_caption = get_radio_option(horizontal, "maybe").locator("input")
+    no_caption = get_radio_option(horizontal, "maybe").get_by_role("radio")
     expect(no_caption).not_to_have_attribute("aria-describedby")
 
     # A sibling in the same group still gets one, so the check above is not just
     # observing a group-wide absence.
-    with_caption = get_radio_option(horizontal, "yes").locator("input")
+    with_caption = get_radio_option(horizontal, "yes").get_by_role("radio")
     expect(with_caption).to_have_attribute("aria-describedby", re.compile(r"\S"))
 
     # The caption is not a click target: it is supplementary text outside the
     # label, so clicking it must leave the selection alone. Assert the input's
     # checked state, not the written value: a regression would trigger a rerun,
     # during which the value still reads "A".
-    option_b = get_radio_option(with_captions, "B").locator("input")
+    option_b = get_radio_option(with_captions, "B").get_by_role("radio")
     with_captions.get_by_text("italics text").click()
     expect(option_b).not_to_be_checked()
     expect(option_a).to_be_checked()
@@ -173,13 +175,23 @@ def test_captions_describe_options_without_being_click_targets(app: Page):
     wait_for_app_run(app)
     expect(option_b).to_be_checked()
 
-    # A link in a caption is a real anchor. Inside the label React Aria's
-    # preventDefault cancelled its navigation; outside it, nothing does.
-    expect(
-        with_captions.get_by_test_id("stRadioCaption").get_by_role(
-            "link", name="link text"
-        )
-    ).to_have_attribute("href", re.compile(r"example\.com"))
+    # Caption links stay navigable because captions sit outside the option label,
+    # where React Aria cancels clicks. Assert the click survives uncancelled
+    # rather than the href, which would pass even when navigation is blocked.
+    # Reads defaultPrevented on document, after React's delegated handlers, then
+    # suppresses the navigation itself — the same trick st_link_button_test.py
+    # uses to avoid flaky popups.
+    caption_link = with_captions.get_by_test_id("stRadioCaption").get_by_role(
+        "link", name="link text"
+    )
+    app.evaluate(
+        "() => document.addEventListener('click', e => {"
+        "  window.__captionLinkPrevented = e.defaultPrevented;"
+        "  e.preventDefault();"
+        "}, {once: true})"
+    )
+    caption_link.click()
+    assert app.evaluate("() => window.__captionLinkPrevented") is False
 
     # Caption and option text are both selectable: neither carries a user-select
     # rule. Check option A, not the B just clicked — react-aria's usePress sets

--- a/e2e_playwright/st_radio_test.py
+++ b/e2e_playwright/st_radio_test.py
@@ -114,7 +114,7 @@ def test_help_tooltip_works(app: Page):
     expect_help_tooltip(app, element_with_help, "help text")
 
 
-def test_captions_are_option_descriptions(app: Page):
+def test_captions_describe_options_without_being_click_targets(app: Page):
     """Captions reach assistive tech as descriptions, not as part of the name."""
     with_captions = get_radio(app, "radio 10 (with captions)")
 
@@ -136,11 +136,12 @@ def test_captions_are_option_descriptions(app: Page):
 
     # The caption is reachable instead through aria-describedby.
     option_a = get_radio_option(with_captions, "A").locator("input")
-    caption_a = with_captions.get_by_test_id("stRadioCaption").first
+    caption_a = with_captions.get_by_test_id("stRadioCaption").filter(
+        has_text="bold text"
+    )
     expect(caption_a).to_have_text("bold text")
-    # React Aria joins several ids into aria-describedby (group description,
-    # error message), so match the caption's id as one entry rather than the
-    # whole value.
+    # Match the caption's id as one entry rather than the whole value, so a
+    # group-level description added later cannot break this.
     caption_id = re.escape(caption_a.get_attribute("id") or "")
     expect(option_a).to_have_attribute(
         "aria-describedby", re.compile(rf"(^|\s){caption_id}(\s|$)")
@@ -150,26 +151,41 @@ def test_captions_are_option_descriptions(app: Page):
     horizontal = get_radio(app, "radio 11 (horizontal, captions)")
     # "maybe" is the option whose caption is "".
     no_caption = get_radio_option(horizontal, "maybe").locator("input")
-    # ".*" matches any present value, so this passes only when absent.
-    expect(no_caption).not_to_have_attribute("aria-describedby", re.compile(r".*"))
+    expect(no_caption).not_to_have_attribute("aria-describedby")
 
     # A sibling in the same group still gets one, so the check above is not just
     # observing a group-wide absence.
     with_caption = get_radio_option(horizontal, "yes").locator("input")
     expect(with_caption).to_have_attribute("aria-describedby", re.compile(r"\S"))
 
-    # Clicking a caption selects its option. The caption sits outside the label,
-    # so this comes from an explicit handler rather than label semantics.
-    # Done last because it changes the app's state.
-    #
-    # The handler also ignores a click that ends a text selection. That is not
-    # asserted here: synthetic mouse events do not drive native text selection in
-    # headless Chromium (a stepped drag across the caption leaves getSelection()
-    # empty), and a Range set from script is collapsed by mousedown before the
-    # click arrives. Radio.test.tsx covers it by stubbing getSelection instead.
+    # The caption is not a click target: it is supplementary text outside the
+    # label, so clicking it must leave the selection alone. Assert the input's
+    # checked state, not the written value: a regression would trigger a rerun,
+    # during which the value still reads "A".
+    option_b = get_radio_option(with_captions, "B").locator("input")
     with_captions.get_by_text("italics text").click()
+    expect(option_b).not_to_be_checked()
+    expect(option_a).to_be_checked()
+
+    # Clicking the label right above it does select, which proves the page was
+    # live and the caption click was ignored rather than merely not seen yet.
+    get_radio_option(with_captions, "B").click()
     wait_for_app_run(app)
-    expect_markdown(app, "value 10: B")
+    expect(option_b).to_be_checked()
+
+    # A link in a caption is a real anchor. Inside the label React Aria's
+    # preventDefault cancelled its navigation; outside it, nothing does.
+    expect(
+        with_captions.get_by_test_id("stRadioCaption").get_by_role(
+            "link", name="link text"
+        )
+    ).to_have_attribute("href", re.compile(r"example\.com"))
+
+    # Caption and option text are both selectable: neither carries a user-select
+    # rule. Check option A, not the B just clicked — react-aria's usePress sets
+    # `user-select: none` inline on a pressed label and clears it after pointer-up.
+    expect(caption_a).not_to_have_css("user-select", "none")
+    expect(get_radio_option(with_captions, "A")).not_to_have_css("user-select", "none")
 
 
 def test_radio_has_correct_default_values(app: Page):

--- a/e2e_playwright/st_radio_test.py
+++ b/e2e_playwright/st_radio_test.py
@@ -114,6 +114,64 @@ def test_help_tooltip_works(app: Page):
     expect_help_tooltip(app, element_with_help, "help text")
 
 
+def test_captions_are_option_descriptions(app: Page):
+    """Captions reach assistive tech as descriptions, not as part of the name."""
+    with_captions = get_radio(app, "radio 10 (with captions)")
+
+    # The accessible name is the option text alone. Captions also render as
+    # sibling nodes, which this snapshot deliberately leaves unpinned: the
+    # contract under test is the names, not how caption markdown nests.
+    expect(with_captions).to_match_aria_snapshot(
+        """
+        - radiogroup "radio 10 (with captions)":
+          - radio "A" [checked]
+          - radio "B"
+          - radio "C"
+          - radio "D"
+          - radio "E"
+          - radio "F"
+          - radio "G"
+        """
+    )
+
+    # The caption is reachable instead through aria-describedby.
+    option_a = get_radio_option(with_captions, "A").locator("input")
+    caption_a = with_captions.get_by_test_id("stRadioCaption").first
+    expect(caption_a).to_have_text("bold text")
+    # React Aria joins several ids into aria-describedby (group description,
+    # error message), so match the caption's id as one entry rather than the
+    # whole value.
+    caption_id = re.escape(caption_a.get_attribute("id") or "")
+    expect(option_a).to_have_attribute(
+        "aria-describedby", re.compile(rf"(^|\s){caption_id}(\s|$)")
+    )
+
+    # An empty caption must not point the description at blank content.
+    horizontal = get_radio(app, "radio 11 (horizontal, captions)")
+    # "maybe" is the option whose caption is "".
+    no_caption = get_radio_option(horizontal, "maybe").locator("input")
+    # ".*" matches any present value, so this passes only when absent.
+    expect(no_caption).not_to_have_attribute("aria-describedby", re.compile(r".*"))
+
+    # A sibling in the same group still gets one, so the check above is not just
+    # observing a group-wide absence.
+    with_caption = get_radio_option(horizontal, "yes").locator("input")
+    expect(with_caption).to_have_attribute("aria-describedby", re.compile(r"\S"))
+
+    # Clicking a caption selects its option. The caption sits outside the label,
+    # so this comes from an explicit handler rather than label semantics.
+    # Done last because it changes the app's state.
+    #
+    # The handler also ignores a click that ends a text selection. That is not
+    # asserted here: synthetic mouse events do not drive native text selection in
+    # headless Chromium (a stepped drag across the caption leaves getSelection()
+    # empty), and a Range set from script is collapsed by mousedown before the
+    # click arrives. Radio.test.tsx covers it by stubbing getSelection instead.
+    with_captions.get_by_text("italics text").click()
+    wait_for_app_run(app)
+    expect_markdown(app, "value 10: B")
+
+
 def test_radio_has_correct_default_values(app: Page):
     """Verify initial markdown values using helper."""
     expect_markdown(app, "value 1: female")
@@ -179,8 +237,8 @@ def test_set_value_correctly_when_click(app: Page):
     # radio 9 (markdown options) -> italics text
     select_radio_option(app, option="italics text", label="radio 9 (markdown options)")
 
-    # radio 10 (with captions) -> B (match at start to avoid caption text)
-    select_radio_option(app, option=re.compile(r"^B"), label="radio 10 (with captions)")
+    # radio 10 (with captions) -> B
+    select_radio_option(app, option="B", label="radio 10 (with captions)")
 
     # radio 11 (horizontal, captions) -> maybe
     select_radio_option(app, option="maybe", label="radio 11 (horizontal, captions)")

--- a/e2e_playwright/st_radio_test.py
+++ b/e2e_playwright/st_radio_test.py
@@ -184,6 +184,8 @@ def test_captions_are_option_descriptions_not_labels(app: Page):
     caption_link = with_captions.get_by_test_id("stRadioCaption").get_by_role(
         "link", name="link text"
     )
+    # Seeded so a probe that never runs is distinguishable from a cancelled click.
+    app.evaluate("() => { window.__captionLinkPrevented = 'listener never fired' }")
     app.evaluate(
         "() => document.addEventListener('click', e => {"
         "  window.__captionLinkPrevented = e.defaultPrevented;"

--- a/frontend/lib/src/components/shared/Radio/Radio.test.tsx
+++ b/frontend/lib/src/components/shared/Radio/Radio.test.tsx
@@ -14,13 +14,16 @@
  * limitations under the License.
  */
 
-import { screen } from "@testing-library/react"
+import { screen, within } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 
 import { render } from "~lib/test_util"
+import { lightTheme } from "~lib/theme/themeConfigs"
 import { LabelVisibilityOptions } from "~lib/util/utils"
 
 import Radio, { Props } from "./Radio"
+
+const { bodyText, fadedText40 } = lightTheme.emotion.colors
 
 const getProps = (props: Partial<Props> = {}): Props => ({
   disabled: false,
@@ -123,10 +126,194 @@ describe("Radio widget", () => {
     const props = getProps({ captions: ["caption1", "", "caption2"] })
     render(<Radio {...props} />)
 
-    expect(screen.getAllByTestId("stCaptionContainer")).toHaveLength(3)
+    // A blank caption renders nothing, so it cannot claim the description slot
+    // and point aria-describedby at empty content.
+    expect(screen.getAllByTestId("stCaptionContainer")).toHaveLength(2)
 
-    expect(screen.getByText("caption1")).toBeInTheDocument()
-    expect(screen.getByText("caption2")).toBeInTheDocument()
+    expect(screen.getByText("caption1")).toBeVisible()
+    expect(screen.getByText("caption2")).toBeVisible()
+  })
+
+  it("exposes a caption as the option's accessible description", () => {
+    const props = getProps({ captions: ["fast", "slow", "medium"] })
+    render(<Radio {...props} />)
+
+    expect(screen.getAllByRole("radio")[0]).toHaveAccessibleDescription("fast")
+  })
+
+  it("keeps a caption out of the option's accessible name", () => {
+    const props = getProps({ captions: ["fast", "slow", "medium"] })
+    render(<Radio {...props} />)
+
+    // Separate from the description assertion above so that a caption leaking
+    // back into the name fails on its own rather than being masked by it.
+    expect(screen.getAllByRole("radio")[0]).toHaveAccessibleName("a")
+  })
+
+  it("reserves caption space in horizontal groups without describing the option", () => {
+    const props = getProps({
+      horizontal: true,
+      captions: ["Opt in", "", "Opt out"],
+    })
+    render(<Radio {...props} />)
+
+    // The spacer keeps partially-captioned horizontal rows aligned, so it has
+    // to render content — but it must stay out of the accessible tree rather
+    // than becoming a blank description.
+    const spacer = screen.getByTestId("stRadioSpacer")
+    expect(spacer).toHaveAttribute("aria-hidden", "true")
+    expect(screen.getAllByRole("radio")[1]).not.toHaveAccessibleDescription()
+  })
+
+  it("renders no caption spacer in vertical groups", () => {
+    const props = getProps({ horizontal: false, captions: ["Opt in", "", ""] })
+    render(<Radio {...props} />)
+
+    // Vertical rows stack from the top, so nothing needs its space reserved.
+    expect(screen.queryByTestId("stRadioSpacer")).not.toBeInTheDocument()
+  })
+
+  it.each([
+    { disabled: true, color: fadedText40, cursor: "not-allowed" },
+    { disabled: false, color: bodyText, cursor: "pointer" },
+  ])(
+    "dims text and sets the click cursors when disabled=$disabled",
+    ({ disabled, color, cursor }) => {
+      const props = getProps({
+        disabled,
+        captions: ["fast", "slow", "medium"],
+      })
+      render(<Radio {...props} />)
+
+      // The field's data-disabled rule sets the colour that both the option text
+      // and the caption inherit. The label and the caption are each clickable,
+      // so both carry the cursor themselves.
+      expect(screen.getAllByTestId("stCaptionContainer")[0]).toHaveStyle({
+        color,
+      })
+      // Scoped to the option: the widget label also renders a markdown
+      // container, and it gets these colours from StyledWidgetLabel instead.
+      expect(
+        within(screen.getAllByTestId("stRadioOption")[0]).getByTestId(
+          "stMarkdownContainer"
+        )
+      ).toHaveStyle({ color })
+      expect(screen.getAllByTestId("stRadioOption")[0]).toHaveStyle({ cursor })
+      expect(screen.getAllByTestId("stRadioCaption")[0]).toHaveStyle({
+        cursor,
+      })
+    }
+  )
+
+  it("selects an option when its caption is clicked", async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    const props = getProps({
+      onChange,
+      value: 0,
+      captions: ["fast", "slow", "medium"],
+    })
+    render(<Radio {...props} />)
+    const radioOptions = screen.getAllByRole("radio")
+
+    // The caption sits outside the label, so this click target comes from an
+    // explicit handler rather than from label semantics.
+    await user.click(screen.getByText("slow"))
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith(1)
+    expect(radioOptions[1]).toBeChecked()
+    expect(radioOptions[0]).not.toBeChecked()
+    // Focus has to land on the input, as it does when the label is clicked, or
+    // arrow keys do nothing until the user tabs back into the group.
+    expect(radioOptions[1]).toHaveFocus()
+  })
+
+  it("does not fire onChange when the selected option's caption is clicked", async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    const props = getProps({
+      onChange,
+      value: 1,
+      captions: ["fast", "slow", "medium"],
+    })
+    render(<Radio {...props} />)
+
+    // React Aria drops a no-op selection on the label, so the caption must too:
+    // otherwise this reruns the script and dirties an enclosing form for a click
+    // that changes nothing.
+    await user.click(screen.getByText("slow"))
+
+    expect(onChange).not.toHaveBeenCalled()
+    expect(screen.getAllByRole("radio")[1]).toBeChecked()
+  })
+
+  it("does not select an option when a click ends a text selection", async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    const props = getProps({
+      onChange,
+      value: 0,
+      captions: ["fast", "slow", "medium"],
+    })
+    render(<Radio {...props} />)
+
+    // Dragging across caption text ends in a click, which must not also answer
+    // the question. jsdom has no real selection, so report a live one.
+    const selection = { isCollapsed: false } as Selection
+    const getSelectionSpy = vi
+      .spyOn(window, "getSelection")
+      .mockReturnValue(selection)
+
+    await user.click(screen.getByText("slow"))
+
+    expect(onChange).not.toHaveBeenCalled()
+    expect(screen.getAllByRole("radio")[1]).not.toBeChecked()
+
+    // With the selection collapsed again, the same click does select.
+    getSelectionSpy.mockReturnValue({ isCollapsed: true } as Selection)
+    await user.click(screen.getByText("slow"))
+
+    expect(onChange).toHaveBeenCalledWith(1)
+    getSelectionSpy.mockRestore()
+  })
+
+  it("does not select an option when a disabled caption is clicked", async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    const props = getProps({
+      onChange,
+      disabled: true,
+      captions: ["fast", "slow", "medium"],
+    })
+    render(<Radio {...props} />)
+
+    await user.click(screen.getByText("slow"))
+
+    expect(onChange).not.toHaveBeenCalled()
+    expect(screen.getAllByRole("radio")[1]).not.toBeChecked()
+  })
+
+  it("treats options past the end of captions as having no caption", () => {
+    // `st.radio` does not require captions to be as long as options, so an
+    // out-of-range read must not describe the option with empty content.
+    const props = getProps({ captions: ["only one"] })
+    render(<Radio {...props} />)
+    const radioOptions = screen.getAllByRole("radio")
+
+    expect(radioOptions[0]).toHaveAccessibleDescription("only one")
+    expect(radioOptions[1]).not.toHaveAccessibleDescription()
+    expect(radioOptions[2]).not.toHaveAccessibleDescription()
+    expect(screen.getAllByTestId("stCaptionContainer")).toHaveLength(1)
+  })
+
+  it("gives an option with a blank caption no description", () => {
+    const props = getProps({ captions: ["fast", "", "medium"] })
+    render(<Radio {...props} />)
+    const radioOptions = screen.getAllByRole("radio")
+
+    expect(radioOptions[1]).not.toHaveAccessibleDescription()
+    expect(radioOptions[1]).toHaveAccessibleName("b")
   })
 
   it("has the correct captions", () => {

--- a/frontend/lib/src/components/shared/Radio/Radio.test.tsx
+++ b/frontend/lib/src/components/shared/Radio/Radio.test.tsx
@@ -122,6 +122,29 @@ describe("Radio widget", () => {
     expect(screen.queryAllByTestId("stCaptionContainer")).toHaveLength(0)
   })
 
+  it.each([true, false])(
+    "describes only the captioned options when some are skipped, horizontal=%s",
+    horizontal => {
+      const props = getProps({
+        horizontal,
+        options: ["o1", "o2", "o3", "o4"],
+        captions: ["c1", "c2", "", "c4"],
+      })
+      render(<Radio {...props} />)
+      const radioOptions = screen.getAllByRole("radio")
+
+      expect(screen.getAllByTestId("stRadioCaption")).toHaveLength(3)
+      expect(radioOptions[0]).toHaveAccessibleDescription("c1")
+      expect(radioOptions[2]).not.toHaveAccessibleDescription()
+      expect(radioOptions[3]).toHaveAccessibleDescription("c4")
+
+      // Only the horizontal layout reserves the skipped option's caption line.
+      expect(screen.queryAllByTestId("stRadioCaptionSpacer")).toHaveLength(
+        horizontal ? 1 : 0
+      )
+    }
+  )
+
   it("skips blank captions", () => {
     const props = getProps({ captions: ["caption1", "", "caption2"] })
     render(<Radio {...props} />)
@@ -161,6 +184,22 @@ describe("Radio widget", () => {
     const spacer = screen.getByTestId("stRadioCaptionSpacer")
     expect(spacer).toHaveAttribute("aria-hidden", "true")
     expect(screen.getAllByRole("radio")[1]).not.toHaveAccessibleDescription()
+  })
+
+  it("ignores captions past the last option when reserving space", () => {
+    const props = getProps({
+      horizontal: true,
+      options: ["a"],
+      captions: ["", "unused"],
+    })
+    render(<Radio {...props} />)
+
+    // "unused" is never rendered, so it must not make the group reserve caption
+    // space for a caption that no option shows.
+    expect(
+      screen.queryByTestId("stRadioCaptionSpacer")
+    ).not.toBeInTheDocument()
+    expect(screen.queryAllByTestId("stRadioCaption")).toHaveLength(0)
   })
 
   it("renders neither captions nor spacers when every caption is blank", () => {

--- a/frontend/lib/src/components/shared/Radio/Radio.test.tsx
+++ b/frontend/lib/src/components/shared/Radio/Radio.test.tsx
@@ -149,19 +149,28 @@ describe("Radio widget", () => {
     const props = getProps({ captions: ["caption1", "", "caption2"] })
     render(<Radio {...props} />)
 
-    // A blank caption renders nothing, so it cannot claim the description slot
-    // and point aria-describedby at empty content.
-    expect(screen.getAllByTestId("stCaptionContainer")).toHaveLength(2)
+    // Counts the caption element, not StreamlitMarkdown's container: a spacer
+    // renders caption-styled markdown too.
+    expect(screen.getAllByTestId("stRadioCaption")).toHaveLength(2)
 
     expect(screen.getByText("caption1")).toBeVisible()
     expect(screen.getByText("caption2")).toBeVisible()
   })
 
-  it("exposes a caption as the option's accessible description", () => {
-    const props = getProps({ captions: ["fast", "slow", "medium"] })
+  it("describes an option with the caption's rendered text, not its markdown", () => {
+    const props = getProps({ captions: ["**fast**", "slow", "medium"] })
     render(<Radio {...props} />)
 
     expect(screen.getAllByRole("radio")[0]).toHaveAccessibleDescription("fast")
+  })
+
+  it("leaves captions inert when there are no options", () => {
+    const props = getProps({ options: [], captions: ["hi"] })
+    render(<Radio {...props} />)
+
+    // The placeholder option is ours, not the user's, so nothing captions it.
+    expect(screen.queryAllByTestId("stRadioCaption")).toHaveLength(0)
+    expect(screen.getAllByRole("radio")[0]).not.toHaveAccessibleDescription()
   })
 
   it("keeps a caption out of the option's accessible name", () => {
@@ -213,16 +222,6 @@ describe("Radio widget", () => {
     ).not.toBeInTheDocument()
     expect(screen.queryAllByTestId("stRadioCaption")).toHaveLength(0)
     expect(screen.getAllByRole("radio")[0]).not.toHaveAccessibleDescription()
-  })
-
-  it("renders no caption spacer in vertical groups", () => {
-    const props = getProps({ horizontal: false, captions: ["Opt in", "", ""] })
-    render(<Radio {...props} />)
-
-    // Vertical rows stack from the top, so nothing needs its space reserved.
-    expect(
-      screen.queryByTestId("stRadioCaptionSpacer")
-    ).not.toBeInTheDocument()
   })
 
   it.each([
@@ -284,30 +283,26 @@ describe("Radio widget", () => {
     expect(screen.getAllByTestId("stCaptionContainer")).toHaveLength(1)
   })
 
-  it("gives an option with a blank caption no description", () => {
-    const props = getProps({ captions: ["fast", "", "medium"] })
-    render(<Radio {...props} />)
-    const radioOptions = screen.getAllByRole("radio")
+  it.each(["", " "])(
+    "gives an option no description when its caption is %j",
+    blank => {
+      const props = getProps({ captions: ["fast", blank, "medium"] })
+      render(<Radio {...props} />)
+      const radioOptions = screen.getAllByRole("radio")
 
-    expect(radioOptions[1]).not.toHaveAccessibleDescription()
-    expect(radioOptions[1]).toHaveAccessibleName("b")
-  })
-
-  it("ignores a whitespace-only caption", () => {
-    const props = getProps({ captions: [" ", "slow", "medium"] })
-    render(<Radio {...props} />)
-
-    // Python preserves whitespace strings, which would otherwise claim the
-    // description slot and describe the option with nothing.
-    expect(screen.getAllByRole("radio")[0]).not.toHaveAccessibleDescription()
-    expect(screen.queryAllByTestId("stRadioCaption")).toHaveLength(2)
-  })
+      // The backend passes whitespace through unchanged, so both spellings of
+      // "no caption" must stay out of aria-describedby.
+      expect(radioOptions[1]).not.toHaveAccessibleDescription()
+      expect(radioOptions[1]).toHaveAccessibleName("b")
+      expect(screen.getAllByTestId("stRadioCaption")).toHaveLength(2)
+    }
+  )
 
   it("has the correct captions", () => {
     const props = getProps({ captions: ["caption1", "caption2", "caption3"] })
     render(<Radio {...props} />)
 
-    expect(screen.getAllByTestId("stCaptionContainer")).toHaveLength(3)
+    expect(screen.getAllByTestId("stRadioCaption")).toHaveLength(3)
 
     props.captions.forEach(caption => {
       expect(screen.getByText(caption)).toBeInTheDocument()

--- a/frontend/lib/src/components/shared/Radio/Radio.test.tsx
+++ b/frontend/lib/src/components/shared/Radio/Radio.test.tsx
@@ -122,7 +122,7 @@ describe("Radio widget", () => {
     expect(screen.queryAllByTestId("stCaptionContainer")).toHaveLength(0)
   })
 
-  it("renders non-blank captions", () => {
+  it("skips blank captions", () => {
     const props = getProps({ captions: ["caption1", "", "caption2"] })
     render(<Radio {...props} />)
 
@@ -145,8 +145,6 @@ describe("Radio widget", () => {
     const props = getProps({ captions: ["fast", "slow", "medium"] })
     render(<Radio {...props} />)
 
-    // Separate from the description assertion above so that a caption leaking
-    // back into the name fails on its own rather than being masked by it.
     expect(screen.getAllByRole("radio")[0]).toHaveAccessibleName("a")
   })
 
@@ -160,9 +158,22 @@ describe("Radio widget", () => {
     // The spacer keeps partially-captioned horizontal rows aligned, so it has
     // to render content — but it must stay out of the accessible tree rather
     // than becoming a blank description.
-    const spacer = screen.getByTestId("stRadioSpacer")
+    const spacer = screen.getByTestId("stRadioCaptionSpacer")
     expect(spacer).toHaveAttribute("aria-hidden", "true")
     expect(screen.getAllByRole("radio")[1]).not.toHaveAccessibleDescription()
+  })
+
+  it("renders neither captions nor spacers when every caption is blank", () => {
+    const props = getProps({ horizontal: true, captions: ["", " ", ""] })
+    render(<Radio {...props} />)
+
+    // Captioning only some options is supported, but when none of them actually
+    // has one there is nothing to reserve space for.
+    expect(
+      screen.queryByTestId("stRadioCaptionSpacer")
+    ).not.toBeInTheDocument()
+    expect(screen.queryAllByTestId("stRadioCaption")).toHaveLength(0)
+    expect(screen.getAllByRole("radio")[0]).not.toHaveAccessibleDescription()
   })
 
   it("renders no caption spacer in vertical groups", () => {
@@ -170,14 +181,16 @@ describe("Radio widget", () => {
     render(<Radio {...props} />)
 
     // Vertical rows stack from the top, so nothing needs its space reserved.
-    expect(screen.queryByTestId("stRadioSpacer")).not.toBeInTheDocument()
+    expect(
+      screen.queryByTestId("stRadioCaptionSpacer")
+    ).not.toBeInTheDocument()
   })
 
   it.each([
     { disabled: true, color: fadedText40, cursor: "not-allowed" },
     { disabled: false, color: bodyText, cursor: "pointer" },
   ])(
-    "dims text and sets the click cursors when disabled=$disabled",
+    "dims option text and caption together and sets the label cursor when disabled=$disabled",
     ({ disabled, color, cursor }) => {
       const props = getProps({
         disabled,
@@ -186,8 +199,7 @@ describe("Radio widget", () => {
       render(<Radio {...props} />)
 
       // The field's data-disabled rule sets the colour that both the option text
-      // and the caption inherit. The label and the caption are each clickable,
-      // so both carry the cursor themselves.
+      // and the caption inherit; the label keeps its own cursor rule.
       expect(screen.getAllByTestId("stCaptionContainer")[0]).toHaveStyle({
         color,
       })
@@ -199,56 +211,10 @@ describe("Radio widget", () => {
         )
       ).toHaveStyle({ color })
       expect(screen.getAllByTestId("stRadioOption")[0]).toHaveStyle({ cursor })
-      expect(screen.getAllByTestId("stRadioCaption")[0]).toHaveStyle({
-        cursor,
-      })
     }
   )
 
-  it("selects an option when its caption is clicked", async () => {
-    const user = userEvent.setup()
-    const onChange = vi.fn()
-    const props = getProps({
-      onChange,
-      value: 0,
-      captions: ["fast", "slow", "medium"],
-    })
-    render(<Radio {...props} />)
-    const radioOptions = screen.getAllByRole("radio")
-
-    // The caption sits outside the label, so this click target comes from an
-    // explicit handler rather than from label semantics.
-    await user.click(screen.getByText("slow"))
-
-    expect(onChange).toHaveBeenCalledTimes(1)
-    expect(onChange).toHaveBeenCalledWith(1)
-    expect(radioOptions[1]).toBeChecked()
-    expect(radioOptions[0]).not.toBeChecked()
-    // Focus has to land on the input, as it does when the label is clicked, or
-    // arrow keys do nothing until the user tabs back into the group.
-    expect(radioOptions[1]).toHaveFocus()
-  })
-
-  it("does not fire onChange when the selected option's caption is clicked", async () => {
-    const user = userEvent.setup()
-    const onChange = vi.fn()
-    const props = getProps({
-      onChange,
-      value: 1,
-      captions: ["fast", "slow", "medium"],
-    })
-    render(<Radio {...props} />)
-
-    // React Aria drops a no-op selection on the label, so the caption must too:
-    // otherwise this reruns the script and dirties an enclosing form for a click
-    // that changes nothing.
-    await user.click(screen.getByText("slow"))
-
-    expect(onChange).not.toHaveBeenCalled()
-    expect(screen.getAllByRole("radio")[1]).toBeChecked()
-  })
-
-  it("does not select an option when a click ends a text selection", async () => {
+  it("does not select an option when its caption is clicked", async () => {
     const user = userEvent.setup()
     const onChange = vi.fn()
     const props = getProps({
@@ -258,40 +224,12 @@ describe("Radio widget", () => {
     })
     render(<Radio {...props} />)
 
-    // Dragging across caption text ends in a click, which must not also answer
-    // the question. jsdom has no real selection, so report a live one.
-    const selection = { isCollapsed: false } as Selection
-    const getSelectionSpy = vi
-      .spyOn(window, "getSelection")
-      .mockReturnValue(selection)
-
+    // The caption is supplementary text outside the label, not a click target.
     await user.click(screen.getByText("slow"))
 
     expect(onChange).not.toHaveBeenCalled()
     expect(screen.getAllByRole("radio")[1]).not.toBeChecked()
-
-    // With the selection collapsed again, the same click does select.
-    getSelectionSpy.mockReturnValue({ isCollapsed: true } as Selection)
-    await user.click(screen.getByText("slow"))
-
-    expect(onChange).toHaveBeenCalledWith(1)
-    getSelectionSpy.mockRestore()
-  })
-
-  it("does not select an option when a disabled caption is clicked", async () => {
-    const user = userEvent.setup()
-    const onChange = vi.fn()
-    const props = getProps({
-      onChange,
-      disabled: true,
-      captions: ["fast", "slow", "medium"],
-    })
-    render(<Radio {...props} />)
-
-    await user.click(screen.getByText("slow"))
-
-    expect(onChange).not.toHaveBeenCalled()
-    expect(screen.getAllByRole("radio")[1]).not.toBeChecked()
+    expect(screen.getAllByRole("radio")[0]).toBeChecked()
   })
 
   it("treats options past the end of captions as having no caption", () => {
@@ -314,6 +252,16 @@ describe("Radio widget", () => {
 
     expect(radioOptions[1]).not.toHaveAccessibleDescription()
     expect(radioOptions[1]).toHaveAccessibleName("b")
+  })
+
+  it("ignores a whitespace-only caption", () => {
+    const props = getProps({ captions: [" ", "slow", "medium"] })
+    render(<Radio {...props} />)
+
+    // Python preserves whitespace strings, which would otherwise claim the
+    // description slot and describe the option with nothing.
+    expect(screen.getAllByRole("radio")[0]).not.toHaveAccessibleDescription()
+    expect(screen.queryAllByTestId("stRadioCaption")).toHaveLength(2)
   })
 
   it("has the correct captions", () => {

--- a/frontend/lib/src/components/shared/Radio/Radio.test.tsx
+++ b/frontend/lib/src/components/shared/Radio/Radio.test.tsx
@@ -280,7 +280,7 @@ describe("Radio widget", () => {
     expect(radioOptions[0]).toHaveAccessibleDescription("only one")
     expect(radioOptions[1]).not.toHaveAccessibleDescription()
     expect(radioOptions[2]).not.toHaveAccessibleDescription()
-    expect(screen.getAllByTestId("stCaptionContainer")).toHaveLength(1)
+    expect(screen.getAllByTestId("stRadioCaption")).toHaveLength(1)
   })
 
   it.each(["", " "])(

--- a/frontend/lib/src/components/shared/Radio/Radio.tsx
+++ b/frontend/lib/src/components/shared/Radio/Radio.tsx
@@ -14,14 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  memo,
-  ReactElement,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from "react"
+import { memo, ReactElement, useCallback, useEffect, useState } from "react"
 
 import StreamlitMarkdown from "~lib/components/shared/StreamlitMarkdown/StreamlitMarkdown"
 import { Placement } from "~lib/components/shared/Tooltip/Tooltip"
@@ -50,108 +43,6 @@ export interface Props {
   label?: string
   labelVisibility?: LabelVisibilityOptions
   help?: string
-}
-
-interface RadioOptionProps {
-  index: number
-  option: string
-  /** Empty when this option has no caption. */
-  caption: string
-  /** When true, renders a blank caption line so horizontal rows stay aligned. */
-  needsSpacer: boolean
-  /**
-   * The whole group is disabled. Only the caption reads this; the label and the
-   * circle use React Aria's per-option state instead.
-   */
-  isDisabled: boolean
-}
-
-/**
- * One option in the group: the clickable label, plus the caption when the option
- * has one. Each option is its own component so it can own the input ref that its
- * caption's click handler needs — `RadioField` takes a `RefObject`, and hooks
- * cannot run inside a loop.
- */
-function RadioOption({
-  index,
-  option,
-  caption,
-  needsSpacer,
-  isDisabled,
-}: Readonly<RadioOptionProps>): ReactElement {
-  const inputRef = useRef<HTMLInputElement>(null)
-
-  /**
-   * Selects this option when its caption is clicked. The caption sits outside the
-   * label, so nothing native does this. It stays a plain pointer target — no
-   * role, no tab stop — because the radio input is already the accessible
-   * control.
-   */
-  const handleCaptionClick = useCallback((): void => {
-    // A click that ends a text selection should not also change the selection.
-    // getSelection() can be null, so compare against false rather than negating.
-    if (window.getSelection()?.isCollapsed === false) {
-      return
-    }
-
-    // Go through the input rather than reimplementing a label click, which keeps
-    // React Aria the only thing deciding what a selection means: it ignores a
-    // selection that changes nothing, so this cannot rerun the script for a
-    // no-op, and a disabled input ignores the click outright.
-    inputRef.current?.click()
-
-    // A programmatic click does not run the browser's focus steps, so move focus
-    // explicitly — otherwise arrow keys do nothing until the group is tabbed
-    // back into.
-    inputRef.current?.focus()
-  }, [])
-
-  return (
-    <StyledRadioField value={index.toString()} inputRef={inputRef}>
-      <StyledRadioButton data-testid="stRadioOption">
-        {({ isSelected: isChecked, isDisabled: isOptionDisabled }) => (
-          <StyledRadioRow>
-            <StyledRadioOuter
-              $isSelected={isChecked}
-              $isDisabled={isOptionDisabled}
-            >
-              <StyledRadioInner $isSelected={isChecked} />
-            </StyledRadioOuter>
-            <StreamlitMarkdown source={option} allowHTML={false} isLabel />
-          </StyledRadioRow>
-        )}
-      </StyledRadioButton>
-      {caption !== "" && (
-        <StyledRadioCaption
-          slot="description"
-          elementType="div"
-          data-testid="stRadioCaption"
-          onClick={handleCaptionClick}
-          $isDisabled={isDisabled}
-        >
-          <StreamlitMarkdown
-            source={caption}
-            allowHTML={false}
-            isCaption
-            isLabel
-          />
-        </StyledRadioCaption>
-      )}
-      {needsSpacer && (
-        <StyledRadioCaptionSpacer
-          aria-hidden="true"
-          data-testid="stRadioSpacer"
-        >
-          <StreamlitMarkdown
-            source="&nbsp;"
-            allowHTML={false}
-            isCaption
-            isLabel
-          />
-        </StyledRadioCaptionSpacer>
-      )}
-    </StyledRadioField>
-  )
 }
 
 function Radio({
@@ -187,7 +78,10 @@ function Radio({
     [onChange]
   )
 
-  const hasCaptions = captions.length > 0
+  // An all-blank captions list must lay out exactly like no captions at all, so
+  // blank entries don't count. Gates the vertical group's gap and the horizontal
+  // spacers; captioning only some options is supported.
+  const hasCaptions = captions.some(caption => caption.trim() !== "")
   const hasOptions = options.length > 0
   const cleanedOptions = hasOptions ? options : ["No options to select."]
 
@@ -220,21 +114,69 @@ function Radio({
         $hasCaptions={hasCaptions}
       >
         {cleanedOptions.map((option: string, index: number) => {
-          // `captions` is not required to be as long as `options`, so an index
-          // past its end reads as a missing caption rather than `undefined`.
-          const caption = captions[index] ?? ""
+          // A missing or whitespace-only caption counts as no caption: `captions`
+          // need not be as long as `options`, and the backend passes whitespace
+          // through unchanged. Either would otherwise point `aria-describedby` at
+          // content with nothing to announce.
+          const rawCaption = captions[index] ?? ""
+          const caption = rawCaption.trim() === "" ? "" : rawCaption
+
+          // In a horizontal group, an option without a caption still needs that
+          // vertical space reserved, or its label stops lining up with the
+          // captioned options'.
+          const needsSpacer = caption === "" && horizontal && hasCaptions
 
           return (
-            <RadioOption
+            <StyledRadioField
               // eslint-disable-next-line @eslint-react/no-array-index-key
               key={index}
-              index={index}
-              option={option}
-              caption={caption}
-              // Only horizontal rows with partial captions need the space kept.
-              needsSpacer={caption === "" && horizontal && hasCaptions}
-              isDisabled={shouldDisable}
-            />
+              value={index.toString()}
+            >
+              <StyledRadioButton data-testid="stRadioOption">
+                {({ isSelected, isDisabled }) => (
+                  <StyledRadioRow>
+                    <StyledRadioOuter
+                      $isSelected={isSelected}
+                      $isDisabled={isDisabled}
+                    >
+                      <StyledRadioInner $isSelected={isSelected} />
+                    </StyledRadioOuter>
+                    <StreamlitMarkdown
+                      source={option}
+                      allowHTML={false}
+                      isLabel
+                    />
+                  </StyledRadioRow>
+                )}
+              </StyledRadioButton>
+              {caption !== "" && (
+                <StyledRadioCaption
+                  slot="description"
+                  elementType="div"
+                  data-testid="stRadioCaption"
+                >
+                  <StreamlitMarkdown
+                    source={caption}
+                    allowHTML={false}
+                    isCaption
+                    isLabel
+                  />
+                </StyledRadioCaption>
+              )}
+              {needsSpacer && (
+                <StyledRadioCaptionSpacer
+                  aria-hidden="true"
+                  data-testid="stRadioCaptionSpacer"
+                >
+                  <StreamlitMarkdown
+                    source="&nbsp;"
+                    allowHTML={false}
+                    isCaption
+                    isLabel
+                  />
+                </StyledRadioCaptionSpacer>
+              )}
+            </StyledRadioField>
           )
         })}
       </StyledRadioGroup>

--- a/frontend/lib/src/components/shared/Radio/Radio.tsx
+++ b/frontend/lib/src/components/shared/Radio/Radio.tsx
@@ -78,12 +78,17 @@ function Radio({
     [onChange]
   )
 
-  // An all-blank captions list must lay out exactly like no captions at all, so
-  // blank entries don't count. Gates the vertical group's gap and the horizontal
-  // spacers; captioning only some options is supported.
-  const hasCaptions = captions.some(caption => caption.trim() !== "")
   const hasOptions = options.length > 0
   const cleanedOptions = hasOptions ? options : ["No options to select."]
+
+  // Gates the vertical group's gap and the horizontal spacers, so it has to mean
+  // "some option actually shows a caption". Captioning only part of a group is
+  // supported, and `captions` may be any length, so blank entries and entries
+  // past the last option are both ignored — otherwise a group with nothing to
+  // show still reserves the space for it.
+  const hasCaptions = captions
+    .slice(0, cleanedOptions.length)
+    .some(caption => caption.trim() !== "")
 
   // Either the user specified it as disabled or it's disabled because we don't have any options
   const shouldDisable = disabled || !hasOptions

--- a/frontend/lib/src/components/shared/Radio/Radio.tsx
+++ b/frontend/lib/src/components/shared/Radio/Radio.tsx
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
-import { memo, ReactElement, useCallback, useEffect, useState } from "react"
+import {
+  memo,
+  ReactElement,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react"
 
 import StreamlitMarkdown from "~lib/components/shared/StreamlitMarkdown/StreamlitMarkdown"
 import { Placement } from "~lib/components/shared/Tooltip/Tooltip"
@@ -25,7 +32,7 @@ import { LabelVisibilityOptions } from "~lib/util/utils"
 import {
   StyledRadioButton,
   StyledRadioCaption,
-  StyledRadioContent,
+  StyledRadioCaptionSpacer,
   StyledRadioField,
   StyledRadioGroup,
   StyledRadioInner,
@@ -43,6 +50,108 @@ export interface Props {
   label?: string
   labelVisibility?: LabelVisibilityOptions
   help?: string
+}
+
+interface RadioOptionProps {
+  index: number
+  option: string
+  /** Empty when this option has no caption. */
+  caption: string
+  /** When true, renders a blank caption line so horizontal rows stay aligned. */
+  needsSpacer: boolean
+  /**
+   * The whole group is disabled. Only the caption reads this; the label and the
+   * circle use React Aria's per-option state instead.
+   */
+  isDisabled: boolean
+}
+
+/**
+ * One option in the group: the clickable label, plus the caption when the option
+ * has one. Each option is its own component so it can own the input ref that its
+ * caption's click handler needs — `RadioField` takes a `RefObject`, and hooks
+ * cannot run inside a loop.
+ */
+function RadioOption({
+  index,
+  option,
+  caption,
+  needsSpacer,
+  isDisabled,
+}: Readonly<RadioOptionProps>): ReactElement {
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  /**
+   * Selects this option when its caption is clicked. The caption sits outside the
+   * label, so nothing native does this. It stays a plain pointer target — no
+   * role, no tab stop — because the radio input is already the accessible
+   * control.
+   */
+  const handleCaptionClick = useCallback((): void => {
+    // A click that ends a text selection should not also change the selection.
+    // getSelection() can be null, so compare against false rather than negating.
+    if (window.getSelection()?.isCollapsed === false) {
+      return
+    }
+
+    // Go through the input rather than reimplementing a label click, which keeps
+    // React Aria the only thing deciding what a selection means: it ignores a
+    // selection that changes nothing, so this cannot rerun the script for a
+    // no-op, and a disabled input ignores the click outright.
+    inputRef.current?.click()
+
+    // A programmatic click does not run the browser's focus steps, so move focus
+    // explicitly — otherwise arrow keys do nothing until the group is tabbed
+    // back into.
+    inputRef.current?.focus()
+  }, [])
+
+  return (
+    <StyledRadioField value={index.toString()} inputRef={inputRef}>
+      <StyledRadioButton data-testid="stRadioOption">
+        {({ isSelected: isChecked, isDisabled: isOptionDisabled }) => (
+          <StyledRadioRow>
+            <StyledRadioOuter
+              $isSelected={isChecked}
+              $isDisabled={isOptionDisabled}
+            >
+              <StyledRadioInner $isSelected={isChecked} />
+            </StyledRadioOuter>
+            <StreamlitMarkdown source={option} allowHTML={false} isLabel />
+          </StyledRadioRow>
+        )}
+      </StyledRadioButton>
+      {caption !== "" && (
+        <StyledRadioCaption
+          slot="description"
+          elementType="div"
+          data-testid="stRadioCaption"
+          onClick={handleCaptionClick}
+          $isDisabled={isDisabled}
+        >
+          <StreamlitMarkdown
+            source={caption}
+            allowHTML={false}
+            isCaption
+            isLabel
+          />
+        </StyledRadioCaption>
+      )}
+      {needsSpacer && (
+        <StyledRadioCaptionSpacer
+          aria-hidden="true"
+          data-testid="stRadioSpacer"
+        >
+          <StreamlitMarkdown
+            source="&nbsp;"
+            allowHTML={false}
+            isCaption
+            isLabel
+          />
+        </StyledRadioCaptionSpacer>
+      )}
+    </StyledRadioField>
+  )
 }
 
 function Radio({
@@ -85,13 +194,6 @@ function Radio({
   // Either the user specified it as disabled or it's disabled because we don't have any options
   const shouldDisable = disabled || !hasOptions
 
-  const spacerNeeded = (caption: string): string => {
-    // When captions are provided for only some options in horizontal layout
-    // we need to add a spacer for the options without captions
-    const spacer = caption === "" && horizontal && hasCaptions
-    return spacer ? "&nbsp;" : caption
-  }
-
   return (
     <div className="stRadio" data-testid="stRadio">
       <WidgetLabel
@@ -117,43 +219,24 @@ function Radio({
         $horizontal={horizontal}
         $hasCaptions={hasCaptions}
       >
-        {cleanedOptions.map((option: string, index: number) => (
-          <StyledRadioField
-            // eslint-disable-next-line @eslint-react/no-array-index-key
-            key={index}
-            value={index.toString()}
-          >
-            <StyledRadioButton data-testid="stRadioOption">
-              {({ isSelected, isDisabled }) => (
-                <StyledRadioContent $isDisabled={isDisabled}>
-                  <StyledRadioRow>
-                    <StyledRadioOuter
-                      $isSelected={isSelected}
-                      $isDisabled={isDisabled}
-                    >
-                      <StyledRadioInner $isSelected={isSelected} />
-                    </StyledRadioOuter>
-                    <StreamlitMarkdown
-                      source={option}
-                      allowHTML={false}
-                      isLabel
-                    />
-                  </StyledRadioRow>
-                  {hasCaptions && (
-                    <StyledRadioCaption>
-                      <StreamlitMarkdown
-                        source={spacerNeeded(captions[index])}
-                        allowHTML={false}
-                        isCaption
-                        isLabel
-                      />
-                    </StyledRadioCaption>
-                  )}
-                </StyledRadioContent>
-              )}
-            </StyledRadioButton>
-          </StyledRadioField>
-        ))}
+        {cleanedOptions.map((option: string, index: number) => {
+          // `captions` is not required to be as long as `options`, so an index
+          // past its end reads as a missing caption rather than `undefined`.
+          const caption = captions[index] ?? ""
+
+          return (
+            <RadioOption
+              // eslint-disable-next-line @eslint-react/no-array-index-key
+              key={index}
+              index={index}
+              option={option}
+              caption={caption}
+              // Only horizontal rows with partial captions need the space kept.
+              needsSpacer={caption === "" && horizontal && hasCaptions}
+              isDisabled={shouldDisable}
+            />
+          )
+        })}
       </StyledRadioGroup>
     </div>
   )

--- a/frontend/lib/src/components/shared/Radio/Radio.tsx
+++ b/frontend/lib/src/components/shared/Radio/Radio.tsx
@@ -81,14 +81,13 @@ function Radio({
   const hasOptions = options.length > 0
   const cleanedOptions = hasOptions ? options : ["No options to select."]
 
-  // Gates the vertical group's gap and the horizontal spacers, so it has to mean
-  // "some option actually shows a caption". Captioning only part of a group is
-  // supported, and `captions` may be any length, so blank entries and entries
-  // past the last option are both ignored — otherwise a group with nothing to
-  // show still reserves the space for it.
-  const hasCaptions = captions
-    .slice(0, cleanedOptions.length)
-    .some(caption => caption.trim() !== "")
+  // `captions` can be any length, and the no-options placeholder is ours rather
+  // than a user option — so only entries lining up with a real option apply.
+  const optionCaptions = captions.slice(0, options.length)
+
+  // Blank entries do not count, so a group with nothing to show reserves no
+  // caption space.
+  const hasCaptions = optionCaptions.some(caption => caption.trim() !== "")
 
   // Either the user specified it as disabled or it's disabled because we don't have any options
   const shouldDisable = disabled || !hasOptions
@@ -119,16 +118,16 @@ function Radio({
         $hasCaptions={hasCaptions}
       >
         {cleanedOptions.map((option: string, index: number) => {
-          // A missing or whitespace-only caption counts as no caption: `captions`
-          // need not be as long as `options`, and the backend passes whitespace
+          // A missing or whitespace-only caption counts as no caption: captioning
+          // only part of a group is supported, and the backend passes whitespace
           // through unchanged. Either would otherwise point `aria-describedby` at
           // content with nothing to announce.
-          const rawCaption = captions[index] ?? ""
+          const rawCaption = optionCaptions[index] ?? ""
           const caption = rawCaption.trim() === "" ? "" : rawCaption
 
           // In a horizontal group, an option without a caption still needs that
           // vertical space reserved, or its label stops lining up with the
-          // captioned options'.
+          // captioned ones.
           const needsSpacer = caption === "" && horizontal && hasCaptions
 
           return (

--- a/frontend/lib/src/components/shared/Radio/Radio.tsx
+++ b/frontend/lib/src/components/shared/Radio/Radio.tsx
@@ -81,13 +81,19 @@ function Radio({
   const hasOptions = options.length > 0
   const cleanedOptions = hasOptions ? options : ["No options to select."]
 
-  // `captions` can be any length, and the no-options placeholder is ours rather
-  // than a user option — so only entries lining up with a real option apply.
-  const optionCaptions = captions.slice(0, options.length)
+  // Only captions that line up with a user option apply. Extra entries and the
+  // no-options placeholder are ignored.
+  const optionCaptions = captions
+    .slice(0, options.length)
+    // A whitespace-only caption counts as no caption, which keeps
+    // `aria-describedby` off content with nothing to announce: captioning only
+    // part of a group is supported, and the backend passes whitespace through
+    // unchanged.
+    .map(caption => (caption.trim() === "" ? "" : caption))
 
-  // Blank entries do not count, so a group with nothing to show reserves no
-  // caption space.
-  const hasCaptions = optionCaptions.some(caption => caption.trim() !== "")
+  // True when any option has a non-blank caption, so an all-blank list lays out
+  // like no captions.
+  const hasCaptions = optionCaptions.some(caption => caption !== "")
 
   // Either the user specified it as disabled or it's disabled because we don't have any options
   const shouldDisable = disabled || !hasOptions
@@ -118,12 +124,7 @@ function Radio({
         $hasCaptions={hasCaptions}
       >
         {cleanedOptions.map((option: string, index: number) => {
-          // A missing or whitespace-only caption counts as no caption: captioning
-          // only part of a group is supported, and the backend passes whitespace
-          // through unchanged. Either would otherwise point `aria-describedby` at
-          // content with nothing to announce.
-          const rawCaption = optionCaptions[index] ?? ""
-          const caption = rawCaption.trim() === "" ? "" : rawCaption
+          const caption = optionCaptions[index] ?? ""
 
           // In a horizontal group, an option without a caption still needs that
           // vertical space reserved, or its label stops lining up with the

--- a/frontend/lib/src/components/shared/Radio/styled-components.tsx
+++ b/frontend/lib/src/components/shared/Radio/styled-components.tsx
@@ -66,8 +66,9 @@ export const StyledRadioGroup = styled(RARadioGroup, {
  * folding it into the accessible name.
  *
  * Owns the text colour, including the disabled variant, because it is the nearest
- * ancestor of both the label and the caption — so the two dim together. The label
- * and the caption each set their own `cursor`, since each is clickable.
+ * ancestor of both the label and the caption — so the two dim together. React Aria
+ * marks this element `data-disabled` as well as the label, so the two split their
+ * state-driven styles: colour here, `cursor` on the label.
  */
 export const StyledRadioField = styled(RARadioField)(({ theme }) => ({
   display: "flex",
@@ -81,17 +82,22 @@ export const StyledRadioField = styled(RARadioField)(({ theme }) => ({
 /**
  * Clickable `<label>` for each radio option. It wraps the hidden input, the
  * circle indicator (`StyledRadioOuter`/`StyledRadioInner`), and the option text,
- * so the whole row is a click target. It stays a plain block container: the
- * children own the circle-and-text alignment so the caption can sit outside that
- * row without manual offset calculations.
+ * so the whole row is a click target. It stays a plain block container:
+ * `StyledRadioRow` owns circle-and-text alignment, so the field can stack the
+ * caption below the label with no offset maths.
  *
- * React Aria sets `data-focus-visible`, `data-disabled`, `data-selected` and
- * friends as data attributes — we use those for state-driven styles.
+ * React Aria sets `data-focus-visible`, `data-hovered`, `data-pressed` and
+ * friends here as data attributes — we use those for state-driven styles.
+ * `data-disabled` and `data-selected` also appear on `StyledRadioField`, so the
+ * two split those styles: colour on the field, `cursor` here.
+ *
+ * No `user-select` rule: React Aria's `usePress` suppresses selection for the
+ * duration of a press, so a standing rule would only stop users copying the
+ * option text. This matches `st.checkbox` and `st.toggle`.
  */
 export const StyledRadioButton = styled(RARadioButton)(({ theme }) => ({
   display: "block",
   cursor: "pointer",
-  userSelect: "none",
   paddingLeft: theme.spacing.none,
   paddingRight: theme.spacing.threeXS,
   marginTop: theme.spacing.none,
@@ -189,56 +195,44 @@ export const StyledRadioInner = styled.div<StyledRadioInnerProps>(
 )
 
 /**
- * Padding shared by the caption and its spacer, so both occupy the same box as
- * the option label above them.
+ * Aligns the caption's text with the label's: `paddingLeft` clears the circle,
+ * `paddingRight` matches the label's. Shared with the spacer so the two cannot
+ * drift.
  *
- * `paddingLeft` indents past the circle (`circle width + row gap`) so caption
- * text aligns with the option text rather than the circle; the field and label
- * share a left edge because `StyledRadioButton` has `paddingLeft: none`.
- * `paddingRight` matches `StyledRadioButton`'s so the caption's content box is as
- * wide as the label's. Drop it and the field shrinks by that much whenever the
- * caption is the wider of the two, shifting later options in a horizontal group
- * left.
+ * A caption wider than its label sets the option's width, so it needs the label's
+ * `paddingRight` too — without it the option is that much narrower and later
+ * options in a horizontal group shift left.
  */
-const captionBox = ({ theme }: { theme: EmotionTheme }): CSSObject => ({
+const captionBoxStyles = ({ theme }: { theme: EmotionTheme }): CSSObject => ({
   paddingLeft: `calc(${theme.sizes.checkbox} + ${theme.spacing.sm})`,
   paddingRight: theme.spacing.threeXS,
 })
-
-interface StyledRadioCaptionProps {
-  $isDisabled: boolean
-}
 
 /**
  * The caption, rendered as React Aria's `description` slot so it reaches the
  * option's `aria-describedby` instead of joining its accessible name.
  *
- * Rendered as a `<div>` (`elementType="div"`) because caption markdown can
- * contain block elements; `Text` defaults to a `<span>`.
+ * `Radio` renders this as a `<div>` (`elementType="div"`): `StreamlitMarkdown`
+ * wraps its output in a `<div>`, which is invalid inside the `<span>` that `Text`
+ * renders by default.
  *
- * Carries the label's cursor because clicking a caption selects its option, the
- * same as clicking the label does.
+ * React Aria drops the description id unless something mounts in this slot, which
+ * is why a blank caption renders nothing at all rather than an empty `Text`.
  *
- * Must stay the element React Aria's `descriptionProps.ref` lands on: wrapping it
- * in another element would leave `aria-describedby` pointing nowhere.
+ * Sets no `cursor`: as supplementary text outside the label it is not a click
+ * target, so the default text cursor correctly signals selectable prose.
  */
-export const StyledRadioCaption = styled(RAText, {
-  shouldForwardProp: (prop: string) => !prop.startsWith("$"),
-})<StyledRadioCaptionProps>(props => ({
-  ...captionBox(props),
-  cursor: props.$isDisabled ? "not-allowed" : "pointer",
-}))
+export const StyledRadioCaption = styled(RAText)(captionBoxStyles)
 
 /**
- * Reserves a caption's height for options that have none, so horizontal groups
- * with partial captions keep their rows aligned — the group centres items
- * vertically, so a shorter field would nudge its own row off the shared baseline.
+ * Keeps horizontal options without captions aligned with captioned ones, without
+ * claiming the `description` slot.
  *
- * - A plain `div`, not a `Text`: it must not claim the `description` slot and
- *   point `aria-describedby` at blank content, and `Text` throws against a
- *   slotted `TextContext` without a `slot` prop.
- * - Call sites fill it with a non-breaking space rather than setting a height,
+ * - A plain `div`, not a `Text`: it must not point `aria-describedby` at blank
+ *   content, and a `Text` inside `RadioField` has to name a slot — React Aria
+ *   throws `A slot prop is required.` otherwise — and the only slot here is
+ *   `description`.
+ * - `Radio` fills it with a non-breaking space rather than setting a height,
  *   because only a real caption line box matches the height exactly.
- * - It shares the caption's indent but not its cursor; there is nothing to click.
  */
-export const StyledRadioCaptionSpacer = styled.div(captionBox)
+export const StyledRadioCaptionSpacer = styled.div(captionBoxStyles)

--- a/frontend/lib/src/components/shared/Radio/styled-components.tsx
+++ b/frontend/lib/src/components/shared/Radio/styled-components.tsx
@@ -65,10 +65,10 @@ export const StyledRadioGroup = styled(RARadioGroup, {
  * React Aria can expose it as the option's `aria-describedby` target rather than
  * folding it into the accessible name.
  *
- * Owns the text colour, including the disabled variant, because it is the nearest
- * ancestor of both the label and the caption — so the two dim together. React Aria
- * marks this element `data-disabled` as well as the label, so the two split their
- * state-driven styles: colour here, `cursor` on the label.
+ * Owns the text colour, including the disabled variant, so the label and the
+ * caption dim together. React Aria marks both this element and the label
+ * `data-disabled`, so they split state-driven styles: colour here, `cursor` on
+ * the label.
  */
 export const StyledRadioField = styled(RARadioField)(({ theme }) => ({
   display: "flex",
@@ -195,11 +195,9 @@ export const StyledRadioInner = styled.div<StyledRadioInnerProps>(
 )
 
 /**
- * Aligns the caption's text with the label's, shared with the spacer so the two
- * cannot drift. `paddingLeft` clears the circle. `paddingRight` mirrors the
- * label's, because a caption wider than its label sets the option's width — drop
- * it and the option is that much narrower, shifting later options in a horizontal
- * group left.
+ * Aligns caption and spacer text with the label so the two cannot drift.
+ * `paddingLeft` clears the circle. `paddingRight` matches the label's so a
+ * caption wider than its label cannot shift later options in a horizontal group.
  */
 const captionBoxStyles = ({ theme }: { theme: EmotionTheme }): CSSObject => ({
   paddingLeft: `calc(${theme.sizes.checkbox} + ${theme.spacing.sm})`,

--- a/frontend/lib/src/components/shared/Radio/styled-components.tsx
+++ b/frontend/lib/src/components/shared/Radio/styled-components.tsx
@@ -88,8 +88,8 @@ export const StyledRadioField = styled(RARadioField)(({ theme }) => ({
  *
  * React Aria sets `data-focus-visible`, `data-hovered`, `data-pressed` and
  * friends here as data attributes — we use those for state-driven styles.
- * `data-disabled` and `data-selected` also appear on `StyledRadioField`, so the
- * two split those styles: colour on the field, `cursor` here.
+ * `data-disabled` and `data-selected` also appear on `StyledRadioField`, which
+ * owns the colour; this element owns `cursor`.
  *
  * No `user-select` rule: React Aria's `usePress` suppresses selection for the
  * duration of a press, so a standing rule would only stop users copying the
@@ -195,13 +195,11 @@ export const StyledRadioInner = styled.div<StyledRadioInnerProps>(
 )
 
 /**
- * Aligns the caption's text with the label's: `paddingLeft` clears the circle,
- * `paddingRight` matches the label's. Shared with the spacer so the two cannot
- * drift.
- *
- * A caption wider than its label sets the option's width, so it needs the label's
- * `paddingRight` too — without it the option is that much narrower and later
- * options in a horizontal group shift left.
+ * Aligns the caption's text with the label's, shared with the spacer so the two
+ * cannot drift. `paddingLeft` clears the circle. `paddingRight` mirrors the
+ * label's, because a caption wider than its label sets the option's width — drop
+ * it and the option is that much narrower, shifting later options in a horizontal
+ * group left.
  */
 const captionBoxStyles = ({ theme }: { theme: EmotionTheme }): CSSObject => ({
   paddingLeft: `calc(${theme.sizes.checkbox} + ${theme.spacing.sm})`,
@@ -212,15 +210,12 @@ const captionBoxStyles = ({ theme }: { theme: EmotionTheme }): CSSObject => ({
  * The caption, rendered as React Aria's `description` slot so it reaches the
  * option's `aria-describedby` instead of joining its accessible name.
  *
- * `Radio` renders this as a `<div>` (`elementType="div"`): `StreamlitMarkdown`
- * wraps its output in a `<div>`, which is invalid inside the `<span>` that `Text`
- * renders by default.
- *
- * React Aria drops the description id unless something mounts in this slot, which
- * is why a blank caption renders nothing at all rather than an empty `Text`.
- *
- * Sets no `cursor`: as supplementary text outside the label it is not a click
- * target, so the default text cursor correctly signals selectable prose.
+ * - Rendered as a `<div>` (`elementType="div"`) because `StreamlitMarkdown` wraps
+ *   its output in a `<div>`, which is invalid inside `Text`'s default `<span>`.
+ * - Blank captions render nothing rather than an empty `Text`: React Aria drops
+ *   the description id unless this slot mounts content.
+ * - No `cursor` rule: it is not a click target, so the default text cursor
+ *   signals selectable prose.
  */
 export const StyledRadioCaption = styled(RAText)(captionBoxStyles)
 
@@ -228,10 +223,9 @@ export const StyledRadioCaption = styled(RAText)(captionBoxStyles)
  * Keeps horizontal options without captions aligned with captioned ones, without
  * claiming the `description` slot.
  *
- * - A plain `div`, not a `Text`: it must not point `aria-describedby` at blank
- *   content, and a `Text` inside `RadioField` has to name a slot — React Aria
- *   throws `A slot prop is required.` otherwise — and the only slot here is
- *   `description`.
+ * - A plain `div`, not a `Text`: it holds no description, and a `Text` here
+ *   would either claim the `description` slot or need `slot={null}` to opt out
+ *   of it.
  * - `Radio` fills it with a non-breaking space rather than setting a height,
  *   because only a real caption line box matches the height exactly.
  */

--- a/frontend/lib/src/components/shared/Radio/styled-components.tsx
+++ b/frontend/lib/src/components/shared/Radio/styled-components.tsx
@@ -14,13 +14,15 @@
  * limitations under the License.
  */
 
-import styled from "@emotion/styled"
+import styled, { CSSObject } from "@emotion/styled"
 import {
   RadioButton as RARadioButton,
   RadioField as RARadioField,
   RadioGroup as RARadioGroup,
+  Text as RAText,
 } from "react-aria-components"
 
+import type { EmotionTheme } from "~lib/theme/types"
 import { convertRemToPx } from "~lib/theme/utils"
 
 interface StyledRadioGroupProps {
@@ -59,15 +61,22 @@ export const StyledRadioGroup = styled(RARadioGroup, {
  * selection state to its `RadioButton` child via context. `RadioButton` must
  * nest inside this field.
  *
- * It needs no styles of its own — as a block-level flex item it shrink-wraps the
- * label, so `StyledRadioGroup`'s `alignItems` and `gap` still apply to the
- * option's visible box.
+ * Stacks the clickable label above the caption, which sits outside the label so
+ * React Aria can expose it as the option's `aria-describedby` target rather than
+ * folding it into the accessible name.
  *
- * Keep state-driven styles on the label's class: React Aria also sets
- * `data-selected`/`data-disabled` on this div, so styling both elements would
- * apply those rules twice.
+ * Owns the text colour, including the disabled variant, because it is the nearest
+ * ancestor of both the label and the caption — so the two dim together. The label
+ * and the caption each set their own `cursor`, since each is clickable.
  */
-export const StyledRadioField = styled(RARadioField)()
+export const StyledRadioField = styled(RARadioField)(({ theme }) => ({
+  display: "flex",
+  flexDirection: "column",
+  color: theme.colors.bodyText,
+  "&[data-disabled]": {
+    color: theme.colors.fadedText40,
+  },
+}))
 
 /**
  * Clickable `<label>` for each radio option. It wraps the hidden input, the
@@ -94,23 +103,6 @@ export const StyledRadioButton = styled(RARadioButton)(({ theme }) => ({
     cursor: "not-allowed",
   },
 }))
-
-interface StyledRadioContentProps {
-  $isDisabled: boolean
-}
-
-/**
- * Flex column that wraps all visible content (option row + caption) for a
- * single radio option. Owns the disabled text-colour so both the option label
- * and the caption dim together without each needing their own prop.
- */
-export const StyledRadioContent = styled.div<StyledRadioContentProps>(
-  ({ theme, $isDisabled }) => ({
-    display: "flex",
-    flexDirection: "column",
-    color: $isDisabled ? theme.colors.fadedText40 : theme.colors.bodyText,
-  })
-)
 
 /**
  * Flex row that contains only the radio circle and the option label text.
@@ -197,11 +189,56 @@ export const StyledRadioInner = styled.div<StyledRadioInnerProps>(
 )
 
 /**
- * Indents the caption text so it aligns with the option label (i.e. starts
- * after the radio circle + gap), not with the circle itself.
- * `paddingLeft = circle width + row gap` is derived entirely from theme tokens
- * with no hardcoded values.
+ * Padding shared by the caption and its spacer, so both occupy the same box as
+ * the option label above them.
+ *
+ * `paddingLeft` indents past the circle (`circle width + row gap`) so caption
+ * text aligns with the option text rather than the circle; the field and label
+ * share a left edge because `StyledRadioButton` has `paddingLeft: none`.
+ * `paddingRight` matches `StyledRadioButton`'s so the caption's content box is as
+ * wide as the label's. Drop it and the field shrinks by that much whenever the
+ * caption is the wider of the two, shifting later options in a horizontal group
+ * left.
  */
-export const StyledRadioCaption = styled.div(({ theme }) => ({
+const captionBox = ({ theme }: { theme: EmotionTheme }): CSSObject => ({
   paddingLeft: `calc(${theme.sizes.checkbox} + ${theme.spacing.sm})`,
+  paddingRight: theme.spacing.threeXS,
+})
+
+interface StyledRadioCaptionProps {
+  $isDisabled: boolean
+}
+
+/**
+ * The caption, rendered as React Aria's `description` slot so it reaches the
+ * option's `aria-describedby` instead of joining its accessible name.
+ *
+ * Rendered as a `<div>` (`elementType="div"`) because caption markdown can
+ * contain block elements; `Text` defaults to a `<span>`.
+ *
+ * Carries the label's cursor because clicking a caption selects its option, the
+ * same as clicking the label does.
+ *
+ * Must stay the element React Aria's `descriptionProps.ref` lands on: wrapping it
+ * in another element would leave `aria-describedby` pointing nowhere.
+ */
+export const StyledRadioCaption = styled(RAText, {
+  shouldForwardProp: (prop: string) => !prop.startsWith("$"),
+})<StyledRadioCaptionProps>(props => ({
+  ...captionBox(props),
+  cursor: props.$isDisabled ? "not-allowed" : "pointer",
 }))
+
+/**
+ * Reserves a caption's height for options that have none, so horizontal groups
+ * with partial captions keep their rows aligned — the group centres items
+ * vertically, so a shorter field would nudge its own row off the shared baseline.
+ *
+ * - A plain `div`, not a `Text`: it must not claim the `description` slot and
+ *   point `aria-describedby` at blank content, and `Text` throws against a
+ *   slotted `TextContext` without a `slot` prop.
+ * - Call sites fill it with a non-breaking space rather than setting a height,
+ *   because only a real caption line box matches the height exactly.
+ * - It shares the caption's indent but not its cursor; there is nothing to click.
+ */
+export const StyledRadioCaptionSpacer = styled.div(captionBox)

--- a/frontend/lib/src/components/widgets/Radio/Radio.test.tsx
+++ b/frontend/lib/src/components/widgets/Radio/Radio.test.tsx
@@ -151,8 +151,10 @@ describe("Radio widget", () => {
     const props = getProps({ captions: ["caption1", "", ""] })
     render(<Radio {...props} />)
 
-    expect(screen.getAllByTestId("stCaptionContainer")).toHaveLength(3)
-    expect(screen.getByText("caption1")).toBeInTheDocument()
+    // Blank captions render nothing, so they cannot claim the description slot
+    // and point aria-describedby at empty content.
+    expect(screen.getAllByTestId("stCaptionContainer")).toHaveLength(1)
+    expect(screen.getByText("caption1")).toBeVisible()
   })
 
   it("shows a message when there are no options to be shown", () => {

--- a/frontend/lib/src/components/widgets/Radio/Radio.test.tsx
+++ b/frontend/lib/src/components/widgets/Radio/Radio.test.tsx
@@ -147,7 +147,7 @@ describe("Radio widget", () => {
     })
   })
 
-  it("renders non-blank captions", () => {
+  it("skips blank captions", () => {
     const props = getProps({ captions: ["caption1", "", ""] })
     render(<Radio {...props} />)
 

--- a/frontend/lib/src/components/widgets/Radio/Radio.test.tsx
+++ b/frontend/lib/src/components/widgets/Radio/Radio.test.tsx
@@ -153,7 +153,7 @@ describe("Radio widget", () => {
 
     // Blank captions render nothing, so they cannot claim the description slot
     // and point aria-describedby at empty content.
-    expect(screen.getAllByTestId("stCaptionContainer")).toHaveLength(1)
+    expect(screen.getAllByTestId("stRadioCaption")).toHaveLength(1)
     expect(screen.getByText("caption1")).toBeVisible()
   })
 

--- a/lib/streamlit/elements/widgets/radio.py
+++ b/lib/streamlit/elements/widgets/radio.py
@@ -313,8 +313,13 @@ class RadioMixin:
             The default is false (vertical buttons).
 
         captions : iterable of str or None
-            A list of captions to show below each radio button. If None (default),
-            no captions are shown.
+            A list of captions to show below each radio button. If this is
+            ``None`` (default), no captions are shown.
+
+            Captions are matched to ``options`` by position. To caption only
+            some options, use ``None`` or an empty string for the others. If
+            this list is shorter than ``options``, the remaining options have no
+            caption. Any captions after the last option are ignored.
 
         label_visibility : "visible", "hidden", or "collapsed"
             The visibility of the label. The default is ``"visible"``. If this


### PR DESCRIPTION
## Describe your changes

Move `st.radio` option captions out of each option's `<label>` and expose them through React Aria's `description` slot (`aria-describedby`), so assistive tech hears the option text as the name and the caption as its description.

They rendered inside the label before, so a caption joined the accessible name — option "A" with caption `**bold text**` exposed a name of `"A bold text"`.

Overriding the name with `aria-labelledby` would have been the smaller change, but it leaves the caption inside the label — so the caption is still not a description, and every option needs a generated id to point at.

Four consequences, each checked against how other component libraries handle per-option descriptions:

- **Clicking a caption no longer selects its option.** Streamlit passed captions as `UIRadio` children, so they have sat inside the clickable label since the BaseWeb implementation — this removes a hit area users have had for a long time. Of 13 libraries surveyed, none hand-rolls a click handler to make a description clickable; descriptions sit outside the label in React Aria, Mantine, GOV.UK, Bootstrap, Primer, Carbon and MUI. Keeping it clickable would mean a hand-rolled click handler plus guards for links inside captions and for clicks that end a text selection, so the hit-area loss is accepted instead.
- **Caption text is selectable, and option text is now copyable.** The caption stopped inheriting the label's `userSelect: "none"` when it moved out, and that rule is gone from the label too. Zero of those libraries set it on a description, 11 of 13 leave radio *labels* selectable, and `st.checkbox`/`st.toggle` set no such rule. To be precise about what changed for the label: React Aria's `usePress` still suppresses selection for the duration of a press, so a drag that *starts* on the option text still selects nothing — same as `st.checkbox` and `st.toggle`. What the standing rule additionally blocked, and no longer does, is ⌘A/Ctrl+A and drags that pass through the option text.
- **A markdown link inside a caption is now followable.** React Aria merges `onClick: e => e.preventDefault()` into the label props, which cancels navigation for any anchor beneath the label; a caption outside it keeps its native behaviour. Wanted — a link in supplementary prose should work — and the e2e asserts the click survives uncancelled rather than only checking the `href`.
- **The keyboard focus highlight** covers the option row and no longer extends behind the caption.

On target size: a captioned option's pointer target is now its label row, the same as an uncaptioned option, `st.checkbox`, and `st.toggle`. That is below WCAG 2.2 SC 2.5.8 (AA), but it is the existing size for every one of those controls rather than a new sub-minimum introduced here.

Two long-standing bugs sit on the lines this rewrites, so they are fixed here:

- `captions` shorter than `options` crashed the frontend. `radio.py` validates `index` but never `len(captions)`, so `st.radio("x", ["a","b","c"], captions=["only one"])` passed `undefined` into `StreamlitMarkdown` → `TypeError: ... reading 'replaceAll'`, thrown above `RenderedMarkdown`'s error boundary.
- A whitespace-only caption claimed the description slot, pointing `aria-describedby` at content with nothing to announce. Blank captions, and captions past the last option, now normalize to "no caption" throughout — so an all-blank list lays out exactly like no captions instead of reserving an empty line under every option, and a caption with no option to attach to cannot reserve space or describe the "no options to select" placeholder.

`StyledRadioContent` is deleted — its flex-column and disabled-colour duties move to `StyledRadioField`, the nearest common ancestor of the label and the caption.

## Testing Plan

- Unit: 60 tests across `shared/Radio` and `widgets/Radio`. New assertions are mutation-tested — putting the caption back in the label fails the name and description tests independently, and re-adding a caption click handler fails the e2e negative.
- E2E: 19 tests in `st_radio_test.py` (the rendering test runs in both themes), with the caption assertions aggregated into one scenario.
- Zero snapshot diffs, confirmed pixel-identical against base for `st_radio_test` plus `theming/custom_theme_test`, `st_form_test`, and `mpa_basics_test` via a two-pass local comparison.
- Keyboard behaviour measured against base and identical: tab order, arrow navigation, Space.
- Not covered: the focus highlight no longer spanning the caption — no snapshot captures focus state.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches a core widget’s DOM, accessibility contract, and click/copy behavior with deliberate UX shifts (caption no longer selects the option), though changes are well-tested and scoped to radio captions.
> 
> **Overview**
> **`st.radio` option captions are rendered outside each option’s clickable label** and wired through React Aria’s `description` slot so assistive tech gets the option text as the **accessible name** and the caption via **`aria-describedby`**, instead of merging caption into the name.
> 
> The frontend **normalizes captions** (positionally matched to options, whitespace-only treated as absent, extras ignored) and fixes **crashes when `captions` is shorter than `options`**. Horizontal layouts use an **`aria-hidden` spacer** so uncaptioned options stay aligned when some options have captions.
> 
> **Intentional interaction changes:** clicking a caption no longer selects the option; **links in captions can navigate** (unlike links in option labels); label **`user-select: none` is removed** so option/caption text is easier to copy. Styling moves disabled dimming to **`StyledRadioField`**; **`StyledRadioContent` is removed**.
> 
> Coverage adds **shared/widget unit tests** and a **Playwright scenario** for ARIA names/descriptions, empty captions, caption clicks, and caption links. **`radio.py` docs** clarify partial/short caption lists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 542caafebc6c98f5ed8aa4b2346c3a240d87d516. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

