### PR TITLE
[chore] Enable ESLint zero-cost frontend guards

### DIFF
--- a/frontend/app/src/components/AppView/AppView.test.tsx
+++ b/frontend/app/src/components/AppView/AppView.test.tsx
@@ -938,7 +938,9 @@ describe("AppView element", () => {
 
   describe("when window.location.hash changes", () => {
     let originalLocation: Location
-    beforeEach(() => (originalLocation = window.location))
+    beforeEach(() => {
+      originalLocation = window.location
+    })
     afterEach(() => {
       Object.defineProperty(window, "location", {
         value: originalLocation,

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -272,14 +272,14 @@ export default defineConfig([
       "no-debugger": "error",
       // Bug-class lock-ins not covered by eslint:recommended
       "no-self-compare": "error",
-      "no-return-assign": "error",
+      "no-return-assign": ["error", "always"],
       "no-sequences": "error",
       "no-template-curly-in-string": "error",
       "no-extend-native": "error",
-      // Complements the ForInStatement ban in no-restricted-syntax
+      // Safety net if the ForInStatement ban in no-restricted-syntax is relaxed
       "guard-for-in": "error",
       "default-case-last": "error",
-      // Complements the LabeledStatement ban in no-restricted-syntax
+      // Safety net if the LabeledStatement ban in no-restricted-syntax is relaxed
       "no-labels": "error",
       // Oxlint eslint/preserve-caught-error owns this check.
       "preserve-caught-error": "off",
@@ -502,8 +502,8 @@ export default defineConfig([
       "no-restricted-properties": getNoRestrictedProperties({
         includeUseTimeout: true,
       }),
-      // Implicit type="submit" is a real form-submit footgun in app source.
-      // Tests still use bare <button> as fixtures (~29 hits).
+      // Buttons without an explicit type submit their enclosing form by default.
+      // Tests still use <button> fixtures without type, so this stays production-only.
       "@eslint-react/dom-no-missing-button-type": "error",
     },
   },

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -270,15 +270,16 @@ export default defineConfig([
       "no-console": "error",
       // Prevent unintentional use of `debugger`
       "no-debugger": "error",
-      // Bug-class lock-ins not covered by eslint:recommended
+      // Correctness rules that eslint.configs.recommended does not enable
       "no-self-compare": "error",
       "no-return-assign": ["error", "always"],
-      "no-sequences": "error",
+      "no-sequences": ["error", { allowInParentheses: false }],
       "no-template-curly-in-string": "error",
       "no-extend-native": "error",
+      // Keep default as the last switch clause
+      "default-case-last": "error",
       // Safety net if the ForInStatement ban in no-restricted-syntax is relaxed
       "guard-for-in": "error",
-      "default-case-last": "error",
       // Safety net if the LabeledStatement ban in no-restricted-syntax is relaxed
       "no-labels": "error",
       // Oxlint eslint/preserve-caught-error owns this check.
@@ -297,7 +298,8 @@ export default defineConfig([
       "@eslint-react/no-unstable-context-value": "error",
       // Default-arg object/array literals are a new reference each render
       "@eslint-react/no-unstable-default-props": "error",
-      // Unsandboxed iframes and target=_blank without rel=noopener
+      // Require sandbox on raw <iframe> JSX, and rel=noopener on raw <a target=_blank>.
+      // Intrinsic elements only — styled.iframe / styled anchors are not checked.
       "@eslint-react/dom-no-missing-iframe-sandbox": "error",
       "@eslint-react/dom-no-unsafe-target-blank": "error",
       // We want to enforce display names for context providers for better debugging
@@ -369,7 +371,8 @@ export default defineConfig([
       "@typescript-eslint/return-await": ["error", "in-try-catch"],
       // Treat @deprecated API usage as errors
       "@typescript-eslint/no-deprecated": "error",
-      // Mixed string/numeric enum members are easy to confuse with protobuf enums
+      // Mixed string/numeric members compare and reverse-map inconsistently;
+      // keep hand-written enums single-typed like generated protobuf ones.
       "@typescript-eslint/no-mixed-enums": "error",
       // Permit for-of loops
       "no-restricted-syntax": [
@@ -400,6 +403,8 @@ export default defineConfig([
         },
       ],
       "import-x/prefer-default-export": "off",
+      // Catch import specifiers that resolve to nothing useful: self-imports,
+      // redundant path segments, empty named blocks.
       "import-x/no-self-import": "error",
       "import-x/no-useless-path-segments": "error",
       "import-x/no-empty-named-blocks": "error",
@@ -502,7 +507,7 @@ export default defineConfig([
       "no-restricted-properties": getNoRestrictedProperties({
         includeUseTimeout: true,
       }),
-      // Buttons without an explicit type submit their enclosing form by default.
+      // Require type on raw <button> JSX (not styled.button); omitted type submits the enclosing form.
       // Tests still use <button> fixtures without type, so this stays production-only.
       "@eslint-react/dom-no-missing-button-type": "error",
     },

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -270,6 +270,17 @@ export default defineConfig([
       "no-console": "error",
       // Prevent unintentional use of `debugger`
       "no-debugger": "error",
+      // Bug-class lock-ins not covered by eslint:recommended
+      "no-self-compare": "error",
+      "no-return-assign": "error",
+      "no-sequences": "error",
+      "no-template-curly-in-string": "error",
+      "no-extend-native": "error",
+      // Complements the ForInStatement ban in no-restricted-syntax
+      "guard-for-in": "error",
+      "default-case-last": "error",
+      // Complements the LabeledStatement ban in no-restricted-syntax
+      "no-labels": "error",
       // Oxlint eslint/preserve-caught-error owns this check.
       "preserve-caught-error": "off",
       // We do want to discourage the usage of flushSync
@@ -284,6 +295,11 @@ export default defineConfig([
       "@eslint-react/jsx-no-useless-fragment": "off",
       // Prevent context values from being recreated on every render
       "@eslint-react/no-unstable-context-value": "error",
+      // Default-arg object/array literals are a new reference each render
+      "@eslint-react/no-unstable-default-props": "error",
+      // Unsandboxed iframes and target=_blank without rel=noopener
+      "@eslint-react/dom-no-missing-iframe-sandbox": "error",
+      "@eslint-react/dom-no-unsafe-target-blank": "error",
       // We want to enforce display names for context providers for better debugging
       "@eslint-react/no-missing-context-display-name": "error",
       // New rules in @eslint-react v4/v5 — disable until existing violations are addressed
@@ -353,6 +369,8 @@ export default defineConfig([
       "@typescript-eslint/return-await": ["error", "in-try-catch"],
       // Treat @deprecated API usage as errors
       "@typescript-eslint/no-deprecated": "error",
+      // Mixed string/numeric enum members are easy to confuse with protobuf enums
+      "@typescript-eslint/no-mixed-enums": "error",
       // Permit for-of loops
       "no-restricted-syntax": [
         "error",
@@ -382,6 +400,9 @@ export default defineConfig([
         },
       ],
       "import-x/prefer-default-export": "off",
+      "import-x/no-self-import": "error",
+      "import-x/no-useless-path-segments": "error",
+      "import-x/no-empty-named-blocks": "error",
       "max-classes-per-file": "off",
       "no-shadow": "off",
       "no-param-reassign": "off",
@@ -459,6 +480,8 @@ export default defineConfig([
       "react-hooks/set-state-in-effect": "off",
       // Enforce "You Might Not Need an Effect" pattern - don't derive state in effects
       "react-hooks/no-deriving-state-in-effects": "error",
+      // useMemo must return a value; side-effect-only memos belong in useEffect
+      "react-hooks/void-use-memo": "error",
     },
     settings: {
       "import-x/resolver": {
@@ -479,6 +502,9 @@ export default defineConfig([
       "no-restricted-properties": getNoRestrictedProperties({
         includeUseTimeout: true,
       }),
+      // Implicit type="submit" is a real form-submit footgun in app source.
+      // Tests still use bare <button> as fixtures (~29 hits).
+      "@eslint-react/dom-no-missing-button-type": "error",
     },
   },
   // Test files specific configuration

--- a/frontend/lib/src/hooks/useResizeObserver.test.tsx
+++ b/frontend/lib/src/hooks/useResizeObserver.test.tsx
@@ -31,6 +31,8 @@ const mockDisconnect = vi.fn()
 const mockObserve = vi.fn()
 let resizeCallback: ((entries: ResizeObserverEntry[]) => void) | null = null
 
+// Stable empty list so the default is not a new `[]` each render
+// (`@eslint-react/no-unstable-default-props`).
 const EMPTY_DEPENDENCIES: DependencyList = []
 
 // Helper component that uses the hook and displays values

--- a/frontend/lib/src/hooks/useResizeObserver.test.tsx
+++ b/frontend/lib/src/hooks/useResizeObserver.test.tsx
@@ -31,12 +31,14 @@ const mockDisconnect = vi.fn()
 const mockObserve = vi.fn()
 let resizeCallback: ((entries: ResizeObserverEntry[]) => void) | null = null
 
+const EMPTY_DEPENDENCIES: DependencyList = []
+
 // Helper component that uses the hook and displays values
 function TestComponent({
   properties,
   throttleMs,
   dimensionsRef,
-  dependencies = [],
+  dependencies = EMPTY_DEPENDENCIES,
   mounted = true,
 }: {
   properties: DOMRectKeys[]

--- a/frontend/lib/src/hooks/useScrollAnimation.test.ts
+++ b/frontend/lib/src/hooks/useScrollAnimation.test.ts
@@ -30,11 +30,15 @@ describe("useScrollAnimation", () => {
     scrollHeight = 200
     offsetHeight = 100
     Object.defineProperty(targetElement, "scrollHeight", {
-      set: value => (scrollHeight = value),
+      set: value => {
+        scrollHeight = value
+      },
       get: () => scrollHeight,
     })
     Object.defineProperty(targetElement, "offsetHeight", {
-      set: value => (offsetHeight = value),
+      set: value => {
+        offsetHeight = value
+      },
       get: () => offsetHeight,
     })
     targetElement.addEventListener = vi.fn()


### PR DESCRIPTION
## Describe your changes

Enables ESLint lock-in rules the frontend already satisfies so iframe sandbox, `target=_blank` noopener, mixed enums, and similar bug classes cannot regress.

`dom-no-missing-button-type` is production-only because tests still use unlabeled `<button>` fixtures. The ResizeObserver test helper now defaults `dependencies` to a module-level empty array instead of `[]`.

Implements wiki queue **P0.3**.
https://github.com/streamlit/streamlit/wiki/2026-09-03-improving-frontend-linting

## GitHub Issue Link (if applicable)

## Testing Plan

- [x] No new tests: lint config plus one test helper; `make frontend-lint` and `useResizeObserver` unit tests are green
- No e2e or manual testing

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

Made with [Cursor](https://cursor.com)