### PR TITLE
[fix] Reject async cache_resource lifecycle callbacks

### DIFF
--- a/lib/streamlit/runtime/caching/cache_resource_api.py
+++ b/lib/streamlit/runtime/caching/cache_resource_api.py
@@ -93,24 +93,27 @@ def _no_op_release(ignored: Any) -> None:
 
 
 def _is_async_callable(func: Callable[..., Any]) -> bool:
-    """Return True if ``func`` is a coroutine or async-generator callable.
+    """Return True if calling ``func`` produces a coroutine or async generator.
+
+    Classification uses the callable Streamlit will invoke, not ``__wrapped__``
+    metadata. A synchronous adapter around an async function is therefore
+    accepted, even when it is built with ``functools.wraps``.
 
     ``inspect.iscoroutinefunction`` is False for callable instances whose
     ``__call__`` is async, so those objects are inspected via ``__call__``.
     """
-    unwrapped: Any = func
-    while isinstance(unwrapped, functools.partial):
-        unwrapped = unwrapped.func
-    unwrapped = inspect.unwrap(unwrapped)
-    if inspect.iscoroutinefunction(unwrapped) or inspect.isasyncgenfunction(unwrapped):
+    target: Any = func
+    while isinstance(target, functools.partial):
+        target = target.func
+    if inspect.iscoroutinefunction(target) or inspect.isasyncgenfunction(target):
         return True
     # Inspect the type's ``__call__`` so callable instances with an async
-    # ``__call__`` are detected. ``inspect.iscoroutinefunction(instance)`` is
-    # False on some supported Python versions.
-    call = type(unwrapped).__call__
-    if call is unwrapped:
+    # ``__call__`` are detected. ``inspect.iscoroutinefunction`` only inspects
+    # the object itself, so a callable instance whose ``__call__`` is async
+    # has to be detected through its type.
+    call = type(target).__call__
+    if call is target:
         return False
-    call = inspect.unwrap(call)
     return inspect.iscoroutinefunction(call) or inspect.isasyncgenfunction(call)
 
 

--- a/lib/streamlit/runtime/caching/cache_resource_api.py
+++ b/lib/streamlit/runtime/caching/cache_resource_api.py
@@ -17,6 +17,8 @@
 
 from __future__ import annotations
 
+import functools
+import inspect
 import math
 import threading
 from collections.abc import Callable, Sequence
@@ -33,7 +35,7 @@ from typing_extensions import ParamSpec
 
 import streamlit as st
 from streamlit import config
-from streamlit.errors import StreamlitValueError
+from streamlit.errors import StreamlitAPIException, StreamlitValueError
 from streamlit.logger import get_logger
 from streamlit.runtime.caching import cache_utils
 from streamlit.runtime.caching.cache_errors import CacheKeyNotFoundError
@@ -88,6 +90,68 @@ def _equal_validate_funcs(a: ValidateFunc | None, b: ValidateFunc | None) -> boo
 
 def _no_op_release(ignored: Any) -> None:
     """No-op OnRelease function."""
+
+
+_ASYNC_LIFECYCLE_CALLBACK_ERROR_ID: Final = "cache-resource-async-lifecycle-callback"
+
+
+def _is_async_callable(func: Callable[..., Any]) -> bool:
+    """Return True if ``func`` is a coroutine or async-generator callable.
+
+    ``inspect.iscoroutinefunction`` is False for callable instances whose
+    ``__call__`` is async, so those objects are inspected via ``__call__``.
+    """
+    unwrapped: Any = func
+    while isinstance(unwrapped, functools.partial):
+        unwrapped = unwrapped.func
+    unwrapped = inspect.unwrap(unwrapped)
+    if inspect.iscoroutinefunction(unwrapped) or inspect.isasyncgenfunction(unwrapped):
+        return True
+    # Inspect the type's ``__call__`` so callable instances with an async
+    # ``__call__`` are detected. ``inspect.iscoroutinefunction(instance)`` is
+    # False on some supported Python versions.
+    call = type(unwrapped).__call__
+    if call is unwrapped:
+        return False
+    call = inspect.unwrap(call)
+    return inspect.iscoroutinefunction(call) or inspect.isasyncgenfunction(call)
+
+
+def _async_lifecycle_callback_message(param_name: str) -> str:
+    return (
+        f"The `{param_name}` callback of `st.cache_resource` must be a synchronous "
+        "function. Async callbacks are not supported and are never awaited."
+    )
+
+
+def _require_sync_lifecycle_callback(
+    callback: Callable[..., Any] | None, *, param_name: str
+) -> Callable[..., Any] | None:
+    """Reject async lifecycle callbacks and discard returned native coroutines."""
+    if callback is None:
+        return None
+    if _is_async_callable(callback):
+        raise StreamlitAPIException(
+            _async_lifecycle_callback_message(param_name),
+            error_id=_ASYNC_LIFECYCLE_CALLBACK_ERROR_ID,
+        )
+
+    def _sync_lifecycle_callback(*args: Any, **kwargs: Any) -> Any:
+        result = callback(*args, **kwargs)
+        if inspect.iscoroutine(result):
+            result.close()
+            raise StreamlitAPIException(
+                _async_lifecycle_callback_message(param_name),
+                error_id=_ASYNC_LIFECYCLE_CALLBACK_ERROR_ID,
+            )
+        if inspect.isawaitable(result):
+            raise StreamlitAPIException(
+                _async_lifecycle_callback_message(param_name),
+                error_id=_ASYNC_LIFECYCLE_CALLBACK_ERROR_ID,
+            )
+        return result
+
+    return _sync_lifecycle_callback
 
 
 class ResourceCaches(StatsProvider):
@@ -482,7 +546,8 @@ class CacheResourceAPI:
         validate : callable or None
             An optional validation function for cached resources. ``validate`` is called
             each time the cached value is accessed. It receives the cached value as
-            its only parameter and it must return a boolean. If ``validate`` returns
+            its only parameter and it must return a boolean. ``validate`` must be
+            synchronous; async callbacks are not supported. If ``validate`` returns
             False, the current cached value is discarded, and the decorated function
             is called to compute a new value. This is useful e.g. to check the
             health of database connections.
@@ -498,6 +563,7 @@ class CacheResourceAPI:
         on_release : callable or None
             A function to call when an entry is removed from the cache.
             The removed item will be provided to the function as an argument.
+            ``on_release`` must be synchronous; async callbacks are not supported.
 
             This is only useful for caches that remove entries normally.
             Most commonly, this is used session-scoped caches to release
@@ -680,6 +746,11 @@ class CacheResourceAPI:
         validate_refresh_mode(
             refresh_mode,
             time_to_seconds(ttl, coerce_none_to_inf=False),
+        )
+
+        validate = _require_sync_lifecycle_callback(validate, param_name="validate")
+        on_release = _require_sync_lifecycle_callback(
+            on_release, param_name="on_release"
         )
 
         # Support passing the params via function decorator, e.g.

--- a/lib/streamlit/runtime/caching/cache_resource_api.py
+++ b/lib/streamlit/runtime/caching/cache_resource_api.py
@@ -93,7 +93,7 @@ def _no_op_release(ignored: Any) -> None:
 
 
 def _is_async_callable(func: Callable[..., Any]) -> bool:
-    """Return True if calling ``func`` produces a coroutine or async generator."""
+    """Return whether ``func`` is an identifiable coroutine or async-generator callable."""
     target: Any = func
     while isinstance(target, functools.partial):
         target = target.func

--- a/lib/streamlit/runtime/caching/cache_resource_api.py
+++ b/lib/streamlit/runtime/caching/cache_resource_api.py
@@ -93,27 +93,16 @@ def _no_op_release(ignored: Any) -> None:
 
 
 def _is_async_callable(func: Callable[..., Any]) -> bool:
-    """Return True if calling ``func`` produces a coroutine or async generator.
-
-    Classification uses the callable Streamlit will invoke, not ``__wrapped__``
-    metadata. A synchronous adapter around an async function is therefore
-    accepted, even when it is built with ``functools.wraps``.
-
-    ``inspect.iscoroutinefunction`` is False for callable instances whose
-    ``__call__`` is async, so those objects are inspected via ``__call__``.
-    """
+    """Return True if calling ``func`` produces a coroutine or async generator."""
     target: Any = func
     while isinstance(target, functools.partial):
         target = target.func
     if inspect.iscoroutinefunction(target) or inspect.isasyncgenfunction(target):
         return True
-    # Inspect the type's ``__call__`` so callable instances with an async
-    # ``__call__`` are detected. ``inspect.iscoroutinefunction`` only inspects
-    # the object itself, so a callable instance whose ``__call__`` is async
-    # has to be detected through its type.
+    # inspect.iscoroutinefunction only inspects the object itself, so a
+    # callable instance whose __call__ is async has to be detected through
+    # its type.
     call = type(target).__call__
-    if call is target:
-        return False
     return inspect.iscoroutinefunction(call) or inspect.isasyncgenfunction(call)
 
 
@@ -129,8 +118,9 @@ def _reject_async_lifecycle_callback(
     if callback is not None and _is_async_callable(callback):
         raise StreamlitAPIException(
             f"The `{param_name}` callback of `st.cache_resource` must be a "
-            "synchronous function. Async callbacks are not supported and are "
-            "never awaited.",
+            "synchronous function. Async callbacks are never awaited; call "
+            "the coroutine from a synchronous wrapper instead (for example "
+            "with `asyncio.run`).",
             error_id="cache-resource-async-lifecycle-callback",
         )
 
@@ -527,11 +517,11 @@ class CacheResourceAPI:
         validate : callable or None
             An optional validation function for cached resources. ``validate`` is called
             each time the cached value is accessed. It receives the cached value as
-            its only parameter and it must return a boolean. ``validate`` must be
-            synchronous; async callbacks are not supported. If ``validate`` returns
+            its only parameter and it must return a boolean. If ``validate`` returns
             False, the current cached value is discarded, and the decorated function
             is called to compute a new value. This is useful e.g. to check the
-            health of database connections.
+            health of database connections. ``validate`` must be a synchronous
+            function; coroutine functions (``async def``) aren't supported.
 
         hash_funcs : dict or None
             Mapping of types or fully qualified names to hash functions.

--- a/lib/streamlit/runtime/caching/cache_resource_api.py
+++ b/lib/streamlit/runtime/caching/cache_resource_api.py
@@ -530,7 +530,8 @@ class CacheResourceAPI:
         on_release : callable or None
             A function to call when an entry is removed from the cache.
             The removed item will be provided to the function as an argument.
-            ``on_release`` must be synchronous; async callbacks are not supported.
+            ``on_release`` must be a synchronous function; coroutine functions
+            (``async def``) aren't supported.
 
             This is only useful for caches that remove entries normally.
             Most commonly, this is used session-scoped caches to release

--- a/lib/streamlit/runtime/caching/cache_resource_api.py
+++ b/lib/streamlit/runtime/caching/cache_resource_api.py
@@ -92,9 +92,6 @@ def _no_op_release(ignored: Any) -> None:
     """No-op OnRelease function."""
 
 
-_ASYNC_LIFECYCLE_CALLBACK_ERROR_ID: Final = "cache-resource-async-lifecycle-callback"
-
-
 def _is_async_callable(func: Callable[..., Any]) -> bool:
     """Return True if ``func`` is a coroutine or async-generator callable.
 
@@ -117,41 +114,22 @@ def _is_async_callable(func: Callable[..., Any]) -> bool:
     return inspect.iscoroutinefunction(call) or inspect.isasyncgenfunction(call)
 
 
-def _async_lifecycle_callback_message(param_name: str) -> str:
-    return (
-        f"The `{param_name}` callback of `st.cache_resource` must be a synchronous "
-        "function. Async callbacks are not supported and are never awaited."
-    )
-
-
-def _require_sync_lifecycle_callback(
+def _reject_async_lifecycle_callback(
     callback: Callable[..., Any] | None, *, param_name: str
-) -> Callable[..., Any] | None:
-    """Reject async lifecycle callbacks and discard returned native coroutines."""
-    if callback is None:
-        return None
-    if _is_async_callable(callback):
+) -> None:
+    """Raise if a lifecycle callback is async.
+
+    ``validate`` and ``on_release`` are invoked synchronously, so an async
+    callback never runs: its awaitable is discarded, which reads as a
+    successful validation or a completed release.
+    """
+    if callback is not None and _is_async_callable(callback):
         raise StreamlitAPIException(
-            _async_lifecycle_callback_message(param_name),
-            error_id=_ASYNC_LIFECYCLE_CALLBACK_ERROR_ID,
+            f"The `{param_name}` callback of `st.cache_resource` must be a "
+            "synchronous function. Async callbacks are not supported and are "
+            "never awaited.",
+            error_id="cache-resource-async-lifecycle-callback",
         )
-
-    def _sync_lifecycle_callback(*args: Any, **kwargs: Any) -> Any:
-        result = callback(*args, **kwargs)
-        if inspect.iscoroutine(result):
-            result.close()
-            raise StreamlitAPIException(
-                _async_lifecycle_callback_message(param_name),
-                error_id=_ASYNC_LIFECYCLE_CALLBACK_ERROR_ID,
-            )
-        if inspect.isawaitable(result):
-            raise StreamlitAPIException(
-                _async_lifecycle_callback_message(param_name),
-                error_id=_ASYNC_LIFECYCLE_CALLBACK_ERROR_ID,
-            )
-        return result
-
-    return _sync_lifecycle_callback
 
 
 class ResourceCaches(StatsProvider):
@@ -748,10 +726,8 @@ class CacheResourceAPI:
             time_to_seconds(ttl, coerce_none_to_inf=False),
         )
 
-        validate = _require_sync_lifecycle_callback(validate, param_name="validate")
-        on_release = _require_sync_lifecycle_callback(
-            on_release, param_name="on_release"
-        )
+        _reject_async_lifecycle_callback(validate, param_name="validate")
+        _reject_async_lifecycle_callback(on_release, param_name="on_release")
 
         # Support passing the params via function decorator, e.g.
         # @st.cache_resource(show_spinner=False)

--- a/lib/streamlit/runtime/caching/cache_resource_api.py
+++ b/lib/streamlit/runtime/caching/cache_resource_api.py
@@ -119,8 +119,7 @@ def _reject_async_lifecycle_callback(
         raise StreamlitAPIException(
             f"The `{param_name}` callback of `st.cache_resource` must be a "
             "synchronous function. Async callbacks are never awaited; call "
-            "the coroutine from a synchronous wrapper instead (for example "
-            "with `asyncio.run`).",
+            "the coroutine from a synchronous wrapper instead.",
             error_id="cache-resource-async-lifecycle-callback",
         )
 

--- a/lib/streamlit/runtime/caching/cache_resource_api.py
+++ b/lib/streamlit/runtime/caching/cache_resource_api.py
@@ -17,7 +17,6 @@
 
 from __future__ import annotations
 
-import functools
 import inspect
 import math
 import threading
@@ -95,8 +94,6 @@ def _no_op_release(ignored: Any) -> None:
 def _is_async_callable(func: Callable[..., Any]) -> bool:
     """Return whether ``func`` is an identifiable coroutine or async-generator callable."""
     target: Any = func
-    while isinstance(target, functools.partial):
-        target = target.func
     if inspect.iscoroutinefunction(target) or inspect.isasyncgenfunction(target):
         return True
     # inspect.iscoroutinefunction only inspects the object itself, so a

--- a/lib/tests/streamlit/runtime/caching/cache_resource_api_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_resource_api_test.py
@@ -17,10 +17,8 @@
 from __future__ import annotations
 
 import functools
-import gc
 import threading
 import unittest
-import warnings
 from unittest.mock import Mock, patch
 
 import pytest
@@ -332,17 +330,6 @@ class CacheResourceValidateTest(unittest.TestCase):
             validate.reset_mock()
 
 
-def _assert_no_unawaited_coroutine_warning(
-    caught: list[warnings.WarningMessage],
-) -> None:
-    """Fail if a RuntimeWarning about an unawaited coroutine was recorded."""
-    assert not any(
-        issubclass(warning.category, RuntimeWarning)
-        and "never awaited" in str(warning.message)
-        for warning in caught
-    )
-
-
 class CacheResourceAsyncLifecycleCallbackTest(unittest.TestCase):
     def setUp(self) -> None:
         add_script_run_ctx(threading.current_thread(), create_mock_script_run_ctx())
@@ -358,14 +345,10 @@ class CacheResourceAsyncLifecycleCallbackTest(unittest.TestCase):
         async def async_callback(value: int) -> bool:
             return True
 
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            with pytest.raises(StreamlitAPIException, match=param_name) as exc_info:
-                st.cache_resource(**{param_name: async_callback})(lambda: 1)
-            gc.collect()
+        with pytest.raises(StreamlitAPIException, match=param_name) as exc_info:
+            st.cache_resource(**{param_name: async_callback})(lambda: 1)
 
         assert exc_info.value.error_id == "cache-resource-async-lifecycle-callback"
-        _assert_no_unawaited_coroutine_warning(caught)
 
     @parameterized.expand([("validate",), ("on_release",)])
     def test_rejects_async_callable_object(self, param_name: str) -> None:
@@ -388,6 +371,32 @@ class CacheResourceAsyncLifecycleCallbackTest(unittest.TestCase):
         callback = functools.partial(async_callback, None)
         with pytest.raises(StreamlitAPIException, match=param_name):
             st.cache_resource(**{param_name: callback})(lambda: 1)
+
+    @parameterized.expand([("validate",), ("on_release",)])
+    def test_rejects_partial_of_async_callable_object(self, param_name: str) -> None:
+        """Partials of callable instances with async ``__call__`` fail at decoration."""
+
+        class AsyncCallback:
+            async def __call__(self, ignored: object, value: int) -> bool:
+                return True
+
+        callback = functools.partial(AsyncCallback(), None)
+        with pytest.raises(StreamlitAPIException, match=param_name) as exc_info:
+            st.cache_resource(**{param_name: callback})(lambda: 1)
+
+        assert exc_info.value.error_id == "cache-resource-async-lifecycle-callback"
+
+    @parameterized.expand([("validate",), ("on_release",)])
+    def test_rejects_async_generator_function(self, param_name: str) -> None:
+        """Async generator functions fail when the decorator is built."""
+
+        async def async_gen_callback(value: int) -> object:
+            yield True
+
+        with pytest.raises(StreamlitAPIException, match=param_name) as exc_info:
+            st.cache_resource(**{param_name: async_gen_callback})(lambda: 1)
+
+        assert exc_info.value.error_id == "cache-resource-async-lifecycle-callback"
 
     @parameterized.expand([("validate",), ("on_release",)])
     def test_accepts_sync_adapter_wrapping_async_function(
@@ -421,8 +430,8 @@ class CacheResourceAsyncLifecycleCallbackTest(unittest.TestCase):
 
         assert exc_info.value.error_id == "cache-resource-async-lifecycle-callback"
 
-    def test_sync_validate_and_on_release_still_work(self) -> None:
-        """Synchronous validate, eviction, clear, and release behavior is unchanged."""
+    def test_sync_validate_and_on_release_fire_on_eviction_and_clear(self) -> None:
+        """Synchronous ``validate`` and ``on_release`` run on LRU eviction and ``clear()``."""
         released: list[int] = []
 
         def validate(value: int) -> bool:

--- a/lib/tests/streamlit/runtime/caching/cache_resource_api_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_resource_api_test.py
@@ -415,6 +415,51 @@ class CacheResourceAsyncLifecycleCallbackTest(unittest.TestCase):
         assert cached() == 1
 
     @parameterized.expand([("validate",), ("on_release",)])
+    def test_accepts_sync_callable_object(self, param_name: str) -> None:
+        """Callable objects with synchronous ``__call__`` are accepted and invoked."""
+
+        class Callback:
+            def __init__(self) -> None:
+                self.values: list[int] = []
+
+            def __call__(self, value: int) -> bool:
+                self.values.append(value)
+                return True
+
+        callback = Callback()
+        cached = st.cache_resource(**{param_name: callback})(lambda: 1)
+        assert cached() == 1
+
+        if param_name == "validate":
+            assert cached() == 1
+        else:
+            cached.clear()
+        assert callback.values == [1]
+
+    @parameterized.expand([("validate",), ("on_release",)])
+    def test_accepts_partial_of_sync_callable_object(self, param_name: str) -> None:
+        """Partials of callable objects with synchronous ``__call__`` are invoked."""
+
+        class Callback:
+            def __init__(self) -> None:
+                self.values: list[tuple[str, int]] = []
+
+            def __call__(self, prefix: str, value: int) -> bool:
+                self.values.append((prefix, value))
+                return True
+
+        callback = Callback()
+        partial_callback = functools.partial(callback, "bound")
+        cached = st.cache_resource(**{param_name: partial_callback})(lambda: 1)
+        assert cached() == 1
+
+        if param_name == "validate":
+            assert cached() == 1
+        else:
+            cached.clear()
+        assert callback.values == [("bound", 1)]
+
+    @parameterized.expand([("validate",), ("on_release",)])
     def test_rejects_async_wrapper_of_sync_function(self, param_name: str) -> None:
         """An ``async def`` wrapper is rejected even if it wraps a sync function."""
 

--- a/lib/tests/streamlit/runtime/caching/cache_resource_api_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_resource_api_test.py
@@ -375,14 +375,8 @@ class CacheResourceAsyncLifecycleCallbackTest(unittest.TestCase):
             async def __call__(self, value: int) -> bool:
                 return True
 
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            with pytest.raises(StreamlitAPIException, match=param_name) as exc_info:
-                st.cache_resource(**{param_name: AsyncCallback()})(lambda: 1)
-            gc.collect()
-
-        assert exc_info.value.error_id == "cache-resource-async-lifecycle-callback"
-        _assert_no_unawaited_coroutine_warning(caught)
+        with pytest.raises(StreamlitAPIException, match=param_name):
+            st.cache_resource(**{param_name: AsyncCallback()})(lambda: 1)
 
     @parameterized.expand([("validate",), ("on_release",)])
     def test_rejects_partial_of_async_function(self, param_name: str) -> None:
@@ -392,64 +386,8 @@ class CacheResourceAsyncLifecycleCallbackTest(unittest.TestCase):
             return True
 
         callback = functools.partial(async_callback, None)
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            with pytest.raises(StreamlitAPIException, match=param_name) as exc_info:
-                st.cache_resource(**{param_name: callback})(lambda: 1)
-            gc.collect()
-
-        assert exc_info.value.error_id == "cache-resource-async-lifecycle-callback"
-        _assert_no_unawaited_coroutine_warning(caught)
-
-    def test_rejects_sync_validate_returning_coroutine(self) -> None:
-        """A sync validator that returns a native coroutine is rejected on access."""
-
-        def validate(value: int) -> bool:
-            async def _inner() -> bool:
-                return True
-
-            return _inner()  # type: ignore[return-value]
-
-        @st.cache_resource(validate=validate)
-        def f() -> int:
-            return 1
-
-        assert f() == 1
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            with pytest.raises(StreamlitAPIException, match="validate") as exc_info:
-                f()
-            gc.collect()
-
-        assert exc_info.value.error_id == "cache-resource-async-lifecycle-callback"
-        _assert_no_unawaited_coroutine_warning(caught)
-
-    def test_rejects_sync_on_release_returning_coroutine(self) -> None:
-        """A sync release callback that returns a native coroutine is rejected on eviction."""
-        released: list[int] = []
-
-        def on_release(value: int) -> None:
-            released.append(value)
-
-            async def _inner() -> None:
-                return None
-
-            return _inner()  # type: ignore[return-value]
-
-        @st.cache_resource(max_entries=1, on_release=on_release)
-        def f(value: int) -> int:
-            return value
-
-        assert f(1) == 1
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            with pytest.raises(StreamlitAPIException, match="on_release") as exc_info:
-                f(2)
-            gc.collect()
-
-        assert released == [1]
-        assert exc_info.value.error_id == "cache-resource-async-lifecycle-callback"
-        _assert_no_unawaited_coroutine_warning(caught)
+        with pytest.raises(StreamlitAPIException, match=param_name):
+            st.cache_resource(**{param_name: callback})(lambda: 1)
 
     def test_sync_validate_and_on_release_still_work(self) -> None:
         """Synchronous validate, eviction, clear, and release behavior is unchanged."""

--- a/lib/tests/streamlit/runtime/caching/cache_resource_api_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_resource_api_test.py
@@ -373,20 +373,6 @@ class CacheResourceAsyncLifecycleCallbackTest(unittest.TestCase):
             st.cache_resource(**{param_name: callback})(lambda: 1)
 
     @parameterized.expand([("validate",), ("on_release",)])
-    def test_rejects_partial_of_async_callable_object(self, param_name: str) -> None:
-        """Partials of callable instances with async ``__call__`` fail at decoration."""
-
-        class AsyncCallback:
-            async def __call__(self, ignored: object, value: int) -> bool:
-                return True
-
-        callback = functools.partial(AsyncCallback(), None)
-        with pytest.raises(StreamlitAPIException, match=param_name) as exc_info:
-            st.cache_resource(**{param_name: callback})(lambda: 1)
-
-        assert exc_info.value.error_id == "cache-resource-async-lifecycle-callback"
-
-    @parameterized.expand([("validate",), ("on_release",)])
     def test_rejects_async_generator_function(self, param_name: str) -> None:
         """Async generator functions fail when the decorator is built."""
 
@@ -435,29 +421,6 @@ class CacheResourceAsyncLifecycleCallbackTest(unittest.TestCase):
         else:
             cached.clear()
         assert callback.values == [1]
-
-    @parameterized.expand([("validate",), ("on_release",)])
-    def test_accepts_partial_of_sync_callable_object(self, param_name: str) -> None:
-        """Partials of callable objects with synchronous ``__call__`` are invoked."""
-
-        class Callback:
-            def __init__(self) -> None:
-                self.values: list[tuple[str, int]] = []
-
-            def __call__(self, prefix: str, value: int) -> bool:
-                self.values.append((prefix, value))
-                return True
-
-        callback = Callback()
-        partial_callback = functools.partial(callback, "bound")
-        cached = st.cache_resource(**{param_name: partial_callback})(lambda: 1)
-        assert cached() == 1
-
-        if param_name == "validate":
-            assert cached() == 1
-        else:
-            cached.clear()
-        assert callback.values == [("bound", 1)]
 
     @parameterized.expand([("validate",), ("on_release",)])
     def test_rejects_async_wrapper_of_sync_function(self, param_name: str) -> None:

--- a/lib/tests/streamlit/runtime/caching/cache_resource_api_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_resource_api_test.py
@@ -389,6 +389,38 @@ class CacheResourceAsyncLifecycleCallbackTest(unittest.TestCase):
         with pytest.raises(StreamlitAPIException, match=param_name):
             st.cache_resource(**{param_name: callback})(lambda: 1)
 
+    @parameterized.expand([("validate",), ("on_release",)])
+    def test_accepts_sync_adapter_wrapping_async_function(
+        self, param_name: str
+    ) -> None:
+        """A synchronous adapter is accepted even if it wraps an async function."""
+
+        async def async_callback(value: int) -> bool:
+            return True
+
+        @functools.wraps(async_callback)
+        def sync_adapter(value: int) -> bool:
+            return True
+
+        cached = st.cache_resource(**{param_name: sync_adapter})(lambda: 1)
+        assert cached() == 1
+
+    @parameterized.expand([("validate",), ("on_release",)])
+    def test_rejects_async_wrapper_of_sync_function(self, param_name: str) -> None:
+        """An ``async def`` wrapper is rejected even if it wraps a sync function."""
+
+        def sync_callback(value: int) -> bool:
+            return True
+
+        @functools.wraps(sync_callback)
+        async def async_wrapper(value: int) -> bool:
+            return True
+
+        with pytest.raises(StreamlitAPIException, match=param_name) as exc_info:
+            st.cache_resource(**{param_name: async_wrapper})(lambda: 1)
+
+        assert exc_info.value.error_id == "cache-resource-async-lifecycle-callback"
+
     def test_sync_validate_and_on_release_still_work(self) -> None:
         """Synchronous validate, eviction, clear, and release behavior is unchanged."""
         released: list[int] = []

--- a/lib/tests/streamlit/runtime/caching/cache_resource_api_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_resource_api_test.py
@@ -16,8 +16,11 @@
 
 from __future__ import annotations
 
+import functools
+import gc
 import threading
 import unittest
+import warnings
 from unittest.mock import Mock, patch
 
 import pytest
@@ -25,6 +28,7 @@ from parameterized import parameterized
 
 import streamlit as st
 from streamlit.errors import (
+    StreamlitAPIException,
     StreamlitMissingRequiredParameterError,
     StreamlitValueError,
 )
@@ -326,6 +330,149 @@ class CacheResourceValidateTest(unittest.TestCase):
             assert expected_call_count == f()
             validate.assert_called_once_with(expected_call_count - 1)
             validate.reset_mock()
+
+
+def _assert_no_unawaited_coroutine_warning(
+    caught: list[warnings.WarningMessage],
+) -> None:
+    """Fail if a RuntimeWarning about an unawaited coroutine was recorded."""
+    assert not any(
+        issubclass(warning.category, RuntimeWarning)
+        and "never awaited" in str(warning.message)
+        for warning in caught
+    )
+
+
+class CacheResourceAsyncLifecycleCallbackTest(unittest.TestCase):
+    def setUp(self) -> None:
+        add_script_run_ctx(threading.current_thread(), create_mock_script_run_ctx())
+
+    def tearDown(self) -> None:
+        st.cache_resource.clear()
+        cache_resource_api.CACHE_RESOURCE_MESSAGE_REPLAY_CTX._cached_func_stack = []
+
+    @parameterized.expand([("validate",), ("on_release",)])
+    def test_rejects_async_function(self, param_name: str) -> None:
+        """Ordinary ``async def`` lifecycle callbacks fail when the decorator is built."""
+
+        async def async_callback(value: int) -> bool:
+            return True
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            with pytest.raises(StreamlitAPIException, match=param_name) as exc_info:
+                st.cache_resource(**{param_name: async_callback})(lambda: 1)
+            gc.collect()
+
+        assert exc_info.value.error_id == "cache-resource-async-lifecycle-callback"
+        _assert_no_unawaited_coroutine_warning(caught)
+
+    @parameterized.expand([("validate",), ("on_release",)])
+    def test_rejects_async_callable_object(self, param_name: str) -> None:
+        """Callable objects with async ``__call__`` fail when the decorator is built."""
+
+        class AsyncCallback:
+            async def __call__(self, value: int) -> bool:
+                return True
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            with pytest.raises(StreamlitAPIException, match=param_name) as exc_info:
+                st.cache_resource(**{param_name: AsyncCallback()})(lambda: 1)
+            gc.collect()
+
+        assert exc_info.value.error_id == "cache-resource-async-lifecycle-callback"
+        _assert_no_unawaited_coroutine_warning(caught)
+
+    @parameterized.expand([("validate",), ("on_release",)])
+    def test_rejects_partial_of_async_function(self, param_name: str) -> None:
+        """Partials of coroutine functions fail when the decorator is built."""
+
+        async def async_callback(ignored: object, value: int) -> bool:
+            return True
+
+        callback = functools.partial(async_callback, None)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            with pytest.raises(StreamlitAPIException, match=param_name) as exc_info:
+                st.cache_resource(**{param_name: callback})(lambda: 1)
+            gc.collect()
+
+        assert exc_info.value.error_id == "cache-resource-async-lifecycle-callback"
+        _assert_no_unawaited_coroutine_warning(caught)
+
+    def test_rejects_sync_validate_returning_coroutine(self) -> None:
+        """A sync validator that returns a native coroutine is rejected on access."""
+
+        def validate(value: int) -> bool:
+            async def _inner() -> bool:
+                return True
+
+            return _inner()  # type: ignore[return-value]
+
+        @st.cache_resource(validate=validate)
+        def f() -> int:
+            return 1
+
+        assert f() == 1
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            with pytest.raises(StreamlitAPIException, match="validate") as exc_info:
+                f()
+            gc.collect()
+
+        assert exc_info.value.error_id == "cache-resource-async-lifecycle-callback"
+        _assert_no_unawaited_coroutine_warning(caught)
+
+    def test_rejects_sync_on_release_returning_coroutine(self) -> None:
+        """A sync release callback that returns a native coroutine is rejected on eviction."""
+        released: list[int] = []
+
+        def on_release(value: int) -> None:
+            released.append(value)
+
+            async def _inner() -> None:
+                return None
+
+            return _inner()  # type: ignore[return-value]
+
+        @st.cache_resource(max_entries=1, on_release=on_release)
+        def f(value: int) -> int:
+            return value
+
+        assert f(1) == 1
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            with pytest.raises(StreamlitAPIException, match="on_release") as exc_info:
+                f(2)
+            gc.collect()
+
+        assert released == [1]
+        assert exc_info.value.error_id == "cache-resource-async-lifecycle-callback"
+        _assert_no_unawaited_coroutine_warning(caught)
+
+    def test_sync_validate_and_on_release_still_work(self) -> None:
+        """Synchronous validate, eviction, clear, and release behavior is unchanged."""
+        released: list[int] = []
+
+        def validate(value: int) -> bool:
+            return True
+
+        def on_release(value: int) -> None:
+            released.append(value)
+
+        @st.cache_resource(max_entries=2, validate=validate, on_release=on_release)
+        def f(value: int) -> int:
+            return value
+
+        assert f(1) == 1
+        assert f(1) == 1
+        assert f(2) == 2
+        assert f(3) == 3
+        assert released == [1]
+
+        f.clear()
+        assert released == [1, 2, 3]
 
 
 class CacheResourceStatsProviderTest(unittest.TestCase):

--- a/lib/tests/streamlit/runtime/caching/cache_resource_api_test.py
+++ b/lib/tests/streamlit/runtime/caching/cache_resource_api_test.py
@@ -438,11 +438,13 @@ class CacheResourceAsyncLifecycleCallbackTest(unittest.TestCase):
 
         assert exc_info.value.error_id == "cache-resource-async-lifecycle-callback"
 
-    def test_sync_validate_and_on_release_fire_on_eviction_and_clear(self) -> None:
-        """Synchronous ``validate`` and ``on_release`` run on LRU eviction and ``clear()``."""
+    def test_sync_validate_on_hit_and_on_release_on_eviction_and_clear(self) -> None:
+        """Synchronous callbacks run on cache hits, LRU eviction, and ``clear()``."""
+        validated: list[int] = []
         released: list[int] = []
 
         def validate(value: int) -> bool:
+            validated.append(value)
             return True
 
         def on_release(value: int) -> None:
@@ -454,6 +456,7 @@ class CacheResourceAsyncLifecycleCallbackTest(unittest.TestCase):
 
         assert f(1) == 1
         assert f(1) == 1
+        assert validated == [1]
         assert f(2) == 2
         assert f(3) == 3
         assert released == [1]


### PR DESCRIPTION
## Describe your changes

`st.cache_resource` now rejects async `validate` and `on_release` callbacks when the decorator is constructed, instead of accepting them and silently discarding the awaitable they return.

Both callbacks run synchronously, so an `async def` callback never executes: a validator's coroutine is truthy without running, and a release hook's coroutine is discarded without cleaning up. Their acceptance was therefore outside the existing synchronous contract.

Detection covers coroutine functions, async generator functions, callable objects with an async `__call__`, and partials of those forms. A synchronous adapter built with `functools.wraps` around async code is accepted, because classification uses the callable Streamlit invokes rather than `__wrapped__` metadata. A synchronous callback that returns an awaitable at call time is still accepted; catching that would require wrapping every callback, which puts a check on `validate` in the per-cache-hit path.

**User-visible break:** Apps that pass an `async def` callback (or another async callable) to `validate` or `on_release` currently start without error but will now raise `StreamlitAPIException` when the decorator is constructed. This tightens validation of callbacks that never worked correctly; it does not add async lifecycle-callback support. Ordinary supported callbacks are unchanged.

## GitHub Issue Link (if applicable)

Follow-up to review discussion on https://github.com/streamlit/streamlit/pull/16168#pullrequestreview-5113091442. Independent of async cached-function support.

## Testing Plan

- [x] Unit Tests (JS and/or Python)
- [ ] E2E Tests
- [ ] Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Stricter validation at decorator setup only; breaking change is limited to apps that incorrectly used async lifecycle callbacks, with clearer failure instead of silent misbehavior.
> 
> **Overview**
> **`st.cache_resource` now fails at decoration time** if `validate` or `on_release` is an async callable, instead of accepting it and never awaiting the coroutine (which could look like a successful validation or a no-op release).
> 
> Detection uses `inspect` for coroutine/async-generator functions, async `__call__` on callable instances, and partials of those forms. **Sync wrappers** (e.g. `functools.wraps` around async code) still pass because only the invoked callable is checked.
> 
> Docs for both parameters state they must be synchronous. Apps that currently pass `async def` for these hooks will get **`StreamlitAPIException`** with error id `cache-resource-async-lifecycle-callback` when the decorator is applied.
> 
> Unit tests cover rejection/acceptance cases and that sync `validate` / `on_release` still run on hits, LRU eviction, and `clear()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c03f267be06f5d1769545b000d518ac8bfc217b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->