### PR TITLE
[chore] Disable auto-invoke of creating-pull-requests

### DIFF
--- a/.claude/skills/AGENTS.md
+++ b/.claude/skills/AGENTS.md
@@ -43,6 +43,12 @@ Instructions for the AI agent...
 | `name` | Unique skill identifier | Lowercase letters, numbers, and hyphens only; max 64 chars |
 | `description` | What the skill does and when to use it | Non-empty; max 1024 chars; include keywords |
 
+### Optional frontmatter fields
+
+| Field | Description |
+|-------|-------------|
+| `disable-model-invocation` | Set to `true` so the skill is never auto-invoked. Claude Code and Cursor then run it only when the user types `/skill-name`. Use for workflows with side effects (for example creating a PR). |
+
 ## Naming conventions
 
 | Item | Convention | Example |

--- a/.claude/skills/AGENTS.md
+++ b/.claude/skills/AGENTS.md
@@ -47,7 +47,7 @@ Instructions for the AI agent...
 
 | Field | Description |
 |-------|-------------|
-| `disable-model-invocation` | Set to `true` so the skill is never auto-invoked. Claude Code and Cursor then run it only when the user types `/skill-name`. Use for workflows with side effects (for example creating a PR). |
+| `disable-model-invocation` | Set to `true` so the skill is never auto-invoked. Claude Code and Cursor then run it only when the user types `/skill-name`. Use for workflows with side effects. |
 
 ## Naming conventions
 

--- a/.claude/skills/assessing-external-test-risk/SKILL.md
+++ b/.claude/skills/assessing-external-test-risk/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: assessing-external-test-risk
 description: Assesses whether branch or PR changes are high-risk for externally hosted or embedded Streamlit usage and recommends whether external e2e coverage with `@pytest.mark.external_test` is needed. Use during code review, PR triage, or test planning when changes touch routing, auth, websocket/session behavior, embedding, assets, cross-origin behavior, SiS/Snowflake runtime, storage, or security headers.
+disable-model-invocation: true
 ---
 
 # Assessing external test risk

--- a/.claude/skills/creating-pull-requests/SKILL.md
+++ b/.claude/skills/creating-pull-requests/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: creating-pull-requests
 description: Creates a draft pull request on GitHub with proper labels, branch naming, and description formatting. Use when changes are ready to be submitted as a PR to the streamlit/streamlit repository.
+disable-model-invocation: true
 ---
 
 # Create pull request

--- a/.claude/skills/finalizing-pr/SKILL.md
+++ b/.claude/skills/finalizing-pr/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: finalizing-pr
 description: Finalizes branch changes for merging by simplifying code, running checks, reviewing changes, and creating a PR if needed. Use when ready to merge changes into the target branch.
+disable-model-invocation: true
 ---
 
 # Finalizing PR

--- a/.claude/skills/finalizing-pr/SKILL.md
+++ b/.claude/skills/finalizing-pr/SKILL.md
@@ -60,8 +60,6 @@ Run the /checking-changes skill in a subagent with `E2E_CHECK=true make check` t
 
 ### 9. Create or update PR
 
-Do **not** invoke `/creating-pull-requests`. This skill creates or updates the PR itself.
-
 > **Note:** If currently on `develop`, create a new branch first following the naming conventions in `wiki/pull-requests.md`.
 
 Check if a PR exists for the current branch:

--- a/.claude/skills/finalizing-pr/SKILL.md
+++ b/.claude/skills/finalizing-pr/SKILL.md
@@ -60,6 +60,8 @@ Run the /checking-changes skill in a subagent with `E2E_CHECK=true make check` t
 
 ### 9. Create or update PR
 
+Do **not** invoke `/creating-pull-requests`. This skill creates or updates the PR itself.
+
 > **Note:** If currently on `develop`, create a new branch first following the naming conventions in `wiki/pull-requests.md`.
 
 Check if a PR exists for the current branch:

--- a/.claude/skills/implementing-feature/SKILL.md
+++ b/.claude/skills/implementing-feature/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: implementing-feature
 description: Implement a feature from a product/tech spec, URL, GitHub issue, or by auto-selecting the next papercut enhancement. Reads the spec, implements the feature following Streamlit patterns, and creates a merge-ready PR. Use when given a spec folder path, document URL, or issue link to implement, or when asked to implement a feature or papercut without a spec.
+disable-model-invocation: true
 ---
 
 # Implementing feature

--- a/.claude/skills/improving-frontend-coverage/SKILL.md
+++ b/.claude/skills/improving-frontend-coverage/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: improving-frontend-coverage
 description: Runs frontend unit tests with coverage, analyzes coverage reports, and implements meaningful tests to increase coverage by ~0.2%. Use when you want to systematically improve frontend test coverage with high-value test cases.
+disable-model-invocation: true
 ---
 
 # Improving frontend coverage

--- a/.claude/skills/improving-python-coverage/SKILL.md
+++ b/.claude/skills/improving-python-coverage/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: improving-python-coverage
 description: Runs Python unit tests with coverage, analyzes coverage reports, and implements meaningful tests to increase coverage by ~0.2%. Use when you want to systematically improve Python test coverage with high-value test cases.
+disable-model-invocation: true
 ---
 
 # Improving Python coverage

--- a/.cursor/rules/skills.mdc
+++ b/.cursor/rules/skills.mdc
@@ -51,6 +51,12 @@ Instructions for the AI agent...
 | `name` | Unique skill identifier | Lowercase letters, numbers, and hyphens only; max 64 chars |
 | `description` | What the skill does and when to use it | Non-empty; max 1024 chars; include keywords |
 
+### Optional frontmatter fields
+
+| Field | Description |
+|-------|-------------|
+| `disable-model-invocation` | Set to `true` so the skill is never auto-invoked. Claude Code and Cursor then run it only when the user types `/skill-name`. Use for workflows with side effects (for example creating a PR). |
+
 ## Naming conventions
 
 | Item | Convention | Example |

--- a/.cursor/rules/skills.mdc
+++ b/.cursor/rules/skills.mdc
@@ -55,7 +55,7 @@ Instructions for the AI agent...
 
 | Field | Description |
 |-------|-------------|
-| `disable-model-invocation` | Set to `true` so the skill is never auto-invoked. Claude Code and Cursor then run it only when the user types `/skill-name`. Use for workflows with side effects (for example creating a PR). |
+| `disable-model-invocation` | Set to `true` so the skill is never auto-invoked. Claude Code and Cursor then run it only when the user types `/skill-name`. Use for workflows with side effects. |
 
 ## Naming conventions
 

--- a/.github/instructions/skills.instructions.md
+++ b/.github/instructions/skills.instructions.md
@@ -53,7 +53,7 @@ Instructions for the AI agent...
 
 | Field | Description |
 |-------|-------------|
-| `disable-model-invocation` | Set to `true` so the skill is never auto-invoked. Claude Code and Cursor then run it only when the user types `/skill-name`. Use for workflows with side effects (for example creating a PR). |
+| `disable-model-invocation` | Set to `true` so the skill is never auto-invoked. Claude Code and Cursor then run it only when the user types `/skill-name`. Use for workflows with side effects. |
 
 ## Naming conventions
 

--- a/.github/instructions/skills.instructions.md
+++ b/.github/instructions/skills.instructions.md
@@ -49,6 +49,12 @@ Instructions for the AI agent...
 | `name` | Unique skill identifier | Lowercase letters, numbers, and hyphens only; max 64 chars |
 | `description` | What the skill does and when to use it | Non-empty; max 1024 chars; include keywords |
 
+### Optional frontmatter fields
+
+| Field | Description |
+|-------|-------------|
+| `disable-model-invocation` | Set to `true` so the skill is never auto-invoked. Claude Code and Cursor then run it only when the user types `/skill-name`. Use for workflows with side effects (for example creating a PR). |
+
 ## Naming conventions
 
 | Item | Convention | Example |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,22 +106,22 @@ This repository includes skills and subagents in `.claude/` usable with Claude C
 | Skill | When to use |
 |-------|-------------|
 | `checking-changes` | After making backend or frontend changes, before committing |
-| `assessing-external-test-risk` | When reviewing branch or PR changes to decide whether `@pytest.mark.external_test` coverage is needed for externally hosted or embedded scenarios |
+| `assessing-external-test-risk` | When reviewing branch or PR changes to decide whether `@pytest.mark.external_test` coverage is needed for externally hosted or embedded scenarios. Manual only (`/assessing-external-test-risk`); not auto-invoked. |
 | `debugging-streamlit` | When testing code changes, investigating bugs, or checking UI behavior |
 | `discovering-make-commands` | To list available `make` commands for build, test, lint, or format tasks |
 | `fixing-streamlit-ci` | When CI checks fail and you need to diagnose and fix errors |
 | `fixing-flaky-e2e-tests` | When E2E tests fail intermittently, show timeout errors, have snapshot mismatches, or exhibit browser-specific failures |
-| `implementing-feature` | When you have a spec folder, URL, or GitHub issue to implement end-to-end, or want the next papercut enhancement selected automatically |
+| `implementing-feature` | When you have a spec folder, URL, or GitHub issue to implement end-to-end, or want the next papercut enhancement selected automatically. Manual only (`/implementing-feature`); not auto-invoked. |
 | `understanding-streamlit-architecture` | When debugging cross-layer issues, understanding how features work end-to-end, or onboarding to the codebase |
 | `creating-pull-requests` | When changes are ready to be submitted as a PR with proper labels and formatting. Manual only (`/creating-pull-requests`); not auto-invoked. |
 | `addressing-pr-review-comments` | When a PR has reviewer feedback to address, including inline and general PR comments |
 | `updating-internal-docs` | After significant codebase changes to review and update internal documentation |
 | `sharing-pr-agent-artifacts` | When you have agent-generated artifacts (specs, plans) relevant for the current PR to share for reviewing |
 | `writing-spec` | When designing new API commands, widgets, or significant changes that need team review before implementation |
-| `finalizing-pr` | When changes are ready to merge — runs quality checks, simplifies code, and creates/updates the PR |
+| `finalizing-pr` | When changes are ready to merge — runs quality checks, simplifies code, and creates/updates the PR. Manual only (`/finalizing-pr`); not auto-invoked. |
 | `generating-changelog` | When preparing release notes between two git tags |
-| `improving-frontend-coverage` | When you want to systematically improve frontend test coverage with high-value test cases |
-| `improving-python-coverage` | When you want to systematically improve Python test coverage with high-value test cases |
+| `improving-frontend-coverage` | When you want to systematically improve frontend test coverage with high-value test cases. Manual only (`/improving-frontend-coverage`); not auto-invoked. |
+| `improving-python-coverage` | When you want to systematically improve Python test coverage with high-value test cases. Manual only (`/improving-python-coverage`); not auto-invoked. |
 | `reviewing-readability` | When reviewing a PR, branch, or changes for comment, docstring, and naming readability — produces findings with concrete proposed rewrites |
 | `reviewing-pr-description` | When reviewing a PR's title and description for clarity and conciseness |
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ To protect maintainer bandwidth and keep the process fair for active contributor
 
 ## AI Agent Skills and Subagents
 
-This repository includes skills and subagents in `.claude/` usable with Claude Code and Cursor to assist AI coding agents with common development tasks. Skills are invoked automatically based on their description, but can also be triggered manually via `/skill-name` (e.g., `/checking-changes`).
+This repository includes skills and subagents in `.claude/` usable with Claude Code and Cursor to assist AI coding agents with common development tasks. Skills are invoked automatically based on their description, but can also be triggered manually via `/skill-name` (e.g., `/checking-changes`). Skills with `disable-model-invocation: true` in their frontmatter (currently `creating-pull-requests`) are never auto-invoked; run them explicitly with `/skill-name`.
 
 ### Skills
 
@@ -113,7 +113,7 @@ This repository includes skills and subagents in `.claude/` usable with Claude C
 | `fixing-flaky-e2e-tests` | When E2E tests fail intermittently, show timeout errors, have snapshot mismatches, or exhibit browser-specific failures |
 | `implementing-feature` | When you have a spec folder, URL, or GitHub issue to implement end-to-end, or want the next papercut enhancement selected automatically |
 | `understanding-streamlit-architecture` | When debugging cross-layer issues, understanding how features work end-to-end, or onboarding to the codebase |
-| `creating-pull-requests` | When changes are ready to be submitted as a PR with proper labels and formatting |
+| `creating-pull-requests` | When changes are ready to be submitted as a PR with proper labels and formatting. Manual only (`/creating-pull-requests`); not auto-invoked. |
 | `addressing-pr-review-comments` | When a PR has reviewer feedback to address, including inline and general PR comments |
 | `updating-internal-docs` | After significant codebase changes to review and update internal documentation |
 | `sharing-pr-agent-artifacts` | When you have agent-generated artifacts (specs, plans) relevant for the current PR to share for reviewing |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ To protect maintainer bandwidth and keep the process fair for active contributor
 
 ## AI Agent Skills and Subagents
 
-This repository includes skills and subagents in `.claude/` usable with Claude Code and Cursor to assist AI coding agents with common development tasks. Skills are invoked automatically based on their description, but can also be triggered manually via `/skill-name` (e.g., `/checking-changes`). Skills with `disable-model-invocation: true` in their frontmatter (currently `creating-pull-requests`) are never auto-invoked; run them explicitly with `/skill-name`.
+This repository includes skills and subagents in `.claude/` usable with Claude Code and Cursor to assist AI coding agents with common development tasks. Skills are invoked automatically based on their description, but can also be triggered manually via `/skill-name` (e.g., `/checking-changes`).
 
 ### Skills
 


### PR DESCRIPTION
## Describe your changes

Stops Cursor and Claude from auto-invoking higher-level, automated workflow skills. Those should be treated as manual invocation (`/skill-name`) so agents do not start long side-effecting workflows on their own.

Applies to `creating-pull-requests`, `finalizing-pr`, `implementing-feature`, `assessing-external-test-risk`, `improving-frontend-coverage`, and `improving-python-coverage`.

`creating-pull-requests` overlaps with `finalizing-pr`, which already creates the PR and has more safeguards. Auto-invoke also caused `/finalizing-pr` to unexpectedly invoke `creating-pull-requests`.

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- No additional tests: skill frontmatter and docs only; no product behavior change.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.