### PR TITLE
[fix] Keep elements stale while a stop is pending

### DIFF
--- a/e2e_playwright/appnode_hierarchy_test.py
+++ b/e2e_playwright/appnode_hierarchy_test.py
@@ -108,7 +108,6 @@ def test_stopping_long_compute_keeps_stale_elements_stale(app: Page) -> None:
     leftover_texts = ["second to last", "bottom"]
 
     def expect_stale_leftovers() -> None:
-        """Expect exactly the leftovers of the previous run to be stale."""
         for text in leftover_texts:
             expect(
                 app.get_by_test_id("stElementContainer").filter(has_text=text)
@@ -120,8 +119,12 @@ def test_stopping_long_compute_keeps_stale_elements_stale(app: Page) -> None:
     expect_stale_leftovers()
 
     # The status widget only reveals the Stop button after 500 ms of running
-    # (RUNNING_MAN_DISPLAY_DELAY_TIME_MS).
-    app.get_by_test_id("stStatusWidget").get_by_role("button", name="Stop").click()
+    # (RUNNING_MAN_DISPLAY_DELAY_TIME_MS). The click has to land inside the app's
+    # 5 s sleep; time out fast so overshooting fails clearly instead of hanging
+    # on the default 30 s action timeout.
+    app.get_by_test_id("stStatusWidget").get_by_role("button", name="Stop").click(
+        timeout=3000
+    )
 
     # The stop is pending: the script is still running, so the elements must
     # remain stale rather than flipping back to not-stale.
@@ -133,9 +136,9 @@ def test_stopping_long_compute_keeps_stale_elements_stale(app: Page) -> None:
     # ever routed as FINISHED_EARLY_FOR_RERUN, since that skips clearStaleNodes.
     wait_for_app_run(app)
     expect(stale_elements).to_have_count(0)
-    # The stop is handled at the enqueue checkpoint before "bottom" is
-    # re-emitted, so neither leftover survives a stopped run. A run that
-    # completes normally keeps "bottom" instead.
+    # Stop is applied when the script next tries to send output, before "bottom"
+    # is written, so both leftovers disappear. A run that completes normally
+    # keeps "bottom".
     for text in leftover_texts:
         expect(app.get_by_text(text)).not_to_be_visible()
 

--- a/e2e_playwright/appnode_hierarchy_test.py
+++ b/e2e_playwright/appnode_hierarchy_test.py
@@ -17,7 +17,11 @@ from __future__ import annotations
 from playwright.sync_api import Page, expect
 
 from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
-from e2e_playwright.shared.app_utils import get_button, get_selectbox
+from e2e_playwright.shared.app_utils import (
+    expect_script_state,
+    get_button,
+    get_selectbox,
+)
 
 
 def _select_mode(app: Page, mode: str) -> None:
@@ -90,6 +94,41 @@ def test_long_compute_shows_spinner_only_during_run(
     expect(app.get_by_text("second to last")).not_to_be_visible()
     for index, text in enumerate(texts + stale_texts):
         expect(app.get_by_test_id("stMarkdown").nth(index)).to_have_text(text)
+
+
+def test_stopping_long_compute_keeps_stale_elements_stale(app: Page) -> None:
+    """Stale elements must stay dimmed while a stop is pending.
+
+    Regression test for #9904: STOP_REQUESTED used to fall through to
+    "not stale", so already-stale elements visibly un-dimmed the moment the
+    user hit Stop.
+    """
+    _select_mode(app, "long_compute")
+
+    get_button(app, "run long compute").click()
+
+    # Wait for the elements to be marked stale (and the fade animation to
+    # finish). Unfortunately, we have to rely on a timeout here.
+    app.wait_for_timeout(1000)
+
+    stale_elements = app.locator("[data-stale='true']")
+    expect(stale_elements).to_have_count(2)
+
+    # The Stop button only appears after ~500ms of the script running, so by now
+    # it is present.
+    app.get_by_test_id("stStatusWidget").get_by_role("button", name="Stop").click()
+
+    # The stop is pending: the script is still running, so the elements must
+    # remain stale rather than flipping back to not-stale.
+    expect_script_state(app, "stopRequested")
+    expect(stale_elements).to_have_count(2)
+
+    # Once the run finishes, the leftovers must actually be cleaned up. This
+    # guards against routing user stops to FINISHED_EARLY_FOR_RERUN, which
+    # would skip clearStaleNodes and leave them dimmed forever.
+    wait_for_app_run(app)
+    expect(app.get_by_text("second to last")).not_to_be_visible()
+    expect(app.locator("[data-stale='true']")).to_have_count(0)
 
 
 def test_placeholder_updates_do_not_leave_stale_elements(app: Page) -> None:

--- a/e2e_playwright/appnode_hierarchy_test.py
+++ b/e2e_playwright/appnode_hierarchy_test.py
@@ -105,15 +105,15 @@ def test_stopping_long_compute_keeps_stale_elements_stale(app: Page) -> None:
     _select_mode(app, "long_compute")
 
     stale_elements = app.locator("[data-stale='true']")
-    stale_texts = ["second to last", "bottom"]
+    leftover_texts = ["second to last", "bottom"]
 
     def expect_stale_leftovers() -> None:
         """Expect exactly the leftovers of the previous run to be stale."""
-        for text in stale_texts:
+        for text in leftover_texts:
             expect(
                 app.get_by_test_id("stElementContainer").filter(has_text=text)
             ).to_have_attribute("data-stale", "true")
-        expect(stale_elements).to_have_count(len(stale_texts))
+        expect(stale_elements).to_have_count(len(leftover_texts))
 
     get_button(app, "run long compute").click()
 
@@ -128,15 +128,15 @@ def test_stopping_long_compute_keeps_stale_elements_stale(app: Page) -> None:
     expect_script_state(app, "stopRequested")
     expect_stale_leftovers()
 
-    # Once the run finishes, the leftovers must actually be cleaned up. This
-    # guards against routing user stops to FINISHED_EARLY_FOR_RERUN, which
-    # would skip clearStaleNodes and leave them dimmed forever.
+    # Once the stopped run finishes, leftovers must be removed. They must not
+    # be left dimmed forever, which is what would happen if a user stop were
+    # ever routed as FINISHED_EARLY_FOR_RERUN, since that skips clearStaleNodes.
     wait_for_app_run(app)
     expect(stale_elements).to_have_count(0)
     # The stop is handled at the enqueue checkpoint before "bottom" is
     # re-emitted, so neither leftover survives a stopped run. A run that
     # completes normally keeps "bottom" instead.
-    for text in stale_texts:
+    for text in leftover_texts:
         expect(app.get_by_text(text)).not_to_be_visible()
 
 

--- a/e2e_playwright/appnode_hierarchy_test.py
+++ b/e2e_playwright/appnode_hierarchy_test.py
@@ -97,38 +97,47 @@ def test_long_compute_shows_spinner_only_during_run(
 
 
 def test_stopping_long_compute_keeps_stale_elements_stale(app: Page) -> None:
-    """Stale elements must stay dimmed while a stop is pending.
+    """Elements from earlier runs stay stale while a stop is pending.
 
-    Regression test for #9904: STOP_REQUESTED used to fall through to
-    "not stale", so already-stale elements visibly un-dimmed the moment the
-    user hit Stop.
+    Regression test for #9904: a pending stop does not end the run, so leftover
+    elements must keep their stale marking until the run actually finishes.
     """
     _select_mode(app, "long_compute")
 
+    stale_elements = app.locator("[data-stale='true']")
+    stale_texts = ["second to last", "bottom"]
+
+    def expect_stale_leftovers() -> None:
+        """Expect exactly the leftovers of the previous run to be stale."""
+        for text in stale_texts:
+            expect(
+                app.get_by_test_id("stElementContainer").filter(has_text=text)
+            ).to_have_attribute("data-stale", "true")
+        expect(stale_elements).to_have_count(len(stale_texts))
+
     get_button(app, "run long compute").click()
 
-    # Wait for the elements to be marked stale (and the fade animation to
-    # finish). Unfortunately, we have to rely on a timeout here.
-    app.wait_for_timeout(1000)
+    expect_stale_leftovers()
 
-    stale_elements = app.locator("[data-stale='true']")
-    expect(stale_elements).to_have_count(2)
-
-    # The Stop button only appears after ~500ms of the script running, so by now
-    # it is present.
+    # The status widget only reveals the Stop button after 500 ms of running
+    # (RUNNING_MAN_DISPLAY_DELAY_TIME_MS).
     app.get_by_test_id("stStatusWidget").get_by_role("button", name="Stop").click()
 
     # The stop is pending: the script is still running, so the elements must
     # remain stale rather than flipping back to not-stale.
     expect_script_state(app, "stopRequested")
-    expect(stale_elements).to_have_count(2)
+    expect_stale_leftovers()
 
     # Once the run finishes, the leftovers must actually be cleaned up. This
     # guards against routing user stops to FINISHED_EARLY_FOR_RERUN, which
     # would skip clearStaleNodes and leave them dimmed forever.
     wait_for_app_run(app)
-    expect(app.get_by_text("second to last")).not_to_be_visible()
-    expect(app.locator("[data-stale='true']")).to_have_count(0)
+    expect(stale_elements).to_have_count(0)
+    # The stop is handled at the enqueue checkpoint before "bottom" is
+    # re-emitted, so neither leftover survives a stopped run. A run that
+    # completes normally keeps "bottom" instead.
+    for text in stale_texts:
+        expect(app.get_by_text(text)).not_to_be_visible()
 
 
 def test_placeholder_updates_do_not_leave_stale_elements(app: Page) -> None:

--- a/frontend/lib/src/components/core/Block/utils.test.ts
+++ b/frontend/lib/src/components/core/Block/utils.test.ts
@@ -100,10 +100,47 @@ describe("isElementStale", () => {
     ).toBe(false)
   })
 
+  // A pending stop does not end the script run, so STOP_REQUESTED must stay
+  // staleness-aware in exactly the same way as RUNNING.
+  it("if stop requested and currentFragmentId is set, compares with node's fragmentId and scriptrunId", () => {
+    expect(
+      isElementStale(node, ScriptRunState.STOP_REQUESTED, "myScriptRunId", [
+        "myFragmentId",
+      ])
+    ).toBe(false)
+
+    expect(
+      isElementStale(node, ScriptRunState.STOP_REQUESTED, "otherScriptRunId", [
+        "myFragmentId",
+      ])
+    ).toBe(true)
+
+    expect(
+      isElementStale(node, ScriptRunState.STOP_REQUESTED, "myScriptRunId", [
+        "someFragmentId",
+        "someOtherFragmentId",
+      ])
+    ).toBe(false)
+  })
+
+  it("if stop requested and currentFragmentId is not set, compares with node's scriptRunId", () => {
+    expect(
+      isElementStale(
+        node,
+        ScriptRunState.STOP_REQUESTED,
+        "someOtherScriptRunId",
+        []
+      )
+    ).toBe(true)
+
+    expect(
+      isElementStale(node, ScriptRunState.STOP_REQUESTED, "myScriptRunId", [])
+    ).toBe(false)
+  })
+
   it("returns false for all other script run states", () => {
     const states = [
       ScriptRunState.NOT_RUNNING,
-      ScriptRunState.STOP_REQUESTED,
       ScriptRunState.COMPILATION_ERROR,
     ]
     states.forEach(s => {

--- a/frontend/lib/src/components/core/Block/utils.test.ts
+++ b/frontend/lib/src/components/core/Block/utils.test.ts
@@ -64,9 +64,8 @@ describe("isElementStale", () => {
     ).toBe(true)
   })
 
-  // A pending stop does not end the script run, so STOP_REQUESTED must behave
-  // exactly like RUNNING: both mean the script is still executing, and staleness
-  // is decided the same way for each.
+  // A pending stop does not end the script run, so STOP_REQUESTED uses the
+  // same staleness rules as RUNNING.
   describe.each([ScriptRunState.RUNNING, ScriptRunState.STOP_REQUESTED])(
     "while the script is executing (%s)",
     state => {
@@ -104,6 +103,14 @@ describe("isElementStale", () => {
         )
 
         expect(isElementStale(node, state, "myScriptRunId", [])).toBe(false)
+      })
+
+      // fragmentIdsThisRun is optional, so omitting it has to behave like
+      // passing no fragment ids rather than throwing.
+      it("if fragmentIdsThisRun is omitted, compares the node's scriptRunId", () => {
+        expect(isElementStale(node, state, "someOtherScriptRunId")).toBe(true)
+
+        expect(isElementStale(node, state, "myScriptRunId")).toBe(false)
       })
     }
   )

--- a/frontend/lib/src/components/core/Block/utils.test.ts
+++ b/frontend/lib/src/components/core/Block/utils.test.ts
@@ -67,7 +67,7 @@ describe("isElementStale", () => {
   // When running in a fragment, the only elements that should be set to stale
   // are those belonging to the fragment that's currently running and only if the script run id is different.
   // If the script run id is the same, the element has just been updated and is not stale.
-  it("if running and currentFragmentId is set, compares with node's fragmentId and scriptrunId", () => {
+  it("if running and fragmentIdsThisRun is set, compares the node's fragmentId and scriptRunId", () => {
     expect(
       isElementStale(node, ScriptRunState.RUNNING, "myScriptRunId", [
         "myFragmentId",
@@ -86,11 +86,19 @@ describe("isElementStale", () => {
         "someOtherFragmentId",
       ])
     ).toBe(false)
+
+    // A differing scriptRunId alone is not enough: with the node's fragment
+    // absent from this run, only the fragment guard can keep this false.
+    expect(
+      isElementStale(node, ScriptRunState.RUNNING, "otherScriptRunId", [
+        "someFragmentId",
+      ])
+    ).toBe(false)
   })
 
   // When not running in a fragment, all elements from script runs aside from
   // the current one should be set to stale.
-  it("if running and currentFragmentId is not set, compares with node's scriptRunId", () => {
+  it("if running and fragmentIdsThisRun is not set, compares the node's scriptRunId", () => {
     expect(
       isElementStale(node, ScriptRunState.RUNNING, "someOtherScriptRunId", [])
     ).toBe(true)
@@ -100,9 +108,10 @@ describe("isElementStale", () => {
     ).toBe(false)
   })
 
-  // A pending stop does not end the script run, so STOP_REQUESTED must stay
-  // staleness-aware in exactly the same way as RUNNING.
-  it("if stop requested and currentFragmentId is set, compares with node's fragmentId and scriptrunId", () => {
+  // A pending stop does not end the script run, so STOP_REQUESTED must behave
+  // exactly like RUNNING here. Within a fragment, that means only elements of
+  // a fragment running this time and carrying an older scriptRunId are stale.
+  it("if stop requested and fragmentIdsThisRun is set, compares the node's fragmentId and scriptRunId", () => {
     expect(
       isElementStale(node, ScriptRunState.STOP_REQUESTED, "myScriptRunId", [
         "myFragmentId",
@@ -121,9 +130,19 @@ describe("isElementStale", () => {
         "someOtherFragmentId",
       ])
     ).toBe(false)
+
+    // A differing scriptRunId alone is not enough: with the node's fragment
+    // absent from this run, only the fragment guard can keep this false.
+    expect(
+      isElementStale(node, ScriptRunState.STOP_REQUESTED, "otherScriptRunId", [
+        "someFragmentId",
+      ])
+    ).toBe(false)
   })
 
-  it("if stop requested and currentFragmentId is not set, compares with node's scriptRunId", () => {
+  // Outside a fragment, a pending stop leaves every element of an earlier
+  // script run stale, exactly as RUNNING does.
+  it("if stop requested and fragmentIdsThisRun is not set, compares the node's scriptRunId", () => {
     expect(
       isElementStale(
         node,

--- a/frontend/lib/src/components/core/Block/utils.test.ts
+++ b/frontend/lib/src/components/core/Block/utils.test.ts
@@ -64,98 +64,49 @@ describe("isElementStale", () => {
     ).toBe(true)
   })
 
-  // When running in a fragment, the only elements that should be set to stale
-  // are those belonging to the fragment that's currently running and only if the script run id is different.
-  // If the script run id is the same, the element has just been updated and is not stale.
-  it("if running and fragmentIdsThisRun is set, compares the node's fragmentId and scriptRunId", () => {
-    expect(
-      isElementStale(node, ScriptRunState.RUNNING, "myScriptRunId", [
-        "myFragmentId",
-      ])
-    ).toBe(false)
-
-    expect(
-      isElementStale(node, ScriptRunState.RUNNING, "otherScriptRunId", [
-        "myFragmentId",
-      ])
-    ).toBe(true)
-
-    expect(
-      isElementStale(node, ScriptRunState.RUNNING, "myScriptRunId", [
-        "someFragmentId",
-        "someOtherFragmentId",
-      ])
-    ).toBe(false)
-
-    // A differing scriptRunId alone is not enough: with the node's fragment
-    // absent from this run, only the fragment guard can keep this false.
-    expect(
-      isElementStale(node, ScriptRunState.RUNNING, "otherScriptRunId", [
-        "someFragmentId",
-      ])
-    ).toBe(false)
-  })
-
-  // When not running in a fragment, all elements from script runs aside from
-  // the current one should be set to stale.
-  it("if running and fragmentIdsThisRun is not set, compares the node's scriptRunId", () => {
-    expect(
-      isElementStale(node, ScriptRunState.RUNNING, "someOtherScriptRunId", [])
-    ).toBe(true)
-
-    expect(
-      isElementStale(node, ScriptRunState.RUNNING, "myScriptRunId", [])
-    ).toBe(false)
-  })
-
   // A pending stop does not end the script run, so STOP_REQUESTED must behave
-  // exactly like RUNNING here. Within a fragment, that means only elements of
-  // a fragment running this time and carrying an older scriptRunId are stale.
-  it("if stop requested and fragmentIdsThisRun is set, compares the node's fragmentId and scriptRunId", () => {
-    expect(
-      isElementStale(node, ScriptRunState.STOP_REQUESTED, "myScriptRunId", [
-        "myFragmentId",
-      ])
-    ).toBe(false)
+  // exactly like RUNNING: both mean the script is still executing, and staleness
+  // is decided the same way for each.
+  describe.each([ScriptRunState.RUNNING, ScriptRunState.STOP_REQUESTED])(
+    "while the script is executing (%s)",
+    state => {
+      // When running in a fragment, the only elements that should be set to stale
+      // are those belonging to the fragment that's currently running and only if the script run id is different.
+      // If the script run id is the same, the element has just been updated and is not stale.
+      it("if fragmentIdsThisRun is set, compares the node's fragmentId and scriptRunId", () => {
+        expect(
+          isElementStale(node, state, "myScriptRunId", ["myFragmentId"])
+        ).toBe(false)
 
-    expect(
-      isElementStale(node, ScriptRunState.STOP_REQUESTED, "otherScriptRunId", [
-        "myFragmentId",
-      ])
-    ).toBe(true)
+        expect(
+          isElementStale(node, state, "otherScriptRunId", ["myFragmentId"])
+        ).toBe(true)
 
-    expect(
-      isElementStale(node, ScriptRunState.STOP_REQUESTED, "myScriptRunId", [
-        "someFragmentId",
-        "someOtherFragmentId",
-      ])
-    ).toBe(false)
+        expect(
+          isElementStale(node, state, "myScriptRunId", [
+            "someFragmentId",
+            "someOtherFragmentId",
+          ])
+        ).toBe(false)
 
-    // A differing scriptRunId alone is not enough: with the node's fragment
-    // absent from this run, only the fragment guard can keep this false.
-    expect(
-      isElementStale(node, ScriptRunState.STOP_REQUESTED, "otherScriptRunId", [
-        "someFragmentId",
-      ])
-    ).toBe(false)
-  })
+        // A fragment that is not running this time is not stale, even when its
+        // scriptRunId differs.
+        expect(
+          isElementStale(node, state, "otherScriptRunId", ["someFragmentId"])
+        ).toBe(false)
+      })
 
-  // Outside a fragment, a pending stop leaves every element of an earlier
-  // script run stale, exactly as RUNNING does.
-  it("if stop requested and fragmentIdsThisRun is not set, compares the node's scriptRunId", () => {
-    expect(
-      isElementStale(
-        node,
-        ScriptRunState.STOP_REQUESTED,
-        "someOtherScriptRunId",
-        []
-      )
-    ).toBe(true)
+      // When not running in a fragment, all elements from script runs aside from
+      // the current one should be set to stale.
+      it("if fragmentIdsThisRun is not set, compares the node's scriptRunId", () => {
+        expect(isElementStale(node, state, "someOtherScriptRunId", [])).toBe(
+          true
+        )
 
-    expect(
-      isElementStale(node, ScriptRunState.STOP_REQUESTED, "myScriptRunId", [])
-    ).toBe(false)
-  })
+        expect(isElementStale(node, state, "myScriptRunId", [])).toBe(false)
+      })
+    }
+  )
 
   it("returns false for all other script run states", () => {
     const states = [

--- a/frontend/lib/src/components/core/Block/utils.ts
+++ b/frontend/lib/src/components/core/Block/utils.ts
@@ -52,7 +52,13 @@ export function isElementStale(
     return true
   }
 
-  if (scriptRunState === ScriptRunState.RUNNING) {
+  // STOP_REQUESTED means the script is still running while it winds down, so
+  // elements from earlier script runs must keep reporting as stale until the
+  // run actually finishes.
+  if (
+    scriptRunState === ScriptRunState.RUNNING ||
+    scriptRunState === ScriptRunState.STOP_REQUESTED
+  ) {
     if (fragmentIdsThisRun?.length) {
       // if the fragmentId is set, we only want to mark elements as stale
       // that belong to the same fragmentId and have a different scriptRunId.

--- a/frontend/lib/src/components/core/Block/utils.ts
+++ b/frontend/lib/src/components/core/Block/utils.ts
@@ -52,9 +52,9 @@ export function isElementStale(
     return true
   }
 
-  // STOP_REQUESTED means the script is still running while it winds down, so
-  // elements from earlier script runs must keep reporting as stale until the
-  // run actually finishes.
+  // STOP_REQUESTED means the user asked to stop but the script is still
+  // executing, so elements from earlier runs must stay stale until the run
+  // actually finishes.
   if (
     scriptRunState === ScriptRunState.RUNNING ||
     scriptRunState === ScriptRunState.STOP_REQUESTED

--- a/frontend/lib/src/components/core/Block/utils.ts
+++ b/frontend/lib/src/components/core/Block/utils.ts
@@ -33,6 +33,8 @@ export function getClassnamePrefix(direction: Direction): string {
     : "stVerticalBlock"
 }
 
+// Only RUNNING: during a pending stop, placeholder updates should still be
+// allowed to render.
 export function shouldComponentBeEnabled(
   elementType: string,
   scriptRunState: ScriptRunState


### PR DESCRIPTION
## Describe your changes

Pressing Stop no longer un-dims leftover elements from earlier script runs. A pending stop does not end
execution, so `isElementStale` now treats `STOP_REQUESTED` like `RUNNING` until the run actually
finishes — previously those elements reported `data-stale="false"` the instant Stop was pressed.

That window is often long rather than momentary: execution control is only checked when a ForwardMsg
is enqueued, so a script blocked in a non-interruptible call keeps running until its next `st.*` call.
Stopping a 10-minute query un-dimmed the whole page for 10 minutes.

Two consequences beyond dimming, both improvements:

- `balloons` / `snow` no longer remount and replay their animation mid-stop (`hideIfStale` unmounts
  rather than dims, so un-staling them re-triggered the effect).
- A leftover tab stays disabled instead of becoming clickable moments before `clearStaleNodes` deletes it.

The fix was originally identified in #13787; that contributor is credited as co-author. Note that
PR's backend half — routing user stops to `FINISHED_EARLY_FOR_RERUN` — is **not** included here and
would be a regression: it makes the frontend skip `clearStaleNodes`, leaving stale elements dimmed
indefinitely. The e2e test below guards against that, which unit tests cannot.


Scoped deliberately to `isElementStale`. `shouldComponentBeEnabled`, a few lines above, still
special-cases only `RUNNING`, so an `empty` placeholder becomes enabled the moment Stop is pressed.
That inconsistency is real but has no visible effect (empty containers render nothing), and widening
it would unfreeze `Maybe`-gated placeholder updates during the stop window — a behavior change
outside a staleness fix. Left for its own change.

Scope note on the linked issue: it carries two expectations. The first — that leftovers must not flip to
non-stale when Stop is pressed — is what this fixes. The second, that the previous run's output should not
still be on screen at all, is inherent rather than a defect: a script blocked in a non-interruptible call
cannot be preempted, so its elements can only be cleared once it actually reaches a checkpoint. The
issue's own closing assertions cover that, and they already pass — leftovers are removed when the stopped
run finishes.

## GitHub Issue Link (if applicable)

Closes https://github.com/streamlit/streamlit/issues/9904

## Testing Plan

- **Unit Tests (JS):** `STOP_REQUESTED` cases mirroring the existing `RUNNING` pair, including the
  fragment path. The pre-existing "returns false for all other script run states" case had
  `STOP_REQUESTED` removed from its array — it asserted the bug verbatim; the remaining entries still
  guard the fallthrough.
- **E2E Tests:** `appnode_hierarchy_test.py` asserts leftovers stay stale through the stop window and
  are cleared once the run finishes. Verified it fails without the production change
  (`data-stale="false"` on 12 containers), and 5 consecutive runs pass.
- Run locally on macOS/chromium; no snapshots involved, so nothing to regenerate.

---

Co-Authored-By: Harshang Akabari <a.harshang@gmail.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core render-tree staleness during script execution, but the change is narrowly scoped to treating STOP_REQUESTED like RUNNING in isElementStale, with unit and e2e regression coverage.
> 
> **Overview**
> Fixes a regression where pressing **Stop** immediately cleared `data-stale` on leftover UI from earlier runs, even though the script was still executing until the next checkpoint.
> 
> **`isElementStale`** now applies the same fragment/script-run-id rules for **`STOP_REQUESTED`** as for **`RUNNING`**, so dimmed leftovers stay stale through the pending-stop window and related behaviors (e.g. balloons/snow remounting, tabs briefly re-enabling) no longer flip mid-stop. **`shouldComponentBeEnabled`** is unchanged and still only special-cases **`RUNNING`**.
> 
> Unit tests parameterize the existing running staleness cases over both states and add coverage when **`fragmentIdsThisRun`** is omitted. A new Playwright test on the long-compute scenario asserts stale leftovers persist while **`stopRequested`**, then disappear after the run finishes (guarding against routing user stops in a way that skips **`clearStaleNodes`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41c671cf0f97799189b252f0da087657df41926c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



