### PR TITLE
[spec] Standardize logging across launch modes

### DIFF
--- a/specs/2026-08-23-logging-strategy/product-spec.md
+++ b/specs/2026-08-23-logging-strategy/product-spec.md
@@ -1,0 +1,261 @@
+---
+author: lukasmasuch
+created: 2026-08-23
+---
+
+# Standard, launch-aware logging
+
+## Summary
+
+Make all `streamlit.*` logs controllable through the standard
+`logging.getLogger("streamlit")` hierarchy while preserving Streamlit's automatic console
+logging when it runs an app. Add an opt-in handler policy for applications that run
+`st.App` through an external ASGI server or embed it in another framework, without allowing
+Streamlit logs to disappear when the host has not configured logging.
+
+## Problem
+
+[#4742](https://github.com/streamlit/streamlit/issues/4742) describes a long-standing
+limitation in Streamlit's logging strategy. Each internal module logger gets its own level,
+formatter, `StreamHandler`, and `propagate=False`. Consequently, the standard customization
+point does not work:
+
+```python
+import logging
+
+streamlit_logger = logging.getLogger("streamlit")
+streamlit_logger.setLevel(logging.DEBUG)
+streamlit_logger.addHandler(my_handler)
+```
+
+The parent logger neither controls the effective level of `streamlit.*` children nor
+receives their records. Users that need structured logging, test capture, filtering, or
+centralized observability must find and rewrite every existing child logger or monkeypatch
+private `streamlit.logger` functions. The issue includes such a workaround.
+
+[#3978](https://github.com/streamlit/streamlit/issues/3978) stopped Streamlit's special
+`"root"` logger from configuring Python's global root logger, but did not change the
+per-child handler topology.
+
+Streamlit is also no longer started through one path. It can run as:
+
+- a traditional app through `streamlit run`;
+- an `st.App` discovered by `streamlit run` and served by Streamlit's Uvicorn runner;
+- an `st.App` launched through `App.run()`;
+- a standalone ASGI app launched by external Uvicorn, Gunicorn, or Hypercorn; or
+- an app mounted in FastAPI, Starlette, or another ASGI framework.
+
+The first three modes are applications whose server lifecycle is owned by Streamlit. They
+must keep useful, formatted logs without requiring Python logging setup. The latter two
+modes run inside a host application that may need to own formatting and delivery. Treating
+all imports as a passive library would break Streamlit's app-first experience, while always
+installing isolated child handlers interferes with embedded hosts.
+
+The current strategy also configures `uvicorn.*` and `websockets` through Streamlit's
+generic logger helper. Uvicorn subsequently applies its own logging configuration, which
+can overwrite levels, remove handlers while leaving propagation disabled, or create
+duplicates after Streamlit reloads its config.
+
+Related requests such as per-message filtering
+([#11645](https://github.com/streamlit/streamlit/issues/11645)), logging to a file
+([#4539](https://github.com/streamlit/streamlit/issues/4539)), and rendering logs inside a
+Streamlit app ([#13610](https://github.com/streamlit/streamlit/issues/13610)) demonstrate
+broader logging interest but are not required to fix the hierarchy and ownership problem.
+
+## Proposal
+
+### Default behavior
+
+All Streamlit-owned log records use the standard `streamlit` namespace hierarchy:
+
+```text
+streamlit
+├── streamlit.config
+├── streamlit.runtime
+│   ├── streamlit.runtime.app_session
+│   └── streamlit.runtime.scriptrunner
+└── streamlit.web
+```
+
+Streamlit installs at most one default console handler on the `streamlit` namespace. Child
+loggers do not install handlers and propagate records to the namespace logger. Existing
+configuration continues to control the built-in handler:
+
+```toml
+[logger]
+level = "info"
+messageFormat = "%(asctime)s %(message)s"
+```
+
+For existing apps, the following remain unchanged:
+
+- which Streamlit records are visible at the default level;
+- the default format, timestamp behavior, and stderr destination;
+- development-mode `DEBUG` logging;
+- runtime config reloads;
+- uncaught app exception logging;
+- direct-execution warnings from using `st.*` outside a Streamlit runtime; and
+- isolation from unrelated Python root logs.
+
+The intentionally changed behavior is the private topology of child logger handlers. Code
+that inspects `logging.getLogger("streamlit.runtime...").handlers` is not a supported API.
+
+### Handler policy configuration
+
+Add a config option with a compatibility-first default:
+
+```toml
+[logger]
+handlerMode = "streamlit"
+```
+
+| Value | Behavior |
+|---|---|
+| `"streamlit"` | Install Streamlit's default namespace handler. This is the initial default and preserves existing output in every launch mode. |
+| `"auto"` | Use Streamlit's handler in Streamlit-managed launches. In externally hosted launches, use host logging when configured and otherwise install Streamlit's handler as a fallback. |
+| `"host"` | Do not install a Streamlit output handler. Propagate `streamlit.*` records to host logging. |
+
+`"host"` is an explicit ownership transfer. If the host has no usable handler, records may
+be discarded. `logger.level` and `logger.messageFormat` configure only Streamlit's default
+output path; the host owns levels, filters, formatting, and destinations in host mode.
+
+An enum is preferred over `enableDefaultHandler = true/false` because it distinguishes an
+explicit host-owned policy from the cooperative fallback needed by external ASGI servers
+that have not configured Python's root logger.
+
+### Launch-mode behavior
+
+| Launch mode | `handlerMode="streamlit"` | `handlerMode="auto"` | `handlerMode="host"` |
+|---|---|---|---|
+| `streamlit run app.py` | Streamlit handler | Streamlit handler | Host handler |
+| `streamlit run` with `st.App`/ASGI discovery | Streamlit handler | Streamlit handler | Host handler |
+| `App.run()` | Streamlit handler | Streamlit handler | Host handler |
+| External `uvicorn module:app` | Streamlit handler | Host handler if present; otherwise Streamlit fallback | Host handler |
+| `st.App` mounted in FastAPI/Starlette | Streamlit handler | Host handler if present; otherwise Streamlit fallback | Host handler |
+
+The initial default remains `"streamlit"` so upgrades do not change console output for
+existing self-hosted or embedded deployments. Making `"auto"` the default can be evaluated
+in a future major release after users have had a deprecation period and the external modes
+have sufficient integration coverage.
+
+### Examples
+
+Use the host application's JSON logging for an embedded app:
+
+```toml
+[logger]
+handlerMode = "host"
+```
+
+```python
+import logging.config
+
+import streamlit as st
+from fastapi import FastAPI
+
+logging.config.dictConfig(
+    {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "handlers": {
+            "json": {
+                "class": "logging.StreamHandler",
+                "formatter": "json",
+            }
+        },
+        "formatters": {
+            "json": {
+                "format": '{"level":"%(levelname)s","logger":"%(name)s","message":"%(message)s"}'
+            }
+        },
+        "root": {"level": "INFO", "handlers": ["json"]},
+    }
+)
+
+streamlit_app = st.App("dashboard.py")
+app = FastAPI(lifespan=streamlit_app.lifespan())
+app.mount("/dashboard", streamlit_app)
+```
+
+Use cooperative detection for an app that may run standalone or embedded:
+
+```toml
+[logger]
+handlerMode = "auto"
+```
+
+The same launcher keeps Streamlit's normal console logs with `App.run()` and integrates
+with host logging under external Uvicorn or FastAPI.
+
+### Behavior guarantees
+
+- Streamlit warnings and errors reach at least one handler in `"streamlit"` and `"auto"`
+  modes.
+- Streamlit never removes, reformats, or replaces handlers it does not own.
+- Repeated config parsing does not increase handler counts.
+- Streamlit does not create duplicate delivery paths. A host can still create duplicates by
+  attaching its own handlers at multiple levels of the hierarchy.
+- Python's global root logger is never configured by Streamlit.
+- Loggers created by the user's app and unrelated libraries are not configured by
+  Streamlit.
+- Externally owned Uvicorn, Gunicorn, Hypercorn, and WebSockets loggers are not configured
+  by Streamlit.
+- Streamlit-managed Uvicorn continues to emit server logs and respects `logger.level`.
+
+### Why this shape
+
+- A namespace handler fixes the underlying interoperability issue rather than adding more
+  Streamlit-specific logging APIs. Standard `logging`, `dictConfig`, and observability
+  tooling can target `streamlit`; host mode also supports root-based test capture.
+- Keeping `"streamlit"` as the default reflects the way Streamlit is normally used: users
+  start an app and expect diagnostics without first configuring a host process.
+- Separating launch context from handler policy avoids guessing from import context. An
+  `st.App` object can be run directly, served by Uvicorn, or mounted after it is created.
+- `"auto"` needs a fallback because an ASGI server can configure only its own logger
+  namespaces and leave the Python root logger without an output handler.
+- `"host"` gives embedded applications deterministic control when fallback output would be
+  undesirable, such as JSON logging or centralized filtering.
+- Leaving externally owned server loggers alone avoids ordering conflicts with Uvicorn,
+  Gunicorn, Hypercorn, and their reload behavior.
+
+### Options considered
+
+**Option A: Configure only a `NullHandler` when Streamlit is imported**
+
+- Pros: Strictest interpretation of Python library guidance.
+- Cons: Breaks the default app experience, misses `App.run()`, and can make logs disappear
+  under external Uvicorn when the host has not configured the global root logger.
+
+**Option B: One Streamlit namespace handler in every mode**
+
+- Pros: Small, preserves output, and fixes parent logger control.
+- Cons: Does not provide a clean ownership model for embedded applications.
+
+**Option C: Namespace handler plus an enum policy** ✅ PREFERRED
+
+- Pros: Preserves app defaults, supports external and embedded hosts, provides a fallback,
+  and can evolve without another boolean option.
+- Cons: Adds one config option and requires launch-mode-aware initialization.
+
+## Out of Scope (Future Work)
+
+- Logging Streamlit records to a file; applications can use standard `FileHandler` once
+  the hierarchy works.
+- A Streamlit-specific public API for filters, handlers, or structured logging.
+- Rendering Python logs as elements in the Streamlit UI.
+- Changing individual log messages or their severity.
+- Adding request/access logging, correlation IDs, session IDs, or user identity to records.
+- Making `handlerMode="auto"` the default.
+- Reconfiguring logging libraries owned by external ASGI servers.
+- Configuring logs emitted by the user's app or unrelated libraries.
+
+## Checklist
+
+| Item | ✅ or comment |
+|---|---|
+| Works on SiS, Cloud, etc? | ✅ Default remains Streamlit-owned logging. Hosted runtimes can explicitly select `"host"` or `"auto"`. |
+| No breaking API changes | ✅ Additive config option; existing level, format, and default output remain. Private child-handler topology changes. |
+| No new dependencies | ✅ Uses Python's standard `logging` package and existing Uvicorn integration. |
+| Metrics collected | No new telemetry in the first implementation. The resolved handler policy may be useful diagnostic context but must not include log content. |
+| Any security/legal impact? | ✅ No log content, retention, or transport changes. Host mode may route existing records to host-configured destinations. |
+| Any docs changes needed? | ✅ Document `logger.handlerMode`, standard `logging.getLogger("streamlit")` customization, and examples for `App.run()`, external Uvicorn, and mounted FastAPI. |

--- a/specs/2026-08-23-logging-strategy/product-spec.md
+++ b/specs/2026-08-23-logging-strategy/product-spec.md
@@ -103,11 +103,14 @@ policy; use `handlerMode="host"` for host-owned output. Code that inspects priva
 `.handlers` is not a supported API.
 
 Handlers attached directly to the namespace receive child records under every policy.
-Handlers attached only to Python's root logger, including pytest's `caplog`, require
-`handlerMode="host"` in ordinary tests. Host-selected `"auto"` also reaches root, but only
-after an external/embedded ASGI launch activates that policy. In `"streamlit"` and fallback
-`"auto"`, `logger.level` remains authoritative whenever config is parsed or reloaded;
-programmatic `Logger.setLevel` changes are not durable in those modes.
+
+- Handlers attached only to Python's root logger, including pytest's `caplog`, require
+  `handlerMode="host"` in ordinary tests. Host-selected `"auto"` also reaches root, but only
+  after an external or embedded ASGI launch activates that policy.
+- In `"streamlit"` and fallback `"auto"`, `logger.level` sets the initial namespace level.
+  A later programmatic `Logger.setLevel` override survives unrelated config reloads. An
+  explicit change to `logger.level`, or reacquiring Streamlit ownership, reapplies the
+  configured level.
 
 ### Handler policy configuration
 
@@ -150,8 +153,8 @@ that have not configured Python's root logger.
 
 The initial default remains `"streamlit"` so upgrades do not change console output for
 existing self-hosted or embedded deployments. Making `"auto"` the default can be evaluated
-in a future major release after users have had a deprecation period and the external modes
-have sufficient integration coverage.
+in a future major release once external modes have sufficient integration coverage and the
+change has been announced in release notes.
 
 External Uvicorn's default configuration normally installs handlers only on `uvicorn.*`,
 not on Python's root logger. In that common case, `"auto"` deliberately keeps Streamlit's
@@ -184,11 +187,11 @@ streamlit_logger.addHandler(file_handler)
 
 With the default `handlerMode="streamlit"`, this intentionally produces two destinations:
 Streamlit's existing console output and `streamlit.log`. Select `"host"` when the custom
-handler should replace Streamlit's destination. The `setLevel` call takes effect
-immediately, but `logger.level` is reapplied on Streamlit config parse/reload; configure
-that option or select host ownership for a durable level. If both a namespace handler and a
-root handler exist, the host must set `streamlit_logger.propagate=False` to avoid emitting
-to both. Streamlit never removes or rewrites either host handler.
+handler should replace Streamlit's destination. The `setLevel` call survives unrelated
+config reloads. An explicit change to `logger.level`, or a transition that reacquires
+Streamlit ownership, reapplies the configured level. If both a namespace handler and a root
+handler exist, the host must set `streamlit_logger.propagate=False` to avoid emitting to
+both. Streamlit never removes or rewrites either host handler.
 
 The config option can be supplied through `config.toml`,
 `STREAMLIT_LOGGER_HANDLER_MODE`, or `--logger.handlerMode`; no new Python configuration API
@@ -308,8 +311,9 @@ sole exception destination.
 
 ### Behavior guarantees
 
-- Streamlit warnings and errors emitted by enabled loggers reach at least one handler in
-  `"streamlit"` and `"auto"` modes. A host can still suppress a specific logger with
+- In `"streamlit"` and fallback `"auto"`, Streamlit warnings and errors emitted by enabled
+  loggers reach Streamlit's handler. In host-selected `"auto"`, records reach the host path,
+  where the host owns levels and filters. A host can suppress a specific logger with
   `Logger.disabled`.
 - Streamlit never removes, reformats, or replaces handlers it does not own.
 - Repeated config parsing does not increase handler counts.

--- a/specs/2026-08-23-logging-strategy/product-spec.md
+++ b/specs/2026-08-23-logging-strategy/product-spec.md
@@ -9,9 +9,9 @@ created: 2026-08-23
 
 Make all `streamlit.*` logs controllable through the standard
 `logging.getLogger("streamlit")` hierarchy while preserving Streamlit's automatic console
-logging when it runs an app. Add an opt-in handler policy for applications that run
-`st.App` through an external ASGI server or embed it in another framework, without allowing
-Streamlit logs to disappear when the host has not configured logging.
+logging when it runs an app. Add `logger.handlerMode` (`"streamlit"`, `"auto"`, or
+`"host"`) for applications that run `st.App` through an external ASGI server or embed it in
+another framework, with a cooperative fallback when the host has not configured logging.
 
 ## Problem
 
@@ -102,6 +102,10 @@ that inspects `logging.getLogger("streamlit.runtime...").handlers` is not a supp
 The customization shown in the problem statement now works: adding a handler to the
 namespace adds a destination alongside Streamlit's default console handler. Use
 `handlerMode="host"` when the namespace or root handler should be the only destination.
+Handlers attached directly to `logging.getLogger("streamlit")` receive child records under
+every policy. Handlers attached only to Python's root logger, including pytest's `caplog`,
+still require `handlerMode="host"` or host-selected `"auto"` because the compatibility
+default remains isolated from root.
 
 ### Handler policy configuration
 
@@ -122,7 +126,7 @@ handlerMode = "streamlit"
 be discarded. `logger.level` and `logger.messageFormat` configure only Streamlit's default
 output path; the host owns levels, filters, formatting, and destinations in host mode.
 
-An enum is preferred over `enableDefaultHandler = true/false` because it distinguishes an
+Prefer an enum over `enableDefaultHandler = true/false` because it distinguishes an
 explicit host-owned policy from the cooperative fallback needed by external ASGI servers
 that have not configured Python's root logger.
 
@@ -146,6 +150,9 @@ not on Python's root logger. In that common case, `"auto"` deliberately keeps St
 fallback and behaves like `"streamlit"`. The value is useful when one deployment artifact
 can either call `App.run()` or be embedded in a host that configures a root or `streamlit`
 handler. Applications that always want external ownership should use `"host"`.
+This spec proposes shipping all three values in the first release. `"auto"` is included for
+hybrid launchers, while its compatibility fallback and the deterministic `"host"` option
+keep the initial default and embedded behavior explicit.
 
 ### Examples
 
@@ -165,10 +172,9 @@ streamlit_logger.addHandler(file_handler)
 With the default `handlerMode="streamlit"`, this intentionally produces two destinations:
 Streamlit's existing console output and `streamlit.log`. Select `"host"` when the custom
 handler should be the only output path. The config option can be supplied through
-`config.toml`, the equivalent `STREAMLIT_LOGGER_HANDLER_MODE` environment variable, or the
-applicable Streamlit CLI option; no new Python configuration API is introduced. As with
-other Streamlit config, removing the owned handler directly in Python is not durable across
-a config reload.
+`config.toml`, `STREAMLIT_LOGGER_HANDLER_MODE`, or `--logger.handlerMode`; no new Python
+configuration API is introduced. As with other Streamlit config, removing the owned handler
+directly in Python is not durable across a config reload.
 
 Use the host application's JSON logging exclusively for an embedded app:
 
@@ -239,8 +245,9 @@ selected handler policy.
 
 ### Behavior guarantees
 
-- Streamlit warnings and errors reach at least one handler in `"streamlit"` and `"auto"`
-  modes.
+- Streamlit warnings and errors emitted by enabled loggers reach at least one handler in
+  `"streamlit"` and `"auto"` modes. A host can still suppress a specific logger with
+  `Logger.disabled`.
 - Streamlit never removes, reformats, or replaces handlers it does not own.
 - Repeated config parsing does not increase handler counts.
 - Streamlit-owned configuration does not create duplicate delivery paths. Adding a custom

--- a/specs/2026-08-23-logging-strategy/product-spec.md
+++ b/specs/2026-08-23-logging-strategy/product-spec.md
@@ -97,15 +97,17 @@ For existing apps, the following remain unchanged:
 - direct-execution warnings from using `st.*` outside a Streamlit runtime; and
 - isolation from unrelated Python root logs.
 
-The intentionally changed behavior is the private topology of child logger handlers. Code
-that inspects `logging.getLogger("streamlit.runtime...").handlers` is not a supported API.
-The customization shown in the problem statement now works: adding a handler to the
-namespace adds a destination alongside Streamlit's default console handler. Use
-`handlerMode="host"` when the namespace or root handler should be the only destination.
-Handlers attached directly to `logging.getLogger("streamlit")` receive child records under
-every policy. Handlers attached only to Python's root logger, including pytest's `caplog`,
-still require `handlerMode="host"` or host-selected `"auto"` because the compatibility
-default remains isolated from root.
+The user-visible change is that `logging.getLogger("streamlit")` now receives and can
+control `streamlit.*` child records. Adding a handler there is additive under the default
+policy; use `handlerMode="host"` for host-owned output. Code that inspects private child
+`.handlers` is not a supported API.
+
+Handlers attached directly to the namespace receive child records under every policy.
+Handlers attached only to Python's root logger, including pytest's `caplog`, require
+`handlerMode="host"` in ordinary tests. Host-selected `"auto"` also reaches root, but only
+after an external/embedded ASGI launch activates that policy. In `"streamlit"` and fallback
+`"auto"`, `logger.level` remains authoritative whenever config is parsed or reloaded;
+programmatic `Logger.setLevel` changes are not durable in those modes.
 
 ### Handler policy configuration
 
@@ -115,6 +117,10 @@ Add a config option with a compatibility-first default:
 [logger]
 handlerMode = "streamlit"
 ```
+
+The option is public and non-scriptable. It appears in `streamlit config show` and can be
+set through deployment configuration, but `st.set_option` cannot change process-wide
+logging ownership during a rerun.
 
 | Value | Behavior |
 |---|---|
@@ -178,10 +184,16 @@ streamlit_logger.addHandler(file_handler)
 
 With the default `handlerMode="streamlit"`, this intentionally produces two destinations:
 Streamlit's existing console output and `streamlit.log`. Select `"host"` when the custom
-handler should be the only output path. The config option can be supplied through
-`config.toml`, `STREAMLIT_LOGGER_HANDLER_MODE`, or `--logger.handlerMode`; no new Python
-configuration API is introduced. As with other Streamlit config, removing the owned handler
-directly in Python is not durable across a config reload.
+handler should replace Streamlit's destination. The `setLevel` call takes effect
+immediately, but `logger.level` is reapplied on Streamlit config parse/reload; configure
+that option or select host ownership for a durable level. If both a namespace handler and a
+root handler exist, the host must set `streamlit_logger.propagate=False` to avoid emitting
+to both. Streamlit never removes or rewrites either host handler.
+
+The config option can be supplied through `config.toml`,
+`STREAMLIT_LOGGER_HANDLER_MODE`, or `--logger.handlerMode`; no new Python configuration API
+is introduced. As with other Streamlit config, removing the owned handler directly in
+Python is not durable across a config reload.
 
 Making output ownership a deployment setting is intentional. Python launchers can select
 exclusive host output before importing Streamlit:
@@ -194,6 +206,10 @@ os.environ["STREAMLIT_LOGGER_HANDLER_MODE"] = "host"
 import streamlit as st
 ```
 
+The implementation must read this specific non-sensitive environment variable directly in
+the config loader so it works under `python`, external Uvicorn, and mounted ASGI launches,
+not only through Click's `streamlit` command.
+
 `App.run(config={"logger.handlerMode": "host"})` provides the corresponding existing
 programmatic config channel. Import-time diagnostics still use the isolated bootstrap
 handler until Streamlit validates and applies config. Isolation prevents delivery to a
@@ -205,6 +221,7 @@ Use the host application's JSON logging exclusively for an embedded app:
 ```toml
 [logger]
 handlerMode = "host"
+enableRich = false
 ```
 
 ```python
@@ -278,6 +295,16 @@ Streamlit-owned in every handler mode to preserve existing exception presentatio
 that requires uncaught exceptions to use only its structured logging path must set
 `logger.enableRich=false`; the fallback `streamlit.error_util` log record then follows the
 selected handler policy.
+
+### Managed server logs
+
+`handlerMode` governs `streamlit.*` records, not server records. In `streamlit run` and
+`App.run()`, Streamlit's managed Uvicorn runner still installs Uvicorn's native console
+handlers and applies `logger.level`; selecting `"host"` does not remove them. Applications
+that require one host-owned format for both Streamlit and server records should use an
+external ASGI server with host logging configuration, or explicitly configure its
+`uvicorn.*` namespaces. Rich output must also be disabled for standard logging to be the
+sole exception destination.
 
 ### Behavior guarantees
 
@@ -355,9 +382,14 @@ selected handler policy.
 
 | Item | ✅ or comment |
 |---|---|
-| Works on SiS, Cloud, etc? | ✅ Default remains Streamlit-owned logging. Hosted runtimes can explicitly select `"host"` or `"auto"`. |
+| Works on SiS, Cloud, etc? | ✅ Default remains Streamlit-owned logging. Before implementation, confirm SiS/SPCS and Community Cloud do not depend on per-child handlers or `streamlit_console_handler`. |
 | No breaking API changes | ✅ Additive config option; existing level, format, and default output remain. Private child-handler topology changes. |
 | No new dependencies | ✅ Uses Python's standard `logging` package and existing Uvicorn integration. |
 | Metrics collected | No new telemetry in the first implementation. The resolved handler policy may be useful diagnostic context but must not include log content. |
 | Any security/legal impact? | ✅ No log content, retention, or transport changes. Host mode may route existing records to host-configured destinations. |
-| Any docs changes needed? | ✅ Document `logger.handlerMode`, standard `logging.getLogger("streamlit")` customization, and examples for `App.run()`, external Uvicorn, and mounted FastAPI. |
+| Any docs changes needed? | ✅ Document `logger.handlerMode`, standard namespace customization, managed-Uvicorn scope, and examples for `App.run()`, external Uvicorn, mounted FastAPI, and pytest `caplog`. |
+
+The pytest documentation should show two valid capture patterns: select `"host"` through
+session configuration before importing Streamlit so root-based `caplog` works, or attach a
+capture handler directly to `logging.getLogger("streamlit")` when retaining the default
+console destination is acceptable.

--- a/specs/2026-08-23-logging-strategy/product-spec.md
+++ b/specs/2026-08-23-logging-strategy/product-spec.md
@@ -123,8 +123,10 @@ handlerMode = "streamlit"
 | `"host"` | Do not install a Streamlit output handler. Propagate `streamlit.*` records to host logging. |
 
 `"host"` is an explicit ownership transfer. If the host has no usable handler, records may
-be discarded. `logger.level` and `logger.messageFormat` configure only Streamlit's default
-output path; the host owns levels, filters, formatting, and destinations in host mode.
+be discarded below `WARNING`; `WARNING` and higher may use Python's minimally formatted
+`lastResort` output. Streamlit does not install that handler. `logger.level` and
+`logger.messageFormat` configure only Streamlit's default output path; the host owns levels,
+filters, formatting, and destinations in host mode.
 
 Prefer an enum over `enableDefaultHandler = true/false` because it distinguishes an
 explicit host-owned policy from the cooperative fallback needed by external ASGI servers
@@ -134,11 +136,11 @@ that have not configured Python's root logger.
 
 | Launch mode | `handlerMode="streamlit"` | `handlerMode="auto"` | `handlerMode="host"` |
 |---|---|---|---|
-| `streamlit run app.py` | Streamlit handler | Streamlit handler | Host handler |
-| `streamlit run` with `st.App`/ASGI discovery | Streamlit handler | Streamlit handler | Host handler |
-| `App.run()` | Streamlit handler | Streamlit handler | Host handler |
-| External `uvicorn module:app` | Streamlit handler | Host handler if present; otherwise Streamlit fallback | Host handler |
-| `st.App` mounted in FastAPI/Starlette | Streamlit handler | Host handler if present; otherwise Streamlit fallback | Host handler |
+| `streamlit run app.py` | Streamlit handler | Streamlit handler | No Streamlit handler; propagate to host |
+| `streamlit run` with `st.App`/ASGI discovery | Streamlit handler | Streamlit handler | No Streamlit handler; propagate to host |
+| `App.run()` | Streamlit handler | Streamlit handler | No Streamlit handler; propagate to host |
+| External `uvicorn module:app` | Streamlit handler | Host handler if present; otherwise Streamlit fallback | No Streamlit handler; propagate to host |
+| `st.App` mounted in FastAPI/Starlette | Streamlit handler | Host handler if present; otherwise Streamlit fallback | No Streamlit handler; propagate to host |
 
 The initial default remains `"streamlit"` so upgrades do not change console output for
 existing self-hosted or embedded deployments. Making `"auto"` the default can be evaluated
@@ -153,6 +155,11 @@ handler. Applications that always want external ownership should use `"host"`.
 This spec proposes shipping all three values in the first release. `"auto"` is included for
 hybrid launchers, while its compatibility fallback and the deterministic `"host"` option
 keep the initial default and embedded behavior explicit.
+
+A concrete hybrid is a packaged app that developers start locally with `App.run()` and no
+Python logging setup, while production mounts the same app in FastAPI with a root JSON
+handler. `"host"` would lose the automatic local diagnostics, while `"streamlit"` would add
+a second production destination. `"auto"` serves both from one deployment configuration.
 
 ### Examples
 
@@ -176,6 +183,23 @@ handler should be the only output path. The config option can be supplied throug
 configuration API is introduced. As with other Streamlit config, removing the owned handler
 directly in Python is not durable across a config reload.
 
+Making output ownership a deployment setting is intentional. Python launchers can select
+exclusive host output before importing Streamlit:
+
+```python
+import os
+
+os.environ["STREAMLIT_LOGGER_HANDLER_MODE"] = "host"
+
+import streamlit as st
+```
+
+`App.run(config={"logger.handlerMode": "host"})` provides the corresponding existing
+programmatic config channel. Import-time diagnostics still use the isolated bootstrap
+handler until Streamlit validates and applies config. Isolation prevents delivery to a
+root-only host during that window; a handler attached directly to the namespace receives
+the records alongside the bootstrap handler.
+
 Use the host application's JSON logging exclusively for an embedded app:
 
 ```toml
@@ -184,7 +208,21 @@ handlerMode = "host"
 ```
 
 ```python
+import json
+import logging
 import logging.config
+
+
+class JsonFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        return json.dumps(
+            {
+                "level": record.levelname,
+                "logger": record.name,
+                "message": record.getMessage(),
+            }
+        )
+
 
 logging.config.dictConfig(
     {
@@ -197,9 +235,7 @@ logging.config.dictConfig(
             }
         },
         "formatters": {
-            "json": {
-                "format": '{"level":"%(levelname)s","logger":"%(name)s","message":"%(message)s"}'
-            }
+            "json": {"()": JsonFormatter},
         },
         "root": {"level": "INFO", "handlers": ["json"]},
     }
@@ -294,6 +330,14 @@ selected handler policy.
 - Pros: Preserves app defaults, supports external and embedded hosts, provides a fallback,
   and can evolve without another boolean option.
 - Cons: Adds one config option and requires launch-mode-aware initialization.
+
+**Option D: Suppress Streamlit output whenever a custom namespace handler exists**
+
+- Pros: A handler added in Python could become the only destination without selecting a
+  handler policy.
+- Cons: Merely attaching an observability or test handler would silently remove the console
+  output that existing apps expect. Handler attachment is commonly additive, so ownership
+  remains an explicit deployment setting.
 
 ## Out of Scope (Future Work)
 

--- a/specs/2026-08-23-logging-strategy/product-spec.md
+++ b/specs/2026-08-23-logging-strategy/product-spec.md
@@ -93,12 +93,15 @@ For existing apps, the following remain unchanged:
 - the default format, timestamp behavior, and stderr destination;
 - development-mode `DEBUG` logging;
 - runtime config reloads;
-- uncaught app exception logging;
+- uncaught app exception presentation (including the existing Rich traceback behavior);
 - direct-execution warnings from using `st.*` outside a Streamlit runtime; and
 - isolation from unrelated Python root logs.
 
 The intentionally changed behavior is the private topology of child logger handlers. Code
 that inspects `logging.getLogger("streamlit.runtime...").handlers` is not a supported API.
+The customization shown in the problem statement now works: adding a handler to the
+namespace adds a destination alongside Streamlit's default console handler. Use
+`handlerMode="host"` when the namespace or root handler should be the only destination.
 
 ### Handler policy configuration
 
@@ -138,9 +141,36 @@ existing self-hosted or embedded deployments. Making `"auto"` the default can be
 in a future major release after users have had a deprecation period and the external modes
 have sufficient integration coverage.
 
+External Uvicorn's default configuration normally installs handlers only on `uvicorn.*`,
+not on Python's root logger. In that common case, `"auto"` deliberately keeps Streamlit's
+fallback and behaves like `"streamlit"`. The value is useful when one deployment artifact
+can either call `App.run()` or be embedded in a host that configures a root or `streamlit`
+handler. Applications that always want external ownership should use `"host"`.
+
 ### Examples
 
-Use the host application's JSON logging for an embedded app:
+Add a custom destination through the standard namespace:
+
+```python
+import logging
+
+import streamlit as st
+
+file_handler = logging.FileHandler("streamlit.log")
+streamlit_logger = logging.getLogger("streamlit")
+streamlit_logger.setLevel(logging.DEBUG)
+streamlit_logger.addHandler(file_handler)
+```
+
+With the default `handlerMode="streamlit"`, this intentionally produces two destinations:
+Streamlit's existing console output and `streamlit.log`. Select `"host"` when the custom
+handler should be the only output path. The config option can be supplied through
+`config.toml`, the equivalent `STREAMLIT_LOGGER_HANDLER_MODE` environment variable, or the
+applicable Streamlit CLI option; no new Python configuration API is introduced. As with
+other Streamlit config, removing the owned handler directly in Python is not durable across
+a config reload.
+
+Use the host application's JSON logging exclusively for an embedded app:
 
 ```toml
 [logger]
@@ -149,9 +179,6 @@ handlerMode = "host"
 
 ```python
 import logging.config
-
-import streamlit as st
-from fastapi import FastAPI
 
 logging.config.dictConfig(
     {
@@ -172,10 +199,21 @@ logging.config.dictConfig(
     }
 )
 
+import streamlit as st
+from fastapi import FastAPI
+
 streamlit_app = st.App("dashboard.py")
 app = FastAPI(lifespan=streamlit_app.lifespan())
 app.mount("/dashboard", streamlit_app)
 ```
+
+Configure host logging before importing Streamlit when possible. Import installs an
+isolated bootstrap handler so early diagnostics remain visible until Streamlit parses
+`handlerMode`; those early records use Streamlit's format and do not also propagate to the
+host. Keep `disable_existing_loggers=False` when reconfiguring after import. Python's
+`dictConfig` default can disable loggers that already exist, and Streamlit does not
+re-enable them. Because `Logger.disabled` applies to an individual logger rather than its
+descendants, it should not be used as a namespace ownership mechanism.
 
 Use cooperative detection for an app that may run standalone or embedded:
 
@@ -185,7 +223,19 @@ handlerMode = "auto"
 ```
 
 The same launcher keeps Streamlit's normal console logs with `App.run()` and integrates
-with host logging under external Uvicorn or FastAPI.
+with host logging under FastAPI when the host configures a root or `streamlit` handler.
+Under external Uvicorn's default logging configuration, no such host path normally exists,
+so Streamlit retains its fallback.
+
+### Rich exception output
+
+`handlerMode` governs records emitted through Python's `logging` package. The existing
+Rich traceback path for uncaught app exceptions writes directly to its own console and
+remains independently controlled by the hidden `logger.enableRich` option. It stays
+Streamlit-owned in every handler mode to preserve existing exception presentation. A host
+that requires uncaught exceptions to use only its structured logging path must set
+`logger.enableRich=false`; the fallback `streamlit.error_util` log record then follows the
+selected handler policy.
 
 ### Behavior guarantees
 
@@ -193,8 +243,9 @@ with host logging under external Uvicorn or FastAPI.
   modes.
 - Streamlit never removes, reformats, or replaces handlers it does not own.
 - Repeated config parsing does not increase handler counts.
-- Streamlit does not create duplicate delivery paths. A host can still create duplicates by
-  attaching its own handlers at multiple levels of the hierarchy.
+- Streamlit-owned configuration does not create duplicate delivery paths. Adding a custom
+  handler with the default `"streamlit"` policy intentionally adds another destination; a
+  host can also create duplicates by attaching handlers at multiple hierarchy levels.
 - Python's global root logger is never configured by Streamlit.
 - Loggers created by the user's app and unrelated libraries are not configured by
   Streamlit.

--- a/specs/2026-08-23-logging-strategy/tech-spec.md
+++ b/specs/2026-08-23-logging-strategy/tech-spec.md
@@ -30,9 +30,9 @@ See the [product spec](./product-spec.md) for user-facing behavior and the propo
 
 It also stores every logger in a private `_loggers` dictionary. `set_log_level` and
 `update_formatter` iterate this registry and mutate every logger independently. There are
-currently 77 `get_logger` call sites across 67 Streamlit consumer files. Importing
-`streamlit` creates approximately 52 child handlers before an app starts, and parsing config
-adds more.
+roughly 80 `get_logger` call sites across roughly 70 Streamlit consumer files. Importing
+`streamlit` creates dozens of child handlers before an app starts, and parsing config adds
+more.
 
 This bypasses the standard hierarchy:
 
@@ -84,7 +84,8 @@ state. A later Streamlit config reload can add another handler alongside Uvicorn
 - Emit each record once per configured destination.
 - Support host-controlled logging for external and embedded ASGI modes.
 - Keep a fallback in cooperative mode when the host has no usable handler.
-- Configure Uvicorn/WebSockets only when Streamlit owns the server runner.
+- Configure Uvicorn only when Streamlit owns the server runner, and leave WebSockets
+  logging to the library or host in every mode.
 - Make config reload idempotent and preserve user-owned logging state.
 
 ## Non-goals
@@ -119,9 +120,7 @@ handler. Cooperative handler detection must ignore `NullHandler` instances.
 ```python
 def get_logger(name: str) -> logging.Logger:
     resolved_name = _NAMESPACE_LOGGER_NAME if name == "root" else name
-    logger = logging.getLogger(resolved_name)
-    _loggers.setdefault(name, logger)  # temporary private compatibility only
-    return logger
+    return logging.getLogger(resolved_name)
 ```
 
 It does not set a level, attach a handler, or change propagation. Existing call sites can
@@ -130,8 +129,9 @@ remain unchanged in the first implementation. The `"root"` alias continues to re
 
 Fresh child loggers retain the standard `level=NOTSET` and `propagate=True`, so their
 effective level comes from the namespace logger. Explicit user configuration on a child is
-respected. `_loggers` no longer owns behavior and can be removed in a later cleanup after
-private integrations have migrated.
+respected. Remove the private `_loggers` registry in the first implementation: after
+centralizing level and formatter updates it has no behavior or remaining consumer, and
+retaining it would accumulate logger references for the life of the process.
 
 Record flow with Streamlit's handler:
 
@@ -177,7 +177,7 @@ config is available, `apply_logging_config()` resolves the effective policy:
 | `logger.handlerMode` | Launch context | Effective policy |
 |---|---|---|
 | `streamlit` | Any | `STREAMLIT` |
-| `auto` | Context not known yet | `STREAMLIT` fallback |
+| `auto` | `UNCONFIGURED` | `STREAMLIT` fallback |
 | `auto` | Streamlit-managed launch | `STREAMLIT` |
 | `auto` | External/embedded launch | `COOPERATIVE` |
 | `host` | Any | `HOST` |
@@ -186,6 +186,8 @@ The initial config default is `streamlit`, preserving current output. A not-yet-
 context is conservative so code that reads Streamlit config before choosing a launcher
 does not lose diagnostics. The launch context is still implemented now so `auto` works
 correctly and a future default change does not require another architecture migration.
+The `logger.handlerMode` config option must explicitly validate membership in the three
+documented values and report an actionable Streamlit config error before resolving policy.
 
 `STREAMLIT_MANAGED` is authoritative for the process once selected by the CLI or
 `App.run()`. An `st.App` mounted inside an ASGI app discovered by `streamlit run` must not
@@ -195,20 +197,23 @@ detection only replaces `UNCONFIGURED`, while `App.run()` may promote an unstart
 
 ### Bootstrapping before config parsing
 
-Under the module policy lock, module initialization atomically installs one Streamlit-owned
-namespace handler using `INFO`, `DEFAULT_LOG_MESSAGE`, and stderr, adds the permanent
-`NullHandler`, and sets namespace propagation to false. Isolation must be active before any
-record can reach the new handler. This replaces the dozens of handlers created during a
+Under the module policy lock, module initialization atomically (1) sets namespace
+propagation to false, (2) adds the permanent `NullHandler`, and (3) installs one
+Streamlit-owned namespace handler using `INFO`, `DEFAULT_LOG_MESSAGE`, and stderr. Setting
+isolation first prevents a root handler configured before `import streamlit` from receiving
+a second copy during initialization. This replaces the dozens of handlers created during a
 normal import while preserving import-time and config-parser diagnostics before
-`logger.level`, `logger.messageFormat`, and `logger.handlerMode` are known. It also prevents
-a root handler configured before `import streamlit` from receiving a second copy.
+`logger.level`, `logger.messageFormat`, and `logger.handlerMode` are known.
 
 After config parsing, `apply_logging_config` updates or removes only the owned handler:
 
 - `STREAMLIT`: retain the handler, set the namespace level and formatter from config, and
   set namespace propagation to false.
-- `COOPERATIVE`: remove the owned handler if a usable host path exists; otherwise retain it
-  as a fallback. Use the host's levels and format when the host path is selected.
+- `COOPERATIVE`: if a usable host path exists, remove the owned handler and apply the same
+  conditional `level=NOTSET` and `propagate=True` restoration as `HOST`, so host levels and
+  formatting are authoritative. Otherwise behave exactly like `STREAMLIT`: retain the
+  fallback, apply `logger.level` and `logger.messageFormat`, and keep namespace propagation
+  false.
 - `HOST`: remove the owned handler, use `level=NOTSET`, and propagate to the host.
 
 The bootstrap handler is deliberately used for config-parser diagnostics even when the
@@ -345,17 +350,22 @@ formatted warning and missing-`ScriptRunContext` diagnostics while an ordinary
 Remove `init_uvicorn_logs` from the global config callback.
 
 In the shared `_get_uvicorn_config_kwargs()` used by the traditional `UvicornServer` and
-the `st.App` `UvicornRunner`, pass the configured level directly to Uvicorn:
+the `st.App` `UvicornRunner`, pass the validated integer level directly to Uvicorn:
 
 ```python
 {
-    "log_level": config.get_option("logger.level"),
+    "log_level": normalized_log_level,
     # Existing kwargs, including access_log=False, remain unchanged.
     "access_log": False,
 }
 ```
 
 This lets Uvicorn apply its own handler configuration and level through its supported API.
+Use the same normalization and validation as the namespace logger. This accepts supported
+case-insensitive config values such as `INFO`, avoids Uvicorn's lowercase-only string map,
+and reports unknown values as an actionable Streamlit config error before constructing
+`uvicorn.Config`.
+
 On Streamlit config reload, a callback registered by the managed runner updates levels on
 the existing Uvicorn logger family without adding handlers or changing propagation.
 
@@ -386,12 +396,20 @@ state is introduced. Python logging's handler mutation APIs provide their own lo
 module should additionally guard policy transitions with one re-entrant lock so a config
 watcher cannot interleave with ASGI startup.
 
+Lock order is always Streamlit's `_config_lock` before the logging policy lock, and code
+holding the policy lock must never read Streamlit config. `apply_logging_config` receives
+an immutable snapshot containing the validated handler mode, integer log level, and message
+format. The config callback builds that snapshot while `_config_lock` is already held, then
+may take the policy lock. Lifespan and request reconciliation first snapshot config under
+`_config_lock`, release it, and only then take the policy lock. This prevents lock-order
+inversion between a reload and ASGI startup.
+
 ### Implementation sequence
 
 1. Centralize Streamlit's handler and level on the namespace logger while keeping
    `handlerMode="streamlit"` in all launch modes.
 2. Replace per-child logger tests with hierarchy and exactly-once tests.
-3. Move managed Uvicorn/WebSockets configuration into the runner.
+3. Move managed Uvicorn configuration into the runner and stop configuring WebSockets.
 4. Add launch-context activation before config/runtime initialization.
 5. Add `logger.handlerMode` and cooperative/host transitions.
 6. Document standard namespace customization and external hosting examples.
@@ -413,7 +431,7 @@ Intentional observable changes are limited to:
 - an explicit child level can override the inherited namespace level using standard Python
   semantics;
 - private inspection of child `.handlers` sees no Streamlit handler; and
-- external server libraries are no longer mutated by Streamlit; and
+- external server libraries are no longer mutated by Streamlit;
 - Streamlit no longer configures the third-party `websockets` logger, even in managed
   launches. Without a host/root handler, its independent records may use Python's
   `lastResort` behavior instead of Streamlit's level and format.
@@ -445,7 +463,8 @@ run in isolated subprocesses rather than rely only on in-process fixture cleanup
 - `get_logger(__name__)` returns the standard logger without adding a child handler.
 - Fresh `streamlit.*` children use `NOTSET` and propagate.
 - The `"root"` alias returns `logging.getLogger("streamlit")`.
-- Managed mode installs exactly one owned handler with the configured level and format.
+- Managed mode installs exactly one owned handler using the configured format, with the
+  configured level set on the namespace logger.
 - Repeated activation and config reload do not increase handler counts.
 - A custom namespace handler is never removed or reformatted.
 - Host mode removes only the owned handler and propagates records.
@@ -465,6 +484,8 @@ run in isolated subprocesses rather than rely only on in-process fixture cleanup
   the existing format.
 - `App.run()` has the same Streamlit logging behavior as `streamlit run`.
 - Streamlit-managed Uvicorn respects `logger.level` after `uvicorn.Config` initialization.
+- Managed Uvicorn accepts every case-insensitive `logger.level` supported by Streamlit and
+  rejects unknown values with Streamlit's config error rather than a Uvicorn `KeyError`.
 - External Uvicorn plus `handlerMode="auto"` uses a host JSON handler exactly once.
 - External Uvicorn with no host handler retains the Streamlit fallback.
 - Cooperative mode reconciles again at lifespan entry when host logging was configured
@@ -477,6 +498,8 @@ run in isolated subprocesses rather than rely only on in-process fixture cleanup
   does not re-enable any disabled logger or treat the flag as a cooperative host path.
 - Bare `st.write` retains the direct-execution and missing-context warnings.
 - A live config reload changes level/format or ownership without duplicating handlers.
+- A config reload racing ASGI lifespan reconciliation completes without deadlock and leaves
+  one policy-consistent output path.
 - With Rich enabled, uncaught exceptions retain their direct Rich console presentation;
   with Rich disabled, exactly one standard record follows the selected handler policy.
 

--- a/specs/2026-08-23-logging-strategy/tech-spec.md
+++ b/specs/2026-08-23-logging-strategy/tech-spec.md
@@ -8,7 +8,7 @@ created: 2026-08-23
 ## Summary
 
 Replace Streamlit's per-module handlers and logger registry behavior with one standard
-`streamlit` namespace handler. Introduce explicit managed, cooperative, and host-owned
+`streamlit` namespace handler. Introduce explicit managed, auto, and host-owned
 logging policies so `streamlit run`, `App.run()`, externally served `st.App`, and embedded
 ASGI apps keep useful logs without duplicate output or mutations to server loggers owned by
 another application.
@@ -83,7 +83,7 @@ state. A later Streamlit config reload can add another handler alongside Uvicorn
 - Make `logging.getLogger("streamlit")` the effective parent for all `streamlit.*` records.
 - Emit each record once per configured destination.
 - Support host-controlled logging for external and embedded ASGI modes.
-- Keep a fallback in cooperative mode when the host has no usable handler.
+- Keep a fallback in auto mode when the host has no usable handler.
 - Configure Uvicorn only when Streamlit owns the server runner, and leave WebSockets
   logging to the library or host in every mode.
 - Make config reload idempotent and preserve user-owned logging state.
@@ -174,13 +174,13 @@ class LoggingContext(Enum):
 
 class OutputPolicy(Enum):
     STREAMLIT = "streamlit"
-    COOPERATIVE = "cooperative"  # handlerMode="auto" in an external launch
+    AUTO = "auto"
     HOST = "host"
 ```
 
-`COOPERATIVE` is a detection step rather than a persistent topology: it immediately
-selects either the host-owned topology or the Streamlit fallback from the handler path
-visible in an external launch.
+`AUTO` is resolved at activation time rather than stored as a topology: Streamlit inspects
+the handler path visible in an external launch and immediately selects either host ownership
+or the Streamlit fallback.
 
 `activate_logging(context)` records the launch context before config is parsed. After
 config is available, `apply_logging_config()` resolves the effective policy:
@@ -190,7 +190,7 @@ config is available, `apply_logging_config()` resolves the effective policy:
 | `streamlit` | Any | `STREAMLIT` |
 | `auto` | `UNCONFIGURED` | `STREAMLIT` fallback |
 | `auto` | Streamlit-managed launch | `STREAMLIT` |
-| `auto` | External/embedded launch | `COOPERATIVE` |
+| `auto` | External/embedded launch | `AUTO`, then `HOST` or `STREAMLIT` fallback |
 | `host` | Any | `HOST` |
 
 The initial config default is `streamlit`, preserving current output. A not-yet-known
@@ -205,14 +205,24 @@ hidden, scriptable `logger.enableRich` option.
 
 Unlike other non-sensitive options, `logger.handlerMode` must also be read directly from
 `STREAMLIT_LOGGER_HANDLER_MODE` by `config.get_config_options`, because external ASGI and
-plain-Python launchers do not pass through Click. Preserve the documented precedence:
-project config overrides global config, this environment variable overrides config files,
-and explicit CLI or `App.run(config=...)` values override the environment.
+plain-Python launchers do not pass through Click. This direct path is specific to
+`handlerMode`; `STREAMLIT_LOGGER_LEVEL` and `STREAMLIT_LOGGER_MESSAGE_FORMAT` retain their
+existing behavior and are not newly read outside Click. Preserve the documented precedence:
+global, project, then script-level config; this environment variable; then an explicit CLI
+or `App.run(config=...)` value.
+
+Environment-sourced `handlerMode` uses `_DEFINED_BY_ENV_VAR` even when Click supplied the
+value. An actual CLI flag, and the existing `App.run(config=...)` override path, use
+`_DEFINED_BY_FLAG`. The Click integration must retain the parameter source or omit its
+environment-derived value from `options_from_flags` so the direct and Click paths do not
+report different provenance for the same environment setting.
 
 An invalid value is rejected during config set/parse. Initial startup emits the actionable
-error through the isolated bootstrap handler and then aborts without guessing a policy. An
-invalid live reload leaves the last successfully applied policy in place and rejects the
-new config rather than falling back.
+error through the isolated bootstrap handler and then aborts without guessing a policy. A
+live reload validates a candidate config before publishing `_config_options` or applying
+callbacks. If validation fails, the prior option value, its `where_defined` provenance, and
+the last successfully applied output policy all remain active; the implementation must not
+leave a rejected value visible through `get_option`.
 
 `STREAMLIT_MANAGED` is authoritative for the process once selected by the CLI or
 `App.run()`. An `st.App` mounted inside an ASGI app discovered by `streamlit run` must not
@@ -235,7 +245,7 @@ After config parsing, `apply_logging_config` updates or removes only the owned h
 
 - `STREAMLIT`: retain the handler at `NOTSET`, set the namespace level and handler formatter
   from config, and set namespace propagation to false.
-- `COOPERATIVE`: if a usable host path exists, remove the owned handler and apply the same
+- `AUTO`: if a usable host path exists, remove the owned handler and apply the same
   last-written-value restoration described under ownership as `HOST`, so host levels and
   formatting are authoritative.
   Otherwise behave exactly like `STREAMLIT`: retain the `NOTSET` fallback handler, apply
@@ -248,7 +258,7 @@ final configured policy is `HOST`. This prevents an invalid logging config from 
 the diagnostic that explains the invalid config. Once valid config is parsed, host mode
 removes it.
 
-### Cooperative handler detection
+### Auto handler detection
 
 A usable host path exists when either:
 
@@ -264,7 +274,7 @@ also stops at `propagate=False` on any user-owned intermediate logger. Only afte
 usable path does Streamlit remove its handler and restore namespace state, so detection
 never creates a duplicate-output window.
 
-`Logger.disabled` is neither a usable host path nor an input to cooperative detection: it
+`Logger.disabled` is neither a usable host path nor an input to auto detection: it
 does not describe handler reachability for descendants, and `dictConfig` can set it based
 on logger creation order. Streamlit never changes the flag. Therefore a host that disables
 an individual logger may suppress records emitted directly by that logger, but does not
@@ -272,7 +282,7 @@ establish a namespace-wide output policy. Streamlit leaves that standard, creati
 dependent behavior unchanged. Host `dictConfig` examples use
 `disable_existing_loggers=False`.
 
-If no usable path exists, cooperative mode retains the Streamlit handler. This is important
+If no usable path exists, auto mode retains the Streamlit handler. This is important
 for external Uvicorn: Uvicorn's default logging configuration typically configures
 `uvicorn.*`, not Python's global root logger.
 
@@ -282,7 +292,7 @@ logging:
 1. Before config parsing or runtime creation, record `EXTERNAL` context and retain the
    compatibility fallback.
 2. At ASGI lifespan entry, or on the first HTTP/WebSocket call for lazy mounts, reconcile
-   cooperative mode after the server has had an opportunity to configure logging.
+   auto mode after the server has had an opportunity to configure logging.
 
 Reconcile again when Streamlit config is reloaded. Streamlit does not monitor arbitrary
 handler changes made after ASGI startup; applications that reconfigure logging later should
@@ -306,9 +316,14 @@ When Streamlit owns the output path:
 - the namespace logger uses `propagate=False`; and
 - the owned handler uses `logger.messageFormat` and the existing millisecond formatting.
 
-The namespace level and propagation values are Streamlit-owned in `STREAMLIT` and
-cooperative-fallback modes. Config application and reload reassert them; applications that
-need host ownership of those values must select `HOST` or host-selected cooperative mode.
+Namespace propagation is Streamlit-owned and reasserted in `STREAMLIT` and auto-fallback
+modes. The namespace level is initially set from `logger.level`. On later config application,
+Streamlit writes it when reacquiring ownership, when the successfully validated
+`logger.level` differs from the last applied config value, or when the current namespace
+level still equals Streamlit's last write. Otherwise, a distinguishable programmatic
+`Logger.setLevel` override survives an unrelated reload. An explicit `logger.level` config
+change wins and becomes the new last-written value. Applications that need ownership of all
+namespace state must select `HOST` or host-selected auto mode.
 
 When ownership is transferred to the host, Streamlit restores the saved pre-ownership level
 and propagation values only if those attributes still contain the last values written by
@@ -322,7 +337,7 @@ always belongs to the host.
 
 `set_log_level` and `update_formatter` remain temporary internal compatibility shims, but
 operate only on the namespace logger and owned handler. They no longer iterate `_loggers`.
-In `HOST` and host-selected cooperative mode, all three compatibility shims are no-ops for
+In `HOST` and host-selected auto mode, all three compatibility shims are no-ops for
 namespace level and propagation; they cannot reclaim or mutate host state.
 `setup_formatter(logger)` also remains during the migration as a redirecting shim: it
 updates the owned namespace handler if one is active and never adds a handler to the passed
@@ -358,7 +373,7 @@ equivalent to `streamlit run`.
 
 When `App.__call__` first builds an app and no Streamlit-managed context has been selected,
 it activates `EXTERNAL` before `_build_starlette_app` creates the runtime. It reconciles
-cooperative output before serving the first HTTP/WebSocket request.
+auto output before serving the first HTTP/WebSocket request.
 
 #### Mounted ASGI with explicit lifespan
 
@@ -366,13 +381,13 @@ Unless the CLI already selected a managed context, `App.lifespan()` activates th
 `EXTERNAL` logging context before calling `_create_runtime`. The existing
 `_external_lifespan=True` assignment stays after runtime creation; only logging-context
 activation moves earlier, so mounted-app lifecycle behavior does not change.
-`_combined_lifespan` reconciles cooperative output when the returned lifespan context is
+`_combined_lifespan` reconciles auto output when the returned lifespan context is
 entered.
 
 #### Mounted ASGI with lazy auto-start
 
 Unless a managed context is already active, the first HTTP/WebSocket call activates
-`EXTERNAL` before `_build_starlette_app`, reconciles cooperative output, and retains that
+`EXTERNAL` before `_build_starlette_app`, reconciles auto output, and retains that
 context when `_auto_start_runtime` later assigns `asgi-mounted`.
 
 Lazy reconciliation uses a double-checked, process-wide reconciled flag. The request path
@@ -415,16 +430,23 @@ longer accurate once `log_level` is supplied. Uvicorn applies the level to its e
 access, and ASGI namespaces, while the separate existing `access_log=False` continues to
 disable access records even at a lower configured level.
 
-Both managed server implementations register the same context-gated Uvicorn level updater
-after constructing their respective `uvicorn.Config`: traditional `UvicornServer` and the
-`st.App` `UvicornRunner`. Each unregisters it during server shutdown/finally cleanup. On a
-managed config reload, the updater changes levels on the existing Uvicorn logger family
-without adding handlers, changing propagation, or re-enabling access logs. It is never
-registered by external ASGI paths.
+Both managed server implementations use the same context-gated Uvicorn level updater:
+traditional `UvicornServer` and the `st.App` `UvicornRunner`. Because each constructs a new
+`uvicorn.Config` inside its bind-retry loop, an updater is registered only after an attempt
+binds successfully and becomes the active server. Registration is idempotent, and the active
+registration is removed during server shutdown/finally cleanup. If implementation mechanics
+require registration before binding, every failed or cancelled attempt must unregister in
+that attempt's `finally` block before retrying. On a managed config reload, the updater
+changes levels on the existing Uvicorn logger family without adding handlers, changing
+propagation, or re-enabling access logs. External ASGI paths never register it.
 
 The managed runner leaves the `websockets` logger entirely alone. Modern Uvicorn protocol
 logs use the `uvicorn.*` hierarchy; independently emitted `websockets` records follow
-normal Python logging rules.
+normal Python logging rules. This is intentionally asymmetric with managed `uvicorn.*`
+configuration: Uvicorn exposes supported configuration for its logger family, but the
+process-global `websockets` logger belongs to a dependency that the host may also use outside
+Streamlit. Changing even only its level could affect those unrelated uses, so Streamlit does
+not mutate it in any launch mode.
 
 For external ASGI servers, Streamlit does not configure `uvicorn.*`, `websockets`, Gunicorn,
 or Hypercorn loggers. Their levels, handlers, access logs, and formatting belong to the host.
@@ -443,7 +465,7 @@ remains idempotent in every mode. The callback must:
 
 - reuse or replace exactly one owned handler;
 - never add a second owned handler;
-- do not remove host handlers;
+- never remove host handlers;
 - transition safely between `streamlit`, `auto`, and `host`; and
 - update managed dependency levels without installing dependency handlers.
 
@@ -471,7 +493,7 @@ through apply prevents a newer reload from being overwritten by a stale lifespan
 3. Replace per-child logger tests with hierarchy and exactly-once tests.
 4. Move managed Uvicorn configuration into the runner and stop configuring WebSockets.
 5. Add launch-context activation before config/runtime initialization.
-6. Add `logger.handlerMode` and cooperative/host transitions.
+6. Add `logger.handlerMode` and auto/host transitions.
 7. Document standard namespace customization and external hosting examples.
 
 Steps 2–4 can merge independently while preserving all default Streamlit output. Steps 5–6
@@ -509,6 +531,13 @@ records. Keep `get_logger`, `set_log_level`, `setup_formatter`, `update_formatte
 `"root"` alias during the migration to reduce risk for internal and third-party code that
 imports these private symbols.
 
+`get_logger` and `DEFAULT_LOG_MESSAGE` remain internal utilities and are not scheduled for
+removal by this project. Keep the topology compatibility shims through the staged rollout
+and for at least one minor release after the final implementation step. A later cleanup PR
+may remove a shim only after all repository call sites have migrated, SiS/SPCS and Community
+Cloud integrations have been rechecked, and the private-symbol cleanup has been announced in
+release notes.
+
 Do not change the default to `auto` in the same release. A later proposal can evaluate that
 change using external-mode integration coverage and user feedback. Rolling back the new
 ownership policy requires only restoring `handlerMode="streamlit"`; it does not require
@@ -537,21 +566,26 @@ run in isolated subprocesses rather than rely only on in-process fixture cleanup
 - A custom namespace handler is never removed or reformatted.
 - Host mode removes only the owned handler and restores the saved namespace level and
   propagation state.
-- Cooperative mode chooses an existing namespace handler, a global root handler, or the
+- Auto mode chooses an existing namespace handler, a global root handler, or the
   Streamlit fallback as appropriate.
-- Cooperative detection ignores `NullHandler` as usable output, evaluates the saved
+- Auto detection ignores `NullHandler` as usable output, evaluates the saved
   namespace propagation state, and respects user-owned `propagate=False` boundaries.
 - `Logger.disabled` does not count as a host handler and is never changed by Streamlit.
 - Invalid `logger.handlerMode` values fail with an actionable config error.
 - Handler mode values are case-insensitive and validation errors list the three canonical
   lowercase choices.
 - The handler-mode environment variable is applied without Click, while explicit CLI and
-  `App.run(config=...)` values retain higher precedence.
-- Invalid startup config aborts after the bootstrap diagnostic; an invalid reload preserves
-  the last applied policy.
-- Streamlit and cooperative-fallback modes reassert the configured namespace level and
-  isolation on reload; transferring ownership preserves pre-existing state and user changes
-  that do not match Streamlit's last written values.
+  `App.run(config=...)` values retain higher precedence; its value has the same
+  `_DEFINED_BY_ENV_VAR` provenance with and without Click, and no other non-sensitive logger
+  environment variable gains this direct path.
+- Invalid startup config aborts after the bootstrap diagnostic. An invalid reload preserves
+  the last applied policy, option value, and `where_defined` provenance as observed through
+  `get_option` and `get_where_defined`.
+- Streamlit and auto-fallback modes reassert namespace isolation on reload. They preserve a
+  distinguishable programmatic namespace-level override across an unrelated config reload,
+  while an explicit `logger.level` change or ownership reacquisition applies the configured
+  level. Transferring ownership preserves pre-existing state and user changes that do not
+  match Streamlit's last written values.
 - `setup_formatter` and the namespace `streamlit_console_handler` compatibility shims do
   not restore Streamlit-owned output in host mode.
 - `set_log_level`, `update_formatter`, and `setup_formatter` do not mutate namespace state
@@ -567,10 +601,17 @@ run in isolated subprocesses rather than rely only on in-process fixture cleanup
 - Streamlit-managed Uvicorn respects `logger.level` after `uvicorn.Config` initialization.
 - Managed Uvicorn accepts every case-insensitive `logger.level` supported by Streamlit and
   rejects unknown values with Streamlit's config error rather than a Uvicorn `KeyError`.
+- A managed Uvicorn port-bind retry leaves no updater from the failed attempt and registers
+  exactly one updater for the successfully bound server; shutdown removes it.
+- In a managed launch with no root handler, an independently emitted `websockets` warning
+  follows `lastResort` once while lower-level records are discarded.
 - External Uvicorn plus `handlerMode="auto"` uses a host JSON handler exactly once.
 - External Uvicorn with no host handler retains the Streamlit fallback.
-- Cooperative mode reconciles again at lifespan entry when host logging was configured
+- Auto mode reconciles again at lifespan entry when host logging was configured
   after constructing the `st.App` object.
+- An external ASGI subprocess preconfigures the `uvicorn.*` and `websockets` levels,
+  handlers, and propagation flags, then verifies Streamlit config parsing leaves every value
+  and handler identity unchanged.
 - Mounted FastAPI plus `handlerMode="host"` captures Streamlit records in the FastAPI/root
   handler without a second Streamlit-formatted copy.
 - A root handler configured before `import streamlit` receives no duplicate bootstrap
@@ -582,14 +623,15 @@ run in isolated subprocesses rather than rely only on in-process fixture cleanup
 - Host mode with no handler anywhere in the restored path leaves Python `lastResort`
   behavior intact for `WARNING` and higher records.
 - `dictConfig(disable_existing_loggers=True)` after import remains authoritative: Streamlit
-  does not re-enable any disabled logger or treat the flag as a cooperative host path.
+  does not re-enable any disabled logger or treat the flag as an auto-selected host path.
 - Bare `st.write` retains the direct-execution and missing-context warnings.
 - A managed-launch live config reload changes level/format or ownership without duplicating
   handlers; external launches do not gain a config-file watcher.
 - A config reload racing ASGI lifespan reconciliation completes without deadlock and leaves
   one policy-consistent output path.
 - Both managed Uvicorn implementations register, apply, and unregister the shared level
-  updater; external ASGI launches never register it.
+  updater without leaking registrations across failed bind attempts; external ASGI launches
+  never register it.
 - With Rich enabled, uncaught exceptions retain their direct Rich console presentation;
   with Rich disabled, exactly one standard record follows the selected handler policy.
 

--- a/specs/2026-08-23-logging-strategy/tech-spec.md
+++ b/specs/2026-08-23-logging-strategy/tech-spec.md
@@ -1,0 +1,488 @@
+---
+author: lukasmasuch
+created: 2026-08-23
+---
+
+# Standard, launch-aware logging
+
+## Summary
+
+Replace Streamlit's per-module handlers and logger registry behavior with one standard
+`streamlit` namespace handler. Introduce explicit managed, cooperative, and host-owned
+logging policies so `streamlit run`, `App.run()`, externally served `st.App`, and embedded
+ASGI apps keep useful logs without duplicate output or mutations to server loggers owned by
+another application.
+
+See the [product spec](./product-spec.md) for user-facing behavior and the proposed
+`logger.handlerMode` option. This is the implementation proposal for
+[#4742](https://github.com/streamlit/streamlit/issues/4742).
+
+## Problem
+
+### Current logger topology
+
+`streamlit.logger.get_logger(name)` currently performs four operations:
+
+1. retrieves a logger through `logging.getLogger`;
+2. sets an explicit Streamlit-global level on that logger;
+3. sets `propagate=False`; and
+4. creates a new `StreamHandler` and formatter on the logger.
+
+It also stores every logger in a private `_loggers` dictionary. `set_log_level` and
+`update_formatter` iterate this registry and mutate every logger independently. There are
+currently 77 `get_logger` call sites across 67 Streamlit consumer files. Importing
+`streamlit` creates approximately 52 child handlers before an app starts, and parsing config
+adds more.
+
+This bypasses the standard hierarchy:
+
+```text
+Record from streamlit.runtime.app_session
+    -> child handler
+    -> propagation stops
+    X  logging.getLogger("streamlit") handlers and level are ignored
+```
+
+The behavior blocks ordinary `dictConfig`, JSON handlers, pytest capture, and namespace
+filtering. It also creates unnecessary handler/formatter objects and makes config reloads
+touch every imported module logger.
+
+### Startup modes and ordering
+
+Streamlit tracks five server modes in `streamlit.config._server_mode`:
+
+- `starlette-managed` — traditional `streamlit run`;
+- `starlette-app` — `st.App` discovered by `streamlit run`;
+- `starlette-app-direct` — `App.run()`;
+- `asgi-server` — standalone external ASGI server; and
+- `asgi-mounted` — mounted in another ASGI application.
+
+The value is currently assigned too late to drive logging policy:
+
+- `_main_run` parses config before it discovers the application and sets a server mode.
+- `App.run()` parses config before `_prepare_asgi_app_run_context` assigns
+  `starlette-app-direct`.
+- `App.lifespan()` creates the runtime before marking the lifespan external.
+- External `App.__call__` can create the runtime before `_combined_lifespan` assigns
+  `asgi-server` or `asgi-mounted`.
+
+Config parsing triggers the global `_update_logger` callback, so logging is configured
+before ownership is known.
+
+### Third-party server loggers
+
+`init_uvicorn_logs()` sends `uvicorn`, `uvicorn.access`, `uvicorn.asgi`, `uvicorn.error`,
+and `websockets` through `get_logger`. This installs Streamlit handlers and disables
+propagation on namespaces Streamlit does not always own. Uvicorn then applies its own
+`dictConfig`, potentially replacing handlers and levels while retaining earlier propagation
+state. A later Streamlit config reload can add another handler alongside Uvicorn's handler.
+
+## Goals
+
+- Preserve default Streamlit console logs for existing apps and all supported launch modes.
+- Make `logging.getLogger("streamlit")` the effective parent for all `streamlit.*` records.
+- Emit each record once per configured destination.
+- Support host-controlled logging for external and embedded ASGI modes.
+- Keep a fallback in cooperative mode when the host has no usable handler.
+- Configure Uvicorn/WebSockets only when Streamlit owns the server runner.
+- Make config reload idempotent and preserve user-owned logging state.
+
+## Non-goals
+
+- Changing log messages, severity, or record fields.
+- Adding public Python logging helpers.
+- File logging, log rotation, remote shipping, or UI rendering.
+- Per-session logging configuration. Logging remains process-wide, like Streamlit config
+  and runtime ownership.
+- Supporting different logger policies for multiple `st.App` instances in one process;
+  multiple independently configured Streamlit runtimes are already unsupported.
+
+## Proposal
+
+### Namespace architecture
+
+Create one module-owned handler and a permanent `NullHandler` on the namespace logger:
+
+```python
+_NAMESPACE_LOGGER_NAME: Final = "streamlit"
+_NAMESPACE_LOGGER = logging.getLogger(_NAMESPACE_LOGGER_NAME)
+_NULL_HANDLER = logging.NullHandler()
+_console_handler: logging.StreamHandler | None = None
+```
+
+The `NullHandler` prevents Python's `lastResort` handler from unexpectedly formatting bare
+library records when no policy has been activated. It does not stop propagation to a host
+handler. Cooperative handler detection must ignore `NullHandler` instances.
+
+`get_logger` becomes a compatibility shim:
+
+```python
+def get_logger(name: str) -> logging.Logger:
+    resolved_name = _NAMESPACE_LOGGER_NAME if name == "root" else name
+    logger = logging.getLogger(resolved_name)
+    _loggers.setdefault(name, logger)  # temporary private compatibility only
+    return logger
+```
+
+It does not set a level, attach a handler, or change propagation. Existing call sites can
+remain unchanged in the first implementation. The `"root"` alias continues to resolve to
+`"streamlit"`, preserving direct-execution warnings.
+
+Fresh child loggers retain the standard `level=NOTSET` and `propagate=True`, so their
+effective level comes from the namespace logger. Explicit user configuration on a child is
+respected. `_loggers` no longer owns behavior and can be removed in a later cleanup after
+private integrations have migrated.
+
+Record flow with Streamlit's handler:
+
+```text
+streamlit.runtime.app_session
+    -> propagate
+streamlit
+    -> one Streamlit console handler
+    -> propagation stops before Python root
+```
+
+Record flow with host ownership:
+
+```text
+streamlit.runtime.app_session
+    -> propagate
+streamlit
+    -> user namespace handlers, if any
+    -> propagate
+Python root / host handlers
+```
+
+### Launch context and output policy
+
+Track the way Streamlit was started separately from the configured output policy:
+
+```python
+class LoggingContext(Enum):
+    UNCONFIGURED = "unconfigured"
+    STREAMLIT_MANAGED = "streamlit-managed"
+    EXTERNAL = "external"
+
+
+class OutputPolicy(Enum):
+    STREAMLIT = "streamlit"
+    COOPERATIVE = "cooperative"
+    HOST = "host"
+```
+
+`activate_logging(context)` records the launch context before config is parsed. After
+config is available, `apply_logging_config()` resolves the effective policy:
+
+| `logger.handlerMode` | Launch context | Effective policy |
+|---|---|---|
+| `streamlit` | Any | `STREAMLIT` |
+| `auto` | Context not known yet | `STREAMLIT` fallback |
+| `auto` | Streamlit-managed launch | `STREAMLIT` |
+| `auto` | External/embedded launch | `COOPERATIVE` |
+| `host` | Any | `HOST` |
+
+The initial config default is `streamlit`, preserving current output. A not-yet-known
+context is conservative so code that reads Streamlit config before choosing a launcher
+does not lose diagnostics. The launch context is still implemented now so `auto` works
+correctly and a future default change does not require another architecture migration.
+
+`STREAMLIT_MANAGED` is authoritative for the process once selected by the CLI or
+`App.run()`. An `st.App` mounted inside an ASGI app discovered by `streamlit run` must not
+downgrade the context to `EXTERNAL`; Streamlit still owns that server runner. External
+detection only replaces `UNCONFIGURED`, while `App.run()` may promote an unstarted app to
+`STREAMLIT_MANAGED`.
+
+### Bootstrapping before config parsing
+
+Module initialization installs one Streamlit-owned namespace handler using `INFO`,
+`DEFAULT_LOG_MESSAGE`, and stderr. This replaces the dozens of handlers created during a
+normal import while preserving import-time and config-parser diagnostics before
+`logger.level`, `logger.messageFormat`, and `logger.handlerMode` are known.
+
+After config parsing, `apply_logging_config` updates or removes only the owned handler:
+
+- `STREAMLIT`: retain the handler, set the namespace level and formatter from config, and
+  set namespace propagation to false.
+- `COOPERATIVE`: remove the owned handler if a usable host path exists; otherwise retain it
+  as a fallback. Use the host's levels and format when the host path is selected.
+- `HOST`: remove the owned handler, use `level=NOTSET`, and propagate to the host.
+
+The bootstrap handler is deliberately used for config-parser diagnostics even when the
+final configured policy is `HOST`. This prevents an invalid logging config from suppressing
+the diagnostic that explains the invalid config. Once valid config is parsed, host mode
+removes it.
+
+### Cooperative handler detection
+
+A usable host path exists when either:
+
+1. the `streamlit` namespace has a non-owned, non-`NullHandler` handler; or
+2. propagation reaches an ancestor with a non-`NullHandler` handler.
+
+Detection walks the hierarchy explicitly rather than calling `Logger.hasHandlers`, because
+the permanent namespace `NullHandler` would otherwise count as a handler. It stops at the
+first logger with `propagate=False`, matching Python logging semantics.
+
+If the namespace logger is disabled, treat that as an explicit host decision and do not
+install a fallback. Streamlit must not silently re-enable a logger disabled through
+`dictConfig`.
+
+If no usable path exists, cooperative mode retains the Streamlit handler. This is important
+for external Uvicorn: Uvicorn's default logging configuration typically configures
+`uvicorn.*`, not Python's global root logger.
+
+External activation is two-phase because hosts can construct an `st.App` before configuring
+logging:
+
+1. Before config parsing or runtime creation, record `EXTERNAL` context and retain the
+   compatibility fallback.
+2. At ASGI lifespan entry, or on the first HTTP/WebSocket call for lazy mounts, reconcile
+   cooperative mode after the server has had an opportunity to configure logging.
+
+Reconcile again when Streamlit config is reloaded. Streamlit does not monitor arbitrary
+handler changes made after ASGI startup; applications that reconfigure logging later should
+select `handlerMode="host"` explicitly.
+
+### Ownership of logger state
+
+Streamlit tracks the exact handler object it creates and never identifies ownership by
+handler class alone. Formatter updates affect only this handler. User handlers and filters
+are never cleared or rewritten.
+
+When Streamlit owns the output path:
+
+- the namespace logger level is set from `logger.level`;
+- the owned handler remains at `NOTSET`, allowing the namespace level and explicit child
+  levels to follow standard Python semantics;
+- the namespace logger uses `propagate=False`; and
+- the owned handler uses `logger.messageFormat` and the existing millisecond formatting.
+
+When ownership is transferred to the host, Streamlit restores `NOTSET` and
+`propagate=True` only if those attributes still contain the last values written by
+Streamlit. A user modification made after activation wins and is not reverted. Streamlit
+never changes `Logger.disabled`; that state always belongs to the host.
+
+`set_log_level` and `update_formatter` remain temporary internal compatibility shims, but
+operate only on the namespace logger and owned handler. They no longer iterate `_loggers`.
+
+### Launch-mode wiring
+
+Logging context must be selected before any launcher call that can parse config or create a
+runtime. Config reads that occur earlier retain the conservative fallback and are reconciled
+when the context becomes known.
+
+#### `streamlit run` and CLI commands
+
+`web.cli._main_run` activates `STREAMLIT_MANAGED` before
+`bootstrap.load_config_options`. This is known before ASGI discovery: invoking the
+Streamlit CLI means Streamlit owns the server runner whether the target is a traditional
+script, `st.App`, FastAPI, or another discovered ASGI app.
+
+Other CLI commands that parse config use `STREAMLIT_MANAGED` bootstrapping so configuration
+errors remain visible.
+
+#### `App.run()`
+
+`App.run()` activates `STREAMLIT_MANAGED` before `bootstrap.load_config_options` and before
+`_prepare_asgi_app_run_context` assigns `starlette-app-direct`. Its logging behavior remains
+equivalent to `streamlit run`.
+
+#### External standalone ASGI
+
+When `App.__call__` first builds an app and no Streamlit-managed context has been selected,
+it activates `EXTERNAL` before `_build_starlette_app` creates the runtime. It reconciles
+cooperative output before serving the first HTTP/WebSocket request.
+
+#### Mounted ASGI with explicit lifespan
+
+`App.lifespan()` sets `_external_lifespan=True` and, unless the CLI already selected a
+managed context, activates `EXTERNAL` before calling `_create_runtime`. This reverses the
+current ordering, where runtime creation happens before the app is marked external.
+`_combined_lifespan` reconciles cooperative output when the returned lifespan context is
+entered.
+
+#### Mounted ASGI with lazy auto-start
+
+Unless a managed context is already active, the first HTTP/WebSocket call activates
+`EXTERNAL` before `_build_starlette_app`, reconciles cooperative output, and retains that
+context when `_auto_start_runtime` later assigns `asgi-mounted`.
+
+#### Bare `st.*` execution
+
+The first direct-execution warning uses the bootstrap handler. This preserves the existing
+formatted warning and missing-`ScriptRunContext` diagnostics while an ordinary
+`import streamlit` installs one output handler instead of dozens.
+
+### Managed server dependencies
+
+Remove `init_uvicorn_logs` from the global config callback.
+
+For Streamlit-owned `UvicornRunner`, pass the configured level directly to Uvicorn:
+
+```python
+{
+    # existing kwargs...
+    "log_level": config.get_option("logger.level"),
+    "access_log": False,
+}
+```
+
+This lets Uvicorn apply its own handler configuration and level through its supported API.
+On Streamlit config reload, a callback registered by the managed runner updates levels on
+the existing Uvicorn logger family without adding handlers or changing propagation.
+
+The managed runner may continue setting the `websockets` logger level for compatibility,
+but it does not install a handler or disable propagation. Modern Uvicorn protocol logs use
+the `uvicorn.*` hierarchy; independently emitted `websockets` records follow normal host
+logging rules.
+
+For external ASGI servers, Streamlit does not configure `uvicorn.*`, `websockets`, Gunicorn,
+or Hypercorn loggers. Their levels, handlers, access logs, and formatting belong to the host.
+
+`logger.messageFormat` continues to apply only to Streamlit records; Uvicorn keeps its
+native formatter. This matches the effective behavior after Uvicorn currently applies its
+own logging configuration.
+
+### Config reloads and idempotency
+
+The existing config watcher can continue invoking a logging callback, but the callback
+calls `apply_logging_config` against the stored launch context. It must be idempotent:
+
+- reuse or replace exactly one owned handler;
+- never add a second owned handler;
+- do not remove host handlers;
+- transition safely between `streamlit`, `auto`, and `host`; and
+- update managed dependency levels without installing dependency handlers.
+
+Because logging and Streamlit config are process-wide, no per-session synchronization or
+state is introduced. Python logging's handler mutation APIs provide their own locks; the
+module should additionally guard policy transitions with one re-entrant lock so a config
+watcher cannot interleave with ASGI startup.
+
+### Implementation sequence
+
+1. Centralize Streamlit's handler and level on the namespace logger while keeping
+   `handlerMode="streamlit"` in all launch modes.
+2. Replace per-child logger tests with hierarchy and exactly-once tests.
+3. Move managed Uvicorn/WebSockets configuration into the runner.
+4. Add launch-context activation before config/runtime initialization.
+5. Add `logger.handlerMode` and cooperative/host transitions.
+6. Document standard namespace customization and external hosting examples.
+
+Steps 1–3 can merge independently while preserving all default Streamlit output. Steps 4–5
+are additive because the initial config default still resolves to Streamlit-owned logging.
+
+## Backward Compatibility and Rollout
+
+The first release keeps `handlerMode="streamlit"` as its default in every launch context.
+Before the first implementation PR merges, capture subprocess fixtures for the current
+default output of `streamlit run`, `App.run()`, external Uvicorn, a mounted app, and bare
+`st.*` execution. The new hierarchy must match their representative Streamlit record
+levels, formatting, destination, and multiplicity.
+
+Intentional observable changes are limited to:
+
+- a handler attached to `logging.getLogger("streamlit")` now receives child records;
+- an explicit child level can override the inherited namespace level using standard Python
+  semantics;
+- private inspection of child `.handlers` sees no Streamlit handler; and
+- external server libraries are no longer mutated by Streamlit.
+
+The first two changes are the requested interoperability behavior. The latter two affect
+private topology rather than a supported Streamlit API. Keep `get_logger`, `set_log_level`,
+`update_formatter`, `DEFAULT_LOG_MESSAGE`, and the `"root"` alias during the migration to
+reduce risk for internal and third-party code that imports these private symbols.
+
+Do not change the default to `auto` in the same release. A later proposal can evaluate that
+change using external-mode integration coverage and user feedback. Rolling back the new
+ownership policy requires only restoring `handlerMode="streamlit"`; it does not require
+reintroducing per-child handlers.
+
+Primary implementation risks are process-global test leakage, duplicate output during
+policy transitions, and observing host logging before it is fully configured. Subprocess
+tests, exact handler identity tracking, idempotent transitions, and the second-phase ASGI
+reconciliation address those risks.
+
+## Testing
+
+Logging uses process-global state, so tests that validate import and startup behavior should
+run in isolated subprocesses rather than rely only on in-process fixture cleanup.
+
+### Unit tests
+
+- `get_logger(__name__)` returns the standard logger without adding a child handler.
+- Fresh `streamlit.*` children use `NOTSET` and propagate.
+- The `"root"` alias returns `logging.getLogger("streamlit")`.
+- Managed mode installs exactly one owned handler with the configured level and format.
+- Repeated activation and config reload do not increase handler counts.
+- A custom namespace handler is never removed or reformatted.
+- Host mode removes only the owned handler and propagates records.
+- Cooperative mode chooses an existing namespace handler, a global root handler, or the
+  Streamlit fallback as appropriate.
+- Cooperative detection ignores `NullHandler` and respects `propagate=False` boundaries.
+- Invalid `logger.handlerMode` values fail with an actionable config error.
+- Transitions between all handler modes preserve user changes made after activation.
+
+### Subprocess integration tests
+
+- `streamlit run` emits representative startup, warning, and shutdown records once with
+  the existing format.
+- `App.run()` has the same Streamlit logging behavior as `streamlit run`.
+- Streamlit-managed Uvicorn respects `logger.level` after `uvicorn.Config` initialization.
+- External Uvicorn plus `handlerMode="auto"` uses a host JSON handler exactly once.
+- External Uvicorn with no host handler retains the Streamlit fallback.
+- Cooperative mode reconciles again at lifespan entry when host logging was configured
+  after constructing the `st.App` object.
+- Mounted FastAPI plus `handlerMode="host"` captures Streamlit records in the FastAPI/root
+  handler without a second Streamlit-formatted copy.
+- Bare `st.write` retains the direct-execution and missing-context warnings.
+- A live config reload changes level/format or ownership without duplicating handlers.
+
+The repository's external-test risk categories are not triggered: the planned lifecycle
+edits select logging context but do not change routes, WebSocket/session transport,
+embedding boundaries, cross-origin behavior, assets, browser storage, or security headers.
+Browser-facing `@pytest.mark.external_test` coverage is therefore not required. The
+externally hosted scenarios need Python subprocess integration coverage instead.
+
+## Alternatives Considered
+
+### Implement the issue literally: standard children plus only `NullHandler`
+
+Configure no output handler except when invoked through the Click CLI.
+
+**Rejected because:** Streamlit is primarily an app runtime, `App.run()` is not the Click
+CLI, and external Uvicorn may not configure Python's root logger. Useful runtime errors
+could disappear.
+
+### Keep per-child handlers and add an opt-out
+
+Add a config flag that disables the current setup.
+
+**Rejected because:** The standard `streamlit` parent still cannot control child levels or
+receive records, handler/formatter duplication remains, and Uvicorn ownership remains
+unsafe.
+
+### Always use one Streamlit namespace handler
+
+Centralize the hierarchy but install the handler unconditionally.
+
+**Rejected as the complete solution because:** It fixes most of #4742 and is the safe first
+migration step, but it still forces embedded applications to remove a handler after every
+config reload.
+
+### Propagate everything to Python's global root
+
+Install no Streamlit handler and rely on `logging.basicConfig` or the host.
+
+**Rejected because:** It changes the default app experience, makes formatting dependent on
+unrelated libraries, can duplicate records, and regresses the isolation fixed by #3978.
+
+### Add public Python APIs for Streamlit handlers and filters
+
+Expose helpers such as `st.configure_logging`, `streamlit.logger.add_filter`, or a custom
+Streamlit log handler.
+
+**Rejected because:** Python's logging APIs already provide these capabilities once the
+namespace hierarchy works. A Streamlit-specific API would increase maintenance burden and
+fragment standard logging configuration.

--- a/specs/2026-08-23-logging-strategy/tech-spec.md
+++ b/specs/2026-08-23-logging-strategy/tech-spec.md
@@ -195,10 +195,13 @@ detection only replaces `UNCONFIGURED`, while `App.run()` may promote an unstart
 
 ### Bootstrapping before config parsing
 
-Module initialization installs one Streamlit-owned namespace handler using `INFO`,
-`DEFAULT_LOG_MESSAGE`, and stderr. This replaces the dozens of handlers created during a
+Under the module policy lock, module initialization atomically installs one Streamlit-owned
+namespace handler using `INFO`, `DEFAULT_LOG_MESSAGE`, and stderr, adds the permanent
+`NullHandler`, and sets namespace propagation to false. Isolation must be active before any
+record can reach the new handler. This replaces the dozens of handlers created during a
 normal import while preserving import-time and config-parser diagnostics before
-`logger.level`, `logger.messageFormat`, and `logger.handlerMode` are known.
+`logger.level`, `logger.messageFormat`, and `logger.handlerMode` are known. It also prevents
+a root handler configured before `import streamlit` from receiving a second copy.
 
 After config parsing, `apply_logging_config` updates or removes only the owned handler:
 
@@ -218,15 +221,24 @@ removes it.
 A usable host path exists when either:
 
 1. the `streamlit` namespace has a non-owned, non-`NullHandler` handler; or
-2. propagation reaches an ancestor with a non-`NullHandler` handler.
+2. an ancestor has a non-`NullHandler` handler that would be reachable after transferring
+   namespace ownership to the host.
 
 Detection walks the hierarchy explicitly rather than calling `Logger.hasHandlers`, because
-the permanent namespace `NullHandler` would otherwise count as a handler. It stops at the
-first logger with `propagate=False`, matching Python logging semantics.
+the permanent namespace `NullHandler` would otherwise count as a handler. When considering
+ancestors, the walk ignores `propagate=False` on the namespace only while that value is the
+bootstrap isolation value last written by Streamlit: selecting the host path will restore
+it to true. The walk still stops at `propagate=False` on any user-owned intermediate
+logger. Only after finding a usable path does Streamlit remove its handler and restore
+namespace propagation, so detection never creates a duplicate-output window.
 
-If the namespace logger is disabled, treat that as an explicit host decision and do not
-install a fallback. Streamlit must not silently re-enable a logger disabled through
-`dictConfig`.
+`Logger.disabled` is neither a usable host path nor an input to cooperative detection: it
+does not describe handler reachability for descendants, and `dictConfig` can set it based
+on logger creation order. Streamlit never changes the flag. Therefore a host that disables
+an individual logger may suppress records emitted directly by that logger, but does not
+establish a namespace-wide output policy. Streamlit leaves that standard, creation-order-
+dependent behavior unchanged. Host `dictConfig` examples use
+`disable_existing_loggers=False`.
 
 If no usable path exists, cooperative mode retains the Streamlit handler. This is important
 for external Uvicorn: Uvicorn's default logging configuration typically configures
@@ -265,6 +277,13 @@ never changes `Logger.disabled`; that state always belongs to the host.
 
 `set_log_level` and `update_formatter` remain temporary internal compatibility shims, but
 operate only on the namespace logger and owned handler. They no longer iterate `_loggers`.
+`setup_formatter(logger)` also remains during the migration as a redirecting shim: it
+updates the owned namespace handler if one is active and never adds a handler to the passed
+child logger. The namespace logger's private `streamlit_console_handler` attribute points
+to the owned handler while it is attached and becomes `None` when ownership is transferred,
+making the handler discoverable to existing integrations. Child loggers no longer expose
+their own `streamlit_console_handler`; that private per-child topology is the behavior this
+proposal replaces.
 
 ### Launch-mode wiring
 
@@ -296,9 +315,10 @@ cooperative output before serving the first HTTP/WebSocket request.
 
 #### Mounted ASGI with explicit lifespan
 
-`App.lifespan()` sets `_external_lifespan=True` and, unless the CLI already selected a
-managed context, activates `EXTERNAL` before calling `_create_runtime`. This reverses the
-current ordering, where runtime creation happens before the app is marked external.
+Unless the CLI already selected a managed context, `App.lifespan()` activates the
+`EXTERNAL` logging context before calling `_create_runtime`. The existing
+`_external_lifespan=True` assignment stays after runtime creation; only logging-context
+activation moves earlier, so mounted-app lifecycle behavior does not change.
 `_combined_lifespan` reconciles cooperative output when the returned lifespan context is
 entered.
 
@@ -307,6 +327,12 @@ entered.
 Unless a managed context is already active, the first HTTP/WebSocket call activates
 `EXTERNAL` before `_build_starlette_app`, reconciles cooperative output, and retains that
 context when `_auto_start_runtime` later assigns `asgi-mounted`.
+
+Lazy reconciliation uses a double-checked, process-wide reconciled flag. The request path
+first performs a cheap flag read and acquires the policy lock only when reconciliation is
+pending; it checks the flag again inside the lock before applying policy. Steady-state
+requests therefore do not acquire the logging lock. Activation and config reload update or
+invalidate this flag as part of the same locked transition.
 
 #### Bare `st.*` execution
 
@@ -318,12 +344,13 @@ formatted warning and missing-`ScriptRunContext` diagnostics while an ordinary
 
 Remove `init_uvicorn_logs` from the global config callback.
 
-For Streamlit-owned `UvicornRunner`, pass the configured level directly to Uvicorn:
+In the shared `_get_uvicorn_config_kwargs()` used by the traditional `UvicornServer` and
+the `st.App` `UvicornRunner`, pass the configured level directly to Uvicorn:
 
 ```python
 {
-    # existing kwargs...
     "log_level": config.get_option("logger.level"),
+    # Existing kwargs, including access_log=False, remain unchanged.
     "access_log": False,
 }
 ```
@@ -332,10 +359,9 @@ This lets Uvicorn apply its own handler configuration and level through its supp
 On Streamlit config reload, a callback registered by the managed runner updates levels on
 the existing Uvicorn logger family without adding handlers or changing propagation.
 
-The managed runner may continue setting the `websockets` logger level for compatibility,
-but it does not install a handler or disable propagation. Modern Uvicorn protocol logs use
-the `uvicorn.*` hierarchy; independently emitted `websockets` records follow normal host
-logging rules.
+The managed runner leaves the `websockets` logger entirely alone. Modern Uvicorn protocol
+logs use the `uvicorn.*` hierarchy; independently emitted `websockets` records follow
+normal Python logging rules.
 
 For external ASGI servers, Streamlit does not configure `uvicorn.*`, `websockets`, Gunicorn,
 or Hypercorn loggers. Their levels, handlers, access logs, and formatting belong to the host.
@@ -387,12 +413,17 @@ Intentional observable changes are limited to:
 - an explicit child level can override the inherited namespace level using standard Python
   semantics;
 - private inspection of child `.handlers` sees no Streamlit handler; and
-- external server libraries are no longer mutated by Streamlit.
+- external server libraries are no longer mutated by Streamlit; and
+- Streamlit no longer configures the third-party `websockets` logger, even in managed
+  launches. Without a host/root handler, its independent records may use Python's
+  `lastResort` behavior instead of Streamlit's level and format.
 
-The first two changes are the requested interoperability behavior. The latter two affect
-private topology rather than a supported Streamlit API. Keep `get_logger`, `set_log_level`,
-`update_formatter`, `DEFAULT_LOG_MESSAGE`, and the `"root"` alias during the migration to
-reduce risk for internal and third-party code that imports these private symbols.
+The first two changes are the requested interoperability behavior. The latter changes
+affect private topology or third-party diagnostics rather than Streamlit application
+records. Keep `get_logger`, `set_log_level`, `setup_formatter`, `update_formatter`,
+`DEFAULT_LOG_MESSAGE`, the namespace `streamlit_console_handler` attribute, and the
+`"root"` alias during the migration to reduce risk for internal and third-party code that
+imports these private symbols.
 
 Do not change the default to `auto` in the same release. A later proposal can evaluate that
 change using external-mode integration coverage and user feedback. Rolling back the new
@@ -420,9 +451,13 @@ run in isolated subprocesses rather than rely only on in-process fixture cleanup
 - Host mode removes only the owned handler and propagates records.
 - Cooperative mode chooses an existing namespace handler, a global root handler, or the
   Streamlit fallback as appropriate.
-- Cooperative detection ignores `NullHandler` and respects `propagate=False` boundaries.
+- Cooperative detection ignores `NullHandler`, looks through Streamlit-owned namespace
+  isolation, and respects user-owned `propagate=False` boundaries.
+- `Logger.disabled` does not count as a host handler and is never changed by Streamlit.
 - Invalid `logger.handlerMode` values fail with an actionable config error.
 - Transitions between all handler modes preserve user changes made after activation.
+- `setup_formatter` and the namespace `streamlit_console_handler` compatibility shims do
+  not restore Streamlit-owned output in host mode.
 
 ### Subprocess integration tests
 
@@ -436,14 +471,21 @@ run in isolated subprocesses rather than rely only on in-process fixture cleanup
   after constructing the `st.App` object.
 - Mounted FastAPI plus `handlerMode="host"` captures Streamlit records in the FastAPI/root
   handler without a second Streamlit-formatted copy.
+- A root handler configured before `import streamlit` receives no duplicate bootstrap
+  record in default/`streamlit` mode.
+- `dictConfig(disable_existing_loggers=True)` after import remains authoritative: Streamlit
+  does not re-enable any disabled logger or treat the flag as a cooperative host path.
 - Bare `st.write` retains the direct-execution and missing-context warnings.
 - A live config reload changes level/format or ownership without duplicating handlers.
+- With Rich enabled, uncaught exceptions retain their direct Rich console presentation;
+  with Rich disabled, exactly one standard record follows the selected handler policy.
 
-The repository's external-test risk categories are not triggered: the planned lifecycle
-edits select logging context but do not change routes, WebSocket/session transport,
+No browser-facing `@pytest.mark.external_test` coverage is expected for the logging-only
+implementation steps because they do not change routes, WebSocket/session transport,
 embedding boundaries, cross-origin behavior, assets, browser storage, or security headers.
-Browser-facing `@pytest.mark.external_test` coverage is therefore not required. The
-externally hosted scenarios need Python subprocess integration coverage instead.
+The externally hosted scenarios need Python subprocess integration coverage instead. This
+assessment must be repeated for each implementation PR, especially any change that touches
+`App.lifespan()`, `App.__call__`, or lazy-mount request ordering.
 
 ## Alternatives Considered
 

--- a/specs/2026-08-23-logging-strategy/tech-spec.md
+++ b/specs/2026-08-23-logging-strategy/tech-spec.md
@@ -102,18 +102,19 @@ state. A later Streamlit config reload can add another handler alongside Uvicorn
 
 ### Namespace architecture
 
-Create one module-owned handler and a permanent `NullHandler` on the namespace logger:
+Create one module-owned handler on the namespace logger:
 
 ```python
 _NAMESPACE_LOGGER_NAME: Final = "streamlit"
 _NAMESPACE_LOGGER = logging.getLogger(_NAMESPACE_LOGGER_NAME)
-_NULL_HANDLER = logging.NullHandler()
 _console_handler: logging.StreamHandler | None = None
 ```
 
-The `NullHandler` prevents Python's `lastResort` handler from unexpectedly formatting bare
-library records when no policy has been activated. It does not stop propagation to a host
-handler. Cooperative handler detection must ignore `NullHandler` instances.
+Do not add a permanent `NullHandler`. The bootstrap console handler covers the period before
+policy activation. In explicit `HOST` mode with no handler anywhere in the restored path,
+standard Python `lastResort` behavior remains available for `WARNING` and higher records;
+lower-level records may be discarded. A host-supplied `NullHandler` keeps its normal Python
+semantics. Cooperative mode still retains Streamlit's handler as its fallback.
 
 `get_logger` becomes a compatibility shim:
 
@@ -126,6 +127,12 @@ def get_logger(name: str) -> logging.Logger:
 It does not set a level, attach a handler, or change propagation. Existing call sites can
 remain unchanged in the first implementation. The `"root"` alias continues to resolve to
 `"streamlit"`, preserving direct-execution warnings.
+
+The compatibility promise applies to Streamlit's internal `streamlit.*` names and the
+special `"root"` alias. A third-party caller passing its own module name receives an
+ordinary, unconfigured standard logger and must migrate to `logging.getLogger(__name__)`
+plus its application logging configuration. Streamlit must not configure unrelated
+namespaces merely because they called this private helper.
 
 Fresh child loggers retain the standard `level=NOTSET` and `propagate=True`, so their
 effective level comes from the namespace logger. Explicit user configuration on a child is
@@ -167,7 +174,7 @@ class LoggingContext(Enum):
 
 class OutputPolicy(Enum):
     STREAMLIT = "streamlit"
-    COOPERATIVE = "cooperative"
+    COOPERATIVE = "cooperative"  # handlerMode="auto" in an external launch
     HOST = "host"
 ```
 
@@ -186,8 +193,9 @@ The initial config default is `streamlit`, preserving current output. A not-yet-
 context is conservative so code that reads Streamlit config before choosing a launcher
 does not lose diagnostics. The launch context is still implemented now so `auto` works
 correctly and a future default change does not require another architecture migration.
-The `logger.handlerMode` config option must explicitly validate membership in the three
-documented values and report an actionable Streamlit config error before resolving policy.
+The `logger.handlerMode` config option normalizes strings to lowercase, explicitly validates
+membership in `"streamlit"`, `"auto"`, and `"host"`, and reports those canonical choices in
+an actionable Streamlit config error before resolving policy.
 
 `STREAMLIT_MANAGED` is authoritative for the process once selected by the CLI or
 `App.run()`. An `st.App` mounted inside an ASGI app discovered by `streamlit run` must not
@@ -197,24 +205,25 @@ detection only replaces `UNCONFIGURED`, while `App.run()` may promote an unstart
 
 ### Bootstrapping before config parsing
 
-Under the module policy lock, module initialization atomically (1) sets namespace
-propagation to false, (2) adds the permanent `NullHandler`, and (3) installs one
-Streamlit-owned namespace handler using `INFO`, `DEFAULT_LOG_MESSAGE`, and stderr. Setting
-isolation first prevents a root handler configured before `import streamlit` from receiving
-a second copy during initialization. This replaces the dozens of handlers created during a
-normal import while preserving import-time and config-parser diagnostics before
-`logger.level`, `logger.messageFormat`, and `logger.handlerMode` are known.
+Before changing logger state, bootstrap saves the namespace's existing level and propagation
+values. Under the module policy lock, initialization atomically (1) sets namespace
+propagation to false and its level to `INFO`, then (2) installs one Streamlit-owned namespace
+handler at `NOTSET` using `DEFAULT_LOG_MESSAGE` and stderr. Setting isolation first prevents
+a root handler configured before `import streamlit` from receiving a second copy during
+initialization. This replaces the dozens of handlers created during a normal import while
+preserving import-time and config-parser diagnostics before `logger.level`,
+`logger.messageFormat`, and `logger.handlerMode` are known.
 
 After config parsing, `apply_logging_config` updates or removes only the owned handler:
 
-- `STREAMLIT`: retain the handler, set the namespace level and formatter from config, and
-  set namespace propagation to false.
+- `STREAMLIT`: retain the handler at `NOTSET`, set the namespace level and handler formatter
+  from config, and set namespace propagation to false.
 - `COOPERATIVE`: if a usable host path exists, remove the owned handler and apply the same
-  conditional `level=NOTSET` and `propagate=True` restoration as `HOST`, so host levels and
-  formatting are authoritative. Otherwise behave exactly like `STREAMLIT`: retain the
-  fallback, apply `logger.level` and `logger.messageFormat`, and keep namespace propagation
-  false.
-- `HOST`: remove the owned handler, use `level=NOTSET`, and propagate to the host.
+  conditional restoration as `HOST`, so host levels and formatting are authoritative.
+  Otherwise behave exactly like `STREAMLIT`: retain the `NOTSET` fallback handler, apply
+  `logger.level` and `logger.messageFormat`, and keep namespace propagation false.
+- `HOST`: remove the owned handler and conditionally restore the namespace state saved
+  before Streamlit took ownership.
 
 The bootstrap handler is deliberately used for config-parser diagnostics even when the
 final configured policy is `HOST`. This prevents an invalid logging config from suppressing
@@ -229,13 +238,13 @@ A usable host path exists when either:
 2. an ancestor has a non-`NullHandler` handler that would be reachable after transferring
    namespace ownership to the host.
 
-Detection walks the hierarchy explicitly rather than calling `Logger.hasHandlers`, because
-the permanent namespace `NullHandler` would otherwise count as a handler. When considering
-ancestors, the walk ignores `propagate=False` on the namespace only while that value is the
-bootstrap isolation value last written by Streamlit: selecting the host path will restore
-it to true. The walk still stops at `propagate=False` on any user-owned intermediate
-logger. Only after finding a usable path does Streamlit remove its handler and restore
-namespace propagation, so detection never creates a duplicate-output window.
+Detection walks the hierarchy explicitly rather than calling `Logger.hasHandlers` so it can
+ignore the Streamlit-owned handler, disregard any host `NullHandler` as a usable output,
+and evaluate the namespace propagation value that would be restored after ownership
+transfer. If the saved pre-ownership value is false, an ancestor is not reachable. The walk
+also stops at `propagate=False` on any user-owned intermediate logger. Only after finding a
+usable path does Streamlit remove its handler and restore namespace state, so detection
+never creates a duplicate-output window.
 
 `Logger.disabled` is neither a usable host path nor an input to cooperative detection: it
 does not describe handler reachability for descendants, and `dictConfig` can set it based
@@ -267,6 +276,10 @@ Streamlit tracks the exact handler object it creates and never identifies owners
 handler class alone. Formatter updates affect only this handler. User handlers and filters
 are never cleared or rewritten.
 
+Before Streamlit takes ownership, it snapshots the current namespace level and propagation
+values. This preserves configuration applied before `import streamlit` and is refreshed
+each time ownership is reacquired after a host-owned period.
+
 When Streamlit owns the output path:
 
 - the namespace logger level is set from `logger.level`;
@@ -275,9 +288,15 @@ When Streamlit owns the output path:
 - the namespace logger uses `propagate=False`; and
 - the owned handler uses `logger.messageFormat` and the existing millisecond formatting.
 
-When ownership is transferred to the host, Streamlit restores `NOTSET` and
-`propagate=True` only if those attributes still contain the last values written by
-Streamlit. A user modification made after activation wins and is not reverted. Streamlit
+The namespace level and propagation values are Streamlit-owned in `STREAMLIT` and
+cooperative-fallback modes. Config application and reload reassert them; applications that
+need host ownership of those values must select `HOST` or host-selected cooperative mode.
+
+When ownership is transferred to the host, Streamlit restores the saved pre-ownership level
+and propagation values only if those attributes still contain the last values written by
+Streamlit. A user modification made after activation wins and is not reverted. For a fresh
+standard logger the saved values are `NOTSET` and `propagate=True`; a namespace handler and
+`propagate=False` configured before import remain isolated as the host intended. Streamlit
 never changes `Logger.disabled`; that state always belongs to the host.
 
 `set_log_level` and `update_formatter` remain temporary internal compatibility shims, but
@@ -337,7 +356,9 @@ Lazy reconciliation uses a double-checked, process-wide reconciled flag. The req
 first performs a cheap flag read and acquires the policy lock only when reconciliation is
 pending; it checks the flag again inside the lock before applying policy. Steady-state
 requests therefore do not acquire the logging lock. Activation and config reload update or
-invalidate this flag as part of the same locked transition.
+invalidate this flag as part of the same locked transition. Reconciliation snapshots and
+applies logging state synchronously and releases the lock before returning to async request
+work.
 
 #### Bare `st.*` execution
 
@@ -366,6 +387,11 @@ case-insensitive config values such as `INFO`, avoids Uvicorn's lowercase-only s
 and reports unknown values as an actionable Streamlit config error before constructing
 `uvicorn.Config`.
 
+Replace the existing source comment that says logging config is not overridden; it is no
+longer accurate once `log_level` is supplied. Uvicorn applies the level to its error,
+access, and ASGI namespaces, while the separate existing `access_log=False` continues to
+disable access records even at a lower configured level.
+
 On Streamlit config reload, a callback registered by the managed runner updates levels on
 the existing Uvicorn logger family without adding handlers or changing propagation.
 
@@ -393,8 +419,9 @@ calls `apply_logging_config` against the stored launch context. It must be idemp
 
 Because logging and Streamlit config are process-wide, no per-session synchronization or
 state is introduced. Python logging's handler mutation APIs provide their own locks; the
-module should additionally guard policy transitions with one re-entrant lock so a config
-watcher cannot interleave with ASGI startup.
+module should additionally guard policy transitions with one `threading.RLock` so a config
+watcher cannot interleave with ASGI startup. Applying policy is synchronous and must not
+`await` while holding this lock.
 
 Lock order is always Streamlit's `_config_lock` before the logging policy lock, and code
 holding the policy lock must never read Streamlit config. `apply_logging_config` receives
@@ -430,11 +457,15 @@ Intentional observable changes are limited to:
 - a handler attached to `logging.getLogger("streamlit")` now receives child records;
 - an explicit child level can override the inherited namespace level using standard Python
   semantics;
-- private inspection of child `.handlers` sees no Streamlit handler; and
+- private inspection of child `.handlers` sees no Streamlit handler;
 - external server libraries are no longer mutated by Streamlit;
 - Streamlit no longer configures the third-party `websockets` logger, even in managed
   launches. Without a host/root handler, its independent records may use Python's
-  `lastResort` behavior instead of Streamlit's level and format.
+  `lastResort` behavior instead of Streamlit's level and format;
+- a third party that passes a non-`streamlit` name to the private `get_logger` helper now
+  receives an unconfigured standard logger and must configure its own namespace; and
+- invalid levels reported through the retained `set_log_level` shim use the actionable
+  Streamlit config error path instead of terminating the process with `sys.exit(1)`.
 
 The first two changes are the requested interoperability behavior. The latter changes
 affect private topology or third-party diagnostics rather than Streamlit application
@@ -465,18 +496,26 @@ run in isolated subprocesses rather than rely only on in-process fixture cleanup
 - The `"root"` alias returns `logging.getLogger("streamlit")`.
 - Managed mode installs exactly one owned handler using the configured format, with the
   configured level set on the namespace logger.
+- Bootstrap and managed output keep the owned handler at `NOTSET`, so an explicit child
+  `DEBUG` level can pass the namespace handler.
 - Repeated activation and config reload do not increase handler counts.
 - A custom namespace handler is never removed or reformatted.
 - Host mode removes only the owned handler and propagates records.
 - Cooperative mode chooses an existing namespace handler, a global root handler, or the
   Streamlit fallback as appropriate.
-- Cooperative detection ignores `NullHandler`, looks through Streamlit-owned namespace
-  isolation, and respects user-owned `propagate=False` boundaries.
+- Cooperative detection ignores `NullHandler` as usable output, evaluates the saved
+  namespace propagation state, and respects user-owned `propagate=False` boundaries.
 - `Logger.disabled` does not count as a host handler and is never changed by Streamlit.
 - Invalid `logger.handlerMode` values fail with an actionable config error.
-- Transitions between all handler modes preserve user changes made after activation.
+- Handler mode values are case-insensitive and validation errors list the three canonical
+  lowercase choices.
+- Streamlit and cooperative-fallback modes reassert the configured namespace level and
+  isolation on reload; transferring ownership preserves pre-existing state and user changes
+  that do not match Streamlit's last written values.
 - `setup_formatter` and the namespace `streamlit_console_handler` compatibility shims do
   not restore Streamlit-owned output in host mode.
+- `get_logger` called with a non-`streamlit` name returns an unconfigured logger and does not
+  attach Streamlit output to a third-party namespace.
 
 ### Subprocess integration tests
 
@@ -494,6 +533,10 @@ run in isolated subprocesses rather than rely only on in-process fixture cleanup
   handler without a second Streamlit-formatted copy.
 - A root handler configured before `import streamlit` receives no duplicate bootstrap
   record in default/`streamlit` mode.
+- Namespace level and propagation configured before import are restored when host ownership
+  activates.
+- Host mode with no handler anywhere in the restored path leaves Python `lastResort`
+  behavior intact for `WARNING` and higher records.
 - `dictConfig(disable_existing_loggers=True)` after import remains authoritative: Streamlit
   does not re-enable any disabled logger or treat the flag as a cooperative host path.
 - Bare `st.write` retains the direct-execution and missing-context warnings.

--- a/specs/2026-08-23-logging-strategy/tech-spec.md
+++ b/specs/2026-08-23-logging-strategy/tech-spec.md
@@ -178,6 +178,10 @@ class OutputPolicy(Enum):
     HOST = "host"
 ```
 
+`COOPERATIVE` is a detection step rather than a persistent topology: it immediately
+selects either the host-owned topology or the Streamlit fallback from the handler path
+visible in an external launch.
+
 `activate_logging(context)` records the launch context before config is parsed. After
 config is available, `apply_logging_config()` resolves the effective policy:
 
@@ -195,7 +199,20 @@ does not lose diagnostics. The launch context is still implemented now so `auto`
 correctly and a future default change does not require another architecture migration.
 The `logger.handlerMode` config option normalizes strings to lowercase, explicitly validates
 membership in `"streamlit"`, `"auto"`, and `"host"`, and reports those canonical choices in
-an actionable Streamlit config error before resolving policy.
+an actionable Streamlit config error before resolving policy. Define it as a public,
+non-scriptable option, matching `logger.level` and `logger.messageFormat` rather than the
+hidden, scriptable `logger.enableRich` option.
+
+Unlike other non-sensitive options, `logger.handlerMode` must also be read directly from
+`STREAMLIT_LOGGER_HANDLER_MODE` by `config.get_config_options`, because external ASGI and
+plain-Python launchers do not pass through Click. Preserve the documented precedence:
+project config overrides global config, this environment variable overrides config files,
+and explicit CLI or `App.run(config=...)` values override the environment.
+
+An invalid value is rejected during config set/parse. Initial startup emits the actionable
+error through the isolated bootstrap handler and then aborts without guessing a policy. An
+invalid live reload leaves the last successfully applied policy in place and rejects the
+new config rather than falling back.
 
 `STREAMLIT_MANAGED` is authoritative for the process once selected by the CLI or
 `App.run()`. An `st.App` mounted inside an ASGI app discovered by `streamlit run` must not
@@ -206,20 +223,21 @@ detection only replaces `UNCONFIGURED`, while `App.run()` may promote an unstart
 ### Bootstrapping before config parsing
 
 Before changing logger state, bootstrap saves the namespace's existing level and propagation
-values. Under the module policy lock, initialization atomically (1) sets namespace
-propagation to false and its level to `INFO`, then (2) installs one Streamlit-owned namespace
-handler at `NOTSET` using `DEFAULT_LOG_MESSAGE` and stderr. Setting isolation first prevents
-a root handler configured before `import streamlit` from receiving a second copy during
-initialization. This replaces the dozens of handlers created during a normal import while
-preserving import-time and config-parser diagnostics before `logger.level`,
-`logger.messageFormat`, and `logger.handlerMode` are known.
+values. Under the module's `threading.RLock`, before config watchers can run, initialization
+atomically (1) sets namespace propagation to false and its level to `INFO`, then (2)
+installs one Streamlit-owned namespace handler at `NOTSET` using `DEFAULT_LOG_MESSAGE` and
+stderr. Setting isolation first prevents a root handler configured before `import streamlit`
+from receiving a second copy during initialization. This replaces the dozens of handlers
+created during a normal import while preserving import-time and config-parser diagnostics
+before `logger.level`, `logger.messageFormat`, and `logger.handlerMode` are known.
 
 After config parsing, `apply_logging_config` updates or removes only the owned handler:
 
 - `STREAMLIT`: retain the handler at `NOTSET`, set the namespace level and handler formatter
   from config, and set namespace propagation to false.
 - `COOPERATIVE`: if a usable host path exists, remove the owned handler and apply the same
-  conditional restoration as `HOST`, so host levels and formatting are authoritative.
+  last-written-value restoration described under ownership as `HOST`, so host levels and
+  formatting are authoritative.
   Otherwise behave exactly like `STREAMLIT`: retain the `NOTSET` fallback handler, apply
   `logger.level` and `logger.messageFormat`, and keep namespace propagation false.
 - `HOST`: remove the owned handler and conditionally restore the namespace state saved
@@ -294,13 +312,18 @@ need host ownership of those values must select `HOST` or host-selected cooperat
 
 When ownership is transferred to the host, Streamlit restores the saved pre-ownership level
 and propagation values only if those attributes still contain the last values written by
-Streamlit. A user modification made after activation wins and is not reverted. For a fresh
-standard logger the saved values are `NOTSET` and `propagate=True`; a namespace handler and
-`propagate=False` configured before import remain isolated as the host intended. Streamlit
-never changes `Logger.disabled`; that state always belongs to the host.
+Streamlit. A distinguishable user modification made after activation wins and is not
+reverted. Reapplying the same value cannot be detected through the standard `Logger` API and
+is deterministically treated as still Streamlit-owned; a host needing that value should set
+it after handoff or before import. For a fresh standard logger the saved values are `NOTSET`
+and `propagate=True`; a namespace handler and `propagate=False` configured before import
+remain isolated as the host intended. Streamlit never changes `Logger.disabled`; that state
+always belongs to the host.
 
 `set_log_level` and `update_formatter` remain temporary internal compatibility shims, but
 operate only on the namespace logger and owned handler. They no longer iterate `_loggers`.
+In `HOST` and host-selected cooperative mode, all three compatibility shims are no-ops for
+namespace level and propagation; they cannot reclaim or mutate host state.
 `setup_formatter(logger)` also remains during the migration as a redirecting shim: it
 updates the owned namespace handler if one is active and never adds a handler to the passed
 child logger. The namespace logger's private `streamlit_console_handler` attribute points
@@ -392,8 +415,12 @@ longer accurate once `log_level` is supplied. Uvicorn applies the level to its e
 access, and ASGI namespaces, while the separate existing `access_log=False` continues to
 disable access records even at a lower configured level.
 
-On Streamlit config reload, a callback registered by the managed runner updates levels on
-the existing Uvicorn logger family without adding handlers or changing propagation.
+Both managed server implementations register the same context-gated Uvicorn level updater
+after constructing their respective `uvicorn.Config`: traditional `UvicornServer` and the
+`st.App` `UvicornRunner`. Each unregisters it during server shutdown/finally cleanup. On a
+managed config reload, the updater changes levels on the existing Uvicorn logger family
+without adding handlers, changing propagation, or re-enabling access logs. It is never
+registered by external ASGI paths.
 
 The managed runner leaves the `websockets` logger entirely alone. Modern Uvicorn protocol
 logs use the `uvicorn.*` hierarchy; independently emitted `websockets` records follow
@@ -408,8 +435,11 @@ own logging configuration.
 
 ### Config reloads and idempotency
 
-The existing config watcher can continue invoking a logging callback, but the callback
-calls `apply_logging_config` against the stored launch context. It must be idempotent:
+The existing config watcher in Streamlit-managed launches can continue invoking a logging
+callback, which calls `apply_logging_config` against the stored launch context. External
+`App.lifespan()` and `App.__call__()` paths do not install Streamlit file watchers, so this
+proposal does not add live `config.toml` reload to those modes. Explicit config parsing
+remains idempotent in every mode. The callback must:
 
 - reuse or replace exactly one owned handler;
 - never add a second owned handler;
@@ -427,21 +457,24 @@ Lock order is always Streamlit's `_config_lock` before the logging policy lock, 
 holding the policy lock must never read Streamlit config. `apply_logging_config` receives
 an immutable snapshot containing the validated handler mode, integer log level, and message
 format. The config callback builds that snapshot while `_config_lock` is already held, then
-may take the policy lock. Lifespan and request reconciliation first snapshot config under
-`_config_lock`, release it, and only then take the policy lock. This prevents lock-order
-inversion between a reload and ASGI startup.
+takes the policy lock. Lifespan and request reconciliation also acquire `_config_lock`,
+snapshot config, acquire the policy lock in that order, and apply synchronously before
+releasing either lock. They do not `await` in the critical section. Holding the config lock
+through apply prevents a newer reload from being overwritten by a stale lifespan snapshot.
 
 ### Implementation sequence
 
-1. Centralize Streamlit's handler and level on the namespace logger while keeping
+1. Confirm SiS/SPCS and Community Cloud do not inspect per-child `.handlers` or
+   `streamlit_console_handler` in their logging wrappers.
+2. Centralize Streamlit's handler and level on the namespace logger while keeping
    `handlerMode="streamlit"` in all launch modes.
-2. Replace per-child logger tests with hierarchy and exactly-once tests.
-3. Move managed Uvicorn configuration into the runner and stop configuring WebSockets.
-4. Add launch-context activation before config/runtime initialization.
-5. Add `logger.handlerMode` and cooperative/host transitions.
-6. Document standard namespace customization and external hosting examples.
+3. Replace per-child logger tests with hierarchy and exactly-once tests.
+4. Move managed Uvicorn configuration into the runner and stop configuring WebSockets.
+5. Add launch-context activation before config/runtime initialization.
+6. Add `logger.handlerMode` and cooperative/host transitions.
+7. Document standard namespace customization and external hosting examples.
 
-Steps 1–3 can merge independently while preserving all default Streamlit output. Steps 4–5
+Steps 2–4 can merge independently while preserving all default Streamlit output. Steps 5–6
 are additive because the initial config default still resolves to Streamlit-owned logging.
 
 ## Backward Compatibility and Rollout
@@ -460,8 +493,10 @@ Intentional observable changes are limited to:
 - private inspection of child `.handlers` sees no Streamlit handler;
 - external server libraries are no longer mutated by Streamlit;
 - Streamlit no longer configures the third-party `websockets` logger, even in managed
-  launches. Without a host/root handler, its independent records may use Python's
-  `lastResort` behavior instead of Streamlit's level and format;
+  launches. Without a host/root handler, its independent `DEBUG`/`INFO` records are
+  discarded and `WARNING` or higher may use Python's `lastResort` format; a host root
+  handler set to `DEBUG` may instead expose protocol chatter that Streamlit previously
+  isolated;
 - a third party that passes a non-`streamlit` name to the private `get_logger` helper now
   receives an unconfigured standard logger and must configure its own namespace; and
 - invalid levels reported through the retained `set_log_level` shim use the actionable
@@ -500,7 +535,8 @@ run in isolated subprocesses rather than rely only on in-process fixture cleanup
   `DEBUG` level can pass the namespace handler.
 - Repeated activation and config reload do not increase handler counts.
 - A custom namespace handler is never removed or reformatted.
-- Host mode removes only the owned handler and propagates records.
+- Host mode removes only the owned handler and restores the saved namespace level and
+  propagation state.
 - Cooperative mode chooses an existing namespace handler, a global root handler, or the
   Streamlit fallback as appropriate.
 - Cooperative detection ignores `NullHandler` as usable output, evaluates the saved
@@ -509,11 +545,17 @@ run in isolated subprocesses rather than rely only on in-process fixture cleanup
 - Invalid `logger.handlerMode` values fail with an actionable config error.
 - Handler mode values are case-insensitive and validation errors list the three canonical
   lowercase choices.
+- The handler-mode environment variable is applied without Click, while explicit CLI and
+  `App.run(config=...)` values retain higher precedence.
+- Invalid startup config aborts after the bootstrap diagnostic; an invalid reload preserves
+  the last applied policy.
 - Streamlit and cooperative-fallback modes reassert the configured namespace level and
   isolation on reload; transferring ownership preserves pre-existing state and user changes
   that do not match Streamlit's last written values.
 - `setup_formatter` and the namespace `streamlit_console_handler` compatibility shims do
   not restore Streamlit-owned output in host mode.
+- `set_log_level`, `update_formatter`, and `setup_formatter` do not mutate namespace state
+  after host ownership is selected.
 - `get_logger` called with a non-`streamlit` name returns an unconfigured logger and does not
   attach Streamlit output to a third-party namespace.
 
@@ -535,14 +577,19 @@ run in isolated subprocesses rather than rely only on in-process fixture cleanup
   record in default/`streamlit` mode.
 - Namespace level and propagation configured before import are restored when host ownership
   activates.
+- Reapplying a value equal to Streamlit's last write follows the deterministic
+  Streamlit-owned restoration rule.
 - Host mode with no handler anywhere in the restored path leaves Python `lastResort`
   behavior intact for `WARNING` and higher records.
 - `dictConfig(disable_existing_loggers=True)` after import remains authoritative: Streamlit
   does not re-enable any disabled logger or treat the flag as a cooperative host path.
 - Bare `st.write` retains the direct-execution and missing-context warnings.
-- A live config reload changes level/format or ownership without duplicating handlers.
+- A managed-launch live config reload changes level/format or ownership without duplicating
+  handlers; external launches do not gain a config-file watcher.
 - A config reload racing ASGI lifespan reconciliation completes without deadlock and leaves
   one policy-consistent output path.
+- Both managed Uvicorn implementations register, apply, and unregister the shared level
+  updater; external ASGI launches never register it.
 - With Rich enabled, uncaught exceptions retain their direct Rich console presentation;
   with Rich disabled, exactly one standard record follows the selected handler policy.
 


### PR DESCRIPTION
## Describe your changes

Make `logging.getLogger("streamlit")` the single control point for Streamlit logs,
and add `logger.handlerMode` so `streamlit run` keeps automatic console diagnostics
while embedded hosts can take ownership.

- Default `"streamlit"` keeps the current stderr output, format, and root isolation,
  with one namespace handler instead of per-child handlers.
- `"auto"` uses host logging when a root or `streamlit` handler exists, otherwise
  keeps the Streamlit fallback; `"host"` transfers ownership entirely.
- Stop configuring Uvicorn and WebSockets loggers that Streamlit does not own;
  configure managed Uvicorn only through `log_level`.

## GitHub Issue Link (if applicable)

- Addresses #4742
- Related to #3978

## Testing Plan

Spec-only change; no tests until implementation.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made
under the Apache 2.0 license.