### PR TITLE
[fix] Raise AppTestError for unsupported AppTest interactions

### DIFF
--- a/lib/streamlit/testing/v1/element_tree.py
+++ b/lib/streamlit/testing/v1/element_tree.py
@@ -179,8 +179,28 @@ class Element(ABC):
         ...
 
     def __getattr__(self, name: str) -> Any:
-        """Fallback attempt to get an attribute from the proto."""
+        """Fallback attempt to get an attribute from the proto.
+
+        ``set_value`` and ``click`` return callables that raise
+        ``AppTestError``. Some inspectable-only protos define those names as
+        fields (pagination's ``set_value`` is a bool).
+        """
+        if name in {"set_value", "click"}:
+
+            def unsupported_interaction(*_args: Any, **_kwargs: Any) -> None:
+                self._raise_unsupported_interaction(name)
+
+            return unsupported_interaction
         return getattr(self.proto, name)
+
+    def _raise_unsupported_interaction(self, method: str) -> None:
+        key_part = f" (key={self.key!r})" if self.key else ""
+        raise AppTestError(
+            f"{method}() is not supported for {self.type}{key_part}. "
+            "This element is inspectable in AppTest but is not interactive. "
+            "Use a typed widget wrapper when one exists, or Playwright e2e "
+            "tests for browser-only behavior."
+        )
 
     def run(self, *, timeout: float | None = None) -> AppTest:
         """Run the ``AppTest`` script which contains the element.

--- a/lib/streamlit/testing/v1/element_tree.py
+++ b/lib/streamlit/testing/v1/element_tree.py
@@ -28,6 +28,7 @@ from typing import (
     Any,
     ClassVar,
     Generic,
+    NoReturn,
     TypeAlias,
     TypeVar,
     cast,
@@ -181,9 +182,10 @@ class Element(ABC):
     def __getattr__(self, name: str) -> Any:
         """Fallback attempt to get an attribute from the proto.
 
-        ``set_value`` and ``click`` return callables that raise
-        ``AppTestError``. Some inspectable-only protos define those names as
-        fields (pagination's ``set_value`` is a bool).
+        Treat ``set_value`` and ``click`` as unsupported AppTest
+        interactions, even when a proto defines those names as fields
+        (pagination's ``set_value`` is a bool). Other missing names still
+        fall through to the proto.
         """
         if name in {"set_value", "click"}:
 
@@ -193,13 +195,18 @@ class Element(ABC):
             return unsupported_interaction
         return getattr(self.proto, name)
 
-    def _raise_unsupported_interaction(self, method: str) -> None:
+    def _raise_unsupported_interaction(self, method: str) -> NoReturn:
         key_part = f" (key={self.key!r})" if self.key else ""
+        if isinstance(self, Widget):
+            raise AppTestError(
+                f"{method}() is not supported for {self.type}{key_part}. "
+                "Use set_value() or one of this widget's typed interaction "
+                "methods."
+            )
         raise AppTestError(
             f"{method}() is not supported for {self.type}{key_part}. "
             "This element is inspectable in AppTest but is not interactive. "
-            "Use a typed widget wrapper when one exists, or Playwright e2e "
-            "tests for browser-only behavior."
+            "Use Playwright e2e tests for browser-only behavior."
         )
 
     def run(self, *, timeout: float | None = None) -> AppTest:

--- a/lib/streamlit/testing/v1/element_tree.py
+++ b/lib/streamlit/testing/v1/element_tree.py
@@ -180,12 +180,11 @@ class Element(ABC):
         ...
 
     def __getattr__(self, name: str) -> Any:
-        """Fallback attempt to get an attribute from the proto.
+        """Look up missing names on the element's proto, except AppTest interactions.
 
-        Treat ``set_value`` and ``click`` as unsupported AppTest
-        interactions, even when a proto defines those names as fields
-        (pagination's ``set_value`` is a bool). Other missing names still
-        fall through to the proto.
+        ``set_value`` and ``click`` are unsupported AppTest interactions even when a
+        proto defines those names as fields (pagination's ``set_value`` is a bool).
+        Other missing names still fall through to the proto.
         """
         if name in {"set_value", "click"}:
 
@@ -196,6 +195,7 @@ class Element(ABC):
         return getattr(self.proto, name)
 
     def _raise_unsupported_interaction(self, method: str) -> NoReturn:
+        """Raise AppTestError: typed widgets already have interaction methods; other nodes do not."""
         key_part = f" (key={self.key!r})" if self.key else ""
         if isinstance(self, Widget):
             raise AppTestError(
@@ -205,8 +205,9 @@ class Element(ABC):
             )
         raise AppTestError(
             f"{method}() is not supported for {self.type}{key_part}. "
-            "This element is inspectable in AppTest but is not interactive. "
-            "Use Playwright e2e tests for browser-only behavior."
+            "AppTest can inspect this element but does not implement "
+            "interactions for it. Set its value through at.session_state if it "
+            "has a key, or use a Playwright e2e test."
         )
 
     def run(self, *, timeout: float | None = None) -> AppTest:

--- a/lib/streamlit/testing/v1/errors.py
+++ b/lib/streamlit/testing/v1/errors.py
@@ -25,8 +25,9 @@ from __future__ import annotations
 class AppTestError(Exception):
     """Raised when an AppTest query or interaction is invalid.
 
-    AppTest can run apps that contain unimplemented or browser-only elements.
-    This error is reserved for an explicit test action that a browser user
-    could not perform, such as updating a disabled widget or calling
-    ``set_value`` / ``click`` on an inspectable-only node.
+    AppTest can run apps that contain unimplemented, partially modeled, or
+    browser-only elements. This error is reserved for an explicit test action
+    that AppTest cannot perform, such as updating a disabled widget or calling
+    ``set_value`` / ``click`` on an element that AppTest can inspect but not
+    interact with.
     """

--- a/lib/streamlit/testing/v1/errors.py
+++ b/lib/streamlit/testing/v1/errors.py
@@ -27,5 +27,6 @@ class AppTestError(Exception):
 
     AppTest can run apps that contain unimplemented or browser-only elements.
     This error is reserved for an explicit test action that a browser user
-    could not perform, such as updating a disabled widget.
+    could not perform, such as updating a disabled widget or calling
+    ``set_value`` / ``click`` on an inspectable-only node.
     """

--- a/lib/tests/streamlit/testing/element_tree_test.py
+++ b/lib/tests/streamlit/testing/element_tree_test.py
@@ -1381,6 +1381,40 @@ def test_parse_tree_unknown_proto_subtypes_become_unknown_element() -> None:
     assert nodes[2].value == "unused format"
 
 
+def test_unknown_element_unsupported_interaction_raises_app_test_error() -> None:
+    """Inspectable-only nodes reject set_value/click with AppTestError.
+
+    ``st.pagination`` is inspectable (key and current page) but has no typed
+    wrapper. Its proto field ``set_value: bool`` must not leak through
+    ``Element.__getattr__`` as a callable.
+    """
+
+    def script():
+        import streamlit as st
+
+        st.pagination(5, key="pager")
+        st.markdown("hi")
+
+    at = AppTest.from_function(script).run()
+    node = at.get("pagination")[0]
+    assert isinstance(node, UnknownElement)
+    assert node.key == "pager"
+    assert node.value == 1
+
+    with pytest.raises(
+        AppTestError, match=r"set_value\(\) is not supported for pagination"
+    ):
+        node.set_value(2)
+    with pytest.raises(
+        AppTestError, match=r"click\(\) is not supported for pagination"
+    ):
+        node.click()
+    with pytest.raises(
+        AppTestError, match=r"set_value\(\) is not supported for markdown"
+    ):
+        at.markdown[0].set_value("nope")
+
+
 def test_element_list_equality():
     """Test ElementList equality comparison."""
 

--- a/lib/tests/streamlit/testing/element_tree_test.py
+++ b/lib/tests/streamlit/testing/element_tree_test.py
@@ -1400,19 +1400,29 @@ def test_inspectable_elements_reject_unsupported_interactions() -> None:
     assert isinstance(node, UnknownElement)
     assert node.key == "pager"
     assert node.value == 1
+    assert node.proto.set_value is False
 
-    with pytest.raises(
-        AppTestError, match=r"set_value\(\) is not supported for pagination"
-    ):
+    inspectable_guidance = (
+        "AppTest can inspect this element but does not implement "
+        "interactions for it. Set its value through at.session_state if it "
+        "has a key, or use a Playwright e2e test."
+    )
+    with pytest.raises(AppTestError) as set_value_info:
         node.set_value(2)
-    with pytest.raises(
-        AppTestError, match=r"click\(\) is not supported for pagination"
-    ):
+    assert str(set_value_info.value) == (
+        "set_value() is not supported for pagination (key='pager'). "
+        f"{inspectable_guidance}"
+    )
+    with pytest.raises(AppTestError) as click_info:
         node.click()
-    with pytest.raises(
-        AppTestError, match=r"set_value\(\) is not supported for markdown"
-    ):
+    assert str(click_info.value) == (
+        f"click() is not supported for pagination (key='pager'). {inspectable_guidance}"
+    )
+    with pytest.raises(AppTestError) as markdown_info:
         at.markdown[0].set_value("nope")
+    assert str(markdown_info.value) == (
+        f"set_value() is not supported for markdown. {inspectable_guidance}"
+    )
 
 
 def test_typed_widget_without_click_raises_app_test_error() -> None:

--- a/lib/tests/streamlit/testing/element_tree_test.py
+++ b/lib/tests/streamlit/testing/element_tree_test.py
@@ -1381,12 +1381,12 @@ def test_parse_tree_unknown_proto_subtypes_become_unknown_element() -> None:
     assert nodes[2].value == "unused format"
 
 
-def test_unknown_element_unsupported_interaction_raises_app_test_error() -> None:
+def test_inspectable_elements_reject_unsupported_interactions() -> None:
     """Inspectable-only nodes reject set_value/click with AppTestError.
 
     ``st.pagination`` is inspectable (key and current page) but has no typed
     wrapper. Its proto field ``set_value: bool`` must not leak through
-    ``Element.__getattr__`` as a callable.
+    ``Element.__getattr__`` as a callable. Typed ``Markdown`` is covered too.
     """
 
     def script():
@@ -1413,6 +1413,25 @@ def test_unknown_element_unsupported_interaction_raises_app_test_error() -> None
         AppTestError, match=r"set_value\(\) is not supported for markdown"
     ):
         at.markdown[0].set_value("nope")
+
+
+def test_typed_widget_without_click_raises_app_test_error() -> None:
+    """Typed widgets without click() point testers at set_value()."""
+
+    def script():
+        import streamlit as st
+
+        st.checkbox("ok")
+
+    at = AppTest.from_function(script).run()
+    with pytest.raises(
+        AppTestError,
+        match=(
+            r"click\(\) is not supported for checkbox\. "
+            r"Use set_value\(\) or one of this widget's typed interaction methods\."
+        ),
+    ):
+        at.checkbox[0].click()
 
 
 def test_element_list_equality():


### PR DESCRIPTION
## Describe your changes

Raises `AppTestError` when AppTest calls `set_value()` or `click()` on
elements with no typed interaction wrapper, such as `st.pagination` and
markdown. `set_value` used to resolve to a protobuf bool field (`TypeError:
'bool' object is not callable`) and `click` to `AttributeError`, so testers
got no pointer to a typed wrapper or Playwright e2e.

The protobuf `set_value` field on `UnknownElement` widgets is no longer readable as an attribute; use `node.proto.set_value` if that internal flag is needed.

`hasattr(element, "set_value")` and `hasattr(element, "click")` now return `True` for every `Element` that does not already define those methods, because a stub callable is returned instead of raising `AttributeError`. Helpers that probed those names as capability checks will now get `AppTestError` at call time.

Implements wiki queue **P0.2** in the [AppTest issue verification and PR queue](https://github.com/streamlit/streamlit/wiki/2026-07-22-app-testing-fixes).

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- [x] `lib/tests/streamlit/testing/element_tree_test.py` — pagination inspects; `set_value` / `click` raise `AppTestError`; typed widgets without `click()` point testers at `set_value()`; `node.proto.set_value` still readable
- E2E tests: not applicable (AppTest-only)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

Made with [Cursor](https://cursor.com)