### PR TITLE
[fix] Stop dropping in-flight Custom Components v2 triggers

### DIFF
--- a/e2e_playwright/bidi_components/basics_test.py
+++ b/e2e_playwright/bidi_components/basics_test.py
@@ -82,7 +82,9 @@ def test_stateful_interactions(app: Page) -> None:
     expect(
         stateful.get_by_text("Result: {'range': '10', 'text': 'Hello'}")
     ).to_be_visible()
-    expect(stateful.get_by_text("session_state: {'range': '10', 'text': 'Hello'}"))
+    expect(
+        stateful.get_by_text("session_state: {'range': '10', 'text': 'Hello'}")
+    ).to_be_visible()
     expect(stateful.get_by_text("Range change count: 1")).to_be_visible()
     expect(stateful.get_by_text("Text change count: 1")).to_be_visible()
 
@@ -91,7 +93,8 @@ def test_trigger_interactions(app: Page) -> None:
     """Test the interactions with trigger callbacks and state in the Bidi Component."""
     trigger = section(app, "Trigger")
 
-    # Bidi components load JS/HTML in an iframe; allow extra time on slower browsers
+    # The component's JS/HTML loads in an iframe, so its first paint can lag
+    # the page load.
     expect(trigger.get_by_text("Foo count: 0")).to_be_visible(timeout=10000)
     expect(trigger.get_by_text("Bar count: 0")).to_be_visible()
     expect(trigger.get_by_text("Result: {'foo': None, 'bar': None}")).to_be_visible()
@@ -101,35 +104,35 @@ def test_trigger_interactions(app: Page) -> None:
     expect(trigger.get_by_text("Foo count: 1")).to_be_visible()
     expect(trigger.get_by_text("Bar count: 0")).to_be_visible()
     expect(trigger.get_by_text("Result: {'foo': True, 'bar': None}")).to_be_visible()
-    expect(trigger.get_by_text("Session state: {'foo': True}"))
+    expect(trigger.get_by_text("Session state: {'foo': True}")).to_be_visible()
 
     trigger.get_by_text("Trigger bar").click()
     expect(trigger.get_by_text("Foo count: 1")).to_be_visible()
     expect(trigger.get_by_text("Bar count: 1")).to_be_visible()
     expect(trigger.get_by_text("Result: {'foo': None, 'bar': True}")).to_be_visible()
-    expect(trigger.get_by_text("Session state: {'bar': True}"))
+    expect(trigger.get_by_text("Session state: {'bar': True}")).to_be_visible()
 
     # Trigger foo again so it has a different value from bar
     trigger.get_by_text("Trigger foo").click()
     expect(trigger.get_by_text("Foo count: 2")).to_be_visible()
     expect(trigger.get_by_text("Bar count: 1")).to_be_visible()
     expect(trigger.get_by_text("Result: {'foo': True, 'bar': None}")).to_be_visible()
-    expect(trigger.get_by_text("Session state: {'foo': True}"))
+    expect(trigger.get_by_text("Session state: {'foo': True}")).to_be_visible()
 
     trigger.get_by_text("Trigger both").click()
-    # "Trigger both" fires two setTriggerValue calls from the iframe; on WebKit
-    # the round-trip can be slower, so allow extra time for the rerun to complete.
-    expect(trigger.get_by_text("Foo count: 3")).to_be_visible(timeout=10000)
+    expect(trigger.get_by_text("Foo count: 3")).to_be_visible()
     expect(trigger.get_by_text("Bar count: 2")).to_be_visible()
     expect(trigger.get_by_text("Result: {'foo': True, 'bar': True}")).to_be_visible()
-    expect(trigger.get_by_text("Session state: {'foo': True, 'bar': True}"))
+    expect(
+        trigger.get_by_text("Session state: {'foo': True, 'bar': True}")
+    ).to_be_visible()
 
     # Trigger a streamlit button to ensure the trigger values in the Bidi Component get reset
     trigger.get_by_text("st.button trigger").click()
     expect(trigger.get_by_text("Foo count: 3")).to_be_visible()
     expect(trigger.get_by_text("Bar count: 2")).to_be_visible()
     expect(trigger.get_by_text("Result: {'foo': None, 'bar': None}")).to_be_visible()
-    expect(trigger.get_by_text("Session state: {}"))
+    expect(trigger.get_by_text("Session state: {}")).to_be_visible()
 
 
 def test_form_interactions_deferred_until_submit(app: Page) -> None:
@@ -154,7 +157,7 @@ def test_form_interactions_deferred_until_submit(app: Page) -> None:
     expect(form.get_by_text("Form Clicked count: 0")).to_be_visible()
 
     # Also the displayed state should still be empty before submit.
-    expect(form.get_by_text("Form session state: {}"))
+    expect(form.get_by_text("Form session state: {}")).to_be_visible()
 
     # Submit the form and verify rerun + updates (only stateful changes apply).
     click_form_button(app, "Submit Form")
@@ -176,7 +179,7 @@ def test_fragment_interactions_rerun_only_fragment(app: Page) -> None:
 
     # Initial state for fragments
     expect(app.get_by_text("Runs: 1", exact=True)).to_be_visible()
-    expect(fragment.get_by_text("Fragment session state: {}"))
+    expect(fragment.get_by_text("Fragment session state: {}")).to_be_visible()
     expect(fragment.get_by_text("Fragment Text changes: 0")).to_be_visible()
     expect(fragment.get_by_text("Fragment Clicked count: 0")).to_be_visible()
 

--- a/e2e_playwright/bidi_components/basics_test.py
+++ b/e2e_playwright/bidi_components/basics_test.py
@@ -104,7 +104,11 @@ def test_trigger_interactions(app: Page) -> None:
     expect(trigger.get_by_text("Foo count: 1")).to_be_visible()
     expect(trigger.get_by_text("Bar count: 0")).to_be_visible()
     expect(trigger.get_by_text("Result: {'foo': True, 'bar': None}")).to_be_visible()
-    expect(trigger.get_by_text("Session state: {'foo': True}")).to_be_visible()
+    # exact=True because this is a strict prefix of "{'foo': True, 'bar': True}",
+    # so substring matching would pass even if a stale bar leaked into state.
+    expect(
+        trigger.get_by_text("Session state: {'foo': True}", exact=True)
+    ).to_be_visible()
 
     trigger.get_by_text("Trigger bar").click()
     expect(trigger.get_by_text("Foo count: 1")).to_be_visible()
@@ -117,7 +121,11 @@ def test_trigger_interactions(app: Page) -> None:
     expect(trigger.get_by_text("Foo count: 2")).to_be_visible()
     expect(trigger.get_by_text("Bar count: 1")).to_be_visible()
     expect(trigger.get_by_text("Result: {'foo': True, 'bar': None}")).to_be_visible()
-    expect(trigger.get_by_text("Session state: {'foo': True}")).to_be_visible()
+    # exact=True because this is a strict prefix of "{'foo': True, 'bar': True}",
+    # so substring matching would pass even if a stale bar leaked into state.
+    expect(
+        trigger.get_by_text("Session state: {'foo': True}", exact=True)
+    ).to_be_visible()
 
     trigger.get_by_text("Trigger both").click()
     expect(trigger.get_by_text("Foo count: 3")).to_be_visible()

--- a/frontend/lib/src/WidgetStateManager.test.ts
+++ b/frontend/lib/src/WidgetStateManager.test.ts
@@ -25,6 +25,7 @@ import {
   Button as ButtonProto,
   FileUploaderState as FileUploaderStateProto,
   UploadedFileInfo as UploadedFileInfoProto,
+  WidgetState,
 } from "@streamlit/protobuf"
 
 import {
@@ -1280,6 +1281,102 @@ describe("Widget State Manager", () => {
     expect(widgetMgr.getElementState(elementId2, "key2")).toEqual(
       "elementState2"
     )
+  })
+
+  it("keeps in-flight trigger values on removeInactive until they are flushed", async () => {
+    // The Custom Components v2 trigger aggregator writes to a synthetic id that
+    // is never an active element id, so a removeInactive landing between the
+    // write and the batched flush used to destroy it, leaving the flush to send
+    // a rerun with no trigger.
+    const aggregatorId = "_streamlit_internal_myComponent:events"
+    const update = { formId: "", fragmentId: undefined, fromUser: true }
+
+    void widgetMgr.setTriggerValue(aggregatorId, update, {
+      event: "foo",
+      value: true,
+    })
+    void widgetMgr.setTriggerValue(aggregatorId, update, {
+      event: "bar",
+      value: true,
+    })
+
+    // A genuinely stale widget, to pin that retention is targeted at in-flight
+    // triggers rather than blanket. `fromUser: false` avoids an extra flush.
+    widgetMgr.setStringValue("staleWidget", "gone", {
+      formId: "",
+      fragmentId: undefined,
+      fromUser: false,
+    })
+
+    widgetMgr.removeInactive(new Set(["myComponent"]))
+
+    await waitFor(() => expect(sendBackMsg).toHaveBeenCalledTimes(1))
+
+    const { widgets } = sendBackMsg.mock.calls[0][0]
+    expect(widgets).toHaveLength(1)
+    expect(widgets[0].id).toEqual(aggregatorId)
+    // Both payloads batched in the same macrotask must survive.
+    expect(JSON.parse(widgets[0].jsonTriggerValue)).toEqual([
+      { event: "foo", value: true },
+      { event: "bar", value: true },
+    ])
+    expect(widgetMgr.getStringValue({ id: "staleWidget" })).toBeUndefined()
+  })
+
+  it("keeps in-flight trigger values for widgets inside a form", () => {
+    const triggerId = "formTriggerWidget"
+    const { formId } = MOCK_FORM_WIDGET
+
+    widgetMgr.setStringTriggerValue(triggerId, "typed", {
+      formId,
+      fragmentId: undefined,
+      fromUser: true,
+    })
+    // A stale non-trigger widget in the same form, to pin that retention is
+    // targeted rather than sparing the whole form dict.
+    widgetMgr.setStringValue(MOCK_FORM_WIDGET.id, "stale", {
+      formId,
+      fragmentId: undefined,
+      fromUser: true,
+    })
+
+    // Form-scoped trigger state lives in the form's own dict, so it needs the
+    // same protection from a removeInactive landing before the flush.
+    widgetMgr.removeInactive(new Set())
+    widgetMgr.submitForm(formId, undefined)
+
+    // The pending flush has not run yet, so the submit is the only message.
+    expect(sendBackMsg).toHaveBeenCalledTimes(1)
+    const { widgets } = sendBackMsg.mock.calls[0][0]
+    expect(
+      widgets.find((widget: WidgetState) => widget.id === triggerId)
+        ?.stringTriggerValue?.data
+    ).toEqual("typed")
+    expect(widgets.map((widget: WidgetState) => widget.id)).not.toContain(
+      MOCK_FORM_WIDGET.id
+    )
+  })
+
+  it("drops widget state for a spent trigger id on a later removeInactive", async () => {
+    const aggregatorId = "_streamlit_internal_myComponent:events"
+
+    await widgetMgr.setTriggerValue(
+      aggregatorId,
+      { formId: "", fragmentId: undefined, fromUser: true },
+      { event: "foo", value: true }
+    )
+
+    // Give the spent id fresh state. If the flush failed to clear it from
+    // `pendingTriggerIds`, removeInactive would wrongly retain this.
+    widgetMgr.setStringValue(aggregatorId, "stale", {
+      formId: "",
+      fragmentId: undefined,
+      fromUser: false,
+    })
+
+    widgetMgr.removeInactive(new Set(["myComponent"]))
+
+    expect(widgetMgr.getStringValue({ id: aggregatorId })).toBeUndefined()
   })
 
   it("cleans up inactive form widget states on removeInactive", () => {

--- a/frontend/lib/src/WidgetStateManager.test.ts
+++ b/frontend/lib/src/WidgetStateManager.test.ts
@@ -1301,8 +1301,8 @@ describe("Widget State Manager", () => {
       value: true,
     })
 
-    // A genuinely stale widget, to pin that retention is targeted at in-flight
-    // triggers rather than blanket. `fromUser: false` avoids an extra flush.
+    // A genuinely stale widget: retention must apply only to in-flight
+    // triggers, not to every widget. `fromUser: false` avoids an extra flush.
     widgetMgr.setStringValue("staleWidget", "gone", {
       formId: "",
       fragmentId: undefined,
@@ -1333,17 +1333,16 @@ describe("Widget State Manager", () => {
       fragmentId: undefined,
       fromUser: true,
     })
-    // A stale non-trigger widget in the same form, to pin that retention is
-    // targeted rather than sparing the whole form dict.
+    // A stale non-trigger widget in the same form: retention must not spare the
+    // whole form dict.
     widgetMgr.setStringValue(MOCK_FORM_WIDGET.id, "stale", {
       formId,
       fragmentId: undefined,
       fromUser: true,
     })
 
-    // Form-scoped trigger state lives in the form's own dict. CCv2 no-ops
-    // triggers inside forms, so this is defense in depth for the other
-    // form-capable trigger writers rather than a reachable CCv2 path.
+    // Defense in depth for form-scoped trigger writers. CCv2 no-ops triggers
+    // inside forms, so this is not a reachable CCv2 path.
     widgetMgr.removeInactive(new Set())
     widgetMgr.submitForm(formId, undefined)
 
@@ -1359,7 +1358,7 @@ describe("Widget State Manager", () => {
     )
   })
 
-  it("drops widget state for a spent trigger id on a later removeInactive", async () => {
+  it("drops widget state for a trigger id after its flush has run", async () => {
     const aggregatorId = makeTriggerAggregatorId("myComponent")
 
     await widgetMgr.setTriggerValue(

--- a/frontend/lib/src/WidgetStateManager.test.ts
+++ b/frontend/lib/src/WidgetStateManager.test.ts
@@ -28,6 +28,8 @@ import {
   WidgetState,
 } from "@streamlit/protobuf"
 
+import { makeTriggerAggregatorId } from "~lib/components/widgets/BidiComponent/utils/idBuilder"
+
 import {
   createFormsData,
   FormsData,
@@ -1284,11 +1286,10 @@ describe("Widget State Manager", () => {
   })
 
   it("keeps in-flight trigger values on removeInactive until they are flushed", async () => {
-    // The Custom Components v2 trigger aggregator writes to a synthetic id that
-    // is never an active element id, so a removeInactive landing between the
-    // write and the batched flush used to destroy it, leaving the flush to send
-    // a rerun with no trigger.
-    const aggregatorId = "_streamlit_internal_myComponent:events"
+    // Custom Components v2 aggregators use a synthetic id that is never an
+    // active element id. removeInactive must keep that state in flight until
+    // the batched flush, or the flush sends a rerun carrying no trigger.
+    const aggregatorId = makeTriggerAggregatorId("myComponent")
     const update = { formId: "", fragmentId: undefined, fromUser: true }
 
     void widgetMgr.setTriggerValue(aggregatorId, update, {
@@ -1340,8 +1341,9 @@ describe("Widget State Manager", () => {
       fromUser: true,
     })
 
-    // Form-scoped trigger state lives in the form's own dict, so it needs the
-    // same protection from a removeInactive landing before the flush.
+    // Form-scoped trigger state lives in the form's own dict. CCv2 no-ops
+    // triggers inside forms, so this is defense in depth for the other
+    // form-capable trigger writers rather than a reachable CCv2 path.
     widgetMgr.removeInactive(new Set())
     widgetMgr.submitForm(formId, undefined)
 
@@ -1358,7 +1360,7 @@ describe("Widget State Manager", () => {
   })
 
   it("drops widget state for a spent trigger id on a later removeInactive", async () => {
-    const aggregatorId = "_streamlit_internal_myComponent:events"
+    const aggregatorId = makeTriggerAggregatorId("myComponent")
 
     await widgetMgr.setTriggerValue(
       aggregatorId,

--- a/frontend/lib/src/WidgetStateManager.ts
+++ b/frontend/lib/src/WidgetStateManager.ts
@@ -946,6 +946,10 @@ export class WidgetStateManager {
    * Remove the state of widgets that are not contained in `activeIds`.
    * This is called when a script finishes running, so that we don't retain
    * data for widgets that have been removed from the app.
+   *
+   * Widget ids in `pendingTriggerIds` are kept even when absent from
+   * `activeIds`, because they are in-flight for the next batched flush.
+   * Element state always follows `activeIds` alone.
    */
   public removeInactive(activeIds: Set<string>): void {
     // Trigger states awaiting the macrotask flush are in-flight, not stale, and
@@ -953,7 +957,11 @@ export class WidgetStateManager {
     // ids that never appear in `activeIds`. Dropping one leaves the
     // already-scheduled flush to send a rerun with no trigger, silently losing
     // the interaction (GitHub issue #16732).
-    const retainedIds = new Set([...activeIds, ...this.pendingTriggerIds])
+    // Nothing in flight is the common case, so avoid copying the set for it.
+    const retainedIds =
+      this.pendingTriggerIds.size === 0
+        ? activeIds
+        : new Set([...activeIds, ...this.pendingTriggerIds])
 
     this.widgetStates.removeInactive(retainedIds)
     this.forms.forEach(form => form.widgetStates.removeInactive(retainedIds))

--- a/frontend/lib/src/WidgetStateManager.ts
+++ b/frontend/lib/src/WidgetStateManager.ts
@@ -948,8 +948,17 @@ export class WidgetStateManager {
    * data for widgets that have been removed from the app.
    */
   public removeInactive(activeIds: Set<string>): void {
-    this.widgetStates.removeInactive(activeIds)
-    this.forms.forEach(form => form.widgetStates.removeInactive(activeIds))
+    // Trigger states awaiting the macrotask flush are in-flight, not stale, and
+    // some (such as the Custom Components v2 trigger aggregator) use synthetic
+    // ids that never appear in `activeIds`. Dropping one leaves the
+    // already-scheduled flush to send a rerun with no trigger, silently losing
+    // the interaction (GitHub issue #16732).
+    const retainedIds = new Set([...activeIds, ...this.pendingTriggerIds])
+
+    this.widgetStates.removeInactive(retainedIds)
+    this.forms.forEach(form => form.widgetStates.removeInactive(retainedIds))
+    // Element states never enter the rerun message, so they follow `activeIds`
+    // exactly.
     this.elementStates.forEach((_, elementId) => {
       if (!activeIds.has(elementId)) {
         this.deleteElementState(elementId)

--- a/frontend/lib/src/WidgetStateManager.ts
+++ b/frontend/lib/src/WidgetStateManager.ts
@@ -943,20 +943,18 @@ export class WidgetStateManager {
   }
 
   /**
-   * Remove the state of widgets that are not contained in `activeIds`.
-   * This is called when a script finishes running, so that we don't retain
-   * data for widgets that have been removed from the app.
+   * Remove widget and element state that is no longer in `activeIds`, except
+   * in-flight trigger ids in `pendingTriggerIds`.
    *
-   * Widget ids in `pendingTriggerIds` are kept even when absent from
-   * `activeIds`, because they are in-flight for the next batched flush.
-   * Element state always follows `activeIds` alone.
+   * Called when a script finishes running so we do not keep data for widgets
+   * that have been removed from the app. The excepted trigger ids are waiting
+   * on the batched flush, and some (such as the Custom Components v2 trigger
+   * aggregator) are synthetic ids that never appear in `activeIds` at all;
+   * dropping one leaves that flush to send a rerun with no trigger, silently
+   * losing the interaction (GitHub issue #16732). Element state is never part
+   * of the rerun message, so it follows `activeIds` only.
    */
   public removeInactive(activeIds: Set<string>): void {
-    // Trigger states awaiting the macrotask flush are in-flight, not stale, and
-    // some (such as the Custom Components v2 trigger aggregator) use synthetic
-    // ids that never appear in `activeIds`. Dropping one leaves the
-    // already-scheduled flush to send a rerun with no trigger, silently losing
-    // the interaction (GitHub issue #16732).
     // Nothing in flight is the common case, so avoid copying the set for it.
     const retainedIds =
       this.pendingTriggerIds.size === 0
@@ -965,8 +963,6 @@ export class WidgetStateManager {
 
     this.widgetStates.removeInactive(retainedIds)
     this.forms.forEach(form => form.widgetStates.removeInactive(retainedIds))
-    // Element states never enter the rerun message, so they follow `activeIds`
-    // exactly.
     this.elementStates.forEach((_, elementId) => {
       if (!activeIds.has(elementId)) {
         this.deleteElementState(elementId)


### PR DESCRIPTION
## Describe your changes

Retain in-flight trigger widget state in `removeInactive`, so a Custom Components v2 aggregator written before its batched `setTimeout(0)` flush isn't deleted as stale. The callback then fires and the value reaches Python instead of the script rerunning with no trigger.

`setTriggerValue` writes to a synthetic aggregator widget id (`$$STREAMLIT_INTERNAL_KEY_<componentId>__events`), and `removeInactive` deletes every widget state whose id isn't an active *element* id — which that synthetic id never is. The window is reachable because deltas and `ScriptFinished` arrive as separate WebSocket frames with separate React commits, so `removeInactive` can fire a macrotask or more after the DOM already shows the new output. Mount-time triggers are the most exposed path, since the component's `default function` runs behind a dynamic `import()`.

The fix retains `pendingTriggerIds` for widget states and form widget states. Element states keep following `activeIds`, since they never enter the rerun message.

Measured on a production build against the repro in the issue: **10 of 85 values lost before, 0 of 85 after**. An instrumented build showed 14 losses correlating exactly with 14 destroying calls across 150 further trials.

## GitHub Issue Link (if applicable)

- Fixes #16732. Deliberately not an auto-closing reference: that issue also carries an open question about whether mount-time `setTriggerValue` should be a supported pattern, which this doesn't answer.

## Testing Plan

- [x] Unit Tests (JS and/or Python)
- [x] E2E Tests — no new test; eight existing assertions in `basics_test.py` repaired (see below)

Three tests in `WidgetStateManager.test.ts`. Two fail without the fix: in-flight retention (plus a stale widget asserted removed, so it can't pass with `removeInactive` as a no-op), and the form-scoped branch. The third — a trigger id dropped after its flush has run — passes either way by design; it guards the retention semantics and fails if `pendingTriggerIds.clear()` is removed.

No new E2E test: reproducing the race in a browser needs artificial delays on both the flush and `removeInactive`, which don't belong in the suite.

`basics_test.py` also had eight assertions that asserted nothing — `expect(locator)` with no `.to_be_visible()` — five of them inside `test_trigger_interactions`. All eight are now real and pass, and the two that are string prefixes of a longer state dict now use `exact=True`.

**Flaky-test verification: [100 iterations, all green](https://github.com/streamlit/streamlit/actions/runs/33954366950).** That is 300 executions of `test_trigger_interactions` across chromium, firefox and webkit with `--reruns 0`, so nothing was retried away. Per `scripts/fetch_flaky_tests.py`, this test recorded 8 reruns over the previous 14 days — the most flaky test in the repo, on all three browsers — so 300 executions is roughly half the CI exposure that produced them. At that ~1.3% per-execution rate, the chance of seeing zero failures if the flake were still present is ~2%; even at half that rate it is ~13%. `st_form_test.py` also passes 27/27, since the fix touches form widget states.

## Notes for reviewers

- **On the recurring `test_trigger_interactions` flake.** Two automated PRs (#14542, #14843) attributed it to a slow iframe round-trip and raised timeouts. That diagnosis was wrong: a slow round-trip leaves the previous step's `Result` intact, whereas the CI failures show `Result` reset to `None`, which only a trigger-less rerun produces. With the race artificially amplified the test fails with exactly that signature and passes with this fix. This therefore removes the `timeout=10000` #14843 added for the misdiagnosed cause, so a regression fails in ~5s instead of being masked for 10; the 100-iteration run above covers that change at the default timeout. The initial-load timeout stays, since iframe first paint genuinely can lag.
- Retention is bounded to one macrotask: every writer that adds to `pendingTriggerIds` calls `scheduleFlush` synchronously, and that flush deletes the state and clears the set. `removeInactive` is on the rerun hot path, so it short-circuits to `activeIds` when nothing is in flight — the common case allocates nothing.
- At the state-machine level, a form-scoped trigger followed by synchronous submission can double-send through the pre-existing queued flush, and in one narrow ordering this fix reaches that instead of silently losing the trigger. No current product path produces that ordering — every `submitForm` call site is a submit click or Enter keypress, and none writes a trigger in the same handler — and CCv2 ignores triggers inside forms. Traced in the review threads rather than filed as an issue.
- `onPageChange` sends `getActiveWidgetStates(activeWidgetIds)`, which has the same synthetic-id gap. Reaching it needs a trigger and a page navigation in the same macrotask, and dropping a trigger while navigating away is defensible — noted, not changed.
- #16732 carries an open question this doesn't answer: should `setTriggerValue` during mount be a supported pattern? It fires on every remount, so churning `data` produces one trigger per remount. That's a Components V2 semantics decision, and it determines whether the issue closes here or splits off a docs/warning change.
