### PR TITLE
[chore] Track protobuf name collisions in telemetry

### DIFF
--- a/lib/streamlit/runtime/metrics_util.py
+++ b/lib/streamlit/runtime/metrics_util.py
@@ -256,17 +256,30 @@ _CANNOT_IMPORT_FROM_RE: Final = re.compile(r"cannot import name '[^']+' from '([
 _STREAMLIT_ATTRIBUTE_RE: Final = re.compile(
     r"module 'streamlit' has no attribute '([^']+)'"
 )
-# Protobuf C++ / pure-Python TypeError markers for descriptor-pool name
-# collisions. Combined with ``streamlit/proto/`` this labels
-# https://github.com/streamlit/streamlit/issues/3082 without recording
-# colliding file names or unrelated library clashes.
+# Label Streamlit protobuf descriptor-pool collisions
+# (https://github.com/streamlit/streamlit/issues/3082) without recording
+# colliding file names. A path-qualified match requires a Streamlit proto
+# path plus one of these collision-specific substrings, not the generic
+# "couldn't build proto file into descriptor pool" prefix.
 _PROTOBUF_COLLISION_MARKERS: Final = (
-    "couldn't build proto file into descriptor pool",
     "conflict register for file",
     "already defined in file",
     "already in the pool",
+    "duplicate file name",
 )
 _STREAMLIT_PROTO_PATH: Final = "streamlit/proto/"
+# protobuf 5+ upb name collisions omit the file path:
+# "Couldn't build proto file into descriptor pool: duplicate symbol 'Empty'".
+_PROTOBUF_DUPLICATE_SYMBOL_RE: Final = re.compile(r"duplicate symbol '([^']+)'")
+# Un-namespaced Streamlit proto types used only as a match gate; the symbol
+# is never emitted in telemetry.
+_STREAMLIT_UNNAMESPACED_PROTO_NAMES: Final = frozenset(
+    {
+        "empty",
+        "image",
+        "imagelist",
+    }
+)
 # Import namespaces used by Streamlit itself or by its optional features. Only
 # these names are appended to telemetry to avoid recording private app modules.
 _STREAMLIT_IMPORT_MODULE_PREFIXES: Final = frozenset(
@@ -556,18 +569,21 @@ def _is_streamlit_import_module(module: str) -> bool:
 
 
 def _is_streamlit_protobuf_collision(msg: str) -> bool:
-    """Return whether ``msg`` is a protobuf descriptor-pool clash with Streamlit.
+    """True when this TypeError text is a descriptor-pool clash with Streamlit.
 
     Streamlit's generated protos are un-namespaced, so a third-party ``Empty``
     or ``Image`` message can collide in the global descriptor pool
-    (https://github.com/streamlit/streamlit/issues/3082). Both the C++ and
-    pure-Python protobuf backends surface this as a ``TypeError`` whose text
-    names a ``streamlit/proto/`` file.
+    (https://github.com/streamlit/streamlit/issues/3082). The C++ and
+    pure-Python backends name a ``streamlit/proto/`` file; protobuf 5+ upb
+    name collisions do not.
     """
     lowered = msg.lower()
-    if _STREAMLIT_PROTO_PATH not in lowered:
-        return False
-    return any(marker in lowered for marker in _PROTOBUF_COLLISION_MARKERS)
+    if _STREAMLIT_PROTO_PATH in lowered and any(
+        marker in lowered for marker in _PROTOBUF_COLLISION_MARKERS
+    ):
+        return True
+    match = _PROTOBUF_DUPLICATE_SYMBOL_RE.search(lowered)
+    return bool(match and match.group(1) in _STREAMLIT_UNNAMESPACED_PROTO_NAMES)
 
 
 def format_uncaught_exception(exc: BaseException) -> str:
@@ -579,7 +595,7 @@ def format_uncaught_exception(exc: BaseException) -> str:
     - unexpected-keyword ``TypeError`` → ``"TypeError:<param>"``
     - missing required argument ``TypeError`` → ``"TypeError:missing:<param>"``
     - protobuf descriptor-pool collisions with Streamlit protos
-      → ``"TypeError:protobuf_collision"``
+      → ``"TypeError:protobuf-collision"``
     - allowlisted ``ImportError`` / ``ModuleNotFoundError``
       → ``"<Type>:<module>"``
     - missing top-level ``streamlit`` attributes → ``"AttributeError:<attribute>"``
@@ -597,7 +613,7 @@ def format_uncaught_exception(exc: BaseException) -> str:
         if isinstance(exc, TypeError):
             msg = str(exc)
             if _is_streamlit_protobuf_collision(msg):
-                return f"{name}:protobuf_collision"
+                return f"{name}:protobuf-collision"
             match = _UNEXPECTED_KWARG_RE.search(msg)
             if match:
                 return f"{name}:{match.group(1)}"

--- a/lib/streamlit/runtime/metrics_util.py
+++ b/lib/streamlit/runtime/metrics_util.py
@@ -256,6 +256,17 @@ _CANNOT_IMPORT_FROM_RE: Final = re.compile(r"cannot import name '[^']+' from '([
 _STREAMLIT_ATTRIBUTE_RE: Final = re.compile(
     r"module 'streamlit' has no attribute '([^']+)'"
 )
+# Protobuf C++ / pure-Python TypeError markers for descriptor-pool name
+# collisions. Combined with ``streamlit/proto/`` this labels
+# https://github.com/streamlit/streamlit/issues/3082 without recording
+# colliding file names or unrelated library clashes.
+_PROTOBUF_COLLISION_MARKERS: Final = (
+    "couldn't build proto file into descriptor pool",
+    "conflict register for file",
+    "already defined in file",
+    "already in the pool",
+)
+_STREAMLIT_PROTO_PATH: Final = "streamlit/proto/"
 # Import namespaces used by Streamlit itself or by its optional features. Only
 # these names are appended to telemetry to avoid recording private app modules.
 _STREAMLIT_IMPORT_MODULE_PREFIXES: Final = frozenset(
@@ -544,6 +555,21 @@ def _is_streamlit_import_module(module: str) -> bool:
     )
 
 
+def _is_streamlit_protobuf_collision(msg: str) -> bool:
+    """Return whether ``msg`` is a protobuf descriptor-pool clash with Streamlit.
+
+    Streamlit's generated protos are un-namespaced, so a third-party ``Empty``
+    or ``Image`` message can collide in the global descriptor pool
+    (https://github.com/streamlit/streamlit/issues/3082). Both the C++ and
+    pure-Python protobuf backends surface this as a ``TypeError`` whose text
+    names a ``streamlit/proto/`` file.
+    """
+    lowered = msg.lower()
+    if _STREAMLIT_PROTO_PATH not in lowered:
+        return False
+    return any(marker in lowered for marker in _PROTOBUF_COLLISION_MARKERS)
+
+
 def format_uncaught_exception(exc: BaseException) -> str:
     """Return a page-profile label for an uncaught exception.
 
@@ -552,6 +578,8 @@ def format_uncaught_exception(exc: BaseException) -> str:
 
     - unexpected-keyword ``TypeError`` → ``"TypeError:<param>"``
     - missing required argument ``TypeError`` → ``"TypeError:missing:<param>"``
+    - protobuf descriptor-pool collisions with Streamlit protos
+      → ``"TypeError:protobuf_collision"``
     - allowlisted ``ImportError`` / ``ModuleNotFoundError``
       → ``"<Type>:<module>"``
     - missing top-level ``streamlit`` attributes → ``"AttributeError:<attribute>"``
@@ -568,6 +596,8 @@ def format_uncaught_exception(exc: BaseException) -> str:
     with contextlib.suppress(Exception):
         if isinstance(exc, TypeError):
             msg = str(exc)
+            if _is_streamlit_protobuf_collision(msg):
+                return f"{name}:protobuf_collision"
             match = _UNEXPECTED_KWARG_RE.search(msg)
             if match:
                 return f"{name}:{match.group(1)}"

--- a/lib/tests/streamlit/runtime/metrics_util_test.py
+++ b/lib/tests/streamlit/runtime/metrics_util_test.py
@@ -870,6 +870,48 @@ def test_gather_metrics_records_time_when_rerun_exception_raised() -> None:
             "TypeError",
         ),
         (
+            TypeError(
+                "Couldn't build proto file into descriptor pool! Invalid proto "
+                'descriptor for file "worker_api.proto": Empty: "Empty" is '
+                'already defined in file "streamlit/proto/Empty.proto".'
+            ),
+            "TypeError:protobuf_collision",
+        ),
+        (
+            TypeError(
+                'Conflict register for file "worker_api.proto": Empty is already '
+                'defined in file "streamlit/proto/Empty.proto".'
+            ),
+            "TypeError:protobuf_collision",
+        ),
+        (
+            TypeError(
+                "Couldn't build proto file into descriptor pool! Invalid proto "
+                'descriptor for file "streamlit/proto/Empty.proto": Empty: '
+                '"Empty" is already defined in file "worker_api.proto".'
+            ),
+            "TypeError:protobuf_collision",
+        ),
+        (
+            TypeError(
+                'Invalid proto descriptor for file "streamlit/proto/Empty.proto": '
+                "streamlit/proto/Empty.proto: A file with this name is already "
+                "in the pool."
+            ),
+            "TypeError:protobuf_collision",
+        ),
+        (
+            TypeError(
+                'Conflict register for file "other.proto": Foo is already '
+                'defined in file "bar.proto".'
+            ),
+            "TypeError",
+        ),
+        (
+            TypeError("failed to load streamlit/proto/Empty.proto"),
+            "TypeError",
+        ),
+        (
             StreamlitValueError("width", ["stretch", "content"]),
             "StreamlitValueError:width",
         ),
@@ -1006,6 +1048,12 @@ def test_gather_metrics_records_time_when_rerun_exception_raised() -> None:
         "unsupported-too-many-positional",
         "unsupported-proto-type",
         "unsupported-byteslike",
+        "protobuf-collision-cpp-backend",
+        "protobuf-collision-python-backend",
+        "protobuf-collision-streamlit-loaded-second",
+        "protobuf-collision-duplicate-filename",
+        "protobuf-collision-unrelated-libraries",
+        "protobuf-path-without-collision-markers",
         "streamlit-value-error",
         "streamlit-value-error-detail",
         "streamlit-missing-required-parameter",

--- a/lib/tests/streamlit/runtime/metrics_util_test.py
+++ b/lib/tests/streamlit/runtime/metrics_util_test.py
@@ -875,14 +875,14 @@ def test_gather_metrics_records_time_when_rerun_exception_raised() -> None:
                 'descriptor for file "worker_api.proto": Empty: "Empty" is '
                 'already defined in file "streamlit/proto/Empty.proto".'
             ),
-            "TypeError:protobuf_collision",
+            "TypeError:protobuf-collision",
         ),
         (
             TypeError(
                 'Conflict register for file "worker_api.proto": Empty is already '
                 'defined in file "streamlit/proto/Empty.proto".'
             ),
-            "TypeError:protobuf_collision",
+            "TypeError:protobuf-collision",
         ),
         (
             TypeError(
@@ -890,7 +890,7 @@ def test_gather_metrics_records_time_when_rerun_exception_raised() -> None:
                 'descriptor for file "streamlit/proto/Empty.proto": Empty: '
                 '"Empty" is already defined in file "worker_api.proto".'
             ),
-            "TypeError:protobuf_collision",
+            "TypeError:protobuf-collision",
         ),
         (
             TypeError(
@@ -898,7 +898,21 @@ def test_gather_metrics_records_time_when_rerun_exception_raised() -> None:
                 "streamlit/proto/Empty.proto: A file with this name is already "
                 "in the pool."
             ),
-            "TypeError:protobuf_collision",
+            "TypeError:protobuf-collision",
+        ),
+        (
+            TypeError(
+                "Couldn't build proto file into descriptor pool: duplicate "
+                "symbol 'Empty'"
+            ),
+            "TypeError:protobuf-collision",
+        ),
+        (
+            TypeError(
+                "Couldn't build proto file into descriptor pool: duplicate "
+                "file name streamlit/proto/Empty.proto"
+            ),
+            "TypeError:protobuf-collision",
         ),
         (
             TypeError(
@@ -909,6 +923,21 @@ def test_gather_metrics_records_time_when_rerun_exception_raised() -> None:
         ),
         (
             TypeError("failed to load streamlit/proto/Empty.proto"),
+            "TypeError",
+        ),
+        (
+            TypeError(
+                "Couldn't build proto file into descriptor pool: duplicate "
+                "symbol 'MyRequest'"
+            ),
+            "TypeError",
+        ),
+        (
+            TypeError(
+                "Couldn't build proto file into descriptor pool! Invalid proto "
+                'descriptor for file "streamlit/proto/Empty.proto": SomeField: '
+                "missing field number."
+            ),
             "TypeError",
         ),
         (
@@ -1052,8 +1081,12 @@ def test_gather_metrics_records_time_when_rerun_exception_raised() -> None:
         "protobuf-collision-python-backend",
         "protobuf-collision-streamlit-loaded-second",
         "protobuf-collision-duplicate-filename",
-        "protobuf-collision-unrelated-libraries",
+        "protobuf-collision-upb-duplicate-symbol",
+        "protobuf-collision-upb-duplicate-filename",
+        "unrelated-proto-collision-not-labeled",
         "protobuf-path-without-collision-markers",
+        "unrelated-upb-duplicate-symbol-not-labeled",
+        "protobuf-descriptor-error-not-collision",
         "streamlit-value-error",
         "streamlit-value-error-detail",
         "streamlit-missing-required-parameter",
@@ -1083,7 +1116,7 @@ def test_gather_metrics_records_time_when_rerun_exception_raised() -> None:
     ],
 )
 def test_format_uncaught_exception(exc: BaseException, expected: str) -> None:
-    """Return ``ExceptionType:<param>`` for known parameter failures; otherwise the bare type name."""
+    """Return a stable ``Type:<suffix>`` label, or the bare type name."""
     assert metrics_util.format_uncaught_exception(exc) == expected
 
 


### PR DESCRIPTION
## Describe your changes

Page-profile telemetry now records uncaught protobuf descriptor-pool collisions with Streamlit protos as `TypeError:protobuf-collision`, so we can measure how often https://github.com/streamlit/streamlit/issues/3082 happens in real apps.

Matches historical C++ and pure-Python messages that mention `streamlit/proto/`, plus protobuf 5+ upb `duplicate symbol` text for Streamlit's un-namespaced types (`Empty`, `Image`, `ImageList`). Colliding file names and symbols are not recorded.

## GitHub Issue Link (if applicable)

https://github.com/streamlit/streamlit/issues/3082

## Testing Plan

- [x] Unit Tests (JS and/or Python)
- `lib/tests/streamlit/runtime/metrics_util_test.py` — C++ / pure-Python / upb collision messages, reverse load order, and negatives

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.