### PR TITLE
[fix] Reject inverted st.number_input min/max bounds

### DIFF
--- a/.cursor/rules/python_lib.mdc
+++ b/.cursor/rules/python_lib.mdc
@@ -240,8 +240,8 @@ actually wrong or data is incomplete — see Logging.
     `value` vs user-configured `min_value` / `max_value`)
   - `StreamlitInvalidMinMaxError` (`min_value` cannot be greater than
     `max_value`; `st.slider` swaps reversed bounds and raises this only
-    for equal bounds, while `st.date_input` / `st.datetime_input` reject
-    reversed bounds and allow a single-day / single-instant range)
+    for equal bounds; `st.date_input` / `st.datetime_input` /
+    `st.number_input` reject reversed bounds and allow equal bounds)
   - `StreamlitInvalidURLError(url, protocols)` (`st.logo(link=)`, page-config
     menu items). Pass the allowed schemes, for example `["http", "https"]`.
     `protocols` defaults to `("http", "https", "mailto")`.

--- a/.github/instructions/python_lib.instructions.md
+++ b/.github/instructions/python_lib.instructions.md
@@ -238,8 +238,8 @@ actually wrong or data is incomplete — see Logging.
     `value` vs user-configured `min_value` / `max_value`)
   - `StreamlitInvalidMinMaxError` (`min_value` cannot be greater than
     `max_value`; `st.slider` swaps reversed bounds and raises this only
-    for equal bounds, while `st.date_input` / `st.datetime_input` reject
-    reversed bounds and allow a single-day / single-instant range)
+    for equal bounds; `st.date_input` / `st.datetime_input` /
+    `st.number_input` reject reversed bounds and allow equal bounds)
   - `StreamlitInvalidURLError(url, protocols)` (`st.logo(link=)`, page-config
     menu items). Pass the allowed schemes, for example `["http", "https"]`.
     `protocols` defaults to `("http", "https", "mailto")`.

--- a/lib/streamlit/AGENTS.md
+++ b/lib/streamlit/AGENTS.md
@@ -232,8 +232,8 @@ actually wrong or data is incomplete — see Logging.
     `value` vs user-configured `min_value` / `max_value`)
   - `StreamlitInvalidMinMaxError` (`min_value` cannot be greater than
     `max_value`; `st.slider` swaps reversed bounds and raises this only
-    for equal bounds, while `st.date_input` / `st.datetime_input` reject
-    reversed bounds and allow a single-day / single-instant range)
+    for equal bounds; `st.date_input` / `st.datetime_input` /
+    `st.number_input` reject reversed bounds and allow equal bounds)
   - `StreamlitInvalidURLError(url, protocols)` (`st.logo(link=)`, page-config
     menu items). Pass the allowed schemes, for example `["http", "https"]`.
     `protocols` defaults to `("http", "https", "mailto")`.

--- a/lib/streamlit/elements/widgets/number_input.py
+++ b/lib/streamlit/elements/widgets/number_input.py
@@ -752,8 +752,9 @@ class NumberInputMixin:
         # Ensure that the value matches arguments' types.
         all_ints = int_value and all_int_args
 
-        # Value-vs-bound checks below skip value is None, so inverted bounds
-        # would otherwise go uncaught in that case.
+        # Compare the bounds against each other before comparing them to the
+        # value: the checks below are skipped when `value` is None, and they
+        # would otherwise report a misleading value error for inverted bounds.
         if min_value is not None and max_value is not None and min_value > max_value:
             raise StreamlitInvalidMinMaxError(min_value, max_value)
 

--- a/lib/streamlit/elements/widgets/number_input.py
+++ b/lib/streamlit/elements/widgets/number_input.py
@@ -37,6 +37,7 @@ from streamlit.elements.lib.utils import (
     to_key,
 )
 from streamlit.errors import (
+    StreamlitInvalidMinMaxError,
     StreamlitInvalidNumberFormatError,
     StreamlitJSNumberBoundsError,
     StreamlitMixedNumericTypesError,
@@ -750,6 +751,11 @@ class NumberInputMixin:
 
         # Ensure that the value matches arguments' types.
         all_ints = int_value and all_int_args
+
+        # Value-vs-bound checks below skip value is None, so inverted bounds
+        # would otherwise go uncaught in that case.
+        if min_value is not None and max_value is not None and min_value > max_value:
+            raise StreamlitInvalidMinMaxError(min_value, max_value)
 
         if min_value is not None and value is not None and min_value > value:
             raise StreamlitValueBelowMinError(value=value, min_value=min_value)

--- a/lib/streamlit/errors.py
+++ b/lib/streamlit/errors.py
@@ -341,10 +341,10 @@ class StreamlitValueAboveMaxError(LocalizableStreamlitException):
 class StreamlitInvalidMinMaxError(LocalizableStreamlitException):
     """Raised when ``min_value`` is greater than ``max_value``.
 
-    ``st.slider`` swaps reversed bounds and raises this only for equal
-    bounds. ``st.date_input`` and ``st.datetime_input`` still reject
-    reversed bounds, and treat equal bounds as a valid single-day /
-    single-instant range.
+    - ``st.slider`` swaps reversed bounds and raises this only for equal
+      bounds.
+    - ``st.date_input``, ``st.datetime_input``, and ``st.number_input``
+      reject reversed bounds. Equal bounds stay valid.
     """
 
     def __init__(self, min_value: object, max_value: object) -> None:

--- a/lib/tests/streamlit/elements/number_input_test.py
+++ b/lib/tests/streamlit/elements/number_input_test.py
@@ -25,9 +25,11 @@ from streamlit.elements.lib.js_number import JSNumber
 from streamlit.elements.widgets.number_input import _LOGGER, NumberInputSerde
 from streamlit.errors import (
     StreamlitAPIException,
+    StreamlitInvalidMinMaxError,
     StreamlitInvalidWidthError,
     StreamlitMixedNumericTypesError,
     StreamlitValueAboveMaxError,
+    StreamlitValueBelowMinError,
     StreamlitValueError,
 )
 from streamlit.proto.LabelVisibility_pb2 import LabelVisibility
@@ -497,17 +499,17 @@ class NumberInputTest(DeltaGeneratorTestCase):
     @parameterized.expand(
         [
             # Integer tests
-            (6, -10, 0),
-            (-11, -10, 0),
+            (6, -10, 0, StreamlitValueAboveMaxError),
+            (-11, -10, 0, StreamlitValueBelowMinError),
             # Float tests
-            (-11.0, -10.0, 0.0),
-            (6.0, -10.0, 0.0),
+            (6.0, -10.0, 0.0, StreamlitValueAboveMaxError),
+            (-11.0, -10.0, 0.0, StreamlitValueBelowMinError),
         ]
     )
     def test_should_raise_exception_when_default_out_of_bounds_min_and_max_defined(
-        self, value, min_value, max_value
+        self, value, min_value, max_value, expected_error
     ):
-        with pytest.raises(StreamlitAPIException):
+        with pytest.raises(expected_error):
             st.number_input(
                 "My Label", value=value, min_value=min_value, max_value=max_value
             )
@@ -515,7 +517,7 @@ class NumberInputTest(DeltaGeneratorTestCase):
     def test_should_raise_exception_when_default_lt_min_and_max_is_none(self):
         value = -11.0
         min_value = -10.0
-        with pytest.raises(StreamlitAPIException):
+        with pytest.raises(StreamlitValueBelowMinError):
             st.number_input("My Label", value=value, min_value=min_value)
 
     def test_should_raise_exception_when_default_gt_max_and_min_is_none(self):
@@ -523,6 +525,41 @@ class NumberInputTest(DeltaGeneratorTestCase):
         max_value = 10
         with pytest.raises(StreamlitValueAboveMaxError):
             st.number_input("My Label", value=value, max_value=max_value)
+
+    @parameterized.expand(
+        [
+            # Integer: value="min", an in-range-looking value, and None.
+            (10, 1, "min"),
+            (10, 1, 5),
+            (10, 1, None),
+            # Float: same value variants.
+            (10.5, 1.0, "min"),
+            (10.5, 1.0, 5.0),
+            (10.5, 1.0, None),
+        ]
+    )
+    def test_min_max_exception(self, min_value, max_value, value):
+        """min_value after max_value raises StreamlitInvalidMinMaxError."""
+        with pytest.raises(StreamlitInvalidMinMaxError, match="cannot be greater than"):
+            st.number_input(
+                "the label", min_value=min_value, max_value=max_value, value=value
+            )
+
+    @parameterized.expand(
+        [
+            (10, 10, "min"),
+            (10, 10, 10),
+            (10, 10, None),
+            (1.5, 1.5, "min"),
+            (1.5, 1.5, 1.5),
+            (1.5, 1.5, None),
+        ]
+    )
+    def test_min_equals_max_is_allowed(self, min_value, max_value, value):
+        """Equal bounds remain a valid single-value range."""
+        st.number_input(
+            "the label", min_value=min_value, max_value=max_value, value=value
+        )
 
     def test_session_state_value_out_of_range_resets_to_default(self):
         """Test that out of range session_state values reset to default.

--- a/lib/tests/streamlit/elements/number_input_test.py
+++ b/lib/tests/streamlit/elements/number_input_test.py
@@ -539,7 +539,7 @@ class NumberInputTest(DeltaGeneratorTestCase):
         ]
     )
     def test_min_max_exception(self, min_value, max_value, value):
-        """min_value after max_value raises StreamlitInvalidMinMaxError."""
+        """Inverted bounds raise StreamlitInvalidMinMaxError."""
         with pytest.raises(StreamlitInvalidMinMaxError, match="cannot be greater than"):
             st.number_input(
                 "the label", min_value=min_value, max_value=max_value, value=value
@@ -560,6 +560,10 @@ class NumberInputTest(DeltaGeneratorTestCase):
         st.number_input(
             "the label", min_value=min_value, max_value=max_value, value=value
         )
+
+        c = self.get_delta_from_queue().new_element.number_input
+        assert c.min == min_value
+        assert c.max == max_value
 
     def test_session_state_value_out_of_range_resets_to_default(self):
         """Test that out of range session_state values reset to default.


### PR DESCRIPTION
## Describe your changes

Raises `StreamlitInvalidMinMaxError` when `st.number_input` is given both bounds and `min_value > max_value`, including `value=None` which previously succeeded.

Does not swap or warn. Equal bounds stay valid (single permitted value), matching `st.date_input` / `st.datetime_input`. `st.slider` remains the exception that swaps reversed bounds.

Inverted bounds with a non-`None` value used to surface as `ValueBelowMin` / `ValueAboveMax`, quoting the wrong problem.

## GitHub Issue Link (if applicable)

## Testing Plan

- [x] Unit Tests (JS and/or Python)
- `lib/tests/streamlit/elements/number_input_test.py` — inverted int/float bounds (`value="min"`, in-range-looking value, `None`); equal bounds including `value=None`; one-sided and in-range value errors still raise `ValueBelowMin` / `ValueAboveMax`

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

Made with [Cursor](https://cursor.com)