### PR TITLE
[chore] Use protobufjs/minimal to shrink the entry chunk

### DIFF
--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -93,11 +93,26 @@ export const getNoRestrictedImports = (
           message: "Test utilities must stay in test files.",
         },
       ]
+
+  // Only protobufjs' minimal runtime (Reader/Writer/util) belongs in the app
+  // bundle, which is what the generated proto code already imports. The full
+  // entry point adds the reflection layer and the .proto parser, and
+  // `protobufjs/light` still ships the reflection layer. Matched as a pattern
+  // rather than by name so deep and extensioned specifiers cannot slip past.
+  // Note that `protobufjs/minimal.d.ts` re-exports the full typings, so
+  // reflection classes like `Root` type-check when imported from
+  // `protobufjs/minimal` but are undefined at runtime.
+  const restrictedProtobufjs = {
+    regex: "^protobufjs$|^protobufjs/(?!minimal(\\.js)?$)",
+    message:
+      "Please import from `protobufjs/minimal` to keep the reflection layer and .proto parser out of the bundle.",
+  }
+
   return [
     "error",
     {
       paths: [...basePaths],
-      patterns: [...additionalPatterns],
+      patterns: [...additionalPatterns, restrictedProtobufjs],
     },
   ]
 }

--- a/frontend/lib/src/WidgetStateManager.test.ts
+++ b/frontend/lib/src/WidgetStateManager.test.ts
@@ -17,6 +17,7 @@
 import { waitFor } from "@testing-library/react"
 import { enableMapSet, enablePatches } from "immer"
 import { getLogger } from "loglevel"
+import { type Long, util } from "protobufjs/minimal"
 import { Mock } from "vitest"
 
 import {
@@ -317,6 +318,56 @@ describe("Widget State Manager", () => {
     })
 
     expect(widgetMgr.getIntValue(MOCK_WIDGET)).toBe(Number.MIN_SAFE_INTEGER)
+  })
+
+  describe("handles protobuf sint64 Long values safely", () => {
+    // Cover the Long branch of requireNumberInt directly. Widget int fields are
+    // sint64 (`number | Long`), but the frontend never decodes a WidgetState
+    // (values only go client -> server), so that branch is otherwise unreachable.
+
+    // `false` selects a signed Long, matching sint64 widget int fields.
+    const asLong = (value: number): Long =>
+      util.LongBits.from(value).toLong(false)
+
+    const update = {
+      formId: MOCK_WIDGET.formId,
+      fragmentId: undefined,
+      fromUser: true,
+    }
+
+    const setRawIntValue = (raw: number | Long): void => {
+      widgetMgr.setIntValue(MOCK_WIDGET.id, 0, update)
+      // @ts-expect-error -- widgetStates is private; reach in to simulate a decoded proto
+      widgetMgr.widgetStates.getState(MOCK_WIDGET.id).intValue = raw
+    }
+
+    it.each([0, 42, -42, Number.MAX_SAFE_INTEGER, Number.MIN_SAFE_INTEGER])(
+      "converts a Long holding %i",
+      value => {
+        setRawIntValue(asLong(value))
+        expect(widgetMgr.getIntValue(MOCK_WIDGET)).toBe(value)
+      }
+    )
+
+    it("converts Longs inside an int array", () => {
+      widgetMgr.setIntArrayValue(MOCK_WIDGET.id, [0, 0], update)
+      const data = [asLong(42), asLong(Number.MIN_SAFE_INTEGER)]
+      // @ts-expect-error -- widgetStates is private; reach in to simulate a decoded proto
+      widgetMgr.widgetStates.getState(MOCK_WIDGET.id).intArrayValue.data = data
+
+      expect(widgetMgr.getIntArrayValue(MOCK_WIDGET)).toEqual([
+        42,
+        Number.MIN_SAFE_INTEGER,
+      ])
+    })
+
+    it("throws when a Long exceeds the safe integer range", () => {
+      // 2^53 is the first positive integer outside JavaScript's safe integer range.
+      setRawIntValue(asLong(2 ** 53))
+      expect(() => widgetMgr.getIntValue(MOCK_WIDGET)).toThrow(
+        /cannot be converted to number without a loss of precision/
+      )
+    })
   })
 
   it("setIntArrayValue can handle MIN_ and MAX_SAFE_INTEGER", () => {

--- a/frontend/lib/src/WidgetStateManager.ts
+++ b/frontend/lib/src/WidgetStateManager.ts
@@ -16,7 +16,7 @@
 
 import { Draft, produce } from "immer"
 import { getLogger } from "loglevel"
-import { Long, util } from "protobufjs"
+import { type Long, util } from "protobufjs/minimal"
 import queryString from "query-string"
 import { Signal, SignalConnection } from "typed-signals"
 

--- a/frontend/lib/src/render-tree/test-utils.ts
+++ b/frontend/lib/src/render-tree/test-utils.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Writer } from "protobufjs"
+import { Writer } from "protobufjs/minimal"
 
 import {
   Block as BlockProto,


### PR DESCRIPTION
## Describe your changes

Switch `WidgetStateManager` (and the render-tree test helpers) from `protobufjs` to `protobufjs/minimal`, so the unused reflection layer and `.proto` text parser drop out of the app entry chunk. That is 28.1 KiB gzip which is unreachable at runtime: Streamlit uses statically generated protobuf code, and `frontend/protobuf/proto.js` already imports `protobufjs/minimal.js`.

| Metric | `develop` | This branch | Change |
| :--- | :--- | :--- | :--- |
| Entry chunk (gzip) | 208.2 KiB | 180.1 KiB | **−13.5%** |
| First-load JS (gzip) | 602.9 KiB | 574.7 KiB | −4.67% |
| Total (gzip) | 9069.8 KiB | 9041.6 KiB | −0.31% |

Entry and total drop by the same 28.1 KiB, which is what confirms the code was removed rather than relocated into another chunk the entry still preloads.

Behavior is provably unchanged: `protobufjs`, `protobufjs/light` and `protobufjs/minimal` all return the same exports object, so `require("protobufjs") === require("protobufjs/minimal")` and `util.LongBits` is an identical reference either way. The outer layers only add `codegen`/`fetch`/`path`; they never touch `util.Long` or `LongBits`.

The eslint rule is the load-bearing part of this PR. Because every entry point exposes the same `util.LongBits`, no test can detect a revert to the full specifier — every test would still pass while the bundle silently regrew. A `no-restricted-imports` pattern, in the spirit of the existing `lodash` → `lodash-es` rule, is the only durable guard. It matches by regex rather than exact name so that `protobufjs/light` (which drops only the `.proto` parser and would readmit 22.7 of the 28.1 KiB) and deep or extensioned forms like `protobufjs/index.js` and `protobufjs/src/index` are all covered, while `protobufjs/minimal` stays allowed.

`render-tree/test-utils.ts` gets the same switch for hygiene. Measured at 0 bytes, since it is imported only by `*.test.ts(x)`.

## Testing Plan

- `requireNumberInt`'s `Long` branch had no coverage — every existing test passes `intValue` as a plain `number` and hits the `typeof value === "number"` early return, so the only line consuming protobufjs' `util` never ran. Added 7 tests covering both call sites (`getIntValue` and `getIntArrayValue`) across `0`, `±42`, `MAX_SAFE_INTEGER`, `MIN_SAFE_INTEGER`, and `2^53` where coercion must throw rather than lose precision.
- Mutation-tested: appending `+ 1` to the coercion fails exactly those 6 value assertions and nothing else.
- The tests reach past `private` visibility to plant a `Long`, matching 14 existing `@ts-expect-error` directives in this file. No public route exists: `requireNumberInt` is module-private, `setIntValue` accepts `number` only, and nothing on the frontend decodes a `WidgetState`.
- Full frontend suite: 338 files, 9133 tests passing; `make check` green. Verified the lint pattern by swapping the import through `protobufjs`, `protobufjs/light`, `protobufjs/light.js`, `protobufjs/index.js` and `protobufjs/src/index` (all rejected) while `protobufjs/minimal` stays clean.
- No E2E or manual testing needed: no public API, config, UI, default or error-message change.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
