### PR TITLE
[docs] Fix chartCategoricalColors and Graphviz docs

### DIFF
--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/api-reference.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/api-reference.md
@@ -73,7 +73,7 @@ Run this command with the Streamlit installation relevant to the code being edit
 | `st.form_submit_button` | Display a form submit button. It must be used inside `st.form` and triggers the form's batched submission. A form needs at least one submit button to be functional. |
 | `st.fragment` | Decorator to turn a function into a fragment which can rerun independently of the full app. Use it to reduce rerun cost for isolated interactive sections or run independent, slow sections in parallel during full app reruns. |
 | `st.get_option` | Return the current value of a given Streamlit configuration option. Use it for runtime-aware behavior that depends on configured settings. |
-| `st.graphviz_chart` | Display a graph using the dagre-d3 library. Use it for directed graphs, diagrams, and node-edge visualizations. |
+| `st.graphviz_chart` | Display a graph using the d3-graphviz library and Graphviz WASM. Use it for directed graphs, diagrams, and node-edge visualizations. |
 | `st.header` | Display text in header formatting. Use it for major sections below the page title. |
 | `st.help` | Display help and other information for a given object. It renders docstrings, signatures, and related information inside the app. |
 | `st.html` | Insert HTML into your app. JavaScript is ignored by default (opt in with `unsafe_allow_javascript=True`); for interactive components that exchange data with Python, use `st.components.v2.component()` instead. |

--- a/lib/streamlit/elements/graphviz_chart.py
+++ b/lib/streamlit/elements/graphviz_chart.py
@@ -50,7 +50,7 @@ class GraphvizMixin:
         width: Width = "content",
         height: Height = "content",
     ) -> DeltaGenerator:
-        """Display a graph using the dagre-d3 library.
+        """Display a graph using the d3-graphviz library and Graphviz WASM.
 
         .. Important::
             You must install ``graphviz>=0.19.0`` to use this command. You can

--- a/lib/streamlit/elements/vega_charts.py
+++ b/lib/streamlit/elements/vega_charts.py
@@ -771,7 +771,7 @@ class VegaChartsMixin:
               for three lines). You can also use built-in color names in the
               list (e.g. ``color=["red", "blue", "green"]``).
 
-            You can set the default colors in the ``theme.chartCategoryColors``
+            You can set the default colors in the ``theme.chartCategoricalColors``
             configuration option.
 
         width : "stretch", "content", or int
@@ -845,7 +845,7 @@ class VegaChartsMixin:
         directly and the series will be unlabeled. If the column contains other
         values, those values will label each line, and the line colors will be
         selected from the default color palette. You can configure this color
-        palette in the ``theme.chartCategoryColors`` configuration option.
+        palette in the ``theme.chartCategoricalColors`` configuration option.
 
         >>> import pandas as pd
         >>> import streamlit as st
@@ -1008,7 +1008,7 @@ class VegaChartsMixin:
               for three lines). You can also use built-in color names in the
               list (e.g. ``color=["red", "blue", "green"]``).
 
-            You can set the default colors in the ``theme.chartCategoryColors``
+            You can set the default colors in the ``theme.chartCategoricalColors``
             configuration option.
 
         stack : bool, "normalize", "center", or None
@@ -1094,7 +1094,7 @@ class VegaChartsMixin:
         directly and the series will be unlabeled. If the column contains other
         values, those values will label each area, and the area colors will be
         selected from the default color palette. You can configure this color
-        palette in the ``theme.chartCategoryColors`` configuration option.
+        palette in the ``theme.chartCategoricalColors`` configuration option.
 
         >>> import pandas as pd
         >>> import streamlit as st
@@ -1296,7 +1296,7 @@ class VegaChartsMixin:
               for three lines). You can also use built-in color names in the
               list (e.g. ``color=["red", "blue", "green"]``).
 
-            You can set the default colors in the ``theme.chartCategoryColors``
+            You can set the default colors in the ``theme.chartCategoricalColors``
             configuration option.
 
         horizontal : bool
@@ -1402,7 +1402,7 @@ class VegaChartsMixin:
         directly and the series will be unlabeled. If the column contains other
         values, those values will label each series, and the bar colors will be
         selected from the default color palette. You can configure this color
-        palette in the ``theme.chartCategoryColors`` configuration option.
+        palette in the ``theme.chartCategoricalColors`` configuration option.
 
         >>> import pandas as pd
         >>> import streamlit as st
@@ -1702,7 +1702,7 @@ class VegaChartsMixin:
         directly and each color group will be unlabeled. If the column contains
         other values, those values will label each group, and the scatter point
         colors will be selected from the default color palette. You can
-        configure this color palette in the ``theme.chartCategoryColors``
+        configure this color palette in the ``theme.chartCategoricalColors``
         configuration option.
 
         >>> import pandas as pd


### PR DESCRIPTION
## Describe your changes

Corrects outdated names in chart API docs:

- Simple-chart (`st.line_chart`, `st.area_chart`, `st.bar_chart`, `st.scatter_chart`) docstrings now use `theme.chartCategoricalColors`.
- `st.graphviz_chart` now documents d3-graphviz and Graphviz WASM instead of dagre-d3.

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- Documentation-only change; no runtime behavior to test.
- Existing Python unit tests for Vega charts still pass.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.