### PR TITLE
[chore] Add typing tests for st.divider

### DIFF
--- a/lib/tests/streamlit/typing/markdown_types.py
+++ b/lib/tests/streamlit/typing/markdown_types.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
     markdown = MarkdownMixin().markdown
     caption = MarkdownMixin().caption
     latex = MarkdownMixin().latex
+    divider = MarkdownMixin().divider
     badge = MarkdownMixin().badge
 
     # =====================================================================
@@ -302,3 +303,32 @@ if TYPE_CHECKING:
 
     # st.badge does not take wrap
     badge("New", wrap=False)  # type: ignore[call-arg]  # ty: ignore[unknown-argument]
+
+    # =====================================================================
+    # st.divider return type tests
+    # =====================================================================
+
+    # Basic usage - returns DeltaGenerator; width defaults to "stretch"
+    assert_type(divider(), DeltaGenerator)
+
+    # width parameter (keyword-only) - WidthWithoutContent
+    assert_type(divider(width="stretch"), DeltaGenerator)
+    assert_type(divider(width=300), DeltaGenerator)
+
+    # =====================================================================
+    # Invalid st.divider usages - should NOT type check
+    # =====================================================================
+
+    # Invalid width value (not "stretch" or int)
+    divider(width="content")  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+    divider(width="auto")  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+    divider(width="invalid")  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+    divider(width=None)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+
+    # Passing width as positional argument (should be keyword-only)
+    divider("stretch")  # type: ignore[call-arg]  # ty: ignore[too-many-positional-arguments]
+
+    # st.divider does not take markdown-only keywords
+    divider(help="A rule")  # type: ignore[call-arg]  # ty: ignore[unknown-argument]
+    divider(text_alignment="center")  # type: ignore[call-arg]  # ty: ignore[unknown-argument]
+    divider(wrap=False)  # type: ignore[call-arg]  # ty: ignore[unknown-argument]

--- a/lib/tests/streamlit/typing/markdown_types.py
+++ b/lib/tests/streamlit/typing/markdown_types.py
@@ -239,6 +239,35 @@ if TYPE_CHECKING:
     latex(r"x^2", wrap=False)  # type: ignore[call-arg]  # ty: ignore[unknown-argument]
 
     # =====================================================================
+    # st.divider return type tests
+    # =====================================================================
+
+    # No-arg call is valid (width is optional) and returns DeltaGenerator
+    assert_type(divider(), DeltaGenerator)
+
+    # width is keyword-only; accepts only "stretch" or an int (not "content")
+    assert_type(divider(width="stretch"), DeltaGenerator)
+    assert_type(divider(width=300), DeltaGenerator)
+
+    # =====================================================================
+    # Invalid st.divider usages - should NOT type check
+    # =====================================================================
+
+    # Invalid width value (not "stretch" or int)
+    # "content" is accepted by sibling markdown commands but NOT by st.divider
+    divider(width="content")  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+    divider(width="auto")  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+    divider(width=None)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+
+    # Passing width as positional argument (should be keyword-only)
+    divider("stretch")  # type: ignore[call-arg]  # ty: ignore[too-many-positional-arguments]
+
+    # st.divider does not take markdown-only keywords
+    divider(help="A rule")  # type: ignore[call-arg]  # ty: ignore[unknown-argument]
+    divider(text_alignment="center")  # type: ignore[call-arg]  # ty: ignore[unknown-argument]
+    divider(wrap=False)  # type: ignore[call-arg]  # ty: ignore[unknown-argument]
+
+    # =====================================================================
     # st.badge return type tests
     # =====================================================================
 
@@ -303,32 +332,3 @@ if TYPE_CHECKING:
 
     # st.badge does not take wrap
     badge("New", wrap=False)  # type: ignore[call-arg]  # ty: ignore[unknown-argument]
-
-    # =====================================================================
-    # st.divider return type tests
-    # =====================================================================
-
-    # Basic usage - returns DeltaGenerator; width defaults to "stretch"
-    assert_type(divider(), DeltaGenerator)
-
-    # width parameter (keyword-only) - WidthWithoutContent
-    assert_type(divider(width="stretch"), DeltaGenerator)
-    assert_type(divider(width=300), DeltaGenerator)
-
-    # =====================================================================
-    # Invalid st.divider usages - should NOT type check
-    # =====================================================================
-
-    # Invalid width value (not "stretch" or int)
-    divider(width="content")  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
-    divider(width="auto")  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
-    divider(width="invalid")  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
-    divider(width=None)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
-
-    # Passing width as positional argument (should be keyword-only)
-    divider("stretch")  # type: ignore[call-arg]  # ty: ignore[too-many-positional-arguments]
-
-    # st.divider does not take markdown-only keywords
-    divider(help="A rule")  # type: ignore[call-arg]  # ty: ignore[unknown-argument]
-    divider(text_alignment="center")  # type: ignore[call-arg]  # ty: ignore[unknown-argument]
-    divider(wrap=False)  # type: ignore[call-arg]  # ty: ignore[unknown-argument]


### PR DESCRIPTION
## Describe your changes

Adds mypy and ty checks for `st.divider`, covering its return type, keyword-only `width` (`"stretch"` or int), and invalid calls (`width="content"`, markdown-only keywords).

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- [x] Verified with `make check` (ruff, mypy, ty)
- [ ] E2E Tests — not needed (typing-only change)
- [ ] Manual testing — not needed

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

Made with [Cursor](https://cursor.com)

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | addressing-pr-review-comments | 1 |
| skill | checking-changes | 1 |
| skill | finalizing-pr | 1 |
| skill | implementing-typing-tests | 1 |
| skill | reviewing-pr-description | 1 |

</details>
<!-- agent-metrics-end -->