### PR TITLE
[feature] Add `on_change="ignore"` mode to st.selectbox

### DIFF
--- a/e2e_playwright/st_selectbox.py
+++ b/e2e_playwright/st_selectbox.py
@@ -296,6 +296,25 @@ v_bound_clear = st.selectbox(
 )
 st.write("bound select clear value:", v_bound_clear)
 
+# Run counter so test_selectbox_on_change_ignore can detect an unexpected rerun.
+if "runs" not in st.session_state:
+    st.session_state.runs = 0
+st.session_state.runs += 1
+st.write("Runs:", st.session_state.runs)
+
+# --- on_change="ignore" selectbox ---
+ignore_select = st.selectbox(
+    "Ignore change selectbox",
+    ["alpha", "beta", "gamma"],
+    key="ignore_select",
+    on_change="ignore",
+    bind="query-params",
+)
+st.write("Ignore selectbox value:", ignore_select)
+
+if st.button("Apply ignore selectbox", key="apply_ignore_selectbox"):
+    st.write("Applied ignore selectbox value:", ignore_select)
+
 # Regression test for https://github.com/streamlit/streamlit/issues/16181:
 # a selectbox near the bottom of the sidebar must flip its dropdown up and stay
 # within the viewport instead of opening downward and overflowing. The

--- a/e2e_playwright/st_selectbox.py
+++ b/e2e_playwright/st_selectbox.py
@@ -296,13 +296,13 @@ v_bound_clear = st.selectbox(
 )
 st.write("bound select clear value:", v_bound_clear)
 
+# --- on_change="ignore" selectbox ---
 # Run counter so test_selectbox_on_change_ignore can detect an unexpected rerun.
 if "runs" not in st.session_state:
     st.session_state.runs = 0
 st.session_state.runs += 1
 st.write("Runs:", st.session_state.runs)
 
-# --- on_change="ignore" selectbox ---
 ignore_select = st.selectbox(
     "Ignore change selectbox",
     ["alpha", "beta", "gamma"],

--- a/e2e_playwright/st_selectbox_test.py
+++ b/e2e_playwright/st_selectbox_test.py
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
     from e2e_playwright.conftest import ImageCompareFunction
 
 
-NUM_SELECTBOXES = 30
+NUM_SELECTBOXES = 31
 
 
 def get_selectbox_input(
@@ -853,3 +853,51 @@ def test_selectbox_in_sidebar_flips_up_within_viewport(app: Page):
     assert dropdown_box["y"] < trigger_box["y"], (
         f"dropdown did not flip up: dropdown={dropdown_box}, trigger={trigger_box}"
     )
+
+
+def test_selectbox_on_change_ignore(app: Page):
+    """Test that on_change='ignore' suppresses rerun and sends value on next rerun."""
+    expect(app.get_by_text("Runs: 1", exact=True)).to_be_visible()
+    expect_prefixed_markdown(app, "Ignore selectbox value:", "alpha")
+    # Default is omitted from the URL.
+    expect(app).not_to_have_url(re.compile(r"[?&]ignore_select="))
+
+    ignore_input = get_selectbox_input(app, "Ignore change selectbox")
+
+    # Filtering is not a commit - URL and Python should stay unchanged.
+    ignore_input.click()
+    ignore_input.fill("be")
+    expect(ignore_input).to_have_value("be")
+    wait_for_app_run(app)
+    expect(app.get_by_text("Runs: 1", exact=True)).to_be_visible()
+    expect_prefixed_markdown(app, "Ignore selectbox value:", "alpha")
+    expect(app).not_to_have_url(re.compile(r"[?&]ignore_select="))
+
+    # Commit with option click - should NOT trigger a rerun, but should update the URL
+    select_selectbox_option(app, "Ignore change selectbox", "beta")
+
+    # Give a spurious rerun a chance to land before asserting the counter.
+    wait_for_app_run(app)
+
+    # Verify no rerun occurred (run count should still be 1)
+    expect(app.get_by_text("Runs: 1", exact=True)).to_be_visible()
+    expect(app.get_by_text("Runs: 2", exact=True)).not_to_be_visible()
+    expect(ignore_input).to_have_value("beta")
+    expect_prefixed_markdown(app, "Ignore selectbox value:", "alpha")
+    expect(app).to_have_url(re.compile(r"[?&]ignore_select=beta"))
+
+    # Click button to trigger a rerun - buffered value should be sent
+    app.get_by_role("button", name="Apply ignore selectbox", exact=True).click()
+    wait_for_app_run(app)
+
+    expect(app.get_by_text("Runs: 2", exact=True)).to_be_visible()
+    expect(app.get_by_text("Ignore selectbox value: beta", exact=True)).to_be_visible()
+    expect(
+        app.get_by_text("Applied ignore selectbox value: beta", exact=True)
+    ).to_be_visible()
+
+    # Bound ignore-mode values persist across reload via the URL.
+    app.reload()
+    wait_for_app_loaded(app)
+    expect(get_selectbox_input(app, "Ignore change selectbox")).to_have_value("beta")
+    expect_prefixed_markdown(app, "Ignore selectbox value:", "beta")

--- a/e2e_playwright/st_selectbox_test.py
+++ b/e2e_playwright/st_selectbox_test.py
@@ -864,7 +864,7 @@ def test_selectbox_on_change_ignore(app: Page):
 
     ignore_input = get_selectbox_input(app, "Ignore change selectbox")
 
-    # Filtering is not a commit - URL and Python should stay unchanged.
+    # Filtering does not commit the value, so Python and the URL remain unchanged.
     ignore_input.click()
     ignore_input.fill("be")
     expect(ignore_input).to_have_value("be")
@@ -873,10 +873,14 @@ def test_selectbox_on_change_ignore(app: Page):
     expect_prefixed_markdown(app, "Ignore selectbox value:", "alpha")
     expect(app).not_to_have_url(re.compile(r"[?&]ignore_select="))
 
-    # Commit with option click - should NOT trigger a rerun, but should update the URL
+    # Reset the combobox so the later option click does not toggle an already-open dropdown.
+    ignore_input.press("Escape")
+    expect(app.get_by_test_id("stSelectboxVirtualDropdown")).not_to_be_visible()
+
+    # Choosing an option updates the URL without rerunning the app.
     select_selectbox_option(app, "Ignore change selectbox", "beta")
 
-    # Give a spurious rerun a chance to land before asserting the counter.
+    # Extra settle on top of select_selectbox_option's wait_for_app_run, to catch a delayed rerun.
     wait_for_app_run(app)
 
     # Verify no rerun occurred (run count should still be 1)

--- a/frontend/lib/src/components/widgets/Selectbox/Selectbox.test.tsx
+++ b/frontend/lib/src/components/widgets/Selectbox/Selectbox.test.tsx
@@ -242,7 +242,7 @@ describe("on_change='ignore' mode", () => {
     vi.restoreAllMocks()
   })
 
-  // WidgetStateManager reaches sendRerunBackMsg via scheduleFlush → setTimeout(0).
+  // Let a scheduled rerun flush before asserting whether one was sent.
   async function flushScheduledRerun(): Promise<void> {
     await act(async () => {
       await new Promise(resolve => {

--- a/frontend/lib/src/components/widgets/Selectbox/Selectbox.test.tsx
+++ b/frontend/lib/src/components/widgets/Selectbox/Selectbox.test.tsx
@@ -236,3 +236,194 @@ describe("Selectbox query param binding", () => {
     )
   })
 })
+
+describe("on_change='ignore' mode", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  // WidgetStateManager reaches sendRerunBackMsg via scheduleFlush → setTimeout(0).
+  async function flushScheduledRerun(): Promise<void> {
+    await act(async () => {
+      await new Promise(resolve => {
+        setTimeout(resolve, 0)
+      })
+    })
+  }
+
+  it("passes triggerRerun: false when ignoreRerun is true", async () => {
+    const sendRerunBackMsg = vi.fn()
+    const widgetMgr = new WidgetStateManager({
+      sendRerunBackMsg,
+      formsDataChanged: vi.fn(),
+    })
+    const props = getProps({ ignoreRerun: true }, { widgetMgr })
+    const setStringValueSpy = vi.spyOn(props.widgetMgr, "setStringValue")
+
+    render(<Selectbox {...props} />)
+    setStringValueSpy.mockClear()
+    sendRerunBackMsg.mockClear()
+
+    const selectbox = screen.getByRole("combobox")
+    await pickOption(selectbox, "b")
+
+    expect(setStringValueSpy).toHaveBeenLastCalledWith(props.element.id, "b", {
+      formId: props.element.formId,
+      fragmentId: undefined,
+      fromUser: true,
+      triggerRerun: false,
+    })
+    await flushScheduledRerun()
+    expect(sendRerunBackMsg).not.toHaveBeenCalled()
+  })
+
+  it("does not pass triggerRerun when ignoreRerun is false", async () => {
+    const sendRerunBackMsg = vi.fn()
+    const widgetMgr = new WidgetStateManager({
+      sendRerunBackMsg,
+      formsDataChanged: vi.fn(),
+    })
+    const props = getProps({ ignoreRerun: false }, { widgetMgr })
+    const setStringValueSpy = vi.spyOn(props.widgetMgr, "setStringValue")
+
+    render(<Selectbox {...props} />)
+    setStringValueSpy.mockClear()
+    sendRerunBackMsg.mockClear()
+
+    const selectbox = screen.getByRole("combobox")
+    await pickOption(selectbox, "b")
+
+    expect(setStringValueSpy).toHaveBeenLastCalledWith(props.element.id, "b", {
+      formId: props.element.formId,
+      fragmentId: undefined,
+      fromUser: true,
+    })
+    await flushScheduledRerun()
+    expect(sendRerunBackMsg).toHaveBeenCalled()
+  })
+
+  it("does not change form batching when ignoreRerun is true", async () => {
+    const sendRerunBackMsg = vi.fn()
+    let pendingFormIds = new Set<string>()
+    const widgetMgr = new WidgetStateManager({
+      sendRerunBackMsg,
+      formsDataChanged: vi.fn(newData => {
+        pendingFormIds = newData.formsWithPendingChanges
+      }),
+    })
+    const props = getProps(
+      {
+        ignoreRerun: true,
+        formId: "testForm",
+      },
+      { widgetMgr }
+    )
+    const setStringValueSpy = vi.spyOn(props.widgetMgr, "setStringValue")
+
+    render(<Selectbox {...props} />)
+    setStringValueSpy.mockClear()
+    sendRerunBackMsg.mockClear()
+
+    const selectbox = screen.getByRole("combobox")
+    await pickOption(selectbox, "b")
+
+    expect(setStringValueSpy).toHaveBeenLastCalledWith(props.element.id, "b", {
+      formId: "testForm",
+      fragmentId: undefined,
+      fromUser: true,
+      triggerRerun: false,
+    })
+    await flushScheduledRerun()
+    expect(sendRerunBackMsg).not.toHaveBeenCalled()
+    expect(pendingFormIds).toEqual(new Set(["testForm"]))
+  })
+
+  it("does not commit on keystroke outside a form when ignoreRerun is true", async () => {
+    const user = userEvent.setup()
+    const props = getProps({ ignoreRerun: true })
+    const setStringValueSpy = vi.spyOn(props.widgetMgr, "setStringValue")
+
+    render(<Selectbox {...props} />)
+    setStringValueSpy.mockClear()
+
+    const selectbox = screen.getByRole("combobox")
+    await user.click(selectbox)
+    await user.type(selectbox, "b")
+
+    expect(setStringValueSpy).not.toHaveBeenCalled()
+  })
+
+  it("passes triggerRerun: false when clear is clicked", async () => {
+    const user = userEvent.setup()
+    const sendRerunBackMsg = vi.fn()
+    const widgetMgr = new WidgetStateManager({
+      sendRerunBackMsg,
+      formsDataChanged: vi.fn(),
+    })
+    const props = getProps({ ignoreRerun: true, default: null }, { widgetMgr })
+    const setStringValueSpy = vi.spyOn(props.widgetMgr, "setStringValue")
+
+    render(<Selectbox {...props} />)
+    setStringValueSpy.mockClear()
+    sendRerunBackMsg.mockClear()
+
+    const selectbox = screen.getByRole("combobox")
+    await pickOption(selectbox, "a")
+    setStringValueSpy.mockClear()
+    sendRerunBackMsg.mockClear()
+
+    await user.click(screen.getByRole("button", { name: "Clear value" }))
+
+    expect(setStringValueSpy).toHaveBeenLastCalledWith(
+      props.element.id,
+      null,
+      {
+        formId: props.element.formId,
+        fragmentId: undefined,
+        fromUser: true,
+        triggerRerun: false,
+      }
+    )
+    await flushScheduledRerun()
+    expect(sendRerunBackMsg).not.toHaveBeenCalled()
+  })
+
+  it("passes triggerRerun: false when a new option is committed with Enter", async () => {
+    const user = userEvent.setup()
+    const sendRerunBackMsg = vi.fn()
+    const widgetMgr = new WidgetStateManager({
+      sendRerunBackMsg,
+      formsDataChanged: vi.fn(),
+    })
+    const props = getProps(
+      {
+        ignoreRerun: true,
+        acceptNewOptions: true,
+        default: null,
+      },
+      { widgetMgr }
+    )
+    const setStringValueSpy = vi.spyOn(props.widgetMgr, "setStringValue")
+
+    render(<Selectbox {...props} />)
+    setStringValueSpy.mockClear()
+    sendRerunBackMsg.mockClear()
+
+    const selectboxInput = screen.getByRole("combobox")
+    await user.type(selectboxInput, "hello world!")
+    await user.keyboard("{enter}")
+
+    expect(setStringValueSpy).toHaveBeenLastCalledWith(
+      props.element.id,
+      "hello world!",
+      {
+        formId: props.element.formId,
+        fragmentId: undefined,
+        fromUser: true,
+        triggerRerun: false,
+      }
+    )
+    await flushScheduledRerun()
+    expect(sendRerunBackMsg).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/lib/src/components/widgets/Selectbox/Selectbox.tsx
+++ b/frontend/lib/src/components/widgets/Selectbox/Selectbox.tsx
@@ -70,6 +70,10 @@ const updateWidgetMgrState = (
     formId: element.formId,
     fragmentId,
     fromUser: valueWithSource.fromUser,
+    // on_change="ignore" buffers the value without scheduling a rerun.
+    // WidgetStateManager ignores triggerRerun inside forms (the form owns
+    // commit timing).
+    ...(element.ignoreRerun ? { triggerRerun: false } : {}),
   })
 }
 

--- a/lib/streamlit/elements/widgets/selectbox.py
+++ b/lib/streamlit/elements/widgets/selectbox.py
@@ -59,12 +59,14 @@ from streamlit.runtime.metrics_util import gather_metrics
 from streamlit.runtime.scriptrunner import ScriptRunContext, get_script_run_ctx
 from streamlit.runtime.state import (
     BindOption,
+    OnChangeMode,
     PersistStateOption,
     WidgetArgs,
     WidgetCallback,
     WidgetKwargs,
     get_session_state,
     register_widget,
+    validate_on_change_mode,
 )
 from streamlit.string_util import to_help_str
 from streamlit.type_util import check_python_comparable
@@ -180,7 +182,7 @@ class SelectboxMixin:
         format_func: Callable[[Any], str] = str,
         key: Key | None = None,
         help: str | None = None,
-        on_change: WidgetCallback | None = None,
+        on_change: WidgetCallback | OnChangeMode | None = "rerun",
         args: WidgetArgs | None = None,
         kwargs: WidgetKwargs | None = None,
         *,  # keyword-only arguments:
@@ -203,7 +205,7 @@ class SelectboxMixin:
         format_func: Callable[[Any], str] = str,
         key: Key | None = None,
         help: str | None = None,
-        on_change: WidgetCallback | None = None,
+        on_change: WidgetCallback | OnChangeMode | None = "rerun",
         args: WidgetArgs | None = None,
         kwargs: WidgetKwargs | None = None,
         *,  # keyword-only arguments:
@@ -226,7 +228,7 @@ class SelectboxMixin:
         format_func: Callable[[Any], str] = str,
         key: Key | None = None,
         help: str | None = None,
-        on_change: WidgetCallback | None = None,
+        on_change: WidgetCallback | OnChangeMode | None = "rerun",
         args: WidgetArgs | None = None,
         kwargs: WidgetKwargs | None = None,
         *,  # keyword-only arguments:
@@ -249,7 +251,7 @@ class SelectboxMixin:
         format_func: Callable[[Any], str] = str,
         key: Key | None = None,
         help: str | None = None,
-        on_change: WidgetCallback | None = None,
+        on_change: WidgetCallback | OnChangeMode | None = "rerun",
         args: WidgetArgs | None = None,
         kwargs: WidgetKwargs | None = None,
         *,  # keyword-only arguments:
@@ -272,7 +274,7 @@ class SelectboxMixin:
         format_func: Callable[[Any], str] = str,
         key: Key | None = None,
         help: str | None = None,
-        on_change: WidgetCallback | None = None,
+        on_change: WidgetCallback | OnChangeMode | None = "rerun",
         args: WidgetArgs | None = None,
         kwargs: WidgetKwargs | None = None,
         *,  # keyword-only arguments:
@@ -300,7 +302,7 @@ class SelectboxMixin:
         format_func: Callable[[Any], str] = str,
         key: Key | None = None,
         help: str | None = None,
-        on_change: WidgetCallback | None = None,
+        on_change: WidgetCallback | OnChangeMode | None = "rerun",
         args: WidgetArgs | None = None,
         kwargs: WidgetKwargs | None = None,
         *,  # keyword-only arguments:
@@ -323,7 +325,7 @@ class SelectboxMixin:
         format_func: Callable[[Any], str] = str,
         key: Key | None = None,
         help: str | None = None,
-        on_change: WidgetCallback | None = None,
+        on_change: WidgetCallback | OnChangeMode | None = "rerun",
         args: WidgetArgs | None = None,
         kwargs: WidgetKwargs | None = None,
         *,  # keyword-only arguments:
@@ -346,7 +348,7 @@ class SelectboxMixin:
         format_func: Callable[[Any], str] = str,
         key: Key | None = None,
         help: str | None = None,
-        on_change: WidgetCallback | None = None,
+        on_change: WidgetCallback | OnChangeMode | None = "rerun",
         args: WidgetArgs | None = None,
         kwargs: WidgetKwargs | None = None,
         *,  # keyword-only arguments:
@@ -430,8 +432,30 @@ class SelectboxMixin:
             including the Markdown directives described in the ``body``
             parameter of ``st.markdown``.
 
-        on_change : callable
-            An optional callback invoked when this selectbox's value changes.
+        on_change : callable, "rerun", "ignore", or None
+            How the selectbox should respond to value changes. This controls
+            whether or not Streamlit reruns the app when the user interacts
+            with the selectbox. ``on_change`` can be one of the following:
+
+            - ``"rerun"`` (default): Streamlit will rerun the app when the
+              user commits a new value (clicking an option, confirming with
+              Enter, adding a new option when ``accept_new_options=True``,
+              or clearing the value).
+
+            - ``"ignore"``: Streamlit will not rerun the app when the user
+              commits a new value. The selectbox still updates in the UI.
+              The new value is available on the next rerun triggered by
+              something else, such as another widget interaction. Ignored
+              commits are held in the browser and are lost if the page is
+              refreshed before that rerun, unless ``bind="query-params"``
+              is set (see ``bind``). Inside ``st.form``, this has no
+              effect: the form already defers all commits until submit.
+
+            - A ``callable``: Streamlit will rerun the app and execute the
+              ``callable`` as a callback function before the rest of the app.
+
+            - ``None``: This is the same as ``on_change="rerun"``. This value
+              exists for backwards compatibility and shouldn't be used.
 
         args : list or tuple
             An optional list or tuple of args to pass to the callback.
@@ -516,6 +540,14 @@ class SelectboxMixin:
             Invalid query parameter values are ignored and removed
             from the URL. If ``index`` is ``None``, an empty query
             parameter (e.g., ``?my_key=``) clears the widget.
+
+            When ``on_change="ignore"``, the URL is updated as soon as the
+            value is committed (clicking an option, confirming with Enter,
+            adding a new option, or clearing the value); typing or filtering
+            alone does not update it. As with widgets inside a form, the
+            URL can show a value that Python hasn't received yet. Python
+            receives the new value on the next rerun, so a page load or
+            share uses the updated URL value.
 
         persist_state : "page", "session", or None
             How long to preserve the widget's value when it isn't rendered.
@@ -630,7 +662,7 @@ class SelectboxMixin:
         format_func: Callable[[Any], Any] = str,
         key: Key | None = None,
         help: str | None = None,
-        on_change: WidgetCallback | None = None,
+        on_change: WidgetCallback | OnChangeMode | None = "rerun",
         args: WidgetArgs | None = None,
         kwargs: WidgetKwargs | None = None,
         *,  # keyword-only arguments:
@@ -646,10 +678,16 @@ class SelectboxMixin:
     ) -> T | str | None:
         key = to_key(key)
 
+        validate_on_change_mode(on_change)
+
+        on_change_callback: WidgetCallback | None = (
+            on_change if callable(on_change) else None
+        )
+
         check_widget_policies(
             self.dg,
             key,
-            on_change,
+            on_change_callback,
             default_value=None if index == 0 else index,
         )
         label = maybe_raise_label_warnings(label, label_visibility)
@@ -727,6 +765,9 @@ class SelectboxMixin:
         if bind == "query-params" and key is not None:
             selectbox_proto.query_param_key = str(key)
 
+        if isinstance(on_change, str) and on_change == "ignore":
+            selectbox_proto.ignore_rerun = True
+
         serde = SelectboxSerde(
             opt,
             formatted_options=formatted_options,
@@ -736,7 +777,7 @@ class SelectboxMixin:
         )
         widget_state = register_widget(
             selectbox_proto.id,
-            on_change_handler=on_change,
+            on_change_handler=on_change_callback,
             args=args,
             kwargs=kwargs,
             deserializer=serde.deserialize,

--- a/lib/tests/streamlit/elements/selectbox_test.py
+++ b/lib/tests/streamlit/elements/selectbox_test.py
@@ -1076,3 +1076,50 @@ class SelectboxBindQueryParamsTest(DeltaGeneratorTestCase):
         c = self.get_delta_from_queue().new_element.selectbox
         assert c.query_param_key == "my_key"
         assert c.accept_new_options
+
+
+class SelectboxOnChangeModeTest(DeltaGeneratorTestCase):
+    """Test on_change mode functionality (rerun, ignore, callable)."""
+
+    @parameterized.expand(
+        [
+            ("ignore", "ignore", True),
+            ("rerun", "rerun", False),
+            ("none", None, False),
+            ("callback", lambda: None, False),
+        ]
+    )
+    def test_on_change_mode_sets_ignore_rerun_proto_field(
+        self, _name: str, on_change: Any, expected_ignore_rerun: bool
+    ) -> None:
+        """Test that on_change modes correctly set the ignore_rerun proto field."""
+        st.selectbox("the label", ("a", "b"), on_change=on_change)
+
+        c = self.get_delta_from_queue().new_element.selectbox
+        assert c.ignore_rerun is expected_ignore_rerun
+
+    def test_on_change_invalid_mode_raises_exception(self) -> None:
+        """Test that invalid on_change mode raises StreamlitValueError."""
+        with pytest.raises(StreamlitValueError) as exc_info:
+            st.selectbox("the label", ("a", "b"), on_change="invalid")
+
+        assert "on_change" in str(exc_info.value)
+        assert "'rerun'" in str(exc_info.value)
+        assert "'ignore'" in str(exc_info.value)
+        assert "a callback function" in str(exc_info.value)
+
+    def test_on_change_non_string_value_raises_exception(self) -> None:
+        """Test that a non-string, non-callable on_change raises StreamlitValueError."""
+        with pytest.raises(StreamlitValueError) as exc_info:
+            st.selectbox("the label", ("a", "b"), on_change=[])  # type: ignore[arg-type]
+
+        assert "on_change" in str(exc_info.value)
+
+    @patch("streamlit.runtime.Runtime.exists", MagicMock(return_value=True))
+    def test_on_change_ignore_allowed_inside_form(self) -> None:
+        """Test that on_change='ignore' inside a form does not raise."""
+        with st.form("form"):
+            st.selectbox("the label", ("a", "b"), on_change="ignore")
+
+        c = self.get_delta_from_queue(1).new_element.selectbox
+        assert c.ignore_rerun is True

--- a/lib/tests/streamlit/typing/selectbox_types.py
+++ b/lib/tests/streamlit/typing/selectbox_types.py
@@ -109,6 +109,17 @@ if TYPE_CHECKING:
         selectbox("foo", ["a", "b"], index=None, persist_state="session"), str | None
     )
 
+    # Check on_change parameter modes
+    assert_type(selectbox("foo", [1, 2, 3], on_change=None), int)
+    assert_type(selectbox("foo", [1, 2, 3], on_change="rerun"), int)
+    assert_type(selectbox("foo", [1, 2, 3], on_change="ignore"), int)
+    assert_type(selectbox("foo", [1, 2, 3], on_change=lambda: None), int)
+    assert_type(selectbox("foo", [1, 2, 3], index=None, on_change="ignore"), int | None)
+    assert_type(
+        selectbox("foo", [1, 2, 3], accept_new_options=True, on_change="ignore"),
+        int | str,
+    )
+
     def on_selectbox_change(prefix: str) -> None: ...
 
     # Common parameters combined

--- a/proto/streamlit/proto/Selectbox.proto
+++ b/proto/streamlit/proto/Selectbox.proto
@@ -36,6 +36,12 @@ message Selectbox {
   optional string query_param_key = 14;
   streamlit.SelectWidgetFilterMode filter_mode = 15;
 
+  // Set by on_change="ignore": do not schedule a rerun; buffer the value until
+  // the next rerun. Bound widgets still update the URL when the value is
+  // committed. Inside a form, this flag has no effect because the form batches
+  // values until submit.
+  bool ignore_rerun = 16;
+  // Next: 17
+
   reserved 7;
-  // Next: 16
 }


### PR DESCRIPTION
## Describe your changes

Adds `on_change="ignore"` to `st.selectbox`. Committing a value (clicking an option, confirming with Enter, adding a new option when `accept_new_options=True`, or clearing the value) updates the widget and any bound query parameter without rerunning the app. Python receives the value on the next rerun, for example after a button click.

As with the other widgets in this rollout, the documented `on_change` default changes from `None` to `"rerun"`. `None` remains supported as an alias, so existing code is unaffected.

- Follows the `st.number_input` / `st.text_input` pattern from #16649 and #16605

## GitHub Issue Link (if applicable)

- Implements `st.selectbox` support from the on-change modes spec (`specs/2026-04-14-on-change-modes`, #14787)
- Related: #5827

## Testing Plan

- [x] Unit Tests (JS and/or Python)
- [x] E2E Tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | assessing-external-test-risk | 1 |
| skill | checking-changes | 2 |
| skill | debugging-streamlit | 1 |
| skill | finalizing-pr | 1 |
| skill | implementing-on-change-ignore | 1 |
| skill | qa-testing-feature | 1 |
| skill | reviewing-pr-description | 1 |
| skill | reviewing-readability | 1 |
| skill | sharing-pr-agent-artifacts | 1 |
| skill | updating-internal-docs | 1 |
| subagent | fixing-pr | 2 |
| subagent | generalPurpose | 8 |
| subagent | qa-testing-feature | 1 |
| subagent | reviewing-local-changes | 1 |
| subagent | simplifying-local-changes | 1 |

</details>
<!-- agent-metrics-end -->