### PR TITLE
[chore] Add bot-pr label to CI-created PRs

### DIFF
--- a/.github/workflows/ai-fix-flaky-e2e-tests.yml
+++ b/.github/workflows/ai-fix-flaky-e2e-tests.yml
@@ -276,7 +276,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: pr.number,
-              labels: ['change:other', 'impact:internal'],
+              labels: ['change:other', 'impact:internal', 'bot-pr'],
             });
 
       - name: Write step summary

--- a/.github/workflows/ai-test-coverage.yml
+++ b/.github/workflows/ai-test-coverage.yml
@@ -351,7 +351,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: pr.number,
-              labels: ['change:other', 'impact:internal'],
+              labels: ['change:other', 'impact:internal', 'bot-pr'],
             });
 
       - name: Write step summary
@@ -488,7 +488,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: pr.number,
-              labels: ['change:other', 'impact:internal'],
+              labels: ['change:other', 'impact:internal', 'bot-pr'],
             });
 
       - name: Write step summary

--- a/.github/workflows/ai-update-docs.yml
+++ b/.github/workflows/ai-update-docs.yml
@@ -396,6 +396,8 @@ jobs:
             core.setOutput('pr_url', pr.html_url);
 
             const labels = ['change:docs', 'impact:internal'];
+            // Only PRs targeting develop are marked as bot PRs; this workflow
+            // can also target a source PR's base branch.
             if (baseBranch === 'develop') {
               labels.push('bot-pr');
             }

--- a/.github/workflows/ai-update-docs.yml
+++ b/.github/workflows/ai-update-docs.yml
@@ -395,11 +395,15 @@ jobs:
             });
             core.setOutput('pr_url', pr.html_url);
 
+            const labels = ['change:docs', 'impact:internal'];
+            if (baseBranch === 'develop') {
+              labels.push('bot-pr');
+            }
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: pr.number,
-              labels: ['change:docs', 'impact:internal'],
+              labels,
             });
 
       - name: Write step summary

--- a/.github/workflows/bump-component-v2-lib.yml
+++ b/.github/workflows/bump-component-v2-lib.yml
@@ -91,7 +91,7 @@ jobs:
               draft: false,
             });
             const pr = created.data;
-            await github.rest.issues.addLabels({ owner: context.repo.owner, repo: context.repo.repo, issue_number: pr.number, labels: ['change:chore', 'impact:internal', 'autofix'] });
+            await github.rest.issues.addLabels({ owner: context.repo.owner, repo: context.repo.repo, issue_number: pr.number, labels: ['change:chore', 'impact:internal', 'bot-pr'] });
             core.setOutput('pr_url', pr.html_url);
 
       - name: Summary (@streamlit/component-v2-lib)

--- a/.github/workflows/update-browserslist-db.yml
+++ b/.github/workflows/update-browserslist-db.yml
@@ -108,7 +108,7 @@ jobs:
 
             core.setOutput('pr_url', pr.html_url);
 
-            const labels = ['change:chore', 'impact:internal', 'autofix'];
+            const labels = ['change:chore', 'impact:internal', 'bot-pr'];
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/update-emojis-material-icons.yml
+++ b/.github/workflows/update-emojis-material-icons.yml
@@ -114,7 +114,7 @@ jobs:
 
             core.setOutput('pr_url', pr.html_url);
 
-            const labels = ['change:chore', 'impact:users', 'autofix', 'update-snapshots'];
+            const labels = ['change:chore', 'impact:users', 'update-snapshots', 'bot-pr'];
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/update-python-lock.yml
+++ b/.github/workflows/update-python-lock.yml
@@ -176,7 +176,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: created.data.number,
-              labels: ['change:chore', 'impact:internal', 'autofix', 'never-stale'],
+              labels: ['change:chore', 'impact:internal', 'never-stale', 'bot-pr'],
             });
 
       - name: Write workflow summary


### PR DESCRIPTION
## Describe your changes

CI-created github-actions PRs targeting `develop` now get `bot-pr` and no longer get `autofix`, so they are marked as bot PRs without triggering the autofix workflow.

Screenshot-update, autofix, and release merge-back PRs are unchanged.

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- No additional tests: only GitHub Actions label lists changed; no product or test code.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

Made with [Cursor](https://cursor.com)