### PR TITLE
[fix] Stringify list columns PyArrow cannot serialize

### DIFF
--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -1346,6 +1346,8 @@ def fix_arrow_incompatible_column_types(
     # causing Arrow issues during conversion.
     # Skipping multi-indices since they won't return
     # the correct value from infer_dtype
+    # ``trial_conversion`` has no effect here: an index has no ``iloc``, so a mixed
+    # one is reported as incompatible before the trial conversion is reached.
     if not selected_columns and (
         not isinstance(
             df.index,

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -1182,15 +1182,13 @@ def determine_arrow_column_fix(
 
     Parameters
     ----------
-    column
-        The column to determine the fix for.
-
     trial_conversion
         Whether to also detect incompatible values that only a PyArrow conversion
-        can rule out, such as lists with inconsistent nesting levels. This
-        converts the column, so it is O(n) in the length of the column. Callers
-        that serialize the column right after and can recover from a failed
-        serialization should pass ``False`` and rely on that failure instead.
+        can rule out, such as lists with inconsistent nesting levels. Detecting
+        those requires materializing the column as an Arrow array, which costs
+        about as much as the real serialization. Callers that serialize the column
+        right after and can recover from a failed serialization should pass
+        ``False`` and rely on that failure instead.
     """
     from pandas.api.extensions import ExtensionArray
     from pandas.api.types import infer_dtype, is_dict_like, is_list_like
@@ -1261,17 +1259,16 @@ def determine_arrow_column_fix(
                 # A list-like first value doesn't prove that the whole column is
                 # serializable: PyArrow rejects columns that mix list nesting
                 # levels (e.g. ``[1, 2]`` next to ``[[1, 2], [3, 4]]``) or hold
-                # values it cannot infer a common type for. Ask PyArrow instead
-                # of guessing from a single value.
-                # These are the same errors we catch around
-                # ``pa.Table.from_pandas`` in ``convert_pandas_df_to_arrow_table``.
+                # values it cannot infer a common type for.
                 try:
                     pa.array(column, from_pandas=True)
-                except (
-                    pa.ArrowTypeError,
-                    pa.ArrowInvalid,
-                    pa.ArrowNotImplementedError,
-                ):
+                except Exception:
+                    # Any failure of this one call means the column isn't
+                    # serializable, which is the verdict we return. Catching
+                    # broadly also keeps values PyArrow rejects outside of its own
+                    # error types (e.g. integers too large for int64, which raise
+                    # ``OverflowError``) from escaping to callers that have no way
+                    # to recover from them.
                     return "string"
             return None
     # We did not detect an incompatible type, so we assume it is compatible:

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -942,6 +942,9 @@ def convert_pandas_df_to_arrow_table(
         pa.ArrowTypeError,
         pa.ArrowInvalid,
         pa.ArrowNotImplementedError,
+        # PyArrow reports values that don't fit its target type with the plain
+        # Python error instead of one of its own, e.g. an int too large for int64.
+        OverflowError,
     )
     try:
         return pa.Table.from_pandas(df, preserve_index=preserve_index)

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -909,6 +909,22 @@ def convert_arrow_table_to_arrow_bytes(table: pa.Table) -> bytes:
     return cast("bytes", sink.getvalue().to_pybytes())
 
 
+def get_arrow_conversion_errors() -> tuple[type[BaseException], ...]:
+    """Return the errors raised when PyArrow cannot convert a pandas object.
+
+    Includes ``OverflowError`` because PyArrow raises it for out-of-range values
+    (e.g. ints larger than int64) instead of an Arrow error.
+    """
+    import pyarrow as pa
+
+    return (
+        pa.ArrowTypeError,
+        pa.ArrowInvalid,
+        pa.ArrowNotImplementedError,
+        OverflowError,
+    )
+
+
 def convert_pandas_df_to_arrow_table(
     df: DataFrame,
     *,
@@ -938,14 +954,7 @@ def convert_pandas_df_to_arrow_table(
     """
     import pyarrow as pa
 
-    arrow_conversion_errors = (
-        pa.ArrowTypeError,
-        pa.ArrowInvalid,
-        pa.ArrowNotImplementedError,
-        # PyArrow reports values that don't fit its target type with the plain
-        # Python error instead of one of its own, e.g. an int too large for int64.
-        OverflowError,
-    )
+    arrow_conversion_errors = get_arrow_conversion_errors()
     try:
         return pa.Table.from_pandas(df, preserve_index=preserve_index)
     except arrow_conversion_errors as ex:
@@ -1185,7 +1194,10 @@ def determine_arrow_column_fix(
 
     Parameters
     ----------
-    trial_conversion
+    column : pandas.Series or pandas.Index
+        The column to inspect.
+
+    trial_conversion : bool
         Whether to also detect incompatible values that only a PyArrow conversion
         can rule out, such as lists with inconsistent nesting levels. Detecting
         those requires materializing the column as an Arrow array, which costs
@@ -1259,19 +1271,16 @@ def determine_arrow_column_fix(
             if trial_conversion:
                 import pyarrow as pa
 
-                # A list-like first value doesn't prove that the whole column is
-                # serializable: PyArrow rejects columns that mix list nesting
-                # levels (e.g. ``[1, 2]`` next to ``[[1, 2], [3, 4]]``) or hold
-                # values it cannot infer a common type for.
+                # A list-like first value does not prove the column is
+                # Arrow-serializable. PyArrow rejects columns that mix list
+                # nesting levels (e.g. ``[1, 2]`` next to ``[[1, 2], [3, 4]]``)
+                # and columns whose values have no common type.
                 try:
                     pa.array(column, from_pandas=True)
                 except Exception:
-                    # Any failure of this one call means the column isn't
-                    # serializable, which is the verdict we return. Catching
-                    # broadly also keeps values PyArrow rejects outside of its own
-                    # error types (e.g. integers too large for int64, which raise
-                    # ``OverflowError``) from escaping to callers that have no way
-                    # to recover from them.
+                    # Return "string" for any failure of this one call, including
+                    # non-Arrow errors such as ``OverflowError``. Callers expect a
+                    # verdict, not an exception.
                     return "string"
             return None
     # We did not detect an incompatible type, so we assume it is compatible:
@@ -1279,7 +1288,10 @@ def determine_arrow_column_fix(
 
 
 def fix_arrow_incompatible_column_types(
-    df: DataFrame, selected_columns: list[str] | None = None
+    df: DataFrame,
+    selected_columns: list[str] | None = None,
+    *,
+    trial_conversion: bool = True,
 ) -> DataFrame:
     """Fix column types that are not supported by Arrow table.
 
@@ -1294,8 +1306,13 @@ def fix_arrow_incompatible_column_types(
     df : pandas.DataFrame
         A dataframe to fix.
 
-    selected_columns: List[str] or None
+    selected_columns : List[str] or None
         A list of columns to fix. If None, all columns are evaluated.
+
+    trial_conversion : bool
+        Passed through to ``determine_arrow_column_fix``. Callers that serialize
+        the dataframe via ``convert_pandas_df_to_arrow_table`` can pass ``False``,
+        since its retry applies the remaining fixes.
 
     Returns
     -------
@@ -1306,7 +1323,9 @@ def fix_arrow_incompatible_column_types(
     # Make a copy, but only initialize if necessary to preserve memory.
     df_copy: DataFrame | None = None
     for col in selected_columns or df.columns:
-        fix_type = determine_arrow_column_fix(df[col])
+        fix_type = determine_arrow_column_fix(
+            df[col], trial_conversion=trial_conversion
+        )
         if fix_type is not None:
             if df_copy is None:
                 df_copy = df.copy()
@@ -1332,7 +1351,8 @@ def fix_arrow_incompatible_column_types(
             df.index,
             pd.MultiIndex,
         )
-        and determine_arrow_column_fix(df.index) is not None
+        and determine_arrow_column_fix(df.index, trial_conversion=trial_conversion)
+        is not None
     ):
         if df_copy is None:
             df_copy = df.copy()

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -1177,7 +1177,11 @@ def determine_arrow_column_fix(
     - "string": convert column values to strings
     - "list": convert iterable values (e.g., frozensets, ExtensionArrays) to lists
     - None: column is already Arrow-compatible
+
+    For mixed object columns holding list-like values, this attempts a trial
+    PyArrow conversion, which is O(n) in the length of the column.
     """
+    import pyarrow as pa
     from pandas.api.extensions import ExtensionArray
     from pandas.api.types import infer_dtype, is_dict_like, is_list_like
 
@@ -1240,6 +1244,25 @@ def determine_arrow_column_fix(
             # are list-like but not directly serializable by PyArrow - convert to lists.
             if isinstance(first_value, (frozenset, ExtensionArray)):
                 return "list"
+
+            # A list-like first value doesn't prove that the whole column is
+            # serializable: PyArrow rejects columns that mix list nesting levels
+            # (e.g. ``[1, 2]`` next to ``[[1, 2], [3, 4]]``) or hold values it
+            # cannot infer a common type for. Ask PyArrow instead of guessing
+            # from a single value.
+            # This discards the converted array, so it costs a full conversion
+            # pass over the column. Only columns that get this far pay it, and
+            # for them the alternative is a failed serialization.
+            # These are the same errors we catch around ``pa.Table.from_pandas``
+            # in ``convert_pandas_df_to_arrow_table``.
+            try:
+                pa.array(column, from_pandas=True)
+            except (
+                pa.ArrowTypeError,
+                pa.ArrowInvalid,
+                pa.ArrowNotImplementedError,
+            ):
+                return "string"
             return None
     # We did not detect an incompatible type, so we assume it is compatible:
     return None

--- a/lib/streamlit/dataframe_util.py
+++ b/lib/streamlit/dataframe_util.py
@@ -1170,6 +1170,8 @@ def convert_anything_to_list(obj: OptionSequence[V_co]) -> list[V_co]:
 
 def determine_arrow_column_fix(
     column: Series[Any] | Index[Any],
+    *,
+    trial_conversion: bool = True,
 ) -> Literal["string", "list"] | None:
     """Determine the fix needed for Arrow compatibility.
 
@@ -1178,10 +1180,18 @@ def determine_arrow_column_fix(
     - "list": convert iterable values (e.g., frozensets, ExtensionArrays) to lists
     - None: column is already Arrow-compatible
 
-    For mixed object columns holding list-like values, this attempts a trial
-    PyArrow conversion, which is O(n) in the length of the column.
+    Parameters
+    ----------
+    column
+        The column to determine the fix for.
+
+    trial_conversion
+        Whether to also detect incompatible values that only a PyArrow conversion
+        can rule out, such as lists with inconsistent nesting levels. This
+        converts the column, so it is O(n) in the length of the column. Callers
+        that serialize the column right after and can recover from a failed
+        serialization should pass ``False`` and rely on that failure instead.
     """
-    import pyarrow as pa
     from pandas.api.extensions import ExtensionArray
     from pandas.api.types import infer_dtype, is_dict_like, is_list_like
 
@@ -1245,24 +1255,24 @@ def determine_arrow_column_fix(
             if isinstance(first_value, (frozenset, ExtensionArray)):
                 return "list"
 
-            # A list-like first value doesn't prove that the whole column is
-            # serializable: PyArrow rejects columns that mix list nesting levels
-            # (e.g. ``[1, 2]`` next to ``[[1, 2], [3, 4]]``) or hold values it
-            # cannot infer a common type for. Ask PyArrow instead of guessing
-            # from a single value.
-            # This discards the converted array, so it costs a full conversion
-            # pass over the column. Only columns that get this far pay it, and
-            # for them the alternative is a failed serialization.
-            # These are the same errors we catch around ``pa.Table.from_pandas``
-            # in ``convert_pandas_df_to_arrow_table``.
-            try:
-                pa.array(column, from_pandas=True)
-            except (
-                pa.ArrowTypeError,
-                pa.ArrowInvalid,
-                pa.ArrowNotImplementedError,
-            ):
-                return "string"
+            if trial_conversion:
+                import pyarrow as pa
+
+                # A list-like first value doesn't prove that the whole column is
+                # serializable: PyArrow rejects columns that mix list nesting
+                # levels (e.g. ``[1, 2]`` next to ``[[1, 2], [3, 4]]``) or hold
+                # values it cannot infer a common type for. Ask PyArrow instead
+                # of guessing from a single value.
+                # These are the same errors we catch around
+                # ``pa.Table.from_pandas`` in ``convert_pandas_df_to_arrow_table``.
+                try:
+                    pa.array(column, from_pandas=True)
+                except (
+                    pa.ArrowTypeError,
+                    pa.ArrowInvalid,
+                    pa.ArrowNotImplementedError,
+                ):
+                    return "string"
             return None
     # We did not detect an incompatible type, so we assume it is compatible:
     return None

--- a/lib/streamlit/elements/lib/built_in_chart_utils.py
+++ b/lib/streamlit/elements/lib/built_in_chart_utils.py
@@ -587,6 +587,9 @@ def _melt_data(
 
     # Arrow has problems with object types after melting two different dtypes
     # > pyarrow.lib.ArrowTypeError: "Expected a <TYPE> object, got a object"
+    # This runs on every chart render, so it skips the trial conversion: the
+    # columns it would detect are fixed by the retry in
+    # ``convert_pandas_df_to_arrow_table``, which serializes this dataframe.
     return dataframe_util.fix_arrow_incompatible_column_types(
         melted_df,
         selected_columns=[
@@ -594,6 +597,7 @@ def _melt_data(
             new_color_column_name,
             new_y_column_name,
         ],
+        trial_conversion=False,
     )
 
 

--- a/lib/streamlit/elements/widgets/data_editor.py
+++ b/lib/streamlit/elements/widgets/data_editor.py
@@ -649,16 +649,13 @@ def _stringify_arrow_incompatible_columns(
     *,
     trial_conversion: bool,
 ) -> None:
-    """Convert Arrow-incompatible columns of the dataframe to strings inplace and
-    deactivate editing for them.
+    """Stringify Arrow-incompatible columns in place and disable editing for them.
 
     A converted column has to be read-only because the frontend sends edits back
     in the column's original type, which the stringified data no longer matches.
 
     With ``trial_conversion=False``, only the checks that don't require converting
-    the column are applied. The caller is then expected to catch the failing Arrow
-    serialization, call this again with ``trial_conversion=True``, and retry the
-    serialization.
+    the column are applied.
     """
     for column_name, column_data in data_df.items():
         if (
@@ -670,6 +667,10 @@ def _stringify_arrow_incompatible_columns(
             update_column_config(
                 column_config_mapping, str(column_name), {"disabled": True}
             )
+            # Every fix becomes a string here, including the ones
+            # ``fix_arrow_incompatible_column_types`` would turn into lists: the
+            # editor cannot round-trip converted values, so the column is disabled
+            # either way and a string is the more readable representation.
             data_df[cast("Any", column_name)] = column_data.astype("string")
 
 
@@ -1268,18 +1269,20 @@ class DataEditorMixin:
         # Convert the user provided column config into the frontend compatible format:
         column_config_mapping = process_config_mapping(processed_column_config)
 
+        apply_data_specific_configs(column_config_mapping, data_format)
+
+        # Fix the column headers to work correctly for data editing:
+        _fix_column_headers(data_df)
+
         # Deactivate editing for columns that are not compatible with Arrow.
+        # This has to run after the column headers are fixed, so that the column
+        # config is keyed by the same names the frontend receives.
         # Columns that only a trial conversion can detect are left to the Arrow
         # serialization below: it fails on them anyway, and this way a dataframe
         # that serializes fine never pays for a trial conversion.
         _stringify_arrow_incompatible_columns(
             data_df, column_config_mapping, trial_conversion=False
         )
-
-        apply_data_specific_configs(column_config_mapping, data_format)
-
-        # Fix the column headers to work correctly for data editing:
-        _fix_column_headers(data_df)
 
         has_range_index = isinstance(data_df.index, pd.RangeIndex)
 
@@ -1336,6 +1339,8 @@ class DataEditorMixin:
             try:
                 arrow_table = pa.Table.from_pandas(data_df)
             except arrow_conversion_errors as retry_ex:
+                # The retry only stringifies columns, never the index: the data
+                # editor identifies rows by their index values.
                 raise StreamlitDataframeConversionError(
                     f"Unable to convert dataframe to Arrow table.\n{retry_ex}"
                 ) from retry_ex

--- a/lib/streamlit/elements/widgets/data_editor.py
+++ b/lib/streamlit/elements/widgets/data_editor.py
@@ -655,9 +655,9 @@ def _stringify_arrow_incompatible_columns(
     edits back in the column's original type.
 
     With ``trial_conversion=False``, only the checks that don't require converting
-    the column are applied. The remaining columns are detected by the failing
-    Arrow serialization, which is retried after another call with
-    ``trial_conversion=True``.
+    the column are applied. The caller is then expected to catch the failing Arrow
+    serialization, call this again with ``trial_conversion=True``, and retry the
+    serialization.
     """
     for column_name, column_data in data_df.items():
         if (
@@ -1267,10 +1267,10 @@ class DataEditorMixin:
         # Convert the user provided column config into the frontend compatible format:
         column_config_mapping = process_config_mapping(processed_column_config)
 
-        # Deactivate editing for columns that are not compatible with arrow.
-        # The columns that can only be detected by a trial conversion are left to
-        # the Arrow serialization below, so that a rerun with editable data
-        # doesn't pay for one conversion per column.
+        # Deactivate editing for columns that are not compatible with Arrow.
+        # Columns that only a trial conversion can detect are left to the Arrow
+        # serialization below: it fails on them anyway, and this way a dataframe
+        # that serializes fine never pays for a trial conversion.
         _stringify_arrow_incompatible_columns(
             data_df, column_config_mapping, trial_conversion=False
         )

--- a/lib/streamlit/elements/widgets/data_editor.py
+++ b/lib/streamlit/elements/widgets/data_editor.py
@@ -643,6 +643,35 @@ def _fix_column_headers(data_df: pd.DataFrame) -> None:
         )
 
 
+def _stringify_arrow_incompatible_columns(
+    data_df: pd.DataFrame,
+    column_config_mapping: ColumnConfigMapping,
+    *,
+    trial_conversion: bool,
+) -> None:
+    """Convert Arrow-incompatible columns of the dataframe to strings inplace.
+
+    Editing is deactivated for every converted column, since the frontend sends
+    edits back in the column's original type.
+
+    With ``trial_conversion=False``, only the checks that don't require converting
+    the column are applied. The remaining columns are detected by the failing
+    Arrow serialization, which is retried after another call with
+    ``trial_conversion=True``.
+    """
+    for column_name, column_data in data_df.items():
+        if (
+            dataframe_util.determine_arrow_column_fix(
+                column_data, trial_conversion=trial_conversion
+            )
+            is not None
+        ):
+            update_column_config(
+                column_config_mapping, str(column_name), {"disabled": True}
+            )
+            data_df[cast("Any", column_name)] = column_data.astype("string")
+
+
 def _check_column_names(data_df: pd.DataFrame) -> None:
     """Check if the column names in the provided dataframe are valid.
 
@@ -1238,14 +1267,13 @@ class DataEditorMixin:
         # Convert the user provided column config into the frontend compatible format:
         column_config_mapping = process_config_mapping(processed_column_config)
 
-        # Deactivate editing for columns that are not compatible with arrow
-        for column_name, column_data in data_df.items():
-            if dataframe_util.determine_arrow_column_fix(column_data) is not None:
-                update_column_config(
-                    column_config_mapping, str(column_name), {"disabled": True}
-                )
-                # Convert incompatible type to string
-                data_df[cast("Any", column_name)] = column_data.astype("string")
+        # Deactivate editing for columns that are not compatible with arrow.
+        # The columns that can only be detected by a trial conversion are left to
+        # the Arrow serialization below, so that a rerun with editable data
+        # doesn't pay for one conversion per column.
+        _stringify_arrow_incompatible_columns(
+            data_df, column_config_mapping, trial_conversion=False
+        )
 
         apply_data_specific_configs(column_config_mapping, data_format)
 
@@ -1292,7 +1320,28 @@ class DataEditorMixin:
         # Convert the dataframe to an arrow table which is used as the main
         # serialization format for sending the data to the frontend.
         # We also utilize the arrow schema to determine the data kinds of every column.
-        arrow_table = pa.Table.from_pandas(data_df)
+        arrow_conversion_errors = (
+            pa.ArrowTypeError,
+            pa.ArrowInvalid,
+            pa.ArrowNotImplementedError,
+        )
+        try:
+            arrow_table = pa.Table.from_pandas(data_df)
+        except arrow_conversion_errors as ex:
+            _LOGGER.info(
+                "Serialization of dataframe to Arrow table was unsuccessful. "
+                "Converting the incompatible columns to strings and retrying.",
+                exc_info=ex,
+            )
+            _stringify_arrow_incompatible_columns(
+                data_df, column_config_mapping, trial_conversion=True
+            )
+            try:
+                arrow_table = pa.Table.from_pandas(data_df)
+            except arrow_conversion_errors as retry_ex:
+                raise StreamlitDataframeConversionError(
+                    f"Unable to convert dataframe to Arrow table.\n{retry_ex}"
+                ) from retry_ex
 
         # Determine the dataframe schema which is required for parsing edited values
         # and for checking type compatibilities.

--- a/lib/streamlit/elements/widgets/data_editor.py
+++ b/lib/streamlit/elements/widgets/data_editor.py
@@ -1324,6 +1324,10 @@ class DataEditorMixin:
             pa.ArrowTypeError,
             pa.ArrowInvalid,
             pa.ArrowNotImplementedError,
+            # PyArrow reports values that don't fit its target type with the plain
+            # Python error instead of one of its own, e.g. an int too large for
+            # int64.
+            OverflowError,
         )
         try:
             arrow_table = pa.Table.from_pandas(data_df)

--- a/lib/streamlit/elements/widgets/data_editor.py
+++ b/lib/streamlit/elements/widgets/data_editor.py
@@ -649,10 +649,11 @@ def _stringify_arrow_incompatible_columns(
     *,
     trial_conversion: bool,
 ) -> None:
-    """Convert Arrow-incompatible columns of the dataframe to strings inplace.
+    """Convert Arrow-incompatible columns of the dataframe to strings inplace and
+    deactivate editing for them.
 
-    Editing is deactivated for every converted column, since the frontend sends
-    edits back in the column's original type.
+    A converted column has to be read-only because the frontend sends edits back
+    in the column's original type, which the stringified data no longer matches.
 
     With ``trial_conversion=False``, only the checks that don't require converting
     the column are applied. The caller is then expected to catch the failing Arrow
@@ -1320,15 +1321,7 @@ class DataEditorMixin:
         # Convert the dataframe to an arrow table which is used as the main
         # serialization format for sending the data to the frontend.
         # We also utilize the arrow schema to determine the data kinds of every column.
-        arrow_conversion_errors = (
-            pa.ArrowTypeError,
-            pa.ArrowInvalid,
-            pa.ArrowNotImplementedError,
-            # PyArrow reports values that don't fit its target type with the plain
-            # Python error instead of one of its own, e.g. an int too large for
-            # int64.
-            OverflowError,
-        )
+        arrow_conversion_errors = dataframe_util.get_arrow_conversion_errors()
         try:
             arrow_table = pa.Table.from_pandas(data_df)
         except arrow_conversion_errors as ex:

--- a/lib/tests/streamlit/dataframe_util_test.py
+++ b/lib/tests/streamlit/dataframe_util_test.py
@@ -482,6 +482,7 @@ class DataframeUtilTest(unittest.TestCase):
             # that doesn't fit into int64 raises ``OverflowError``):
             (pd.Series([[2**70], [1]]), "string"),
             # Supported types:
+            #
             # Consistently nested lists are serializable by PyArrow:
             (pd.Series([[[1, 2], [3, 4]], [[5, 6], [7, 8]]]), None),
             (pd.Series([[[[1]]], [[[2]]]]), None),
@@ -507,28 +508,27 @@ class DataframeUtilTest(unittest.TestCase):
             f"Expected {column} to have fix_type={fix_type!r}."
         )
 
-    def test_determine_arrow_column_fix_without_trial_conversion(self) -> None:
+    @parameterized.expand(
+        [
+            (pd.Series([[1, 2], [[1, 2], [3, 4]]]),),
+            (pd.Series([[1, 2], {"a": 1}]),),
+            (pd.Series([[2**70], [1]]),),
+        ]
+    )
+    def test_determine_arrow_column_fix_without_trial_conversion(
+        self, column: pd.Series
+    ) -> None:
         """Test that `trial_conversion=False` skips the trial PyArrow conversion.
 
         Callers that serialize right after pass ``trial_conversion=False`` to keep
         the check cheap (see `st.data_editor`), so these columns must stay
         undetected here and be caught by the failing serialization instead.
         """
-        undetectable_columns = [
-            pd.Series([[1, 2], [[1, 2], [3, 4]]]),
-            pd.Series([[1, 2], {"a": 1}]),
-            pd.Series([[2**70], [1]]),
-        ]
-
-        for column in undetectable_columns:
-            assert (
-                dataframe_util.determine_arrow_column_fix(
-                    column, trial_conversion=False
-                )
-                is None
-            ), f"Expected {column.tolist()} to require a trial conversion."
-            # The trial conversion is what detects them:
-            assert dataframe_util.determine_arrow_column_fix(column) == "string"
+        assert (
+            dataframe_util.determine_arrow_column_fix(column, trial_conversion=False)
+            is None
+        ), f"Expected {column.tolist()} to require a trial conversion."
+        assert dataframe_util.determine_arrow_column_fix(column) == "string"
 
     @parameterized.expand(
         [

--- a/lib/tests/streamlit/dataframe_util_test.py
+++ b/lib/tests/streamlit/dataframe_util_test.py
@@ -455,7 +455,7 @@ class DataframeUtilTest(unittest.TestCase):
             (pd.Series([frozenset([1, 2]), frozenset([3, 4])]), "list"),
             # Dicts serialize fine in PyArrow, but are stringified because of
             # Arrow JS issues (see comments in Quiver.ts). This check has to stay
-            # ahead of the PyArrow probe, which would let dicts through:
+            # ahead of the trial conversion, which would let dicts through:
             (pd.Series([{"a": 1}, {"b": 2}]), "string"),
             # Complex types:
             (pd.Series([TestObject(), TestObject()]), "string"),
@@ -476,8 +476,11 @@ class DataframeUtilTest(unittest.TestCase):
                 "string",
             ),
             # A list next to a dict: the first value isn't dict-like, so only the
-            # PyArrow probe catches this:
+            # trial conversion catches this:
             (pd.Series([[1, 2], {"a": 1}]), "string"),
+            # Values PyArrow rejects without one of its own error types (an int
+            # that doesn't fit into int64 raises ``OverflowError``):
+            (pd.Series([[2**70], [1]]), "string"),
             # Supported types:
             # Consistently nested lists are serializable by PyArrow:
             (pd.Series([[[1, 2], [3, 4]], [[5, 6], [7, 8]]]), None),
@@ -503,6 +506,29 @@ class DataframeUtilTest(unittest.TestCase):
         assert dataframe_util.determine_arrow_column_fix(column) == fix_type, (
             f"Expected {column} to have fix_type={fix_type!r}."
         )
+
+    def test_determine_arrow_column_fix_without_trial_conversion(self) -> None:
+        """Test that `trial_conversion=False` skips the trial PyArrow conversion.
+
+        Callers that serialize right after pass ``trial_conversion=False`` to keep
+        the check cheap (see `st.data_editor`), so these columns must stay
+        undetected here and be caught by the failing serialization instead.
+        """
+        undetectable_columns = [
+            pd.Series([[1, 2], [[1, 2], [3, 4]]]),
+            pd.Series([[1, 2], {"a": 1}]),
+            pd.Series([[2**70], [1]]),
+        ]
+
+        for column in undetectable_columns:
+            assert (
+                dataframe_util.determine_arrow_column_fix(
+                    column, trial_conversion=False
+                )
+                is None
+            ), f"Expected {column.tolist()} to require a trial conversion."
+            # The trial conversion is what detects them:
+            assert dataframe_util.determine_arrow_column_fix(column) == "string"
 
     @parameterized.expand(
         [

--- a/lib/tests/streamlit/dataframe_util_test.py
+++ b/lib/tests/streamlit/dataframe_util_test.py
@@ -453,11 +453,39 @@ class DataframeUtilTest(unittest.TestCase):
             (pd.Series([1, 2.1, "3", True]), "string"),
             # Frozenset (converted to list, not string):
             (pd.Series([frozenset([1, 2]), frozenset([3, 4])]), "list"),
-            # Dicts:
+            # Dicts serialize fine in PyArrow, but are stringified because of
+            # Arrow JS issues (see comments in Quiver.ts). This check has to stay
+            # ahead of the PyArrow probe, which would let dicts through:
             (pd.Series([{"a": 1}, {"b": 2}]), "string"),
             # Complex types:
             (pd.Series([TestObject(), TestObject()]), "string"),
+            # Lists with inconsistent nesting levels are not serializable by
+            # PyArrow, in either order:
+            (pd.Series([[1, 2], [[1, 2], [3, 4]]]), "string"),
+            (pd.Series([[[1, 2], [3, 4]], [1, 2]]), "string"),
+            # Same, with a leading null so the first value is found via dropna():
+            (pd.Series([None, [1, 2], [[3, 4]]]), "string"),
+            # GeoJSON-shaped coordinates (Polygon next to MultiPolygon):
+            (
+                pd.Series(
+                    [
+                        [[[0, 0], [1, 0], [1, 1], [0, 0]]],
+                        [[[[0, 0], [1, 0], [1, 1], [0, 0]]]],
+                    ]
+                ),
+                "string",
+            ),
+            # A list next to a dict: the first value isn't dict-like, so only the
+            # PyArrow probe catches this:
+            (pd.Series([[1, 2], {"a": 1}]), "string"),
             # Supported types:
+            # Consistently nested lists are serializable by PyArrow:
+            (pd.Series([[[1, 2], [3, 4]], [[5, 6], [7, 8]]]), None),
+            (pd.Series([[[[1]]], [[[2]]]]), None),
+            # Tuples mix with lists, lengths may differ, and nulls are fine:
+            (pd.Series([(1, 2), [3, 4]]), None),
+            (pd.Series([[1, 2, 3], [4]]), None),
+            (pd.Series([[1, 2], None]), None),
             (pd.Series([1, 2, 3]), None),
             (pd.Series([1, 2, 3.0]), None),
             (pd.Series(["foo", "bar"]), None),
@@ -599,6 +627,34 @@ class DataframeUtilTest(unittest.TestCase):
                 "No exception should have been thrown here. "
                 f"Unsupported types of this dataframe should have been automatically fixed: {ex}"
             )
+
+    @parameterized.expand(
+        [
+            ("flat_and_nested_lists", [[1, 2], [[1, 2], [3, 4]]]),
+            (
+                "polygon_and_multipolygon",
+                [
+                    [[[0, 0], [1, 0], [1, 1], [0, 0]]],
+                    [[[[0, 0], [1, 0], [1, 1], [0, 0]]]],
+                ],
+            ),
+        ]
+    )
+    def test_arrow_conversion_stringifies_unserializable_list_columns(
+        self, _name: str, values: list[Any]
+    ) -> None:
+        """Test that columns of lists that PyArrow cannot serialize are stringified.
+
+        Regression test for https://github.com/streamlit/streamlit/issues/9380
+        """
+        df = pd.DataFrame({"c1": values})
+
+        converted_bytes = dataframe_util.convert_pandas_df_to_arrow_bytes(df)
+
+        reconstructed_df = dataframe_util.convert_arrow_bytes_to_pandas_df(
+            converted_bytes
+        )
+        assert reconstructed_df["c1"].tolist() == [str(value) for value in values]
 
     @pytest.mark.skipif(
         dataframe_util.is_pandas_version_less_than("3.0.0"),

--- a/lib/tests/streamlit/dataframe_util_test.py
+++ b/lib/tests/streamlit/dataframe_util_test.py
@@ -664,6 +664,8 @@ class DataframeUtilTest(unittest.TestCase):
                     [[[[0, 0], [1, 0], [1, 1], [0, 0]]]],
                 ],
             ),
+            # PyArrow raises OverflowError instead of one of its own errors here:
+            ("int_too_large_for_int64", [[2**70], [1]]),
         ]
     )
     def test_arrow_conversion_stringifies_unserializable_list_columns(

--- a/lib/tests/streamlit/elements/data_editor_test.py
+++ b/lib/tests/streamlit/elements/data_editor_test.py
@@ -1377,7 +1377,7 @@ class DataEditorTest(DeltaGeneratorTestCase):
         assert columns_config["c"]["disabled"]
         assert columns_config["d"]["disabled"]
 
-    def test_disables_columns_with_inconsistently_nested_lists(self):
+    def test_disables_columns_with_inconsistently_nested_lists(self) -> None:
         """Test that columns of lists PyArrow cannot serialize are disabled.
 
         Regression test for https://github.com/streamlit/streamlit/issues/9380
@@ -1412,7 +1412,7 @@ class DataEditorTest(DeltaGeneratorTestCase):
     )
     def test_disables_and_stringifies_columns_detected_by_arrow_retry(
         self, _name: str, values: list[Any]
-    ):
+    ) -> None:
         """Test that columns fixed after a failed Arrow conversion are stringified
         and disabled.
 
@@ -1433,7 +1433,7 @@ class DataEditorTest(DeltaGeneratorTestCase):
         assert reconstructed_df["col1"].tolist() == expected_values
         assert return_df["col1"].tolist() == expected_values
 
-    def test_raises_when_arrow_retry_cannot_fix_the_dataframe(self):
+    def test_raises_when_arrow_retry_cannot_fix_the_dataframe(self) -> None:
         """Test that a dataframe that stays Arrow incompatible raises.
 
         The retry only stringifies columns, so a mixed-type index still fails the

--- a/lib/tests/streamlit/elements/data_editor_test.py
+++ b/lib/tests/streamlit/elements/data_editor_test.py
@@ -1397,35 +1397,41 @@ class DataEditorTest(DeltaGeneratorTestCase):
         assert "a" not in columns_config
         assert columns_config["b"]["disabled"]
 
-    def test_disables_and_stringifies_columns_detected_by_arrow_retry(self):
+    @parameterized.expand(
+        [
+            (
+                "polygon_and_multipolygon",
+                [
+                    [[[0, 0], [1, 0], [1, 1], [0, 0]]],
+                    [[[[0, 0], [1, 0], [1, 1], [0, 0]]]],
+                ],
+            ),
+            # PyArrow raises OverflowError instead of one of its own errors here:
+            ("int_too_large_for_int64", [[2**70], [1]]),
+        ]
+    )
+    def test_disables_and_stringifies_columns_detected_by_arrow_retry(
+        self, _name: str, values: list[Any]
+    ):
         """Test that columns fixed after a failed Arrow conversion are stringified
         and disabled.
 
         These columns are only detected once the Arrow serialization fails, so the
         column config has to be updated from that retry as well.
         """
-        data_df = pd.DataFrame(
-            {
-                "geometry": pd.Series(
-                    [
-                        [[[0, 0], [1, 0], [1, 1], [0, 0]]],
-                        [[[[0, 0], [1, 0], [1, 1], [0, 0]]]],
-                    ]
-                ),
-            }
-        )
-        expected_values = [str(value) for value in data_df["geometry"]]
+        data_df = pd.DataFrame({"col1": pd.Series(values)})
+        expected_values = [str(value) for value in values]
 
         return_df = st.data_editor(data_df)
 
         proto = self.get_delta_from_queue().new_element.dataframe
         columns_config = json.loads(proto.columns)
 
-        assert columns_config["geometry"]["disabled"]
+        assert columns_config["col1"]["disabled"]
         # The values reaching the frontend are the stringified ones:
         reconstructed_df = convert_arrow_bytes_to_pandas_df(proto.arrow_data.data)
-        assert reconstructed_df["geometry"].tolist() == expected_values
-        assert return_df["geometry"].tolist() == expected_values
+        assert reconstructed_df["col1"].tolist() == expected_values
+        assert return_df["col1"].tolist() == expected_values
 
     def test_raises_when_arrow_retry_cannot_fix_the_dataframe(self):
         """Test that a dataframe that stays Arrow incompatible raises.

--- a/lib/tests/streamlit/elements/data_editor_test.py
+++ b/lib/tests/streamlit/elements/data_editor_test.py
@@ -53,7 +53,7 @@ from streamlit.elements.widgets.data_editor import (
     _compute_data_editor_signature,
     _parse_value,
 )
-from streamlit.errors import StreamlitAPIException
+from streamlit.errors import StreamlitAPIException, StreamlitDataframeConversionError
 from streamlit.proto.Dataframe_pb2 import Dataframe as DataframeProto
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 from tests.streamlit.data_test_cases import SHARED_TEST_CASES, CaseMetadata
@@ -1397,7 +1397,7 @@ class DataEditorTest(DeltaGeneratorTestCase):
         assert "a" not in columns_config
         assert columns_config["b"]["disabled"]
 
-    def test_stringifies_and_disables_columns_fixed_after_arrow_failure(self):
+    def test_disables_and_stringifies_columns_detected_by_arrow_retry(self):
         """Test that columns fixed after a failed Arrow conversion are stringified
         and disabled.
 
@@ -1426,6 +1426,19 @@ class DataEditorTest(DeltaGeneratorTestCase):
         reconstructed_df = convert_arrow_bytes_to_pandas_df(proto.arrow_data.data)
         assert reconstructed_df["geometry"].tolist() == expected_values
         assert return_df["geometry"].tolist() == expected_values
+
+    def test_raises_when_arrow_retry_cannot_fix_the_dataframe(self):
+        """Test that a dataframe that stays Arrow incompatible raises.
+
+        The retry only stringifies columns, so a mixed-type index still fails the
+        second Arrow conversion.
+        """
+        data_df = pd.DataFrame({"a": [1, 2]}, index=pd.Index([1, "x"]))
+
+        with pytest.raises(
+            StreamlitDataframeConversionError, match="Unable to convert dataframe"
+        ):
+            st.data_editor(data_df)
 
     @parameterized.expand(
         [

--- a/lib/tests/streamlit/elements/data_editor_test.py
+++ b/lib/tests/streamlit/elements/data_editor_test.py
@@ -1377,6 +1377,26 @@ class DataEditorTest(DeltaGeneratorTestCase):
         assert columns_config["c"]["disabled"]
         assert columns_config["d"]["disabled"]
 
+    def test_disables_columns_with_inconsistently_nested_lists(self):
+        """Test that columns of lists PyArrow cannot serialize are disabled.
+
+        Regression test for https://github.com/streamlit/streamlit/issues/9380
+        """
+        data_df = pd.DataFrame(
+            {
+                "a": pd.Series([[1, 2], [3, 4]]),
+                # PyArrow cannot mix list nesting levels within one column:
+                "b": pd.Series([[1, 2], [[1, 2], [3, 4]]]),
+            }
+        )
+        st.data_editor(data_df)
+
+        proto = self.get_delta_from_queue().new_element.dataframe
+        columns_config = json.loads(proto.columns)
+
+        assert "a" not in columns_config
+        assert columns_config["b"]["disabled"]
+
     @parameterized.expand(
         [
             (pd.PeriodIndex(["2020-01-01", "2020-01-02", "2020-01-03"], freq="D"),),

--- a/lib/tests/streamlit/elements/data_editor_test.py
+++ b/lib/tests/streamlit/elements/data_editor_test.py
@@ -1397,6 +1397,36 @@ class DataEditorTest(DeltaGeneratorTestCase):
         assert "a" not in columns_config
         assert columns_config["b"]["disabled"]
 
+    def test_stringifies_and_disables_columns_fixed_after_arrow_failure(self):
+        """Test that columns fixed after a failed Arrow conversion are stringified
+        and disabled.
+
+        These columns are only detected once the Arrow serialization fails, so the
+        column config has to be updated from that retry as well.
+        """
+        data_df = pd.DataFrame(
+            {
+                "geometry": pd.Series(
+                    [
+                        [[[0, 0], [1, 0], [1, 1], [0, 0]]],
+                        [[[[0, 0], [1, 0], [1, 1], [0, 0]]]],
+                    ]
+                ),
+            }
+        )
+        expected_values = [str(value) for value in data_df["geometry"]]
+
+        return_df = st.data_editor(data_df)
+
+        proto = self.get_delta_from_queue().new_element.dataframe
+        columns_config = json.loads(proto.columns)
+
+        assert columns_config["geometry"]["disabled"]
+        # The values reaching the frontend are the stringified ones:
+        reconstructed_df = convert_arrow_bytes_to_pandas_df(proto.arrow_data.data)
+        assert reconstructed_df["geometry"].tolist() == expected_values
+        assert return_df["geometry"].tolist() == expected_values
+
     @parameterized.expand(
         [
             (pd.PeriodIndex(["2020-01-01", "2020-01-02", "2020-01-03"], freq="D"),),

--- a/lib/tests/streamlit/elements/data_editor_test.py
+++ b/lib/tests/streamlit/elements/data_editor_test.py
@@ -1428,10 +1428,33 @@ class DataEditorTest(DeltaGeneratorTestCase):
         columns_config = json.loads(proto.columns)
 
         assert columns_config["col1"]["disabled"]
-        # The values reaching the frontend are the stringified ones:
         reconstructed_df = convert_arrow_bytes_to_pandas_df(proto.arrow_data.data)
         assert reconstructed_df["col1"].tolist() == expected_values
         assert return_df["col1"].tolist() == expected_values
+
+    def test_disables_incompatible_columns_under_flattened_multiindex_name(
+        self,
+    ) -> None:
+        """Test that the disabled config uses the flattened MultiIndex column name.
+
+        Hierarchical column headers are flattened for editing, so a config keyed by
+        the original tuple would not match any column on the frontend.
+        """
+        data_df = pd.DataFrame(
+            {
+                ("a", "b"): pd.Series([1, "foo"]),  # Incompatible
+                ("c", "d"): pd.Series([1, 2]),
+            }
+        )
+        assert isinstance(data_df.columns, pd.MultiIndex)
+
+        st.data_editor(data_df)
+
+        proto = self.get_delta_from_queue().new_element.dataframe
+        columns_config = json.loads(proto.columns)
+
+        assert columns_config["a_b"]["disabled"]
+        assert "c_d" not in columns_config
 
     def test_raises_when_arrow_retry_cannot_fix_the_dataframe(self) -> None:
         """Test that a dataframe that stays Arrow incompatible raises.

--- a/lib/tests/streamlit/elements/lib/built_in_chart_utils_test.py
+++ b/lib/tests/streamlit/elements/lib/built_in_chart_utils_test.py
@@ -23,6 +23,7 @@ import altair as alt
 import pandas as pd
 import pytest
 
+from streamlit import dataframe_util
 from streamlit.elements.lib import built_in_chart_utils as chart_utils
 from streamlit.errors import (
     StreamlitAPIException,
@@ -339,6 +340,45 @@ def test_melt_data_raises_on_too_many_mixed_types() -> None:
     )
     with pytest.raises(StreamlitAPIException, match="too many values"):
         chart_utils._melt_data(df, ["x"], ["ints", "strs"], "value", "color")
+
+
+def test_melt_data_leaves_trial_conversion_to_the_serialization() -> None:
+    """Melting skips the trial Arrow conversion, which runs on every chart render.
+
+    A column of lists with inconsistent nesting levels is only detectable by a
+    trial conversion, so melting leaves it untouched and the Arrow serialization
+    stringifies it on its retry instead.
+    """
+    df = pd.DataFrame(
+        {
+            # An id column, so the mixed-type guard on the melted values
+            # does not apply to it:
+            "x": [[1, 2], [[1, 2], [3, 4]]],
+            "a": [1.0, 2.0],
+            "b": [3.0, 4.0],
+        }
+    )
+
+    melted_df = chart_utils._melt_data(df, ["x"], ["a", "b"], "value", "color")
+
+    # The column is left as-is, so no trial conversion was paid for:
+    assert melted_df["x"].tolist() == [
+        [1, 2],
+        [[1, 2], [3, 4]],
+        [1, 2],
+        [[1, 2], [3, 4]],
+    ]
+
+    # Serializing the melted dataframe still recovers and stringifies it:
+    reconstructed_df = dataframe_util.convert_arrow_bytes_to_pandas_df(
+        dataframe_util.convert_anything_to_arrow_bytes(melted_df)
+    )
+    assert reconstructed_df["x"].tolist() == [
+        "[1, 2]",
+        "[[1, 2], [3, 4]]",
+        "[1, 2]",
+        "[[1, 2], [3, 4]]",
+    ]
 
 
 def test_convert_col_names_to_str_in_place_stringifies_columns() -> None:


### PR DESCRIPTION
## Describe your changes

Stringify mixed list-like columns that PyArrow cannot serialize, instead of crashing `st.dataframe` /
`st.data_editor` when nesting levels differ.

`determine_arrow_column_fix` judged a mixed-dtype object column from its first non-null value alone, so
columns mixing list nesting levels — `[1, 2]` next to `[[1, 2], [3, 4]]`, or a GeoJSON Polygon next to a
MultiPolygon — were judged Arrow-compatible and then raised during serialization. The existing dict and
frozenset gates are unchanged; a trial `pa.array()` conversion is now the final gate of that branch.

- The trial conversion is **additive on purpose**. Dict columns *pass* `pa.array` but must still be
  stringified for Arrow JS, and frozensets/ExtensionArrays *raise* but want the list fix. Replacing the
  single-value checks with the probe would regress both.
- `st.data_editor` previously crashed with a raw `pyarrow.lib.ArrowInvalid` — no Streamlit error at all.
  It now stringifies and disables the column, and raises `StreamlitDataframeConversionError` if
  serialization still fails, matching `st.dataframe`.
- `trial_conversion=False` keeps the expensive gate off `st.data_editor`'s per-rerun path, which calls
  this for every column. It runs only after a serialization failure. On a 200k × 4 frame including a
  list column: **46.9 ms before, 47.0 ms after** (68.7 ms without the opt-out).

The `except` around the probe is deliberately broad. `pa.array` can raise outside PyArrow's own error
types — `pd.Series([[2**70], [1]])` raises `OverflowError` — and the function's contract is to return a
verdict, not to raise. The `try` body is a single call, so there is no application logic for a broad
catch to mask.

`built_in_chart_utils` skips the trial probe because that preprocessing runs on every chart render. The
melted scalar y column can never reach it — the gate requires `infer_dtype` to return exactly `"mixed"`,
and melting scalars yields `"mixed-integer"` or `"floating"` — but the unmelted `columns_to_leave_alone`
id columns (`x`, `size`, `sort`) can, and did. Incompatible values are still handled by the subsequent
Arrow serialization retry. Verified to leave the Vega spec and Arrow payload byte-identical, while
reducing a 400k-row melt from **56.2 ms to 11.3 ms** per render.

**Also fixes a MultiIndex bug this PR surfaced.** `st.data_editor`'s pre-emptive pass ran before
`_fix_column_headers`, so for MultiIndex columns it registered `disabled` under `"('a', 'b')"` rather
than the flattened `"a_b"` — a stringified but still *editable* column. The retry path added here keys
correctly, so the two disagreed. The pass now runs after the flatten. Note this affects MultiIndex
editors with **any** Arrow-incompatible column, not only the nested-list shapes above.

Two gaps left deliberately, both pre-existing in kind: a frozenset next to a nested list still raises for
`st.dataframe` (the frozenset gate returns `"list"` before the probe, and nothing re-checks after the
conversion), and a mixed `pd.Index` is stringified by an earlier defensive branch so the probe never
sees it.

## GitHub Issue Link (if applicable)

Closes https://github.com/streamlit/streamlit/issues/9380

## Testing Plan

- **Unit Tests (Python):** the failing shapes in both orders, with a leading null and the GeoJSON case;
  the non-triggering shapes (consistent nesting, tuples, ragged lists, `list + None`) so the probe can't
  over-fire; the `OverflowError` shape; the `disabled` config reaching a column fixed via the retry; and
  the new `StreamlitDataframeConversionError` path.
- **No E2E:** stringified-incompatible-column is already covered end-to-end by `UNSUPPORTED_TYPES_DF`
  (which carries `period`, `complex` and dict columns). This adds a new *input* shape to an
  already-covered *output* path.
- **Manual:** rendered in a browser against a production build — both `st.dataframe` and `st.data_editor`,
  with a consistently-nested control column confirmed still rendering as a list. The GeoJSON values are
  fully legible at default column width, which was the reporter's actual ask. A pre-fix build was used as
  a control to confirm the crash.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core Arrow serialization and per-rerun data-editor/chart preprocessing; behavior is mostly additive (stringify/disable) but affects performance and which columns stay editable.
> 
> **Overview**
> Fixes crashes when **object columns mix list nesting levels** (e.g. `[1, 2]` beside `[[1, 2], [3, 4]]`, GeoJSON Polygon/MultiPolygon) that PyArrow rejects but the old “first non-null value” heuristic treated as safe.
> 
> **Arrow compatibility detection** adds an optional **`pa.array()` trial** (with **`OverflowError`** in the shared conversion-error set) and a **`trial_conversion`** flag so hot paths can skip the probe. **`st.data_editor`** now stringifies and **disables** bad columns (after header flattening), **retries** Arrow conversion on failure, and raises **`StreamlitDataframeConversionError`** instead of a raw PyArrow error; **built-in charts** pass **`trial_conversion=False`** and rely on the existing serialize-and-retry path for speed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afb17d77a4fd5ea6128dcdd9e092fc39d3d413dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


