### PR TITLE
[chore] Label automated AI PRs for final review

### DIFF
--- a/.cursor/rules/workflows.mdc
+++ b/.cursor/rules/workflows.mdc
@@ -153,9 +153,9 @@ runner's system Python.
 | `ai-pr-review.yml` | `ai-review`/`ai-final-review` label or manual | AI-powered code and product-alignment review using Cursor CLI |
 | `ai-qa-testing.yml` | `ai-qa-test` label or manual | AI-powered QA testing on PR branches |
 | `ai-issue-triage.yml` | `ai-review` label on issue or manual | AI-powered issue triage (duplicates, labels) |
-| `ai-update-docs.yml` | Weekly (Tuesdays) or manual | AI-powered documentation review; weekly/full mode uses recently merged PRs as leads, including bundled skills |
-| `ai-fix-flaky-e2e-tests.yml` | Weekly (Fridays) or manual | AI-powered flaky E2E test diagnosis and fixing |
-| `ai-test-coverage.yml` | Weekly (Wednesdays) or manual | AI-powered test coverage improvement for frontend and Python |
+| `ai-update-docs.yml` | Weekly (Tuesdays) or manual | AI-powered documentation review; weekly/full mode uses recently merged PRs as leads, including bundled skills. Created PRs get `ai-final-review`. |
+| `ai-fix-flaky-e2e-tests.yml` | Weekly (Fridays) or manual | AI-powered flaky E2E test diagnosis and fixing. Created PRs get `ai-final-review`. |
+| `ai-test-coverage.yml` | Weekly (Wednesdays) or manual | AI-powered test coverage improvement for frontend and Python. Created PRs get `ai-final-review`. |
 
 ### Maintenance & Updates
 

--- a/.github/instructions/workflows.instructions.md
+++ b/.github/instructions/workflows.instructions.md
@@ -151,9 +151,9 @@ runner's system Python.
 | `ai-pr-review.yml` | `ai-review`/`ai-final-review` label or manual | AI-powered code and product-alignment review using Cursor CLI |
 | `ai-qa-testing.yml` | `ai-qa-test` label or manual | AI-powered QA testing on PR branches |
 | `ai-issue-triage.yml` | `ai-review` label on issue or manual | AI-powered issue triage (duplicates, labels) |
-| `ai-update-docs.yml` | Weekly (Tuesdays) or manual | AI-powered documentation review; weekly/full mode uses recently merged PRs as leads, including bundled skills |
-| `ai-fix-flaky-e2e-tests.yml` | Weekly (Fridays) or manual | AI-powered flaky E2E test diagnosis and fixing |
-| `ai-test-coverage.yml` | Weekly (Wednesdays) or manual | AI-powered test coverage improvement for frontend and Python |
+| `ai-update-docs.yml` | Weekly (Tuesdays) or manual | AI-powered documentation review; weekly/full mode uses recently merged PRs as leads, including bundled skills. Created PRs get `ai-final-review`. |
+| `ai-fix-flaky-e2e-tests.yml` | Weekly (Fridays) or manual | AI-powered flaky E2E test diagnosis and fixing. Created PRs get `ai-final-review`. |
+| `ai-test-coverage.yml` | Weekly (Wednesdays) or manual | AI-powered test coverage improvement for frontend and Python. Created PRs get `ai-final-review`. |
 
 ### Maintenance & Updates
 

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -145,9 +145,9 @@ runner's system Python.
 | `ai-pr-review.yml` | `ai-review`/`ai-final-review` label or manual | AI-powered code and product-alignment review using Cursor CLI |
 | `ai-qa-testing.yml` | `ai-qa-test` label or manual | AI-powered QA testing on PR branches |
 | `ai-issue-triage.yml` | `ai-review` label on issue or manual | AI-powered issue triage (duplicates, labels) |
-| `ai-update-docs.yml` | Weekly (Tuesdays) or manual | AI-powered documentation review; weekly/full mode uses recently merged PRs as leads, including bundled skills |
-| `ai-fix-flaky-e2e-tests.yml` | Weekly (Fridays) or manual | AI-powered flaky E2E test diagnosis and fixing |
-| `ai-test-coverage.yml` | Weekly (Wednesdays) or manual | AI-powered test coverage improvement for frontend and Python |
+| `ai-update-docs.yml` | Weekly (Tuesdays) or manual | AI-powered documentation review; weekly/full mode uses recently merged PRs as leads, including bundled skills. Created PRs get `ai-final-review`. |
+| `ai-fix-flaky-e2e-tests.yml` | Weekly (Fridays) or manual | AI-powered flaky E2E test diagnosis and fixing. Created PRs get `ai-final-review`. |
+| `ai-test-coverage.yml` | Weekly (Wednesdays) or manual | AI-powered test coverage improvement for frontend and Python. Created PRs get `ai-final-review`. |
 
 ### Maintenance & Updates
 

--- a/.github/workflows/ai-fix-flaky-e2e-tests.yml
+++ b/.github/workflows/ai-fix-flaky-e2e-tests.yml
@@ -169,6 +169,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      actions: write
 
     defaults:
       run:
@@ -241,6 +242,7 @@ jobs:
           BRANCH_NAME: ${{ steps.create-branch.outputs.branch_name }}
           MODEL_NAME: ${{ env.MODEL }}
           CHANGES_SUMMARY: ${{ steps.apply-patch.outputs.changes_summary }}
+          DISPATCH_REF: ${{ github.ref_name }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -276,7 +278,17 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: pr.number,
-              labels: ['change:other', 'impact:internal'],
+              labels: ['change:other', 'impact:internal', 'ai-final-review'],
+            });
+
+            // GITHUB_TOKEN cannot trigger other workflows via `labeled`, so
+            // dispatch the final AI review after applying the trigger label.
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'ai-pr-review.yml',
+              ref: process.env.DISPATCH_REF,
+              inputs: { pr_number: String(pr.number) },
             });
 
       - name: Write step summary

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -28,6 +28,10 @@ jobs:
   parse-models:
     if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'ai-review' || github.event.label.name == 'ai-final-review'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
     outputs:
       models_json: ${{ steps.parse.outputs.models_json }}
       model_count: ${{ steps.parse.outputs.model_count }}
@@ -52,10 +56,25 @@ jobs:
         id: parse
         env:
           EVENT_LABEL: ${{ github.event.label.name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          PR_NUMBER_ENV: ${{ env.PR_NUMBER }}
         run: |
           REVIEW_LABEL=""
           if [ "$EVENT_LABEL" = "ai-review" ] || [ "$EVENT_LABEL" = "ai-final-review" ]; then
             REVIEW_LABEL="$EVENT_LABEL"
+          fi
+
+          # workflow_dispatch has no labeled event. Honor review labels already on
+          # the PR so automated AI workflows can request a final review: adding a
+          # label with GITHUB_TOKEN does not start other `labeled` workflows.
+          if [ -z "$REVIEW_LABEL" ] && [ -n "$PR_NUMBER_ENV" ]; then
+            PR_LABELS=$(gh api "repos/$REPOSITORY/issues/$PR_NUMBER_ENV/labels" --jq '.[].name')
+            if echo "$PR_LABELS" | grep -Fxq "ai-final-review"; then
+              REVIEW_LABEL="ai-final-review"
+            elif echo "$PR_LABELS" | grep -Fxq "ai-review"; then
+              REVIEW_LABEL="ai-review"
+            fi
           fi
 
           if [ "$REVIEW_LABEL" = "ai-final-review" ]; then
@@ -423,18 +442,23 @@ jobs:
 
     steps:
       - name: Remove AI review request label
-        if: github.event_name == 'pull_request'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER_ENV: ${{ env.PR_NUMBER }}
           REPOSITORY: ${{ github.repository }}
           EVENT_LABEL: ${{ github.event.label.name }}
+          TRIGGER_LABEL: ${{ needs.parse-models.outputs.trigger_label }}
         run: |
-          # Derive the label to remove from the triggering event rather than the
-          # parse-models output, so the label is still cleaned up even if the parse
-          # step failed. The equality checks keep removal limited to known labels.
+          # Prefer the triggering labeled event so the label is still cleaned up
+          # if parse-models failed. Fall back to parse-models for workflow_dispatch.
+          LABEL_TO_REMOVE=""
           if [ "$EVENT_LABEL" = "ai-review" ] || [ "$EVENT_LABEL" = "ai-final-review" ]; then
-            gh pr edit "$PR_NUMBER_ENV" --remove-label "$EVENT_LABEL" --repo "$REPOSITORY" || true
+            LABEL_TO_REMOVE="$EVENT_LABEL"
+          elif [ "$TRIGGER_LABEL" = "ai-review" ] || [ "$TRIGGER_LABEL" = "ai-final-review" ]; then
+            LABEL_TO_REMOVE="$TRIGGER_LABEL"
+          fi
+          if [ -n "$LABEL_TO_REMOVE" ]; then
+            gh pr edit "$PR_NUMBER_ENV" --remove-label "$LABEL_TO_REMOVE" --repo "$REPOSITORY" || true
           fi
 
       - name: Download consolidated review

--- a/.github/workflows/ai-test-coverage.yml
+++ b/.github/workflows/ai-test-coverage.yml
@@ -244,6 +244,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      actions: write
 
     defaults:
       run:
@@ -316,6 +317,7 @@ jobs:
           BRANCH_NAME: ${{ steps.create-branch.outputs.branch_name }}
           MODEL_NAME: ${{ env.MODEL }}
           CHANGES_SUMMARY: ${{ steps.apply-patch.outputs.changes_summary }}
+          DISPATCH_REF: ${{ github.ref_name }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -351,7 +353,17 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: pr.number,
-              labels: ['change:other', 'impact:internal'],
+              labels: ['change:other', 'impact:internal', 'ai-final-review'],
+            });
+
+            // GITHUB_TOKEN cannot trigger other workflows via `labeled`, so
+            // dispatch the final AI review after applying the trigger label.
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'ai-pr-review.yml',
+              ref: process.env.DISPATCH_REF,
+              inputs: { pr_number: String(pr.number) },
             });
 
       - name: Write step summary
@@ -381,6 +393,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      actions: write
 
     defaults:
       run:
@@ -453,6 +466,7 @@ jobs:
           BRANCH_NAME: ${{ steps.create-branch.outputs.branch_name }}
           MODEL_NAME: ${{ env.MODEL }}
           CHANGES_SUMMARY: ${{ steps.apply-patch.outputs.changes_summary }}
+          DISPATCH_REF: ${{ github.ref_name }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -488,7 +502,17 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: pr.number,
-              labels: ['change:other', 'impact:internal'],
+              labels: ['change:other', 'impact:internal', 'ai-final-review'],
+            });
+
+            // GITHUB_TOKEN cannot trigger other workflows via `labeled`, so
+            // dispatch the final AI review after applying the trigger label.
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'ai-pr-review.yml',
+              ref: process.env.DISPATCH_REF,
+              inputs: { pr_number: String(pr.number) },
             });
 
       - name: Write step summary

--- a/.github/workflows/ai-update-docs.yml
+++ b/.github/workflows/ai-update-docs.yml
@@ -268,6 +268,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      actions: write
 
     defaults:
       run:
@@ -343,6 +344,7 @@ jobs:
           CHANGES_SUMMARY: ${{ steps.apply-patch.outputs.changes_summary }}
           SOURCE_PR_NUMBER: ${{ env.PR_NUMBER }}
           BASE_BRANCH: ${{ needs.ai-update-docs.outputs.base_branch || 'develop' }}
+          DISPATCH_REF: ${{ github.ref_name }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -399,7 +401,17 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: pr.number,
-              labels: ['change:docs', 'impact:internal'],
+              labels: ['change:docs', 'impact:internal', 'ai-final-review'],
+            });
+
+            // GITHUB_TOKEN cannot trigger other workflows via `labeled`, so
+            // dispatch the final AI review after applying the trigger label.
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'ai-pr-review.yml',
+              ref: process.env.DISPATCH_REF,
+              inputs: { pr_number: String(pr.number) },
             });
 
       - name: Write step summary


### PR DESCRIPTION
## Describe your changes

Automated docs, flaky-test, and coverage PRs now get `ai-final-review` so they go through the final AI review.

`GITHUB_TOKEN` cannot start other workflows from a `labeled` event, so those jobs also dispatch `ai-pr-review.yml`. Dispatched reviews honor review labels already on the PR.

## GitHub Issue Link (if applicable)

## Testing Plan

- Workflow YAML only; no unit or E2E tests apply.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

Made with [Cursor](https://cursor.com)