### PR TITLE
[fix] Skip no-op query-param history entries

### DIFF
--- a/e2e_playwright/st_query_params_history.py
+++ b/e2e_playwright/st_query_params_history.py
@@ -1,0 +1,19 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import streamlit as st
+
+st.checkbox("Toggle this")
+st.query_params["number"] = 1
+st.markdown(str(st.query_params))

--- a/e2e_playwright/st_query_params_history.py
+++ b/e2e_playwright/st_query_params_history.py
@@ -16,4 +16,6 @@ import streamlit as st
 
 st.checkbox("Toggle this")
 st.query_params["number"] = 1
+if st.button("Set extra param"):
+    st.query_params["extra"] = "yes"
 st.markdown(str(st.query_params))

--- a/e2e_playwright/st_query_params_history_test.py
+++ b/e2e_playwright/st_query_params_history_test.py
@@ -16,7 +16,8 @@ import re
 
 from playwright.sync_api import Page, expect
 
-from e2e_playwright.shared.app_utils import click_checkbox
+from e2e_playwright.conftest import wait_for_app_run
+from e2e_playwright.shared.app_utils import click_button, click_checkbox
 
 
 def test_repeated_query_param_assignment_does_not_push_history(app: Page):
@@ -25,7 +26,6 @@ def test_repeated_query_param_assignment_does_not_push_history(app: Page):
     Regression test for https://github.com/streamlit/streamlit/issues/9878
     """
     expect(app).to_have_url(re.compile(r"[?&]number=1(?:&|$)"))
-    expect(app).not_to_have_url(re.compile(r"number=1.*number=1"))
 
     history_length_before = app.evaluate("window.history.length")
 
@@ -33,7 +33,21 @@ def test_repeated_query_param_assignment_does_not_push_history(app: Page):
 
     expect(app).to_have_url(re.compile(r"[?&]number=1(?:&|$)"))
     expect(app).not_to_have_url(re.compile(r"number=1.*number=1"))
-    history_length_after = app.evaluate("window.history.length")
-    assert history_length_after == history_length_before, (
-        f"history.length grew from {history_length_before} to {history_length_after}"
+    history_length_after_noop = app.evaluate("window.history.length")
+    assert history_length_after_noop == history_length_before, (
+        f"history.length grew from {history_length_before} to {history_length_after_noop}"
     )
+
+    click_button(app, "Set extra param")
+
+    expect(app).to_have_url(re.compile(r"[?&]extra=yes(?:&|$)"))
+    history_length_after_change = app.evaluate("window.history.length")
+    assert history_length_after_change == history_length_before + 1, (
+        "history.length did not grow after a real query-param change: "
+        f"before={history_length_before}, after={history_length_after_change}"
+    )
+
+    app.go_back()
+    wait_for_app_run(app)
+    expect(app).to_have_url(re.compile(r"[?&]number=1(?:&|$)"))
+    expect(app).not_to_have_url(re.compile(r"[?&]extra=yes(?:&|$)"))

--- a/e2e_playwright/st_query_params_history_test.py
+++ b/e2e_playwright/st_query_params_history_test.py
@@ -31,7 +31,8 @@ def test_repeated_query_param_assignment_does_not_push_history(app: Page):
     click_checkbox(app, "Toggle this")
 
     expect(app).to_have_url(re.compile(r"[?&]number=1(?:&|$)"))
-    expect(app).not_to_have_url(re.compile(r"number=1.*number=1"))
+    # Guard against the param being appended again instead of replaced.
+    expect(app).not_to_have_url(re.compile(r"number=1(&.*)?&number="))
     history_length_after_noop = app.evaluate("window.history.length")
     assert history_length_after_noop == history_length_before, (
         f"history.length grew from {history_length_before} to {history_length_after_noop}"

--- a/e2e_playwright/st_query_params_history_test.py
+++ b/e2e_playwright/st_query_params_history_test.py
@@ -1,0 +1,39 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+
+from playwright.sync_api import Page, expect
+
+from e2e_playwright.shared.app_utils import click_checkbox
+
+
+def test_repeated_query_param_assignment_does_not_push_history(app: Page):
+    """Re-assigning the same query param on rerun must not add a history entry.
+
+    Regression test for https://github.com/streamlit/streamlit/issues/9878
+    """
+    expect(app).to_have_url(re.compile(r"[?&]number=1(?:&|$)"))
+    expect(app).not_to_have_url(re.compile(r"number=1.*number=1"))
+
+    history_length_before = app.evaluate("window.history.length")
+
+    click_checkbox(app, "Toggle this")
+
+    expect(app).to_have_url(re.compile(r"[?&]number=1(?:&|$)"))
+    expect(app).not_to_have_url(re.compile(r"number=1.*number=1"))
+    history_length_after = app.evaluate("window.history.length")
+    assert history_length_after == history_length_before, (
+        f"history.length grew from {history_length_before} to {history_length_after}"
+    )

--- a/e2e_playwright/st_query_params_history_test.py
+++ b/e2e_playwright/st_query_params_history_test.py
@@ -16,7 +16,6 @@ import re
 
 from playwright.sync_api import Page, expect
 
-from e2e_playwright.conftest import wait_for_app_run
 from e2e_playwright.shared.app_utils import click_button, click_checkbox
 
 
@@ -46,8 +45,3 @@ def test_repeated_query_param_assignment_does_not_push_history(app: Page):
         "history.length did not grow after a real query-param change: "
         f"before={history_length_before}, after={history_length_after_change}"
     )
-
-    app.go_back()
-    wait_for_app_run(app)
-    expect(app).to_have_url(re.compile(r"[?&]number=1(?:&|$)"))
-    expect(app).not_to_have_url(re.compile(r"[?&]extra=yes(?:&|$)"))

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -1874,8 +1874,8 @@ describe("App", () => {
     it("does not override the pathname when resetting query params", () => {
       renderApp(getProps())
       const pathname = "/foo/bar/"
-      // Set the value of document.location.pathname to pathname.
-      window.history.pushState({}, "", pathname)
+      window.history.pushState({}, "", `${pathname}?flying=spaghetti`)
+      pushStateSpy.mockClear()
 
       sendForwardMessage("pageInfoChanged", {
         queryString: "",
@@ -1886,8 +1886,8 @@ describe("App", () => {
 
     it("resets query params as expected when at the root pathname", () => {
       renderApp(getProps())
-      // Note: One would typically set the value of document.location.pathname to '/' here,
-      // However, this is already taking place in beforeEach().
+      window.history.pushState({}, "", "/?flying=spaghetti")
+      pushStateSpy.mockClear()
 
       sendForwardMessage("pageInfoChanged", {
         queryString: "",
@@ -1909,6 +1909,50 @@ describe("App", () => {
 
       const expectedUrl = `/?${queryString}`
       expect(pushStateSpy).toHaveBeenLastCalledWith({}, "", expectedUrl)
+    })
+
+    it("does not push history when the query string is unchanged", () => {
+      renderApp(getProps())
+      const queryString = "flying=spaghetti&monster=omg"
+      window.history.pushState({}, "", `/?${queryString}`)
+      pushStateSpy.mockClear()
+
+      sendForwardMessage("pageInfoChanged", {
+        queryString,
+      })
+
+      expect(pushStateSpy).not.toHaveBeenCalled()
+    })
+
+    it("does not push history when resetting already-empty query params", () => {
+      renderApp(getProps())
+      pushStateSpy.mockClear()
+
+      sendForwardMessage("pageInfoChanged", {
+        queryString: "",
+      })
+
+      expect(pushStateSpy).not.toHaveBeenCalled()
+    })
+
+    it("still confirms query params to the host when the URL is unchanged", () => {
+      renderApp(getProps())
+      const queryString = "flying=spaghetti&monster=omg"
+      window.history.pushState({}, "", `/?${queryString}`)
+
+      const hostCommunicationMgr = getStoredValue<HostCommunicationManager>(
+        HostCommunicationManager
+      )
+      ;(hostCommunicationMgr.sendMessageToHost as Mock).mockClear()
+
+      sendForwardMessage("pageInfoChanged", {
+        queryString,
+      })
+
+      expect(hostCommunicationMgr.sendMessageToHost).toHaveBeenCalledWith({
+        type: "SET_QUERY_PARAM",
+        queryParams: `?${queryString}`,
+      })
     })
   })
 

--- a/frontend/app/src/App.test.tsx
+++ b/frontend/app/src/App.test.tsx
@@ -1874,6 +1874,7 @@ describe("App", () => {
     it("does not override the pathname when resetting query params", () => {
       renderApp(getProps())
       const pathname = "/foo/bar/"
+      // Seed a query string so that resetting it is an actual URL change.
       window.history.pushState({}, "", `${pathname}?flying=spaghetti`)
       pushStateSpy.mockClear()
 
@@ -1886,6 +1887,7 @@ describe("App", () => {
 
     it("resets query params as expected when at the root pathname", () => {
       renderApp(getProps())
+      // Seed a query string so that resetting it is an actual URL change.
       window.history.pushState({}, "", "/?flying=spaghetti")
       pushStateSpy.mockClear()
 
@@ -1935,7 +1937,7 @@ describe("App", () => {
       expect(pushStateSpy).not.toHaveBeenCalled()
     })
 
-    it("still confirms query params to the host when the URL is unchanged", () => {
+    it("still sends SET_QUERY_PARAM to the host when the query string is unchanged", () => {
       renderApp(getProps())
       const queryString = "flying=spaghetti&monster=omg"
       window.history.pushState({}, "", `/?${queryString}`)

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1256,9 +1256,10 @@ export class App extends PureComponent<Props, State> {
       document.location.pathname + (queryString ? `?${queryString}` : "")
     const currentSearch = document.location.search.replace(/^\?/, "")
 
-    // Skip pushState when the query string is already current so reruns do not
-    // fill the back stack (an unchanged query string still creates a history
-    // entry). Always update React state and notify the host so embeds stay in sync.
+    // `pushState` always adds a history entry, even when the resulting URL is
+    // identical, so reruns that re-assign the same query params would otherwise
+    // fill the back stack with no-op entries. React state and the host message
+    // below are still updated so embeds stay in sync.
     if (queryString !== currentSearch) {
       window.history.pushState({}, "", targetUrl)
     }

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1256,9 +1256,9 @@ export class App extends PureComponent<Props, State> {
       document.location.pathname + (queryString ? `?${queryString}` : "")
     const currentSearch = document.location.search.replace(/^\?/, "")
 
-    // Identical URLs still create a history entry under the HTML spec, so
-    // skip pushState when the query string is already current. Still update
-    // React state and notify the host so embeds stay in sync.
+    // Skip pushState when the query string is already current so reruns do not
+    // fill the back stack (an unchanged query string still creates a history
+    // entry). Always update React state and notify the host so embeds stay in sync.
     if (queryString !== currentSearch) {
       window.history.pushState({}, "", targetUrl)
     }

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -1254,7 +1254,14 @@ export class App extends PureComponent<Props, State> {
     const { queryString } = pageInfo
     const targetUrl =
       document.location.pathname + (queryString ? `?${queryString}` : "")
-    window.history.pushState({}, "", targetUrl)
+    const currentSearch = document.location.search.replace(/^\?/, "")
+
+    // Identical URLs still create a history entry under the HTML spec, so
+    // skip pushState when the query string is already current. Still update
+    // React state and notify the host so embeds stay in sync.
+    if (queryString !== currentSearch) {
+      window.history.pushState({}, "", targetUrl)
+    }
 
     this.setState({ queryParams: queryString })
 


### PR DESCRIPTION
## Describe your changes

Apps that assign `st.query_params` on every run added a browser history entry per rerun, so the Back button only stepped through duplicate URLs instead of leaving the app. `history.pushState` creates an entry even when the URL is unchanged, so `App.handlePageInfoChanged` now skips it when the query string already matches `document.location.search`.

- Still updates React state and sends `SET_QUERY_PARAM` so embedded hosts stay in sync
- Real query-string changes still use `pushState` so the previous query string remains on the Back stack; `replaceState` would make those writes un-undoable

## GitHub Issue Link (if applicable)

- Closes #9878

## Testing Plan

- [x] Unit Tests (JS and/or Python)
- [x] E2E Tests