### PR TITLE
[docs] Discourage custom HTML in markdown docs

### DIFF
--- a/lib/streamlit/elements/html.py
+++ b/lib/streamlit/elements/html.py
@@ -64,6 +64,10 @@ class HtmlMixin:
         ``unsafe_allow_javascript=True``. Use this with caution and never pass
         untrusted input.
 
+        .. note::
+            Prefer native Streamlit features and advanced theming over custom
+            CSS or custom HTML components.
+
         Parameters
         ----------
         body : any

--- a/lib/streamlit/elements/html.py
+++ b/lib/streamlit/elements/html.py
@@ -65,8 +65,8 @@ class HtmlMixin:
         untrusted input.
 
         .. note::
-            Prefer native Streamlit features and advanced theming over custom
-            CSS or custom HTML components.
+            Prefer native Streamlit features and theming over custom CSS or
+            HTML.
 
         Parameters
         ----------

--- a/lib/streamlit/elements/markdown.py
+++ b/lib/streamlit/elements/markdown.py
@@ -180,10 +180,10 @@ class MarkdownMixin:
             expressions within ``body`` will be rendered.
 
             Adding custom HTML to your app impacts safety, styling, and
-            maintainability. Don't use this to build custom components or
-            inject custom CSS. Prefer native Streamlit features and advanced
-            theming instead. If custom CSS or HTML (without Markdown) is
-            necessary, use ``st.html``.
+            maintainability. Don't use ``unsafe_allow_html`` to recreate UI
+            or inject CSS. Prefer native Streamlit features and theming
+            instead. If you need HTML or CSS without Markdown, use
+            ``st.html``.
 
             ``unsafe_allow_html=True`` cannot be combined with ``wrap=False``.
 
@@ -320,10 +320,10 @@ class MarkdownMixin:
             expressions within ``body`` will be rendered.
 
             Adding custom HTML to your app impacts safety, styling, and
-            maintainability. Don't use this to build custom components or
-            inject custom CSS. Prefer native Streamlit features and advanced
-            theming instead. If custom CSS or HTML (without Markdown) is
-            necessary, use ``st.html``.
+            maintainability. Don't use ``unsafe_allow_html`` to recreate UI
+            or inject CSS. Prefer native Streamlit features and theming
+            instead. If you need HTML or CSS without Markdown, use
+            ``st.html``.
 
             ``unsafe_allow_html=True`` cannot be combined with ``wrap=False``.
 

--- a/lib/streamlit/elements/markdown.py
+++ b/lib/streamlit/elements/markdown.py
@@ -180,13 +180,12 @@ class MarkdownMixin:
             expressions within ``body`` will be rendered.
 
             Adding custom HTML to your app impacts safety, styling, and
-            maintainability.
+            maintainability. Don't use this to build custom components or
+            inject custom CSS. Prefer native Streamlit features and advanced
+            theming instead. If custom CSS or HTML (without Markdown) is
+            necessary, use ``st.html``.
 
             ``unsafe_allow_html=True`` cannot be combined with ``wrap=False``.
-
-            .. note::
-                If you only want to insert HTML or CSS without Markdown text,
-                we recommend using ``st.html`` instead.
 
         help : str or None
             A tooltip that gets displayed next to the Markdown. If this is
@@ -321,13 +320,12 @@ class MarkdownMixin:
             expressions within ``body`` will be rendered.
 
             Adding custom HTML to your app impacts safety, styling, and
-            maintainability.
+            maintainability. Don't use this to build custom components or
+            inject custom CSS. Prefer native Streamlit features and advanced
+            theming instead. If custom CSS or HTML (without Markdown) is
+            necessary, use ``st.html``.
 
             ``unsafe_allow_html=True`` cannot be combined with ``wrap=False``.
-
-            .. note::
-                If you only want to insert HTML or CSS without Markdown text,
-                we recommend using ``st.html`` instead.
 
         help : str or None
             A tooltip that gets displayed next to the caption. If this is

--- a/lib/streamlit/elements/write.py
+++ b/lib/streamlit/elements/write.py
@@ -366,11 +366,10 @@ class WriteMixin:
             HTML expressions within ``body`` will be rendered.
 
             Adding custom HTML to your app impacts safety, styling, and
-            maintainability.
-
-            .. note::
-                If you only want to insert HTML or CSS without Markdown text,
-                we recommend using ``st.html`` instead.
+            maintainability. Don't use ``unsafe_allow_html`` to recreate UI
+            or inject CSS. Prefer native Streamlit features and theming
+            instead. If you need HTML or CSS without Markdown, use
+            ``st.html``.
 
         Examples
         --------


### PR DESCRIPTION
## Describe your changes

- Discourage using `unsafe_allow_html` on `st.markdown`, `st.caption`, and `st.write` to recreate UI or inject CSS. Prefer native features and theming; use `st.html` for HTML or CSS without Markdown.
- Note on `st.html` that native features and theming are preferred over custom CSS or HTML.

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- Documentation-only docstring updates; no runtime behavior to test.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.