### PR TITLE
[fix] Improve nested url_path error message

### DIFF
--- a/lib/streamlit/navigation/page.py
+++ b/lib/streamlit/navigation/page.py
@@ -53,6 +53,21 @@ def _sanitize_url_path(title: str) -> str:
     return path
 
 
+def _raise_if_nested_url_path(url_path: str) -> None:
+    """Reject nested URL pathnames until they are supported.
+
+    Nested pathnames break static-asset resolution relative to the page URL.
+    """
+    if "/" not in url_path:
+        return
+    raise StreamlitAPIException(
+        f"The `url_path` `{url_path}` cannot contain a nested path (e.g. `foo/bar`). "
+        "Nested URL pathnames are not supported yet. To upvote enabling them, "
+        "see GitHub issue [#8971](https://github.com/streamlit/streamlit/issues/8971).",
+        error_id="page-nested-url-path",
+    )
+
+
 if TYPE_CHECKING:
     from collections.abc import Callable
 
@@ -144,8 +159,9 @@ class Page:
 
         The default page will have a pathname of ``""``, indicating the root
         URL of the app. If you set ``default=True``, ``url_path`` is ignored.
-        ``url_path`` can't include forward slashes; paths can't include
-        subdirectories.
+        ``url_path`` can't include forward slashes; nested URL pathnames are
+        not supported yet. To upvote enabling them, see GitHub issue
+        `#8971 <https://github.com/streamlit/streamlit/issues/8971>`_.
 
     default : bool
         Whether this page is the default page to be shown when the app is
@@ -301,11 +317,7 @@ class Page:
                         "`title` that can be converted to a valid URL path."
                     ),
                 )
-            if "/" in self._url_path:
-                raise StreamlitAPIException(
-                    "The URL path cannot contain a nested path (e.g. foo/bar).",
-                    error_id="page-nested-url-path",
-                )
+            _raise_if_nested_url_path(self._url_path)
 
             self._can_be_called: bool = False
             return
@@ -379,11 +391,7 @@ class Page:
                 )
 
             self._url_path = stripped_url_path
-            if "/" in self._url_path:
-                raise StreamlitAPIException(
-                    "The URL path cannot contain a nested path (e.g. foo/bar).",
-                    error_id="page-nested-url-path",
-                )
+            _raise_if_nested_url_path(self._url_path)
 
         if self._icon:
             validate_icon_or_emoji(self._icon)

--- a/lib/streamlit/navigation/page.py
+++ b/lib/streamlit/navigation/page.py
@@ -57,14 +57,14 @@ def _raise_if_nested_url_path(url_path: str) -> None:
     """Reject nested URL pathnames until they are supported."""
     # Browsers would resolve static assets relative to the nested page URL,
     # so a path like foo/bar would look for assets under /foo/ instead of the app root.
-    if "/" not in url_path:
-        return
-    raise StreamlitAPIException(
-        f"The `url_path` `{url_path}` cannot contain a nested path. "
-        "Nested URL pathnames are not supported yet. To upvote enabling them, "
-        "see GitHub issue [#8971](https://github.com/streamlit/streamlit/issues/8971).",
-        error_id="page-nested-url-path",
-    )
+    if "/" in url_path:
+        raise StreamlitAPIException(
+            f"The `url_path` `{url_path}` cannot include `/`. "
+            "Streamlit does not support nested URL pathnames yet, so use a single "
+            "path segment (e.g. `foo_bar`). To upvote support for nested pathnames, "
+            "see GitHub issue [#8971](https://github.com/streamlit/streamlit/issues/8971).",
+            error_id="page-nested-url-path",
+        )
 
 
 if TYPE_CHECKING:
@@ -158,8 +158,9 @@ class Page:
 
         The default page will have a pathname of ``""``, indicating the root
         URL of the app. If you set ``default=True``, ``url_path`` is ignored.
-        ``url_path`` can't include forward slashes; Streamlit does not support
-        nested URL pathnames yet. To upvote enabling them, see GitHub issue
+        ``url_path`` can't include forward slashes because Streamlit doesn't
+        support nested URL pathnames yet. To upvote support for nested
+        pathnames, see GitHub issue
         `#8971 <https://github.com/streamlit/streamlit/issues/8971>`_.
 
     default : bool

--- a/lib/streamlit/navigation/page.py
+++ b/lib/streamlit/navigation/page.py
@@ -54,14 +54,13 @@ def _sanitize_url_path(title: str) -> str:
 
 
 def _raise_if_nested_url_path(url_path: str) -> None:
-    """Reject nested URL pathnames until they are supported.
-
-    Nested pathnames break static-asset resolution relative to the page URL.
-    """
+    """Reject nested URL pathnames until they are supported."""
+    # Browsers would resolve static assets relative to the nested page URL,
+    # so a path like foo/bar would look for assets under /foo/ instead of the app root.
     if "/" not in url_path:
         return
     raise StreamlitAPIException(
-        f"The `url_path` `{url_path}` cannot contain a nested path (e.g. `foo/bar`). "
+        f"The `url_path` `{url_path}` cannot contain a nested path. "
         "Nested URL pathnames are not supported yet. To upvote enabling them, "
         "see GitHub issue [#8971](https://github.com/streamlit/streamlit/issues/8971).",
         error_id="page-nested-url-path",
@@ -159,8 +158,8 @@ class Page:
 
         The default page will have a pathname of ``""``, indicating the root
         URL of the app. If you set ``default=True``, ``url_path`` is ignored.
-        ``url_path`` can't include forward slashes; nested URL pathnames are
-        not supported yet. To upvote enabling them, see GitHub issue
+        ``url_path`` can't include forward slashes; Streamlit does not support
+        nested URL pathnames yet. To upvote enabling them, see GitHub issue
         `#8971 <https://github.com/streamlit/streamlit/issues/8971>`_.
 
     default : bool

--- a/lib/tests/streamlit/navigation/page_test.py
+++ b/lib/tests/streamlit/navigation/page_test.py
@@ -260,14 +260,29 @@ class StPagesTest(DeltaGeneratorTestCase):
         with pytest.raises(StreamlitMissingRequiredParameterError):
             st.Page(page_9, url_path="")
 
-    def test_non_default_pages_cannot_have_nested_url_path(self):
-        """Tests that an error is raised if the url path contains a nested path"""
+    @parameterized.expand(
+        [
+            ("simple", "foo/bar"),
+            ("leading_slash", "/foo/bar"),
+            ("trailing_slash", "foo/bar/"),
+            ("deeply_nested", "foo/bar/baz"),
+        ]
+    )
+    def test_non_default_pages_cannot_have_nested_url_path(
+        self, _name: str, url_path: str
+    ) -> None:
+        """Tests that an error is raised if the url path contains a nested path."""
 
         def page_9():
             pass
 
-        with pytest.raises(StreamlitAPIException):
-            st.Page(page_9, url_path="foo/bar")
+        with pytest.raises(StreamlitAPIException) as exc_info:
+            st.Page(page_9, url_path=url_path)
+
+        assert exc_info.value.error_id == "page-nested-url-path"
+        message = str(exc_info.value)
+        assert "nested path" in message
+        assert "https://github.com/streamlit/streamlit/issues/8971" in message
 
     def test_page_with_no_title_raises_api_exception(self):
         """Tests that an error is raised if the title is empty or inferred to be empty"""
@@ -467,12 +482,25 @@ class TestExternalUrlSupport(DeltaGeneratorTestCase):
         ):
             st.Page("https://example.com", **kwargs)
 
-    def test_external_url_cannot_have_nested_url_path(self):
+    @parameterized.expand(
+        [
+            ("simple", "foo/bar"),
+            ("leading_slash", "/foo/bar"),
+            ("trailing_slash", "foo/bar/"),
+            ("deeply_nested", "foo/bar/baz"),
+        ]
+    )
+    def test_external_url_cannot_have_nested_url_path(
+        self, _name: str, url_path: str
+    ) -> None:
         """Test that external URL pages cannot have nested url_path."""
         with pytest.raises(StreamlitAPIException) as exc_info:
-            st.Page("https://example.com", title="Test", url_path="foo/bar")
+            st.Page("https://example.com", title="Test", url_path=url_path)
 
-        assert "nested path" in str(exc_info.value)
+        assert exc_info.value.error_id == "page-nested-url-path"
+        message = str(exc_info.value)
+        assert "nested path" in message
+        assert "https://github.com/streamlit/streamlit/issues/8971" in message
 
     @parameterized.expand(
         [

--- a/lib/tests/streamlit/navigation/page_test.py
+++ b/lib/tests/streamlit/navigation/page_test.py
@@ -282,6 +282,7 @@ class StPagesTest(DeltaGeneratorTestCase):
         assert exc_info.value.error_id == "page-nested-url-path"
         message = str(exc_info.value)
         assert "nested path" in message
+        assert url_path.strip().strip("/") in message
         assert "https://github.com/streamlit/streamlit/issues/8971" in message
 
     def test_page_with_no_title_raises_api_exception(self):
@@ -500,6 +501,7 @@ class TestExternalUrlSupport(DeltaGeneratorTestCase):
         assert exc_info.value.error_id == "page-nested-url-path"
         message = str(exc_info.value)
         assert "nested path" in message
+        assert url_path.strip().strip("/") in message
         assert "https://github.com/streamlit/streamlit/issues/8971" in message
 
     @parameterized.expand(

--- a/lib/tests/streamlit/navigation/page_test.py
+++ b/lib/tests/streamlit/navigation/page_test.py
@@ -32,6 +32,12 @@ from streamlit.navigation.page import Page, StreamlitPage, _create_page
 from tests.conftest import enable_mpa_v2_mode
 from tests.delta_generator_test_case import DeltaGeneratorTestCase
 
+_NESTED_URL_PATHS = [
+    ("simple", "foo/bar", "foo/bar"),
+    ("leading_slash", "/foo/bar", "foo/bar"),
+    ("trailing_slash", "foo/bar/", "foo/bar"),
+]
+
 
 def test_page_is_a_class_with_compatibility_alias() -> None:
     """st.Page is the concrete Page class, with StreamlitPage as an alias."""
@@ -260,16 +266,9 @@ class StPagesTest(DeltaGeneratorTestCase):
         with pytest.raises(StreamlitMissingRequiredParameterError):
             st.Page(page_9, url_path="")
 
-    @parameterized.expand(
-        [
-            ("simple", "foo/bar"),
-            ("leading_slash", "/foo/bar"),
-            ("trailing_slash", "foo/bar/"),
-            ("deeply_nested", "foo/bar/baz"),
-        ]
-    )
+    @parameterized.expand(_NESTED_URL_PATHS)
     def test_non_default_pages_cannot_have_nested_url_path(
-        self, _name: str, url_path: str
+        self, _name: str, url_path: str, expected_path: str
     ) -> None:
         """Tests that an error is raised if the url path contains a nested path."""
 
@@ -281,8 +280,7 @@ class StPagesTest(DeltaGeneratorTestCase):
 
         assert exc_info.value.error_id == "page-nested-url-path"
         message = str(exc_info.value)
-        assert "nested path" in message
-        assert url_path.strip().strip("/") in message
+        assert f"`{expected_path}`" in message
         assert "https://github.com/streamlit/streamlit/issues/8971" in message
 
     def test_page_with_no_title_raises_api_exception(self):
@@ -483,16 +481,9 @@ class TestExternalUrlSupport(DeltaGeneratorTestCase):
         ):
             st.Page("https://example.com", **kwargs)
 
-    @parameterized.expand(
-        [
-            ("simple", "foo/bar"),
-            ("leading_slash", "/foo/bar"),
-            ("trailing_slash", "foo/bar/"),
-            ("deeply_nested", "foo/bar/baz"),
-        ]
-    )
+    @parameterized.expand(_NESTED_URL_PATHS)
     def test_external_url_cannot_have_nested_url_path(
-        self, _name: str, url_path: str
+        self, _name: str, url_path: str, expected_path: str
     ) -> None:
         """Test that external URL pages cannot have nested url_path."""
         with pytest.raises(StreamlitAPIException) as exc_info:
@@ -500,8 +491,7 @@ class TestExternalUrlSupport(DeltaGeneratorTestCase):
 
         assert exc_info.value.error_id == "page-nested-url-path"
         message = str(exc_info.value)
-        assert "nested path" in message
-        assert url_path.strip().strip("/") in message
+        assert f"`{expected_path}`" in message
         assert "https://github.com/streamlit/streamlit/issues/8971" in message
 
     @parameterized.expand(


### PR DESCRIPTION
## Describe your changes

Nested `url_path` values (e.g. `foo/bar`) already raise an API exception. The message now names the invalid path and links to GitHub issue #8971 so users can upvote nested pathname support.

## GitHub Issue Link (if applicable)

- Related to #8971

## Testing Plan

- [x] Unit Tests (JS and/or Python)
- `lib/tests/streamlit/navigation/page_test.py` — nested `url_path` rejection for internal and external pages, including leading/trailing slashes

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

Made with [Cursor](https://cursor.com)