### PR TITLE
[fix] Close leftover dialogs on full-app rerun

### DIFF
--- a/e2e_playwright/st_dialog.py
+++ b/e2e_playwright/st_dialog.py
@@ -423,6 +423,10 @@ if st.button("Open Dialog with JSON Path Tooltip"):
 
 # Regression coverage for #9405: a dialog closed via st.rerun() must disappear
 # as soon as the next full-app run starts, even if that run then blocks.
+# Keep this longer than the hide-assertion window in
+# test_dialog_closes_before_blocking_follow_up_work. If the sleep finishes
+# first, clearStaleNodes can unmount the leftover dialog and the test would
+# pass without the early-hide fix.
 _BLOCKING_AFTER_DIALOG_CLOSE_SECONDS = 4
 
 

--- a/e2e_playwright/st_dialog.py
+++ b/e2e_playwright/st_dialog.py
@@ -419,3 +419,25 @@ def dialog_with_json_path_tooltip() -> None:
 
 if st.button("Open Dialog with JSON Path Tooltip"):
     dialog_with_json_path_tooltip()
+
+
+# Regression coverage for #9405: a dialog closed via st.rerun() must disappear
+# as soon as the next full-app run starts, even if that run then blocks.
+_BLOCKING_AFTER_DIALOG_CLOSE_SECONDS = 4
+
+
+@st.dialog("Dialog closed before blocking work")
+def dialog_closed_before_blocking() -> None:
+    st.write("Submit to close this dialog, then the app will block.")
+    if st.button("Submit then block", key="dialog-submit-then-block"):
+        st.session_state.block_after_dialog_close = True
+        st.rerun()
+
+
+if st.session_state.get("block_after_dialog_close"):
+    st.write("Blocking operation started")
+    time.sleep(_BLOCKING_AFTER_DIALOG_CLOSE_SECONDS)
+    st.write("Blocking operation done")
+    st.session_state.block_after_dialog_close = False
+elif st.button("Open dialog that blocks after close"):
+    dialog_closed_before_blocking()

--- a/e2e_playwright/st_dialog_test.py
+++ b/e2e_playwright/st_dialog_test.py
@@ -868,14 +868,14 @@ def test_dialog_closes_before_blocking_follow_up_work(app: Page):
     # hide the bug this test is meant to catch.
     get_button(dialog, "Submit then block").click()
 
-    expect(dialog).not_to_be_attached(timeout=3000)
+    # Wait for the next run to start so we assert hide during the blocking
+    # window, not against a timeout that can miss startup or outlast the sleep.
     expect(app.get_by_text("Blocking operation started")).to_be_visible()
+    expect(dialog).not_to_be_attached()
     expect(app.get_by_text("Blocking operation done")).not_to_be_attached()
 
-    # Let the blocking run finish so later tests in this module are not left
-    # with a still-running script. The hide is only applied while the script
-    # is running; after a successful finish the leftover node is pruned, so
-    # the dialog must stay gone.
+    # The hide only applies while the script is executing. After a successful
+    # finish the leftover node is pruned, so the dialog must stay gone.
     expect(app.get_by_text("Blocking operation done")).to_be_visible(timeout=10000)
     expect(dialog).not_to_be_attached()
 

--- a/e2e_playwright/st_dialog_test.py
+++ b/e2e_playwright/st_dialog_test.py
@@ -130,6 +130,10 @@ def open_on_dismiss_callback_dialog(app: Page):
     click_button(app, "Open on_dismiss callback Dialog")
 
 
+def open_dialog_that_blocks_after_close(app: Page):
+    click_button(app, "Open dialog that blocks after close")
+
+
 def click_to_dismiss(app: Page):
     # Click somewhere outside the close popover container:
     app.keyboard.press("Escape")
@@ -848,6 +852,29 @@ def test_non_dismissible_dialog_can_be_closed_programmatically(app: Page):
 
     # Dialog should now be closed
     expect(main_dialog).to_have_count(0)
+
+
+def test_dialog_closes_before_blocking_follow_up_work(app: Page):
+    """A dialog closed with st.rerun() must disappear before later blocking work.
+
+    Reproduces issue #9405: stale dialog nodes used to stay visible until the
+    next full-app run finished, so time.sleep after submit left the modal up.
+    """
+    open_dialog_that_blocks_after_close(app)
+    dialog = app.get_by_test_id(modal_test_id)
+    expect(dialog).to_be_visible()
+
+    # Do not wait_for_app_run: that would wait out the blocking sleep and
+    # hide the bug this test is meant to catch.
+    get_button(dialog, "Submit then block").click()
+
+    expect(dialog).not_to_be_attached(timeout=3000)
+    expect(app.get_by_text("Blocking operation started")).to_be_visible()
+    expect(app.get_by_text("Blocking operation done")).not_to_be_attached()
+
+    # Let the blocking run finish so later tests in this module are not left
+    # with a still-running script.
+    expect(app.get_by_text("Blocking operation done")).to_be_visible(timeout=10000)
 
 
 def test_dialog_on_dismiss_rerun(app: Page):

--- a/e2e_playwright/st_dialog_test.py
+++ b/e2e_playwright/st_dialog_test.py
@@ -873,8 +873,11 @@ def test_dialog_closes_before_blocking_follow_up_work(app: Page):
     expect(app.get_by_text("Blocking operation done")).not_to_be_attached()
 
     # Let the blocking run finish so later tests in this module are not left
-    # with a still-running script.
+    # with a still-running script. The hide is only applied while the script
+    # is running; after a successful finish the leftover node is pruned, so
+    # the dialog must stay gone.
     expect(app.get_by_text("Blocking operation done")).to_be_visible(timeout=10000)
+    expect(dialog).not_to_be_attached()
 
 
 def test_dialog_on_dismiss_rerun(app: Page):

--- a/frontend/lib/src/components/core/Block/Block.test.tsx
+++ b/frontend/lib/src/components/core/Block/Block.test.tsx
@@ -848,6 +848,121 @@ describe("BlockNodeRenderer container types", () => {
     expect(screen.getByText("dialog body")).toBeVisible()
   })
 
+  it("hides a leftover dialog from a previous full-app run", () => {
+    const dialogBlock = new BlockNode(
+      FAKE_SCRIPT_HASH,
+      [text("dialog body")],
+      new BlockProto({
+        allowEmpty: true,
+        dialog: {
+          title: "My dialog",
+          isOpen: true,
+          dismissible: true,
+          width: BlockProto.Dialog.DialogWidth.LARGE,
+        },
+      }),
+      "previous-run"
+    )
+    const setTriggerValue = vi.spyOn(widgetMgr, "setTriggerValue")
+
+    renderWithContexts(makeBlockNodeComponent(dialogBlock), {
+      scriptRunContext: {
+        scriptRunState: ScriptRunState.RUNNING,
+        scriptRunId: "current-run",
+        fragmentIdsThisRun: [],
+      },
+    })
+
+    expect(screen.queryByTestId("stDialog")).not.toBeInTheDocument()
+    expect(screen.queryByText("dialog body")).not.toBeInTheDocument()
+    expect(setTriggerValue).not.toHaveBeenCalled()
+  })
+
+  it("keeps a dialog from the current full-app run visible while running", () => {
+    const dialogBlock = new BlockNode(
+      FAKE_SCRIPT_HASH,
+      [text("dialog body")],
+      new BlockProto({
+        allowEmpty: true,
+        dialog: {
+          title: "My dialog",
+          isOpen: true,
+          dismissible: true,
+          width: BlockProto.Dialog.DialogWidth.LARGE,
+        },
+      }),
+      "current-run"
+    )
+
+    renderWithContexts(makeBlockNodeComponent(dialogBlock), {
+      scriptRunContext: {
+        scriptRunState: ScriptRunState.RUNNING,
+        scriptRunId: "current-run",
+        fragmentIdsThisRun: [],
+      },
+    })
+
+    expect(screen.getByTestId("stDialog")).toBeVisible()
+    expect(screen.getByText("dialog body")).toBeVisible()
+  })
+
+  it("keeps a leftover dialog visible while a rerun is only requested", () => {
+    const dialogBlock = new BlockNode(
+      FAKE_SCRIPT_HASH,
+      [text("dialog body")],
+      new BlockProto({
+        allowEmpty: true,
+        dialog: {
+          title: "My dialog",
+          isOpen: true,
+          dismissible: true,
+          width: BlockProto.Dialog.DialogWidth.LARGE,
+        },
+      }),
+      "previous-run"
+    )
+
+    renderWithContexts(makeBlockNodeComponent(dialogBlock), {
+      scriptRunContext: {
+        scriptRunState: ScriptRunState.RERUN_REQUESTED,
+        scriptRunId: "current-run",
+        fragmentIdsThisRun: [],
+      },
+    })
+
+    expect(screen.getByTestId("stDialog")).toBeVisible()
+    expect(screen.getByText("dialog body")).toBeVisible()
+  })
+
+  it("keeps a leftover dialog visible during a fragment run", () => {
+    const dialogBlock = new BlockNode(
+      FAKE_SCRIPT_HASH,
+      [text("dialog body")],
+      new BlockProto({
+        allowEmpty: true,
+        dialog: {
+          title: "My dialog",
+          isOpen: true,
+          dismissible: true,
+          width: BlockProto.Dialog.DialogWidth.LARGE,
+        },
+      }),
+      "previous-run",
+      "dialog-fragment"
+    )
+
+    renderWithContexts(makeBlockNodeComponent(dialogBlock), {
+      scriptRunContext: {
+        scriptRunState: ScriptRunState.RUNNING,
+        scriptRunId: "current-run",
+        fragmentIdsThisRun: ["dialog-fragment"],
+      },
+    })
+
+    expect(screen.getByTestId("stDialog")).toBeVisible()
+    expect(screen.getByText("dialog body")).toBeVisible()
+  })
+
   it("renders a tab container", () => {
     const tab = makeVerticalBlock([text("tab body")], {
       tab: { label: "Tab 0" },

--- a/frontend/lib/src/components/core/Block/Block.test.tsx
+++ b/frontend/lib/src/components/core/Block/Block.test.tsx
@@ -881,90 +881,59 @@ describe("BlockNodeRenderer container types", () => {
     expect(setTriggerValue).not.toHaveBeenCalled()
   })
 
-  it("keeps a dialog from the current full-app run visible while running", () => {
-    const dialogBlock = new BlockNode(
-      FAKE_SCRIPT_HASH,
-      [text("dialog body")],
-      new BlockProto({
-        allowEmpty: true,
-        dialog: {
-          title: "My dialog",
-          isOpen: true,
-          dismissible: true,
-          width: BlockProto.Dialog.DialogWidth.LARGE,
+  it.each([
+    {
+      desc: "from the current full-app run while running",
+      nodeScriptRunId: "current-run",
+      fragmentId: undefined,
+      scriptRunState: ScriptRunState.RUNNING,
+      fragmentIdsThisRun: [] as string[],
+    },
+    {
+      desc: "leftover while a rerun is only requested",
+      nodeScriptRunId: "previous-run",
+      fragmentId: undefined,
+      scriptRunState: ScriptRunState.RERUN_REQUESTED,
+      fragmentIdsThisRun: [] as string[],
+    },
+    {
+      desc: "leftover during a fragment run",
+      nodeScriptRunId: "previous-run",
+      fragmentId: "dialog-fragment",
+      scriptRunState: ScriptRunState.RUNNING,
+      fragmentIdsThisRun: ["dialog-fragment"],
+    },
+  ])(
+    "keeps a dialog $desc",
+    ({ nodeScriptRunId, fragmentId, scriptRunState, fragmentIdsThisRun }) => {
+      const dialogBlock = new BlockNode(
+        FAKE_SCRIPT_HASH,
+        [text("dialog body")],
+        new BlockProto({
+          allowEmpty: true,
+          dialog: {
+            title: "My dialog",
+            isOpen: true,
+            dismissible: true,
+            width: BlockProto.Dialog.DialogWidth.LARGE,
+          },
+        }),
+        nodeScriptRunId,
+        fragmentId
+      )
+
+      renderWithContexts(makeBlockNodeComponent(dialogBlock), {
+        scriptRunContext: {
+          scriptRunState,
+          scriptRunId: "current-run",
+          fragmentIdsThisRun,
         },
-      }),
-      "current-run"
-    )
+      })
 
-    renderWithContexts(makeBlockNodeComponent(dialogBlock), {
-      scriptRunContext: {
-        scriptRunState: ScriptRunState.RUNNING,
-        scriptRunId: "current-run",
-        fragmentIdsThisRun: [],
-      },
-    })
-
-    expect(screen.getByTestId("stDialog")).toBeVisible()
-    expect(screen.getByText("dialog body")).toBeVisible()
-  })
-
-  it("keeps a leftover dialog visible while a rerun is only requested", () => {
-    const dialogBlock = new BlockNode(
-      FAKE_SCRIPT_HASH,
-      [text("dialog body")],
-      new BlockProto({
-        allowEmpty: true,
-        dialog: {
-          title: "My dialog",
-          isOpen: true,
-          dismissible: true,
-          width: BlockProto.Dialog.DialogWidth.LARGE,
-        },
-      }),
-      "previous-run"
-    )
-
-    renderWithContexts(makeBlockNodeComponent(dialogBlock), {
-      scriptRunContext: {
-        scriptRunState: ScriptRunState.RERUN_REQUESTED,
-        scriptRunId: "current-run",
-        fragmentIdsThisRun: [],
-      },
-    })
-
-    expect(screen.getByTestId("stDialog")).toBeVisible()
-    expect(screen.getByText("dialog body")).toBeVisible()
-  })
-
-  it("keeps a leftover dialog visible during a fragment run", () => {
-    const dialogBlock = new BlockNode(
-      FAKE_SCRIPT_HASH,
-      [text("dialog body")],
-      new BlockProto({
-        allowEmpty: true,
-        dialog: {
-          title: "My dialog",
-          isOpen: true,
-          dismissible: true,
-          width: BlockProto.Dialog.DialogWidth.LARGE,
-        },
-      }),
-      "previous-run",
-      "dialog-fragment"
-    )
-
-    renderWithContexts(makeBlockNodeComponent(dialogBlock), {
-      scriptRunContext: {
-        scriptRunState: ScriptRunState.RUNNING,
-        scriptRunId: "current-run",
-        fragmentIdsThisRun: ["dialog-fragment"],
-      },
-    })
-
-    expect(screen.getByTestId("stDialog")).toBeVisible()
-    expect(screen.getByText("dialog body")).toBeVisible()
-  })
+      expect(screen.getByTestId("stDialog")).toBeVisible()
+      expect(screen.getByText("dialog body")).toBeVisible()
+    }
+  )
 
   it("renders a tab container", () => {
     const tab = makeVerticalBlock([text("tab body")], {

--- a/frontend/lib/src/components/core/Block/Block.test.tsx
+++ b/frontend/lib/src/components/core/Block/Block.test.tsx
@@ -858,6 +858,9 @@ describe("BlockNodeRenderer container types", () => {
           title: "My dialog",
           isOpen: true,
           dismissible: true,
+          // id activates on_dismiss; the spy below would fire if this hide
+          // went through Dialog.handleClose instead of unmounting.
+          id: "test-dialog-id",
           width: BlockProto.Dialog.DialogWidth.LARGE,
         },
       }),

--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -65,6 +65,7 @@ import {
   isComponentStale,
   shouldActivateScrollToBottom,
   shouldComponentBeEnabled,
+  shouldHideStaleDialog,
 } from "./utils"
 
 const ChildRenderer = (props: BlockPropsWithoutWidth): ReactElement => {
@@ -345,6 +346,22 @@ export const BlockNodeRenderer = (
   }
 
   if (node.deltaBlock.dialog) {
+    // Hide leftover dialogs from a previous full-app run as soon as the next
+    // full-app run starts. Stale-node cleanup waits until the run finishes,
+    // which would leave the overlay up during blocking work (issue #9405).
+    // Unmount without going through Dialog's onClose so on_dismiss is not
+    // fired for this script-driven hide.
+    if (
+      shouldHideStaleDialog(
+        node,
+        scriptRunState,
+        scriptRunId,
+        fragmentIdsThisRun
+      )
+    ) {
+      return <></>
+    }
+
     return (
       <Dialog
         element={node.deltaBlock.dialog as BlockProto.Dialog}

--- a/frontend/lib/src/components/core/Block/Block.tsx
+++ b/frontend/lib/src/components/core/Block/Block.tsx
@@ -349,8 +349,10 @@ export const BlockNodeRenderer = (
     // Hide leftover dialogs from a previous full-app run as soon as the next
     // full-app run starts. Stale-node cleanup waits until the run finishes,
     // which would leave the overlay up during blocking work (issue #9405).
-    // Unmount without going through Dialog's onClose so on_dismiss is not
-    // fired for this script-driven hide.
+    // Same unmount as that later prune. Do not go through Dialog's onClose:
+    // that path is user dismiss and would newly fire on_dismiss.
+    // Re-opening the same dialog in this run remounts it when the new delta
+    // arrives; keeping a dialog open across st.rerun() is not supported.
     if (
       shouldHideStaleDialog(
         node,

--- a/frontend/lib/src/components/core/Block/utils.test.ts
+++ b/frontend/lib/src/components/core/Block/utils.test.ts
@@ -31,6 +31,7 @@ import {
   getKeyFromId,
   isElementStale,
   shouldActivateScrollToBottom,
+  shouldHideStaleDialog,
 } from "./utils"
 
 vi.mock("~lib/render-tree/visitors/ElementsSetVisitor", () => ({
@@ -123,6 +124,89 @@ describe("isElementStale", () => {
     states.forEach(s => {
       expect(isElementStale(node, s, "someOtherScriptRunId", [])).toBe(false)
     })
+  })
+})
+
+describe("shouldHideStaleDialog", () => {
+  const node = new ElementNode(
+    // @ts-expect-error
+    null,
+    null,
+    "myScriptRunId",
+    "activeScriptHash",
+    "myFragmentId"
+  )
+
+  it("hides a leftover dialog during a full-app run", () => {
+    expect(
+      shouldHideStaleDialog(
+        node,
+        ScriptRunState.RUNNING,
+        "someOtherScriptRunId",
+        []
+      )
+    ).toBe(true)
+  })
+
+  it("hides a leftover dialog while stop is requested", () => {
+    expect(
+      shouldHideStaleDialog(
+        node,
+        ScriptRunState.STOP_REQUESTED,
+        "someOtherScriptRunId",
+        []
+      )
+    ).toBe(true)
+  })
+
+  it("keeps the dialog when it belongs to the current run", () => {
+    expect(
+      shouldHideStaleDialog(node, ScriptRunState.RUNNING, "myScriptRunId", [])
+    ).toBe(false)
+  })
+
+  it("keeps the dialog during a fragment run", () => {
+    expect(
+      shouldHideStaleDialog(
+        node,
+        ScriptRunState.RUNNING,
+        "someOtherScriptRunId",
+        ["myFragmentId"]
+      )
+    ).toBe(false)
+  })
+
+  it("keeps the dialog while a rerun is only requested", () => {
+    // RERUN_REQUESTED is set before we know whether this is a fragment or
+    // full-app rerun. Hiding here would unmount the dialog on every widget
+    // interaction inside it.
+    expect(
+      shouldHideStaleDialog(
+        node,
+        ScriptRunState.RERUN_REQUESTED,
+        "someOtherScriptRunId",
+        []
+      )
+    ).toBe(false)
+  })
+
+  it("keeps the dialog when the script is not executing", () => {
+    expect(
+      shouldHideStaleDialog(
+        node,
+        ScriptRunState.NOT_RUNNING,
+        "someOtherScriptRunId",
+        []
+      )
+    ).toBe(false)
+    expect(
+      shouldHideStaleDialog(
+        node,
+        ScriptRunState.COMPILATION_ERROR,
+        "someOtherScriptRunId",
+        []
+      )
+    ).toBe(false)
   })
 })
 

--- a/frontend/lib/src/components/core/Block/utils.test.ts
+++ b/frontend/lib/src/components/core/Block/utils.test.ts
@@ -176,6 +176,20 @@ describe("shouldHideStaleDialog", () => {
     ).toBe(false)
   })
 
+  it("keeps the dialog during an unrelated fragment run", () => {
+    // NewSession still assigns a new scriptRunId for fragment reruns, so any
+    // non-empty fragmentIdsThisRun must keep the dialog — not only the
+    // dialog's own fragment.
+    expect(
+      shouldHideStaleDialog(
+        node,
+        ScriptRunState.RUNNING,
+        "someOtherScriptRunId",
+        ["otherFragmentId"]
+      )
+    ).toBe(false)
+  })
+
   it("keeps the dialog while a rerun is only requested", () => {
     // RERUN_REQUESTED is set before we know whether this is a fragment or
     // full-app rerun. Hiding here would unmount the dialog on every widget

--- a/frontend/lib/src/components/core/Block/utils.ts
+++ b/frontend/lib/src/components/core/Block/utils.ts
@@ -90,6 +90,37 @@ export function isComponentStale(
   )
 }
 
+/**
+ * Whether a leftover dialog from a previous full-app run should be hidden.
+ *
+ * Stale nodes are only pruned after the script finishes successfully, so a
+ * dialog closed via `st.rerun()` would otherwise stay on screen for the whole
+ * next run (issue #9405). Fragment reruns and `RERUN_REQUESTED` must not hide
+ * it: those are how widgets inside the dialog update.
+ *
+ * Not the same as {@link isElementStale}: that function marks every element
+ * stale on `RERUN_REQUESTED`, which would unmount the dialog on each keystroke.
+ */
+export function shouldHideStaleDialog(
+  node: AppNode,
+  scriptRunState: ScriptRunState,
+  scriptRunId: string,
+  fragmentIdsThisRun?: Array<string>
+): boolean {
+  if (fragmentIdsThisRun?.length) {
+    return false
+  }
+
+  if (
+    scriptRunState !== ScriptRunState.RUNNING &&
+    scriptRunState !== ScriptRunState.STOP_REQUESTED
+  ) {
+    return false
+  }
+
+  return node.scriptRunId !== scriptRunId
+}
+
 export function assignDividerColor(
   node: BlockNode,
   theme: EmotionTheme

--- a/frontend/lib/src/components/core/Block/utils.ts
+++ b/frontend/lib/src/components/core/Block/utils.ts
@@ -95,11 +95,19 @@ export function isComponentStale(
  *
  * Stale nodes are only pruned after the script finishes successfully, so a
  * dialog closed via `st.rerun()` would otherwise stay on screen for the whole
- * next run (issue #9405). Fragment reruns and `RERUN_REQUESTED` must not hide
- * it: those are how widgets inside the dialog update.
+ * next run (issue #9405).
+ *
+ * Any fragment rerun keeps the dialog: unlike {@link isElementStale}, this
+ * does not check whether the node's `fragmentId` is in `fragmentIdsThisRun`.
+ * Fragment `newSession` still assigns a new `scriptRunId`, so hiding on
+ * mismatch would also close the dialog when an unrelated fragment refreshes.
+ *
+ * `RERUN_REQUESTED` also keeps it. That state is set before we know whether
+ * the next run is a fragment or full-app rerun; hiding here would unmount
+ * the dialog on every widget interaction inside it.
  *
  * Not the same as {@link isElementStale}: that function marks every element
- * stale on `RERUN_REQUESTED`, which would unmount the dialog on each keystroke.
+ * stale on `RERUN_REQUESTED`.
  */
 export function shouldHideStaleDialog(
   node: AppNode,


### PR DESCRIPTION
## Describe your changes

Hides a leftover `st.dialog` as soon as the next full-app run starts, so `st.rerun()` closes the modal before later blocking work.

Stale element cleanup still waits until a run finishes successfully, which avoids flickering normal widgets. Dialogs are overlays, so a leftover one from the previous run is hidden earlier. Fragment reruns and `RERUN_REQUESTED` keep the dialog open so widgets inside it still work.

The hide unmounts the leftover overlay the same way stale-node prune already did, so `on_dismiss` is not fired. Re-opening the same dialog in that full-app run (for example via session state) remounts it when the new delta arrives; keeping a dialog open across `st.rerun()` is not a supported pattern.

## GitHub Issue Link (if applicable)

- Closes #9405

## Testing Plan

- [x] Unit Tests (JS and/or Python)
- [x] E2E Tests

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

Made with [Cursor](https://cursor.com)