### PR TITLE
[chore] De-flake slider float-formatting snapshot

### DIFF
--- a/e2e_playwright/st_slider_test.py
+++ b/e2e_playwright/st_slider_test.py
@@ -28,6 +28,7 @@ from e2e_playwright.shared.app_utils import (
     check_top_level_class,
     click_form_button,
     click_toggle,
+    expect_font,
     expect_help_tooltip,
     expect_markdown,
     expect_prefixed_markdown,
@@ -264,7 +265,9 @@ def test_slider_works_with_fragments(app: Page):
     expect(app.get_by_text("Runs: 1")).to_be_visible()
 
 
-def test_slider_with_float_formatting(app: Page, assert_snapshot: ImageCompareFunction):
+def test_slider_with_float_formatting(
+    app: Page, assert_snapshot: ImageCompareFunction, browser_name: str
+):
     slider = get_slider(app, "Slider 11 (formatted float)")
     slider.click()
 
@@ -277,15 +280,21 @@ def test_slider_with_float_formatting(app: Page, assert_snapshot: ImageCompareFu
     # Assert the formatted label directly. This, not the snapshot, is what pins
     # down `format="%f%%"`: the markdown above only shows the raw value (0.8).
     expect(slider.get_by_test_id("stSliderThumbValue")).to_have_text("0.8%")
-    # The tick bar's opacity flips instantly (it has no transition), so this just
-    # confirms reset_hovering above actually took effect before we snapshot.
+    # Once unhovered the tick bar fades out (opacity 300ms after a 200ms delay), so
+    # wait for it to reach 0 rather than capturing it mid-fade.
     expect(slider.get_by_test_id("stSliderTickBar")).to_have_css("opacity", "0")
-    # The thumb value label is positioned at a fractional offset, so its glyphs
-    # can snap to either of two adjacent pixel rows. That 1px shift measures
-    # 116px (0.239%) on this 704x69 element, just over the 0.002 default. 0.003
-    # (145px) absorbs it while still failing a 2px shift (147px) or a retained
-    # focus ring (187px).
-    assert_snapshot(slider, name="st_slider-float_formatting", image_threshold=0.003)
+    # Playwright's screenshot already waits for fonts; kept as belt and braces.
+    expect_font(app, "Source Sans")
+    # The thumb value label sits at a fractional offset, so its glyphs can snap to
+    # either of two adjacent pixel rows. On chromium that 1px shift measures 116px
+    # (0.239%) of this 704x69 element, just over the 0.002 default; 0.003 (145px)
+    # absorbs it while still failing a 2px shift (147px) or a retained focus ring
+    # (187px). Firefox and webkit have never shown it, so they keep the default.
+    assert_snapshot(
+        slider,
+        name="st_slider-float_formatting",
+        image_threshold=0.003 if browser_name == "chromium" else 0.002,
+    )
 
 
 def test_check_top_level_class(app: Page):

--- a/e2e_playwright/st_slider_test.py
+++ b/e2e_playwright/st_slider_test.py
@@ -283,13 +283,13 @@ def test_slider_with_float_formatting(
     # Once unhovered the tick bar fades out (opacity 300ms after a 200ms delay), so
     # wait for it to reach 0 rather than capturing it mid-fade.
     expect(slider.get_by_test_id("stSliderTickBar")).to_have_css("opacity", "0")
-    # Playwright's screenshot already waits for fonts; kept as belt and braces.
+    # An unloaded Source Sans would drop the label rather than shift it; failing here
+    # reports that as a font timeout instead of an opaque snapshot mismatch.
     expect_font(app, "Source Sans")
-    # The thumb value label sits at a fractional offset, so its glyphs can snap to
-    # either of two adjacent pixel rows. On chromium that 1px shift measures 116px
-    # (0.239%) of this 704x69 element, just over the 0.002 default; 0.003 (145px)
-    # absorbs it while still failing a 2px shift (147px) or a retained focus ring
-    # (187px). Firefox and webkit have never shown it, so they keep the default.
+    # This label is fractionally positioned, so its glyphs can snap one pixel up or
+    # down. Chromium only: 0.003 (145px) absorbs the observed 116px shift, while a 2px
+    # shift (147px) or a leftover focus ring (187px) still fails. Firefox and webkit
+    # have never shown it, so they keep the 0.002 default.
     assert_snapshot(
         slider,
         name="st_slider-float_formatting",

--- a/e2e_playwright/st_slider_test.py
+++ b/e2e_playwright/st_slider_test.py
@@ -283,13 +283,15 @@ def test_slider_with_float_formatting(
     # Once unhovered the tick bar fades out (opacity 300ms after a 200ms delay), so
     # wait for it to reach 0 rather than capturing it mid-fade.
     expect(slider.get_by_test_id("stSliderTickBar")).to_have_css("opacity", "0")
-    # An unloaded Source Sans would drop the label rather than shift it; failing here
-    # reports that as a font timeout instead of an opaque snapshot mismatch.
+    # Source Sans sets no font-display, so until it loads the label renders invisible
+    # rather than shifted. Waiting reports that as a font timeout instead of an opaque
+    # snapshot mismatch.
     expect_font(app, "Source Sans")
     # This label is fractionally positioned, so its glyphs can snap one pixel up or
-    # down. Chromium only: 0.003 (145px) absorbs the observed 116px shift, while a 2px
-    # shift (147px) or a leftover focus ring (187px) still fails. Firefox and webkit
-    # have never shown it, so they keep the 0.002 default.
+    # down. Of the 704x69 capture, Chromium's 0.003 lets up to 144 pixels differ, which
+    # absorbs the observed 116px shift, while a 2px shift (147px) or a leftover focus
+    # ring (187px) still fails. Firefox and WebKit have never shown it, so they keep
+    # the 0.002 default.
     assert_snapshot(
         slider,
         name="st_slider-float_formatting",

--- a/e2e_playwright/st_slider_test.py
+++ b/e2e_playwright/st_slider_test.py
@@ -28,7 +28,6 @@ from e2e_playwright.shared.app_utils import (
     check_top_level_class,
     click_form_button,
     click_toggle,
-    expect_font,
     expect_help_tooltip,
     expect_markdown,
     expect_prefixed_markdown,
@@ -275,15 +274,18 @@ def test_slider_with_float_formatting(app: Page, assert_snapshot: ImageCompareFu
     reset_hovering(app)
     reset_focus(app)
     expect(app.get_by_text("Slider 11: 0.8")).to_be_visible()
-    # Wait for the tick bar (min/max labels) to fully fade out (transition: 300ms + 200ms delay)
-    # so the snapshot is stable and not captured mid-transition.
+    # Assert the formatted label directly. This, not the snapshot, is what pins
+    # down `format="%f%%"`: the markdown above only shows the raw value (0.8).
+    expect(slider.get_by_test_id("stSliderThumbValue")).to_have_text("0.8%")
+    # The tick bar's opacity flips instantly (it has no transition), so this just
+    # confirms reset_hovering above actually took effect before we snapshot.
     expect(slider.get_by_test_id("stSliderTickBar")).to_have_css("opacity", "0")
-    # The "0.8%" thumb value label only renders after this interaction, so on a
-    # cold page load it can be captured before the "Source Sans" web font finishes
-    # loading (flash-of-fallback-text). Wait for the font to avoid a snapshot flake
-    # where only the value label differs.
-    expect_font(app, "Source Sans")
-    assert_snapshot(slider, name="st_slider-float_formatting")
+    # The thumb value label is positioned at a fractional offset, so its glyphs
+    # can snap to either of two adjacent pixel rows. That 1px shift measures
+    # 116px (0.239%) on this 704x69 element, just over the 0.002 default. 0.003
+    # (145px) absorbs it while still failing a 2px shift (147px) or a retained
+    # focus ring (187px).
+    assert_snapshot(slider, name="st_slider-float_formatting", image_threshold=0.003)
 
 
 def test_check_top_level_class(app: Page):


### PR DESCRIPTION
## Describe your changes

Raises the chromium snapshot tolerance for `test_slider_with_float_formatting` from 0.002 to 0.003, so a one-pixel shift of the `0.8%` thumb label no longer fails it. The test flaked on ~2% of runs — 11 times in 14 days, across 9 branches including develop.

Every failure was identical: the label renders one pixel higher, 116 px (0.239%) of the 704×69 capture, with the diff confined to the label. 0.003 lets up to 144 px differ, so it absorbs that while a 2 px shift (147 px) or a leftover focus ring (187 px) still fails. Firefox and webkit never showed it and keep the default.

Also asserts the thumb label reads `0.8%`, so `format="%f%%"` is checked as text rather than only as pixels — the existing assertion covers only the raw `0.8`.

The root cause is unidentified: crossing the pixel boundary needs a ~0.43 px layout shift, and font loading, container offset and phase proximity were each ruled out. So this is a symptom fix, calibrated to a magnitude measured across every observed failure — a larger shift would still fail rather than pass silently. The `expect_font()` wait from #15940 stays, though it doesn't address this: the rate was unchanged across it (2.10% before, 2.24% after).

## Testing Plan

- E2E Tests: adds a `0.8%` label assertion to the existing slider test and loosens the Chromium snapshot tolerance. No new test case needed. Passes locally on chromium.
- 100 runs all passed on the current commit: https://github.com/streamlit/streamlit/actions/runs/34168559822 (an earlier 100 ran against the first commit: https://github.com/streamlit/streamlit/actions/runs/34164627138). That confirms the new assertion isn't flaky. It doesn't confirm the flake is fixed — the test only failed once in every 65 runs before, so a clean 100 wouldn't be surprising even if nothing had changed.
- The evidence for the fix is the 11 failures above: every one measured 116 px, comfortably under the new 145 px limit.
- Worth re-checking in two weeks. CI runs this test around 700 times a fortnight, which is plenty to show whether it still fails.
---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Playwright E2E test-only changes with no production or runtime behavior impact.
> 
> **Overview**
> Stabilizes **`test_slider_with_float_formatting`** against intermittent Chromium snapshot failures where the formatted thumb label (`0.8%`) shifts by one pixel.
> 
> The test now **asserts** `stSliderThumbValue` shows `0.8%` so `format="%f%%"` is checked in text, not only via pixels. It still waits for the tick bar opacity to reach `0` and calls **`expect_font`**, with comments reframed around opacity timing and font-load failures vs. subpixel label shifts.
> 
> For the image compare, the test takes **`browser_name`** and passes **`image_threshold=0.003`** on Chromium (default `0.002` elsewhere) so a ~1px glyph snap on the fractionally positioned label is tolerated while larger visual regressions should still fail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b137afe3101cd8f59885c05522b8361109f1030d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->




