### PR TITLE
[fix] Add dict methods to AppTest.session_state

### DIFF
--- a/lib/streamlit/testing/v1/app_test.py
+++ b/lib/streamlit/testing/v1/app_test.py
@@ -99,12 +99,89 @@ from streamlit.testing.v1.util import patch_config_options
 from streamlit.util import calc_hash
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterator, Sequence
+    from collections.abc import (
+        Callable,
+        ItemsView,
+        Iterator,
+        KeysView,
+        Sequence,
+        ValuesView,
+    )
 
     from streamlit.proto.WidgetStates_pb2 import WidgetStates
     from streamlit.source_util import PageHash, PageInfo
 
 TMP_DIR = tempfile.TemporaryDirectory()
+
+
+class _AppTestSessionState:
+    """Dict-like Session State for AppTest.
+
+    ``st.session_state`` is a ``MutableMapping``. AppTest previously exposed
+    the inner ``SafeSessionState``, whose ``__getattr__`` treats missing names
+    as session keys, so ``.get`` / ``.keys`` raised ``AttributeError``.
+    """
+
+    _state: SafeSessionState
+
+    def __init__(self, state: SafeSessionState) -> None:
+        object.__setattr__(self, "_state", state)
+
+    def get(self, key: str, default: Any = None) -> Any:
+        """Return the value for ``key``, or ``default`` if it is unset."""
+        try:
+            return self._state[key]
+        except KeyError:
+            return default
+
+    def keys(self) -> KeysView[str]:
+        return self._state.filtered_state.keys()
+
+    def items(self) -> ItemsView[str, Any]:
+        return self._state.filtered_state.items()
+
+    def values(self) -> ValuesView[Any]:
+        return self._state.filtered_state.values()
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return user state and keyed widget values."""
+        return self._state.filtered_state
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._state.filtered_state)
+
+    def __len__(self) -> int:
+        return len(self._state.filtered_state)
+
+    def __getitem__(self, key: str) -> Any:
+        return self._state[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self._state[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self._state[key]
+
+    def __contains__(self, key: object) -> bool:
+        return key in self._state.filtered_state
+
+    def __getattr__(self, key: str) -> Any:
+        try:
+            return self[key]
+        except KeyError:
+            raise AttributeError(f"{key} not found in session_state.")
+
+    def __setattr__(self, key: str, value: Any) -> None:
+        self[key] = value
+
+    def __delattr__(self, key: str) -> None:
+        try:
+            del self[key]
+        except KeyError:
+            raise AttributeError(f"{key} not found in session_state.")
+
+    def __repr__(self) -> str:
+        return repr(self._state)
 
 
 class AppTest:
@@ -159,9 +236,11 @@ class AppTest:
         Dictionary of secrets to be used by the simulated app. Use dict-like
         syntax to set secret values for the simulated app.
 
-    session_state: SafeSessionState
-        Session State for the simulated app. SafeSessionState object supports
-        read and write operations as usual for Streamlit apps.
+    session_state
+        Session State for the simulated app. Supports item and attribute
+        access plus the dict methods of ``st.session_state`` (``get``,
+        ``keys``, ``items``, ``values``, ``to_dict``, ``len``, and
+        iteration).
 
     query_params: dict[str, Any]
         Dictionary of query parameters to be used by the simulated app. Use
@@ -180,7 +259,8 @@ class AppTest:
         self.default_timeout = default_timeout
         session_state = SessionState()
         session_state[TESTING_KEY] = {}
-        self.session_state = SafeSessionState(session_state, lambda: None)
+        self._session_state = SafeSessionState(session_state, lambda: None)
+        self.session_state = _AppTestSessionState(self._session_state)
         self.query_params: dict[str, Any] = {}
         self.secrets: dict[str, Any] = {}
         self.args = args
@@ -405,7 +485,7 @@ class AppTest:
 
         script_runner = LocalScriptRunner(
             self._script_path,
-            self.session_state,
+            self._session_state,
             pages_manager,
             args=self.args,
             kwargs=self.kwargs,

--- a/lib/streamlit/testing/v1/app_test.py
+++ b/lib/streamlit/testing/v1/app_test.py
@@ -115,12 +115,12 @@ TMP_DIR = tempfile.TemporaryDirectory()
 
 
 class _AppTestSessionState:
-    """User-facing Session State for AppTest.
+    """Dict-like session state for AppTest testers.
 
-    Wraps ``SafeSessionState`` so testers get the same item/attribute access
-    and dict methods as ``st.session_state``. Mapping methods use filtered
-    user state. Production ``SafeSessionState`` is unchanged; its
-    ``__getattr__`` would treat ``get`` / ``keys`` as missing session keys.
+    Item and attribute access match ``st.session_state``. Mapping methods
+    (``get``, ``keys``, ``items``, ``values``, ``to_dict``, iteration)
+    expose filtered user state and keyed widgets, not internal Streamlit
+    keys.
     """
 
     _state: SafeSessionState

--- a/lib/streamlit/testing/v1/app_test.py
+++ b/lib/streamlit/testing/v1/app_test.py
@@ -115,11 +115,12 @@ TMP_DIR = tempfile.TemporaryDirectory()
 
 
 class _AppTestSessionState:
-    """Dict-like Session State for AppTest.
+    """User-facing Session State for AppTest.
 
-    ``st.session_state`` is a ``MutableMapping``. AppTest previously exposed
-    the inner ``SafeSessionState``, whose ``__getattr__`` treats missing names
-    as session keys, so ``.get`` / ``.keys`` raised ``AttributeError``.
+    Wraps ``SafeSessionState`` so testers get the same item/attribute access
+    and dict methods as ``st.session_state``. Mapping methods use filtered
+    user state. Production ``SafeSessionState`` is unchanged; its
+    ``__getattr__`` would treat ``get`` / ``keys`` as missing session keys.
     """
 
     _state: SafeSessionState
@@ -163,6 +164,8 @@ class _AppTestSessionState:
         del self._state[key]
 
     def __contains__(self, key: object) -> bool:
+        # Membership follows the tester-facing filtered view; item access
+        # still reaches internal keys that AppTest itself reads.
         return key in self._state.filtered_state
 
     def __getattr__(self, key: str) -> Any:
@@ -181,7 +184,7 @@ class _AppTestSessionState:
             raise AttributeError(f"{key} not found in session_state.")
 
     def __repr__(self) -> str:
-        return repr(self._state)
+        return repr(self._state.filtered_state)
 
 
 class AppTest:
@@ -238,9 +241,8 @@ class AppTest:
 
     session_state
         Session State for the simulated app. Supports item and attribute
-        access plus the dict methods of ``st.session_state`` (``get``,
-        ``keys``, ``items``, ``values``, ``to_dict``, ``len``, and
-        iteration).
+        access plus dict-style operations from ``st.session_state``: ``get``,
+        ``keys``, ``items``, ``values``, ``to_dict``, ``len``, and iteration.
 
     query_params: dict[str, Any]
         Dictionary of query parameters to be used by the simulated app. Use

--- a/lib/streamlit/testing/v1/element_tree.py
+++ b/lib/streamlit/testing/v1/element_tree.py
@@ -2665,7 +2665,9 @@ class ElementTree(Block):
     @property
     def session_state(self) -> SafeSessionState:
         assert self._runner is not None
-        return self._runner.session_state
+        # Widget internals need SafeSessionState; AppTest.session_state is the
+        # dict-like wrapper testers use.
+        return self._runner._session_state
 
     def get_widget_states(self) -> WidgetStates:
         ws = WidgetStates()

--- a/lib/tests/streamlit/testing/app_test_test.py
+++ b/lib/tests/streamlit/testing/app_test_test.py
@@ -840,15 +840,18 @@ def test_session_state_get_returns_script_value() -> None:
         import streamlit as st
 
         st.session_state["x"] = 7
+        st.session_state["empty"] = None
 
     at = AppTest.from_function(script).run()
     assert at.session_state.get("x") == 7
+    assert at.session_state.get("empty") is None
+    assert at.session_state.get("empty", "fallback") is None
     assert at.session_state.get("missing") is None
     assert at.session_state.get("missing", "fallback") == "fallback"
 
 
 def test_session_state_dict_api_matches_filtered_state() -> None:
-    """``keys`` / ``items`` / ``values`` / ``to_dict`` / ``len`` / iteration use filtered state."""
+    """Dict-style access exposes only user state and keyed widget values."""
 
     def script() -> None:
         import streamlit as st
@@ -868,3 +871,13 @@ def test_session_state_dict_api_matches_filtered_state() -> None:
     assert at.session_state.to_dict() == {"count": 1, "r": "a"}
     assert len(at.session_state) == 2
     assert set(at.session_state) == {"count", "r"}
+    assert "count" in repr(at.session_state)
+    assert TESTING_KEY not in repr(at.session_state)
+
+    at.session_state["count"] = 2
+    at.session_state.extra = "yes"
+    del at.session_state.extra
+    with pytest.raises(AttributeError, match="missing not found in session_state"):
+        _ = at.session_state.missing
+    assert at.session_state["count"] == 2
+    assert "extra" not in at.session_state

--- a/lib/tests/streamlit/testing/app_test_test.py
+++ b/lib/tests/streamlit/testing/app_test_test.py
@@ -20,6 +20,7 @@ from pathlib import Path
 import pytest
 
 from streamlit.runtime.pages_manager import PagesManager
+from streamlit.runtime.state.common import TESTING_KEY
 from streamlit.testing.v1 import AppTest, local_script_runner
 from streamlit.util import calc_hash
 
@@ -830,3 +831,40 @@ def test_keyed_fragment_rerun_button_before_fragment() -> None:
     at.button[0].click().run()
     assert not at.exception, at.exception
     assert at.text[0].value == "fragment ran 2 time(s)"
+
+
+def test_session_state_get_returns_script_value() -> None:
+    """``AppTest.session_state.get`` returns a key the script set."""
+
+    def script() -> None:
+        import streamlit as st
+
+        st.session_state["x"] = 7
+
+    at = AppTest.from_function(script).run()
+    assert at.session_state.get("x") == 7
+    assert at.session_state.get("missing") is None
+    assert at.session_state.get("missing", "fallback") == "fallback"
+
+
+def test_session_state_dict_api_matches_filtered_state() -> None:
+    """``keys`` / ``items`` / ``values`` / ``to_dict`` / ``len`` / iteration use filtered state."""
+
+    def script() -> None:
+        import streamlit as st
+
+        st.session_state["count"] = 1
+        st.radio("radio", options=["a", "b"], key="r")
+
+    at = AppTest.from_function(script).run()
+    assert at.session_state["count"] == 1
+    assert at.session_state.count == 1
+    assert "count" in at.session_state
+    assert "r" in at.session_state
+    assert TESTING_KEY not in at.session_state
+    assert set(at.session_state.keys()) == {"count", "r"}
+    assert dict(at.session_state.items()) == {"count": 1, "r": "a"}
+    assert set(at.session_state.values()) == {1, "a"}
+    assert at.session_state.to_dict() == {"count": 1, "r": "a"}
+    assert len(at.session_state) == 2
+    assert set(at.session_state) == {"count", "r"}

--- a/lib/tests/streamlit/testing/app_test_test.py
+++ b/lib/tests/streamlit/testing/app_test_test.py
@@ -873,8 +873,10 @@ def test_session_state_dict_api_matches_filtered_state() -> None:
     assert TESTING_KEY not in at.session_state
     assert set(at.session_state.keys()) == {"count", "r", "seeded"}
     assert dict(at.session_state.items()) == {"count": 1, "r": "a", "seeded": True}
+    assert dict(
+        zip(at.session_state.keys(), at.session_state.values(), strict=True)
+    ) == {"count": 1, "r": "a", "seeded": True}
     assert at.session_state.to_dict() == {"count": 1, "r": "a", "seeded": True}
-    assert len(at.session_state.values()) == 3
     assert len(at.session_state) == 3
     assert set(at.session_state) == {"count", "r", "seeded"}
     assert "count" in repr(at.session_state)

--- a/lib/tests/streamlit/testing/app_test_test.py
+++ b/lib/tests/streamlit/testing/app_test_test.py
@@ -859,25 +859,31 @@ def test_session_state_dict_api_matches_filtered_state() -> None:
         st.session_state["count"] = 1
         st.radio("radio", options=["a", "b"], key="r")
 
-    at = AppTest.from_function(script).run()
+    at = AppTest.from_function(script)
+    at.session_state["seeded"] = True
+    assert "seeded" in at.session_state
+    assert set(at.session_state.keys()) == {"seeded"}
+    assert len(at.session_state) == 1
+    at = at.run()
     assert at.session_state["count"] == 1
     assert at.session_state.count == 1
     assert "count" in at.session_state
     assert "r" in at.session_state
+    assert "seeded" in at.session_state
     assert TESTING_KEY not in at.session_state
-    assert set(at.session_state.keys()) == {"count", "r"}
-    assert dict(at.session_state.items()) == {"count": 1, "r": "a"}
-    assert set(at.session_state.values()) == {1, "a"}
-    assert at.session_state.to_dict() == {"count": 1, "r": "a"}
-    assert len(at.session_state) == 2
-    assert set(at.session_state) == {"count", "r"}
+    assert set(at.session_state.keys()) == {"count", "r", "seeded"}
+    assert dict(at.session_state.items()) == {"count": 1, "r": "a", "seeded": True}
+    assert at.session_state.to_dict() == {"count": 1, "r": "a", "seeded": True}
+    assert len(at.session_state.values()) == 3
+    assert len(at.session_state) == 3
+    assert set(at.session_state) == {"count", "r", "seeded"}
     assert "count" in repr(at.session_state)
     assert TESTING_KEY not in repr(at.session_state)
 
-    at.session_state["count"] = 2
     at.session_state.extra = "yes"
     del at.session_state.extra
+    del at.session_state["count"]
     with pytest.raises(AttributeError, match="missing not found in session_state"):
         _ = at.session_state.missing
-    assert at.session_state["count"] == 2
+    assert "count" not in at.session_state
     assert "extra" not in at.session_state


### PR DESCRIPTION
## Describe your changes

`AppTest.session_state` now supports the same dict methods as `st.session_state` (`get`, `keys`, `items`, `values`, `to_dict`, `len`, and iteration). `.get("x")` previously raised `AttributeError` because AppTest exposed `SafeSessionState`, whose `__getattr__` treats missing names as session keys.

A thin wrapper on AppTest provides that API; production `SafeSessionState` is unchanged.

Implements wiki queue **P0.4**.
https://github.com/streamlit/streamlit/wiki/2026-07-22-app-testing-fixes

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- [x] Unit Tests (JS and/or Python): `lib/tests/streamlit/testing/app_test_test.py` — `get` after a script sets a key; mapping methods over filtered state (keyed widgets included, internal testing key omitted); item and attribute access unchanged.
- [ ] E2E Tests: Not applicable (AppTest-only).
- [ ] Any manual testing needed?: No.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.


Made with [Cursor](https://cursor.com)

<!-- agent-metrics-start -->
<details>
<summary>Agent metrics</summary>

| Type | Name | Count |
|------|------|------:|
| skill | addressing-pr-review-comments | 1 |
| skill | checking-changes | 1 |
| skill | finalizing-pr | 1 |
| skill | implementing-app-testing-fixes | 1 |
| skill | reviewing-pr-description | 1 |
| skill | sharing-pr-agent-artifacts | 1 |

</details>
<!-- agent-metrics-end -->