### PR TITLE
[fix] Add AppTest proto-variant parse smoke tests

### DIFF
--- a/lib/tests/streamlit/testing/proto_variant_parse_test.py
+++ b/lib/tests/streamlit/testing/proto_variant_parse_test.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""AppTest parse smoke tests for every public Element/Block proto oneof (P0.5)."""
+"""AppTest smoke tests asserting that every public Element/Block proto oneof parses."""
 
 from __future__ import annotations
 
 import textwrap
-from typing import Any, NamedTuple
+from typing import TYPE_CHECKING, NamedTuple
 
 import pytest
 
@@ -26,8 +26,11 @@ from streamlit.proto.Element_pb2 import Element as ElementProto
 from streamlit.runtime.state import SCRIPT_RUN_WITHOUT_ERRORS_KEY
 from streamlit.testing.v1 import AppTest
 
+if TYPE_CHECKING:
+    from google.protobuf.descriptor import Descriptor
 
-def _oneof_names(descriptor: Any) -> set[str]:
+
+def _oneof_names(descriptor: Descriptor) -> set[str]:
     """Return field names in the ``type`` oneof of a proto message descriptor."""
     return {field.name for field in descriptor.oneofs_by_name["type"].fields}
 
@@ -39,32 +42,37 @@ EXCLUDED_ELEMENT_TYPES: dict[str, str] = {
 EXCLUDED_BLOCK_TYPES: dict[str, str] = {
     "vertical": "legacy; layouts emit flex_container",
     "horizontal": "legacy; layouts emit flex_container",
-    "transparent": "internal fragment outside-container wrapper, not a public st.* command",
 }
 
 
 class ParseCase(NamedTuple):
-    """One AppTest script that must emit the given proto oneofs."""
+    """One AppTest script covering proto oneofs.
+
+    ``proto_names`` is the inventory lock (Element/Block ``type`` oneof names).
+    ``tree_types`` is what ``test_public_st_command_proto_variant_parses``
+    asserts on ``node.type`` and can differ (``alert`` → ``error``,
+    ``imgs`` → ``image``, ``heading`` → ``title``). ``absent_types`` must not
+    appear (transients such as spinner).
+    """
 
     proto_names: frozenset[str]
     body: str
     tree_types: frozenset[str]
     case_id: str
+    absent_types: frozenset[str] = frozenset()
 
 
-def _el(name: str, body: str, *tree: str) -> ParseCase:
-    return ParseCase(frozenset({name}), body, frozenset(tree), name)
-
-
-def _blk(name: str, body: str, *tree: str) -> ParseCase:
-    return ParseCase(frozenset({name}), body, frozenset(tree), name)
+def _parse_case(
+    name: str, body: str, *tree: str, absent: tuple[str, ...] = ()
+) -> ParseCase:
+    return ParseCase(frozenset({name}), body, frozenset(tree), name, frozenset(absent))
 
 
 # One case per public Element/Block oneof (tabs share a script). spinner is
-# transient and is skipped by parse_tree; .run() must still succeed.
+# sent as a new_transient delta and is skipped by parse_tree.
 PARSE_CASES: list[ParseCase] = [
-    _el("alert", "st.error('e')", "error"),
-    _el(
+    _parse_case("alert", "st.error('e')", "error"),
+    _parse_case(
         "dataframe",
         "import pandas as pd\n"
         "df = pd.DataFrame({'a': [1]})\n"
@@ -72,105 +80,105 @@ PARSE_CASES: list[ParseCase] = [
         "st.data_editor(df)",
         "dataframe",
     ),
-    _el("table", "import pandas as pd\nst.table(pd.DataFrame({'a': [1]}))", "table"),
-    _el(
+    _parse_case(
+        "table", "import pandas as pd\nst.table(pd.DataFrame({'a': [1]}))", "table"
+    ),
+    _parse_case(
         "vega_lite_chart",
         "import pandas as pd\nst.line_chart(pd.DataFrame({'y': [1, 2]}))",
         "vega_lite_chart",
     ),
-    _el("audio", "st.audio(b'\\x11\\x22')", "audio"),
-    _el("audio_input", "st.audio_input('a')", "audio_input"),
-    _el("balloons", "st.balloons()", "balloons"),
-    _el(
+    _parse_case("audio", "st.audio(b'\\x11\\x22')", "audio"),
+    _parse_case("audio_input", "st.audio_input('a')", "audio_input"),
+    _parse_case("balloons", "st.balloons()", "balloons"),
+    _parse_case(
         "bidi_component",
-        "c = st.components.v2.component('p05_bidi', html='<div>hi</div>')\nc()",
+        "c = st.components.v2.component('smoke_test_bidi', html='<div>hi</div>')\nc()",
         "bidi_component",
     ),
-    _el("button", "st.button('b')", "button"),
-    _el("button_group", "st.pills('p', ['a'])", "button_group"),
-    _el(
+    _parse_case("button", "st.button('b')", "button"),
+    _parse_case("button_group", "st.pills('p', ['a'])", "button_group"),
+    _parse_case(
         "download_button",
         "st.download_button('d', data='x', file_name='a.txt')",
         "download_button",
     ),
-    _el("camera_input", "st.camera_input('c')", "camera_input"),
-    _el("chat_input", "st.chat_input('c')", "chat_input"),
-    _el("checkbox", "st.checkbox('c')", "checkbox"),
-    _el("color_picker", "st.color_picker('c')", "color_picker"),
-    _el(
+    _parse_case("camera_input", "st.camera_input('c')", "camera_input"),
+    _parse_case("chat_input", "st.chat_input('c')", "chat_input"),
+    _parse_case("checkbox", "st.checkbox('c')", "checkbox"),
+    _parse_case("color_picker", "st.color_picker('c')", "color_picker"),
+    _parse_case(
         "component_instance",
         "import streamlit.components.v1 as components\n"
-        "foo = components.declare_component('p05_v1', url='http://example.com')\n"
+        "foo = components.declare_component('smoke_test_v1', url='http://example.com')\n"
         "foo()",
         "component_instance",
     ),
-    _el("date_input", "st.date_input('d')", "date_input"),
-    _el("deck_gl_json_chart", "st.map()", "deck_gl_json_chart"),
-    _el("help_info", "st.help(st.write)", "help_info"),
-    _el("empty", "st.empty()", "empty"),
-    _el("exception", "st.exception(RuntimeError('boom'))", "exception"),
-    _el("feedback", "st.feedback('thumbs')", "feedback"),
-    _el("file_uploader", "st.file_uploader('f')", "file_uploader"),
-    _el(
+    _parse_case("date_input", "st.date_input('d')", "date_input"),
+    _parse_case("deck_gl_json_chart", "st.map()", "deck_gl_json_chart"),
+    _parse_case("help_info", "st.help(st.write)", "help_info"),
+    _parse_case("empty", "st.empty()", "empty"),
+    _parse_case("exception", "st.exception(RuntimeError('boom'))", "exception"),
+    _parse_case("feedback", "st.feedback('thumbs')", "feedback"),
+    _parse_case("file_uploader", "st.file_uploader('f')", "file_uploader"),
+    _parse_case(
         "graphviz_chart",
         "st.graphviz_chart('digraph { a -> b }')",
         "graphviz_chart",
     ),
-    _el("html", "st.html('<b>h</b>')", "html"),
-    _el(
-        "iframe",
-        "st.components.v1.iframe('https://example.com')",
-        "iframe",
-    ),
-    _el("imgs", "st.image('https://example.com/x.png')", "image"),
-    _el("json", "st.json({'a': 1})", "json"),
-    _el(
+    _parse_case("html", "st.html('<b>h</b>')", "html"),
+    _parse_case("iframe", "st.iframe('https://example.com')", "iframe"),
+    _parse_case("imgs", "st.image('https://example.com/x.png')", "image"),
+    _parse_case("json", "st.json({'a': 1})", "json"),
+    _parse_case(
         "link_button",
         "st.link_button('Go', 'https://example.com')",
         "link_button",
     ),
-    _el("markdown", "st.markdown('hi')", "markdown"),
-    _el("metric", "st.metric('m', 1)", "metric"),
-    _el("multiselect", "st.multiselect('m', ['a'])", "multiselect"),
-    _el("number_input", "st.number_input('n')", "number_input"),
-    _el(
+    _parse_case("markdown", "st.markdown('hi')", "markdown"),
+    _parse_case("metric", "st.metric('m', 1)", "metric"),
+    _parse_case("multiselect", "st.multiselect('m', ['a'])", "multiselect"),
+    _parse_case("number_input", "st.number_input('n')", "number_input"),
+    _parse_case(
         "page_link",
         "st.page_link('https://example.com', label='Ex')",
         "page_link",
     ),
-    _el(
+    _parse_case(
         "plotly_chart",
         "st.plotly_chart({'data': [{'x': [1], 'y': [2], 'type': 'scatter'}]})",
         "plotly_chart",
     ),
-    _el("progress", "st.progress(40)", "progress"),
-    _el("radio", "st.radio('r', ['a'])", "radio"),
-    _el("selectbox", "st.selectbox('s', ['a'])", "selectbox"),
-    _el("skeleton", "st.skeleton()", "skeleton"),
-    _el("slider", "st.slider('s')", "slider"),
-    _el("snow", "st.snow()", "snow"),
-    _el("space", "st.space()", "space"),
-    _el("spinner", "with st.spinner('w'):\n    pass"),
-    _el("text", "st.text('t')", "text"),
-    _el("text_area", "st.text_area('t')", "text_area"),
-    _el("text_input", "st.text_input('t')", "text_input"),
-    _el("time_input", "st.time_input('t')", "time_input"),
-    _el("date_time_input", "st.datetime_input('d')", "date_time_input"),
-    _el("toast", "st.toast('t')", "toast"),
-    _el("video", "st.video(b'\\x12\\x10')", "video"),
-    _el("heading", "st.title('T')", "title"),
-    _el("code", "st.code('x=1')", "code"),
-    _el("menu_button", "st.menu_button('m', ['a'])", "menu_button"),
-    _el("pagination", "st.pagination(5)", "pagination"),
-    _el(
+    _parse_case("progress", "st.progress(40)", "progress"),
+    _parse_case("radio", "st.radio('r', ['a'])", "radio"),
+    _parse_case("selectbox", "st.selectbox('s', ['a'])", "selectbox"),
+    _parse_case("skeleton", "st.skeleton()", "skeleton"),
+    _parse_case("slider", "st.slider('s')", "slider"),
+    _parse_case("snow", "st.snow()", "snow"),
+    _parse_case("space", "st.space()", "space"),
+    _parse_case("spinner", "with st.spinner('w'):\n    pass", absent=("spinner",)),
+    _parse_case("text", "st.text('t')", "text"),
+    _parse_case("text_area", "st.text_area('t')", "text_area"),
+    _parse_case("text_input", "st.text_input('t')", "text_input"),
+    _parse_case("time_input", "st.time_input('t')", "time_input"),
+    _parse_case("date_time_input", "st.datetime_input('d')", "date_time_input"),
+    _parse_case("toast", "st.toast('t')", "toast"),
+    _parse_case("video", "st.video(b'\\x12\\x10')", "video"),
+    _parse_case("heading", "st.title('T')", "title"),
+    _parse_case("code", "st.code('x=1')", "code"),
+    _parse_case("menu_button", "st.menu_button('m', ['a'])", "menu_button"),
+    _parse_case("pagination", "st.pagination(5)", "pagination"),
+    _parse_case(
         "echarts_chart",
         "st.echarts_chart({'xAxis': {'type': 'category', 'data': ['A']}, "
         "'yAxis': {'type': 'value'}, 'series': [{'type': 'bar', 'data': [1]}]})",
         "echarts_chart",
     ),
-    _blk("column", "c1, c2 = st.columns(2)\nc1.write('a')\nc2.write('b')", "column"),
-    _blk("expandable", "with st.expander('e'):\n    st.write('x')", "expander"),
-    _blk(
+    _parse_case(
+        "column", "c1, c2 = st.columns(2)\nc1.write('a')\nc2.write('b')", "column"
+    ),
+    _parse_case("expandable", "with st.expander('e'):\n    st.write('x')", "expander"),
+    _parse_case(
         "form",
         "with st.form('f'):\n    st.text_input('n')\n    st.form_submit_button('go')",
         "form",
@@ -181,18 +189,30 @@ PARSE_CASES: list[ParseCase] = [
         frozenset({"tab_container", "tab"}),
         "tabs",
     ),
-    _blk(
+    _parse_case(
         "chat_message",
         "with st.chat_message('user'):\n    st.write('hi')",
         "chat_message",
     ),
-    _blk("popover", "with st.popover('p'):\n    st.write('x')", "popover"),
-    _blk(
+    _parse_case("popover", "with st.popover('p'):\n    st.write('x')", "popover"),
+    _parse_case(
         "dialog",
         "@st.dialog('D')\ndef _dlg():\n    st.write('x')\n_dlg()",
         "dialog",
     ),
-    _blk("flex_container", "with st.container():\n    st.write('x')", "flex_container"),
+    _parse_case(
+        "flex_container", "with st.container():\n    st.write('x')", "flex_container"
+    ),
+    _parse_case(
+        "transparent",
+        "outside = st.container()\n"
+        "outside.empty()\n"
+        "@st.fragment\n"
+        "def _frag():\n"
+        "    outside.write('hi')\n"
+        "_frag()",
+        "transparent",
+    ),
 ]
 
 
@@ -226,3 +246,4 @@ def test_public_st_command_proto_variant_parses(case: ParseCase) -> None:
     ]
     tree_types = {node.type for node in at}
     assert case.tree_types <= tree_types, tree_types
+    assert case.absent_types.isdisjoint(tree_types), tree_types

--- a/lib/tests/streamlit/testing/proto_variant_parse_test.py
+++ b/lib/tests/streamlit/testing/proto_variant_parse_test.py
@@ -1,0 +1,228 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""AppTest parse smoke tests for every public Element/Block proto oneof (P0.5)."""
+
+from __future__ import annotations
+
+import textwrap
+from typing import Any, NamedTuple
+
+import pytest
+
+from streamlit.proto.Block_pb2 import Block as BlockProto
+from streamlit.proto.Element_pb2 import Element as ElementProto
+from streamlit.runtime.state import SCRIPT_RUN_WITHOUT_ERRORS_KEY
+from streamlit.testing.v1 import AppTest
+
+
+def _oneof_names(descriptor: Any) -> set[str]:
+    """Return field names in the ``type`` oneof of a proto message descriptor."""
+    return {field.name for field in descriptor.oneofs_by_name["type"].fields}
+
+
+# Public st.* never puts these oneofs in the AppTest element tree.
+EXCLUDED_ELEMENT_TYPES: dict[str, str] = {
+    "favicon": "st.set_page_config sends page_config_changed, not Element.favicon",
+}
+EXCLUDED_BLOCK_TYPES: dict[str, str] = {
+    "vertical": "legacy; layouts emit flex_container",
+    "horizontal": "legacy; layouts emit flex_container",
+    "transparent": "internal fragment outside-container wrapper, not a public st.* command",
+}
+
+
+class ParseCase(NamedTuple):
+    """One AppTest script that must emit the given proto oneofs."""
+
+    proto_names: frozenset[str]
+    body: str
+    tree_types: frozenset[str]
+    case_id: str
+
+
+def _el(name: str, body: str, *tree: str) -> ParseCase:
+    return ParseCase(frozenset({name}), body, frozenset(tree), name)
+
+
+def _blk(name: str, body: str, *tree: str) -> ParseCase:
+    return ParseCase(frozenset({name}), body, frozenset(tree), name)
+
+
+# One case per public Element/Block oneof (tabs share a script). spinner is
+# transient and is skipped by parse_tree; .run() must still succeed.
+PARSE_CASES: list[ParseCase] = [
+    _el("alert", "st.error('e')", "error"),
+    _el(
+        "dataframe",
+        "import pandas as pd\n"
+        "df = pd.DataFrame({'a': [1]})\n"
+        "st.dataframe(df)\n"
+        "st.data_editor(df)",
+        "dataframe",
+    ),
+    _el("table", "import pandas as pd\nst.table(pd.DataFrame({'a': [1]}))", "table"),
+    _el(
+        "vega_lite_chart",
+        "import pandas as pd\nst.line_chart(pd.DataFrame({'y': [1, 2]}))",
+        "vega_lite_chart",
+    ),
+    _el("audio", "st.audio(b'\\x11\\x22')", "audio"),
+    _el("audio_input", "st.audio_input('a')", "audio_input"),
+    _el("balloons", "st.balloons()", "balloons"),
+    _el(
+        "bidi_component",
+        "c = st.components.v2.component('p05_bidi', html='<div>hi</div>')\nc()",
+        "bidi_component",
+    ),
+    _el("button", "st.button('b')", "button"),
+    _el("button_group", "st.pills('p', ['a'])", "button_group"),
+    _el(
+        "download_button",
+        "st.download_button('d', data='x', file_name='a.txt')",
+        "download_button",
+    ),
+    _el("camera_input", "st.camera_input('c')", "camera_input"),
+    _el("chat_input", "st.chat_input('c')", "chat_input"),
+    _el("checkbox", "st.checkbox('c')", "checkbox"),
+    _el("color_picker", "st.color_picker('c')", "color_picker"),
+    _el(
+        "component_instance",
+        "import streamlit.components.v1 as components\n"
+        "foo = components.declare_component('p05_v1', url='http://example.com')\n"
+        "foo()",
+        "component_instance",
+    ),
+    _el("date_input", "st.date_input('d')", "date_input"),
+    _el("deck_gl_json_chart", "st.map()", "deck_gl_json_chart"),
+    _el("help_info", "st.help(st.write)", "help_info"),
+    _el("empty", "st.empty()", "empty"),
+    _el("exception", "st.exception(RuntimeError('boom'))", "exception"),
+    _el("feedback", "st.feedback('thumbs')", "feedback"),
+    _el("file_uploader", "st.file_uploader('f')", "file_uploader"),
+    _el(
+        "graphviz_chart",
+        "st.graphviz_chart('digraph { a -> b }')",
+        "graphviz_chart",
+    ),
+    _el("html", "st.html('<b>h</b>')", "html"),
+    _el(
+        "iframe",
+        "st.components.v1.iframe('https://example.com')",
+        "iframe",
+    ),
+    _el("imgs", "st.image('https://example.com/x.png')", "image"),
+    _el("json", "st.json({'a': 1})", "json"),
+    _el(
+        "link_button",
+        "st.link_button('Go', 'https://example.com')",
+        "link_button",
+    ),
+    _el("markdown", "st.markdown('hi')", "markdown"),
+    _el("metric", "st.metric('m', 1)", "metric"),
+    _el("multiselect", "st.multiselect('m', ['a'])", "multiselect"),
+    _el("number_input", "st.number_input('n')", "number_input"),
+    _el(
+        "page_link",
+        "st.page_link('https://example.com', label='Ex')",
+        "page_link",
+    ),
+    _el(
+        "plotly_chart",
+        "st.plotly_chart({'data': [{'x': [1], 'y': [2], 'type': 'scatter'}]})",
+        "plotly_chart",
+    ),
+    _el("progress", "st.progress(40)", "progress"),
+    _el("radio", "st.radio('r', ['a'])", "radio"),
+    _el("selectbox", "st.selectbox('s', ['a'])", "selectbox"),
+    _el("skeleton", "st.skeleton()", "skeleton"),
+    _el("slider", "st.slider('s')", "slider"),
+    _el("snow", "st.snow()", "snow"),
+    _el("space", "st.space()", "space"),
+    _el("spinner", "with st.spinner('w'):\n    pass"),
+    _el("text", "st.text('t')", "text"),
+    _el("text_area", "st.text_area('t')", "text_area"),
+    _el("text_input", "st.text_input('t')", "text_input"),
+    _el("time_input", "st.time_input('t')", "time_input"),
+    _el("date_time_input", "st.datetime_input('d')", "date_time_input"),
+    _el("toast", "st.toast('t')", "toast"),
+    _el("video", "st.video(b'\\x12\\x10')", "video"),
+    _el("heading", "st.title('T')", "title"),
+    _el("code", "st.code('x=1')", "code"),
+    _el("menu_button", "st.menu_button('m', ['a'])", "menu_button"),
+    _el("pagination", "st.pagination(5)", "pagination"),
+    _el(
+        "echarts_chart",
+        "st.echarts_chart({'xAxis': {'type': 'category', 'data': ['A']}, "
+        "'yAxis': {'type': 'value'}, 'series': [{'type': 'bar', 'data': [1]}]})",
+        "echarts_chart",
+    ),
+    _blk("column", "c1, c2 = st.columns(2)\nc1.write('a')\nc2.write('b')", "column"),
+    _blk("expandable", "with st.expander('e'):\n    st.write('x')", "expander"),
+    _blk(
+        "form",
+        "with st.form('f'):\n    st.text_input('n')\n    st.form_submit_button('go')",
+        "form",
+    ),
+    ParseCase(
+        frozenset({"tab_container", "tab"}),
+        "a, b = st.tabs(['A', 'B'])\na.write('a')\nb.write('b')",
+        frozenset({"tab_container", "tab"}),
+        "tabs",
+    ),
+    _blk(
+        "chat_message",
+        "with st.chat_message('user'):\n    st.write('hi')",
+        "chat_message",
+    ),
+    _blk("popover", "with st.popover('p'):\n    st.write('x')", "popover"),
+    _blk(
+        "dialog",
+        "@st.dialog('D')\ndef _dlg():\n    st.write('x')\n_dlg()",
+        "dialog",
+    ),
+    _blk("flex_container", "with st.container():\n    st.write('x')", "flex_container"),
+]
+
+
+def test_every_public_proto_oneof_has_a_parse_smoke_case() -> None:
+    """Every Element/Block type oneof is covered by a smoke case or an exclusion."""
+    covered = {name for case in PARSE_CASES for name in case.proto_names}
+    missing_elements = (
+        _oneof_names(ElementProto.DESCRIPTOR) - covered - set(EXCLUDED_ELEMENT_TYPES)
+    )
+    missing_blocks = (
+        _oneof_names(BlockProto.DESCRIPTOR) - covered - set(EXCLUDED_BLOCK_TYPES)
+    )
+    assert missing_elements == set()
+    assert missing_blocks == set()
+
+    extra = (
+        covered
+        - _oneof_names(ElementProto.DESCRIPTOR)
+        - _oneof_names(BlockProto.DESCRIPTOR)
+    )
+    assert extra == set()
+
+
+@pytest.mark.parametrize("case", PARSE_CASES, ids=[c.case_id for c in PARSE_CASES])
+def test_public_st_command_proto_variant_parses(case: ParseCase) -> None:
+    """AppTest.run() must parse each public st.* proto variant without crashing."""
+    script = "import streamlit as st\n" + textwrap.dedent(case.body).strip() + "\n"
+    at = AppTest.from_string(script, default_timeout=10).run()
+    assert at.session_state[SCRIPT_RUN_WITHOUT_ERRORS_KEY], [
+        getattr(exc, "message", str(exc)) for exc in at.exception
+    ]
+    tree_types = {node.type for node in at}
+    assert case.tree_types <= tree_types, tree_types

--- a/lib/tests/streamlit/testing/proto_variant_parse_test.py
+++ b/lib/tests/streamlit/testing/proto_variant_parse_test.py
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""AppTest smoke tests asserting that every public Element/Block proto oneof parses."""
+"""AppTest smoke tests asserting that every public Element/Block proto oneof parses.
+
+Elements without a dedicated AppTest node class parse as ``UnknownElement``, so
+these cases assert that ``run()`` succeeds and the variant reaches the tree, not
+that AppTest exposes a typed accessor for it.
+"""
 
 from __future__ import annotations
 
@@ -46,13 +51,14 @@ EXCLUDED_BLOCK_TYPES: dict[str, str] = {
 
 
 class ParseCase(NamedTuple):
-    """One AppTest script covering proto oneofs.
+    """One AppTest script that exercises one or more proto oneofs.
 
-    ``proto_names`` is the inventory lock (Element/Block ``type`` oneof names).
-    ``tree_types`` is what ``test_public_st_command_proto_variant_parses``
-    asserts on ``node.type`` and can differ (``alert`` → ``error``,
-    ``imgs`` → ``image``, ``heading`` → ``title``). ``absent_types`` must not
-    appear (transients such as spinner).
+    ``proto_names`` are the Element/Block ``type`` oneof names this case claims
+    coverage for; ``test_every_public_proto_oneof_has_a_parse_smoke_case``
+    checks them against the protos. ``tree_types`` are the ``node.type`` values
+    the parsed tree must contain, which can differ from the oneof name
+    (``alert`` → ``error``, ``imgs`` → ``image``, ``heading`` → ``title``).
+    ``absent_types`` must not appear, for transients such as spinner.
     """
 
     proto_names: frozenset[str]
@@ -65,11 +71,13 @@ class ParseCase(NamedTuple):
 def _parse_case(
     name: str, body: str, *tree: str, absent: tuple[str, ...] = ()
 ) -> ParseCase:
+    """Build a case for a single proto oneof ``name``, expecting ``tree`` node types."""
     return ParseCase(frozenset({name}), body, frozenset(tree), name, frozenset(absent))
 
 
-# One case per public Element/Block oneof (tabs share a script). spinner is
-# sent as a new_transient delta and is skipped by parse_tree.
+# One case per public Element/Block oneof; tab_container and tab share one
+# script. Spinner is sent as a new_transient delta; parse_tree_from_messages
+# skips those deltas.
 PARSE_CASES: list[ParseCase] = [
     _parse_case("alert", "st.error('e')", "error"),
     _parse_case(
@@ -156,6 +164,9 @@ PARSE_CASES: list[ParseCase] = [
     _parse_case("slider", "st.slider('s')", "slider"),
     _parse_case("snow", "st.snow()", "snow"),
     _parse_case("space", "st.space()", "space"),
+    # Exiting immediately cancels the 0.5s timer, so only the clearing
+    # transient is sent — not Element.spinner. That still proves .run()
+    # skips new_transient and spinner never appears as a tree node.
     _parse_case("spinner", "with st.spinner('w'):\n    pass", absent=("spinner",)),
     _parse_case("text", "st.text('t')", "text"),
     _parse_case("text_area", "st.text_area('t')", "text_area"),
@@ -219,21 +230,32 @@ PARSE_CASES: list[ParseCase] = [
 def test_every_public_proto_oneof_has_a_parse_smoke_case() -> None:
     """Every Element/Block type oneof is covered by a smoke case or an exclusion."""
     covered = {name for case in PARSE_CASES for name in case.proto_names}
-    missing_elements = (
-        _oneof_names(ElementProto.DESCRIPTOR) - covered - set(EXCLUDED_ELEMENT_TYPES)
+    element_oneofs = _oneof_names(ElementProto.DESCRIPTOR)
+    block_oneofs = _oneof_names(BlockProto.DESCRIPTOR)
+    assert set(EXCLUDED_ELEMENT_TYPES) <= element_oneofs, (
+        "EXCLUDED_ELEMENT_TYPES names that are no longer Element oneofs: "
+        f"{sorted(set(EXCLUDED_ELEMENT_TYPES) - element_oneofs)}"
     )
-    missing_blocks = (
-        _oneof_names(BlockProto.DESCRIPTOR) - covered - set(EXCLUDED_BLOCK_TYPES)
+    assert set(EXCLUDED_BLOCK_TYPES) <= block_oneofs, (
+        "EXCLUDED_BLOCK_TYPES names that are no longer Block oneofs: "
+        f"{sorted(set(EXCLUDED_BLOCK_TYPES) - block_oneofs)}"
     )
-    assert missing_elements == set()
-    assert missing_blocks == set()
+    missing_elements = element_oneofs - covered - set(EXCLUDED_ELEMENT_TYPES)
+    missing_blocks = block_oneofs - covered - set(EXCLUDED_BLOCK_TYPES)
+    assert not missing_elements, (
+        f"Element oneofs without a parse smoke case: {sorted(missing_elements)}. "
+        "Add a PARSE_CASES entry, or an EXCLUDED_ELEMENT_TYPES entry with a reason."
+    )
+    assert not missing_blocks, (
+        f"Block oneofs without a parse smoke case: {sorted(missing_blocks)}. "
+        "Add a PARSE_CASES entry, or an EXCLUDED_BLOCK_TYPES entry with a reason."
+    )
 
-    extra = (
-        covered
-        - _oneof_names(ElementProto.DESCRIPTOR)
-        - _oneof_names(BlockProto.DESCRIPTOR)
+    extra = covered - element_oneofs - block_oneofs
+    assert not extra, (
+        "PARSE_CASES references names that are no longer Element/Block oneofs: "
+        f"{sorted(extra)}"
     )
-    assert extra == set()
 
 
 @pytest.mark.parametrize("case", PARSE_CASES, ids=[c.case_id for c in PARSE_CASES])
@@ -242,7 +264,7 @@ def test_public_st_command_proto_variant_parses(case: ParseCase) -> None:
     script = "import streamlit as st\n" + textwrap.dedent(case.body).strip() + "\n"
     at = AppTest.from_string(script, default_timeout=10).run()
     assert at.session_state[SCRIPT_RUN_WITHOUT_ERRORS_KEY], [
-        getattr(exc, "message", str(exc)) for exc in at.exception
+        exc.message for exc in at.exception
     ]
     tree_types = {node.type for node in at}
     assert case.tree_types <= tree_types, tree_types

--- a/lib/tests/streamlit/testing/proto_variant_parse_test.py
+++ b/lib/tests/streamlit/testing/proto_variant_parse_test.py
@@ -14,6 +14,9 @@
 
 """AppTest smoke tests asserting that every public Element/Block proto oneof parses.
 
+Producers come from ``element_mocks`` (the public ``st.*`` inventory). A few
+oneofs are not a public command — those use extra scripts below.
+
 Elements without a dedicated AppTest node class parse as ``UnknownElement``, so
 these cases assert that ``run()`` succeeds and the variant reaches the tree, not
 that AppTest exposes a typed accessor for it.
@@ -21,7 +24,6 @@ that AppTest exposes a typed accessor for it.
 
 from __future__ import annotations
 
-import textwrap
 from typing import TYPE_CHECKING, NamedTuple
 
 import pytest
@@ -30,15 +32,16 @@ from streamlit.proto.Block_pb2 import Block as BlockProto
 from streamlit.proto.Element_pb2 import Element as ElementProto
 from streamlit.runtime.state import SCRIPT_RUN_WITHOUT_ERRORS_KEY
 from streamlit.testing.v1 import AppTest
+from tests.streamlit.element_mocks import (
+    CONTAINER_ELEMENTS,
+    NON_WIDGET_ELEMENTS,
+    WIDGET_ELEMENTS,
+)
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from google.protobuf.descriptor import Descriptor
-
-
-def _oneof_names(descriptor: Descriptor) -> set[str]:
-    """Return field names in the ``type`` oneof of a proto message descriptor."""
-    return {field.name for field in descriptor.oneofs_by_name["type"].fields}
-
 
 # Public st.* never puts these oneofs in the AppTest element tree.
 EXCLUDED_ELEMENT_TYPES: dict[str, str] = {
@@ -49,187 +52,239 @@ EXCLUDED_BLOCK_TYPES: dict[str, str] = {
     "horizontal": "legacy; layouts emit flex_container",
 }
 
+# AppTest node.type values that are not Element/Block type oneofs.
+_ROOT_TYPES = frozenset({"root", "main", "sidebar", "event", "unknown"})
 
-class ParseCase(NamedTuple):
-    """One AppTest script that exercises one or more proto oneofs.
+# Mock command name -> proto oneofs, when the names differ or the mock does
+# not emit a oneof (logo, echo, spinner, dialog, pdf, form_submit_button).
+_MOCK_PROTO_OVERRIDES: dict[str, frozenset[str]] = {
+    "form_submit_button": frozenset(),
+    "logo": frozenset(),
+    "echo": frozenset(),
+    "spinner": frozenset(),
+    "dialog": frozenset(),
+    "pdf": frozenset(),
+    "datetime_input": frozenset({"date_time_input"}),
+    "help": frozenset({"help_info"}),
+    "tabs": frozenset({"tab_container", "tab"}),
+    "columns": frozenset({"column"}),
+    "container": frozenset({"flex_container"}),
+    "expander": frozenset({"expandable"}),
+    "status": frozenset({"expandable"}),
+    "error": frozenset({"alert"}),
+    "info": frozenset({"alert"}),
+    "success": frozenset({"alert"}),
+    "warning": frozenset({"alert"}),
+    "title": frozenset({"heading"}),
+    "header": frozenset({"heading"}),
+    "subheader": frozenset({"heading"}),
+    "caption": frozenset({"markdown"}),
+    "badge": frozenset({"markdown"}),
+    "divider": frozenset({"markdown"}),
+    "latex": frozenset({"markdown"}),
+    "write": frozenset({"markdown"}),
+    "write_stream": frozenset({"markdown"}),
+    "mermaid_chart": frozenset({"markdown"}),
+    "image": frozenset({"imgs"}),
+    "pyplot": frozenset({"imgs"}),
+    "pills": frozenset({"button_group"}),
+    "segmented_control": frozenset({"button_group"}),
+    "toggle": frozenset({"checkbox"}),
+    "select_slider": frozenset({"slider"}),
+    "data_editor": frozenset({"dataframe"}),
+    "line_chart": frozenset({"vega_lite_chart"}),
+    "area_chart": frozenset({"vega_lite_chart"}),
+    "bar_chart": frozenset({"vega_lite_chart"}),
+    "scatter_chart": frozenset({"vega_lite_chart"}),
+    "altair_chart": frozenset({"vega_lite_chart"}),
+    "map": frozenset({"deck_gl_json_chart"}),
+    "pydeck_chart": frozenset({"deck_gl_json_chart"}),
+}
 
-    ``proto_names`` are the Element/Block ``type`` oneof names this case claims
-    coverage for; ``test_every_public_proto_oneof_has_a_parse_smoke_case``
-    checks them against the protos. ``tree_types`` are the ``node.type`` values
-    the parsed tree must contain, which can differ from the oneof name
-    (``alert`` → ``error``, ``imgs`` → ``image``, ``heading`` → ``title``).
-    ``absent_types`` must not appear, for transients such as spinner.
-    """
+# AppTest node.type -> Element/Block type oneof when they differ.
+_TREE_TYPE_TO_PROTO: dict[str, str] = {
+    "error": "alert",
+    "info": "alert",
+    "success": "alert",
+    "warning": "alert",
+    "image": "imgs",
+    "title": "heading",
+    "header": "heading",
+    "subheader": "heading",
+    "caption": "markdown",
+    "latex": "markdown",
+    "divider": "markdown",
+    "toggle": "checkbox",
+    "select_slider": "slider",
+    "expander": "expandable",
+    "status": "expandable",
+}
 
-    proto_names: frozenset[str]
-    body: str
-    tree_types: frozenset[str]
-    case_id: str
-    absent_types: frozenset[str] = frozenset()
+_MOCK_GROUPS: dict[str, list[tuple[str, Callable[[], object]]]] = {
+    "widget": WIDGET_ELEMENTS,
+    "non_widget": NON_WIDGET_ELEMENTS,
+    "container": CONTAINER_ELEMENTS,
+}
+
+MOCK_CASES: list[tuple[str, str]] = [
+    (group, name) for group, producers in _MOCK_GROUPS.items() for name, _ in producers
+]
 
 
-def _parse_case(
-    name: str, body: str, *tree: str, absent: tuple[str, ...] = ()
-) -> ParseCase:
-    """Build a case for a single proto oneof ``name``, expecting ``tree`` node types."""
-    return ParseCase(frozenset({name}), body, frozenset(tree), name, frozenset(absent))
+def _oneof_names(descriptor: Descriptor) -> set[str]:
+    """Return field names in the ``type`` oneof of a proto message descriptor."""
+    return {field.name for field in descriptor.oneofs_by_name["type"].fields}
 
 
-# One case per public Element/Block oneof; tab_container and tab share one
-# script. Spinner is sent as a new_transient delta; parse_tree_from_messages
-# skips those deltas.
-PARSE_CASES: list[ParseCase] = [
-    _parse_case("alert", "st.error('e')", "error"),
-    _parse_case(
-        "dataframe",
-        "import pandas as pd\n"
-        "df = pd.DataFrame({'a': [1]})\n"
-        "st.dataframe(df)\n"
-        "st.data_editor(df)",
-        "dataframe",
-    ),
-    _parse_case(
-        "table", "import pandas as pd\nst.table(pd.DataFrame({'a': [1]}))", "table"
-    ),
-    _parse_case(
-        "vega_lite_chart",
-        "import pandas as pd\nst.line_chart(pd.DataFrame({'y': [1, 2]}))",
-        "vega_lite_chart",
-    ),
-    _parse_case("audio", "st.audio(b'\\x11\\x22')", "audio"),
-    _parse_case("audio_input", "st.audio_input('a')", "audio_input"),
-    _parse_case("balloons", "st.balloons()", "balloons"),
-    _parse_case(
-        "bidi_component",
-        "c = st.components.v2.component('smoke_test_bidi', html='<div>hi</div>')\nc()",
-        "bidi_component",
-    ),
-    _parse_case("button", "st.button('b')", "button"),
-    _parse_case("button_group", "st.pills('p', ['a'])", "button_group"),
-    _parse_case(
-        "download_button",
-        "st.download_button('d', data='x', file_name='a.txt')",
-        "download_button",
-    ),
-    _parse_case("camera_input", "st.camera_input('c')", "camera_input"),
-    _parse_case("chat_input", "st.chat_input('c')", "chat_input"),
-    _parse_case("checkbox", "st.checkbox('c')", "checkbox"),
-    _parse_case("color_picker", "st.color_picker('c')", "color_picker"),
-    _parse_case(
-        "component_instance",
-        "import streamlit.components.v1 as components\n"
-        "foo = components.declare_component('smoke_test_v1', url='http://example.com')\n"
-        "foo()",
-        "component_instance",
-    ),
-    _parse_case("date_input", "st.date_input('d')", "date_input"),
-    _parse_case("deck_gl_json_chart", "st.map()", "deck_gl_json_chart"),
-    _parse_case("help_info", "st.help(st.write)", "help_info"),
-    _parse_case("empty", "st.empty()", "empty"),
-    _parse_case("exception", "st.exception(RuntimeError('boom'))", "exception"),
-    _parse_case("feedback", "st.feedback('thumbs')", "feedback"),
-    _parse_case("file_uploader", "st.file_uploader('f')", "file_uploader"),
-    _parse_case(
-        "graphviz_chart",
-        "st.graphviz_chart('digraph { a -> b }')",
-        "graphviz_chart",
-    ),
-    _parse_case("html", "st.html('<b>h</b>')", "html"),
-    _parse_case("iframe", "st.iframe('https://example.com')", "iframe"),
-    _parse_case("imgs", "st.image('https://example.com/x.png')", "image"),
-    _parse_case("json", "st.json({'a': 1})", "json"),
-    _parse_case(
-        "link_button",
-        "st.link_button('Go', 'https://example.com')",
-        "link_button",
-    ),
-    _parse_case("markdown", "st.markdown('hi')", "markdown"),
-    _parse_case("metric", "st.metric('m', 1)", "metric"),
-    _parse_case("multiselect", "st.multiselect('m', ['a'])", "multiselect"),
-    _parse_case("number_input", "st.number_input('n')", "number_input"),
-    _parse_case(
-        "page_link",
-        "st.page_link('https://example.com', label='Ex')",
-        "page_link",
-    ),
-    _parse_case(
-        "plotly_chart",
-        "st.plotly_chart({'data': [{'x': [1], 'y': [2], 'type': 'scatter'}]})",
-        "plotly_chart",
-    ),
-    _parse_case("progress", "st.progress(40)", "progress"),
-    _parse_case("radio", "st.radio('r', ['a'])", "radio"),
-    _parse_case("selectbox", "st.selectbox('s', ['a'])", "selectbox"),
-    _parse_case("skeleton", "st.skeleton()", "skeleton"),
-    _parse_case("slider", "st.slider('s')", "slider"),
-    _parse_case("snow", "st.snow()", "snow"),
-    _parse_case("space", "st.space()", "space"),
+def _all_oneofs() -> set[str]:
+    return _oneof_names(ElementProto.DESCRIPTOR) | _oneof_names(BlockProto.DESCRIPTOR)
+
+
+def _protos_claimed_by_mock(name: str) -> frozenset[str]:
+    if name in _MOCK_PROTO_OVERRIDES:
+        return _MOCK_PROTO_OVERRIDES[name]
+    return frozenset({name})
+
+
+def _proto_names_from_tree(at: AppTest) -> set[str]:
+    names: set[str] = set()
+    for node in at:
+        if node.type in _ROOT_TYPES:
+            continue
+        names.add(_TREE_TYPE_TO_PROTO.get(node.type, node.type))
+    return names
+
+
+def _run_ok(at: AppTest) -> None:
+    assert at.session_state[SCRIPT_RUN_WITHOUT_ERRORS_KEY], [
+        exc.message for exc in at.exception
+    ]
+
+
+def _call_element_mock(group: str, name: str) -> None:
+    from tests.streamlit.element_mocks import (
+        CONTAINER_ELEMENTS,
+        NON_WIDGET_ELEMENTS,
+        WIDGET_ELEMENTS,
+    )
+
+    groups = {
+        "widget": WIDGET_ELEMENTS,
+        "non_widget": NON_WIDGET_ELEMENTS,
+        "container": CONTAINER_ELEMENTS,
+    }
+    for mock_name, producer in groups[group]:
+        if mock_name == name:
+            producer()
+            return
+    raise KeyError((group, name))
+
+
+def _extra_bidi_component() -> None:
+    import streamlit as st
+
+    c = st.components.v2.component("smoke_test_bidi", html="<div>hi</div>")
+    c()
+
+
+def _extra_component_instance() -> None:
+    import streamlit.components.v1 as components
+
+    foo = components.declare_component("smoke_test_v1", url="http://example.com")
+    foo()
+
+
+def _extra_spinner() -> None:
+    import streamlit as st
+
     # Exiting immediately cancels the 0.5s timer, so only the clearing
     # transient is sent — not Element.spinner. That still proves .run()
     # skips new_transient and spinner never appears as a tree node.
-    _parse_case("spinner", "with st.spinner('w'):\n    pass", absent=("spinner",)),
-    _parse_case("text", "st.text('t')", "text"),
-    _parse_case("text_area", "st.text_area('t')", "text_area"),
-    _parse_case("text_input", "st.text_input('t')", "text_input"),
-    _parse_case("time_input", "st.time_input('t')", "time_input"),
-    _parse_case("date_time_input", "st.datetime_input('d')", "date_time_input"),
-    _parse_case("toast", "st.toast('t')", "toast"),
-    _parse_case("video", "st.video(b'\\x12\\x10')", "video"),
-    _parse_case("heading", "st.title('T')", "title"),
-    _parse_case("code", "st.code('x=1')", "code"),
-    _parse_case("menu_button", "st.menu_button('m', ['a'])", "menu_button"),
-    _parse_case("pagination", "st.pagination(5)", "pagination"),
-    _parse_case(
-        "echarts_chart",
-        "st.echarts_chart({'xAxis': {'type': 'category', 'data': ['A']}, "
-        "'yAxis': {'type': 'value'}, 'series': [{'type': 'bar', 'data': [1]}]})",
-        "echarts_chart",
+    with st.spinner("w"):
+        pass
+
+
+def _extra_dialog() -> None:
+    import streamlit as st
+
+    @st.dialog("D")
+    def _dlg() -> None:
+        st.write("x")
+
+    _dlg()
+
+
+def _extra_transparent() -> None:
+    import streamlit as st
+
+    outside = st.container()
+    outside.empty()
+
+    @st.fragment
+    def _frag() -> None:
+        outside.write("hi")
+
+    _frag()
+
+
+class ExtraCase(NamedTuple):
+    """Script for a proto oneof that no ``element_mocks`` producer emits.
+
+    ``proto_names`` are the Element/Block ``type`` oneof names this case claims
+    coverage for. ``tree_types`` are the ``node.type`` values the parsed tree
+    must contain. ``absent_types`` must not appear, for transients such as
+    spinner.
+    """
+
+    case_id: str
+    script: Callable[[], None]
+    proto_names: frozenset[str]
+    tree_types: frozenset[str] = frozenset()
+    absent_types: frozenset[str] = frozenset()
+
+
+EXTRA_CASES: list[ExtraCase] = [
+    ExtraCase(
+        "bidi_component",
+        _extra_bidi_component,
+        frozenset({"bidi_component"}),
+        frozenset({"bidi_component"}),
     ),
-    _parse_case(
-        "column", "c1, c2 = st.columns(2)\nc1.write('a')\nc2.write('b')", "column"
+    ExtraCase(
+        "component_instance",
+        _extra_component_instance,
+        frozenset({"component_instance"}),
+        frozenset({"component_instance"}),
     ),
-    _parse_case("expandable", "with st.expander('e'):\n    st.write('x')", "expander"),
-    _parse_case(
-        "form",
-        "with st.form('f'):\n    st.text_input('n')\n    st.form_submit_button('go')",
-        "form",
+    ExtraCase(
+        "spinner",
+        _extra_spinner,
+        frozenset({"spinner"}),
+        absent_types=frozenset({"spinner"}),
     ),
-    ParseCase(
-        frozenset({"tab_container", "tab"}),
-        "a, b = st.tabs(['A', 'B'])\na.write('a')\nb.write('b')",
-        frozenset({"tab_container", "tab"}),
-        "tabs",
-    ),
-    _parse_case(
-        "chat_message",
-        "with st.chat_message('user'):\n    st.write('hi')",
-        "chat_message",
-    ),
-    _parse_case("popover", "with st.popover('p'):\n    st.write('x')", "popover"),
-    _parse_case(
+    ExtraCase(
         "dialog",
-        "@st.dialog('D')\ndef _dlg():\n    st.write('x')\n_dlg()",
-        "dialog",
+        _extra_dialog,
+        frozenset({"dialog"}),
+        frozenset({"dialog"}),
     ),
-    _parse_case(
-        "flex_container", "with st.container():\n    st.write('x')", "flex_container"
-    ),
-    _parse_case(
+    ExtraCase(
         "transparent",
-        "outside = st.container()\n"
-        "outside.empty()\n"
-        "@st.fragment\n"
-        "def _frag():\n"
-        "    outside.write('hi')\n"
-        "_frag()",
-        "transparent",
+        _extra_transparent,
+        frozenset({"transparent"}),
+        frozenset({"transparent"}),
     ),
 ]
 
 
 def test_every_public_proto_oneof_has_a_parse_smoke_case() -> None:
-    """Every Element/Block type oneof is covered by a smoke case or an exclusion."""
-    covered = {name for case in PARSE_CASES for name in case.proto_names}
+    """Every Element/Block type oneof is covered by a mock, extra, or exclusion."""
+    covered = {
+        name
+        for _, mock_name in MOCK_CASES
+        for name in _protos_claimed_by_mock(mock_name)
+    }
+    covered |= {name for case in EXTRA_CASES for name in case.proto_names}
     element_oneofs = _oneof_names(ElementProto.DESCRIPTOR)
     block_oneofs = _oneof_names(BlockProto.DESCRIPTOR)
     assert set(EXCLUDED_ELEMENT_TYPES) <= element_oneofs, (
@@ -244,28 +299,67 @@ def test_every_public_proto_oneof_has_a_parse_smoke_case() -> None:
     missing_blocks = block_oneofs - covered - set(EXCLUDED_BLOCK_TYPES)
     assert not missing_elements, (
         f"Element oneofs without a parse smoke case: {sorted(missing_elements)}. "
-        "Add a PARSE_CASES entry, or an EXCLUDED_ELEMENT_TYPES entry with a reason."
+        "Add an element_mocks producer, an EXTRA_CASES entry, or an "
+        "EXCLUDED_ELEMENT_TYPES entry with a reason."
     )
     assert not missing_blocks, (
         f"Block oneofs without a parse smoke case: {sorted(missing_blocks)}. "
-        "Add a PARSE_CASES entry, or an EXCLUDED_BLOCK_TYPES entry with a reason."
+        "Add an element_mocks producer, an EXTRA_CASES entry, or an "
+        "EXCLUDED_BLOCK_TYPES entry with a reason."
     )
 
     extra = covered - element_oneofs - block_oneofs
     assert not extra, (
-        "PARSE_CASES references names that are no longer Element/Block oneofs: "
+        "Parse cases reference names that are no longer Element/Block oneofs: "
         f"{sorted(extra)}"
     )
 
 
-@pytest.mark.parametrize("case", PARSE_CASES, ids=[c.case_id for c in PARSE_CASES])
-def test_public_st_command_proto_variant_parses(case: ParseCase) -> None:
-    """AppTest.run() must parse each public st.* proto variant without crashing."""
-    script = "import streamlit as st\n" + textwrap.dedent(case.body).strip() + "\n"
-    at = AppTest.from_string(script, default_timeout=10).run()
-    assert at.session_state[SCRIPT_RUN_WITHOUT_ERRORS_KEY], [
-        exc.message for exc in at.exception
-    ]
+def test_element_mock_proto_overrides_match_oneofs() -> None:
+    """Mock names either match a oneof or have an override table entry."""
+    oneofs = _all_oneofs()
+    for _, name in MOCK_CASES:
+        claimed = _protos_claimed_by_mock(name)
+        if name in _MOCK_PROTO_OVERRIDES:
+            extra = claimed - oneofs
+            assert not extra, (
+                f"element_mocks {name!r} override names that are not oneofs: "
+                f"{sorted(extra)}"
+            )
+            continue
+        assert name in oneofs, (
+            f"element_mocks {name!r} is not an Element/Block oneof. "
+            "Add it to _MOCK_PROTO_OVERRIDES."
+        )
+
+
+@pytest.mark.parametrize(
+    ("group", "name"),
+    MOCK_CASES,
+    ids=[f"{group}-{name}" for group, name in MOCK_CASES],
+)
+def test_element_mock_proto_variant_parses(group: str, name: str) -> None:
+    """AppTest.run() must parse each element_mocks producer without crashing."""
+    at = AppTest.from_function(
+        _call_element_mock, default_timeout=10, args=(group, name)
+    ).run()
+    _run_ok(at)
+    claimed = _protos_claimed_by_mock(name)
+    if claimed:
+        assert claimed <= _proto_names_from_tree(at), {
+            node.type for node in at if node.type not in _ROOT_TYPES
+        }
+
+
+@pytest.mark.parametrize("case", EXTRA_CASES, ids=[c.case_id for c in EXTRA_CASES])
+def test_extra_proto_variant_parses(case: ExtraCase) -> None:
+    """AppTest.run() must parse oneofs that element_mocks do not emit."""
+    at = AppTest.from_function(case.script, default_timeout=10).run()
+    _run_ok(at)
     tree_types = {node.type for node in at}
     assert case.tree_types <= tree_types, tree_types
     assert case.absent_types.isdisjoint(tree_types), tree_types
+    if case.proto_names - case.absent_types:
+        assert case.proto_names - case.absent_types <= _proto_names_from_tree(at), (
+            tree_types
+        )

--- a/lib/tests/streamlit/testing/proto_variant_parse_test.py
+++ b/lib/tests/streamlit/testing/proto_variant_parse_test.py
@@ -14,8 +14,8 @@
 
 """AppTest smoke tests asserting that every public Element/Block proto oneof parses.
 
-Producers come from ``element_mocks`` (the public ``st.*`` inventory). A few
-oneofs are not a public command — those use extra scripts below.
+Producers come from ``element_mocks`` (the public ``st.*`` inventory). Extra
+scripts cover proto behavior those producers do not.
 
 Elements without a dedicated AppTest node class parse as ``UnknownElement``, so
 these cases assert that ``run()`` succeeds and the variant reaches the tree, not
@@ -44,19 +44,24 @@ if TYPE_CHECKING:
     from google.protobuf.descriptor import Descriptor
 
 # Public st.* never puts these oneofs in the AppTest element tree.
-EXCLUDED_ELEMENT_TYPES: dict[str, str] = {
+_EXCLUDED_ELEMENT_TYPES: dict[str, str] = {
     "favicon": "st.set_page_config sends page_config_changed, not Element.favicon",
+    "spinner": "transient-only; AppTest skips new_transient deltas",
 }
-EXCLUDED_BLOCK_TYPES: dict[str, str] = {
+_EXCLUDED_BLOCK_TYPES: dict[str, str] = {
     "vertical": "legacy; layouts emit flex_container",
     "horizontal": "legacy; layouts emit flex_container",
 }
 
-# AppTest node.type values that are not Element/Block type oneofs.
-_ROOT_TYPES = frozenset({"root", "main", "sidebar", "event", "unknown"})
+# AppTest node.type values that are not Element/Block type oneofs
+# (unknown is a synthetic placeholder for intermediate delta-path segments).
+_NON_PROTO_NODE_TYPES = frozenset({"root", "main", "sidebar", "event", "unknown"})
 
-# Mock command name -> proto oneofs, when the names differ or the mock does
-# not emit a oneof (logo, echo, spinner, dialog, pdf, form_submit_button).
+# Mock command name -> proto oneofs claimed for inventory coverage.
+# Empty frozenset: the mock emits nothing unique (logo is a top-level
+# ForwardMsg; echo/spinner/dialog are never entered) or only a oneof
+# another mock already claims (form_submit_button proxies text_input;
+# pdf delegates to bidi_component).
 _MOCK_PROTO_OVERRIDES: dict[str, frozenset[str]] = {
     "form_submit_button": frozenset(),
     "logo": frozenset(),
@@ -126,7 +131,7 @@ _MOCK_GROUPS: dict[str, list[tuple[str, Callable[[], object]]]] = {
     "container": CONTAINER_ELEMENTS,
 }
 
-MOCK_CASES: list[tuple[str, str]] = [
+_MOCK_CASES: list[tuple[str, str]] = [
     (group, name) for group, producers in _MOCK_GROUPS.items() for name, _ in producers
 ]
 
@@ -149,19 +154,23 @@ def _protos_claimed_by_mock(name: str) -> frozenset[str]:
 def _proto_names_from_tree(at: AppTest) -> set[str]:
     names: set[str] = set()
     for node in at:
-        if node.type in _ROOT_TYPES:
+        if node.type in _NON_PROTO_NODE_TYPES:
             continue
         names.add(_TREE_TYPE_TO_PROTO.get(node.type, node.type))
     return names
 
 
 def _run_ok(at: AppTest) -> None:
+    # st.exception() is a successful display command, so at.exception is
+    # non-empty on that mock; SCRIPT_RUN_WITHOUT_ERRORS_KEY is the run status.
     assert at.session_state[SCRIPT_RUN_WITHOUT_ERRORS_KEY], [
         exc.message for exc in at.exception
     ]
 
 
 def _call_element_mock(group: str, name: str) -> None:
+    # AppTest.from_function compiles only this function as the app script, so
+    # module globals such as _MOCK_GROUPS are out of scope here.
     from tests.streamlit.element_mocks import (
         CONTAINER_ELEMENTS,
         NON_WIDGET_ELEMENTS,
@@ -197,9 +206,9 @@ def _extra_component_instance() -> None:
 def _extra_spinner() -> None:
     import streamlit as st
 
-    # Exiting immediately cancels the 0.5s timer, so only the clearing
-    # transient is sent — not Element.spinner. That still proves .run()
-    # skips new_transient and spinner never appears as a tree node.
+    # Exiting immediately cancels the 0.5s timer, so only an empty
+    # clear_transient new_transient delta is sent. AppTest skips those
+    # deltas, and spinner never appears as a tree node.
     with st.spinner("w"):
         pass
 
@@ -227,8 +236,8 @@ def _extra_transparent() -> None:
     _frag()
 
 
-class ExtraCase(NamedTuple):
-    """Script for a proto oneof that no ``element_mocks`` producer emits.
+class _ExtraCase(NamedTuple):
+    """Additional script for proto behavior that element_mocks does not cover.
 
     ``proto_names`` are the Element/Block ``type`` oneof names this case claims
     coverage for. ``tree_types`` are the ``node.type`` values the parsed tree
@@ -238,37 +247,36 @@ class ExtraCase(NamedTuple):
 
     case_id: str
     script: Callable[[], None]
-    proto_names: frozenset[str]
+    proto_names: frozenset[str] = frozenset()
     tree_types: frozenset[str] = frozenset()
     absent_types: frozenset[str] = frozenset()
 
 
-EXTRA_CASES: list[ExtraCase] = [
-    ExtraCase(
+_EXTRA_CASES: list[_ExtraCase] = [
+    _ExtraCase(
         "bidi_component",
         _extra_bidi_component,
         frozenset({"bidi_component"}),
         frozenset({"bidi_component"}),
     ),
-    ExtraCase(
+    _ExtraCase(
         "component_instance",
         _extra_component_instance,
         frozenset({"component_instance"}),
         frozenset({"component_instance"}),
     ),
-    ExtraCase(
+    _ExtraCase(
         "spinner",
         _extra_spinner,
-        frozenset({"spinner"}),
         absent_types=frozenset({"spinner"}),
     ),
-    ExtraCase(
+    _ExtraCase(
         "dialog",
         _extra_dialog,
         frozenset({"dialog"}),
         frozenset({"dialog"}),
     ),
-    ExtraCase(
+    _ExtraCase(
         "transparent",
         _extra_transparent,
         frozenset({"transparent"}),
@@ -281,31 +289,31 @@ def test_every_public_proto_oneof_has_a_parse_smoke_case() -> None:
     """Every Element/Block type oneof is covered by a mock, extra, or exclusion."""
     covered = {
         name
-        for _, mock_name in MOCK_CASES
+        for _, mock_name in _MOCK_CASES
         for name in _protos_claimed_by_mock(mock_name)
     }
-    covered |= {name for case in EXTRA_CASES for name in case.proto_names}
+    covered |= {name for case in _EXTRA_CASES for name in case.proto_names}
     element_oneofs = _oneof_names(ElementProto.DESCRIPTOR)
     block_oneofs = _oneof_names(BlockProto.DESCRIPTOR)
-    assert set(EXCLUDED_ELEMENT_TYPES) <= element_oneofs, (
-        "EXCLUDED_ELEMENT_TYPES names that are no longer Element oneofs: "
-        f"{sorted(set(EXCLUDED_ELEMENT_TYPES) - element_oneofs)}"
+    assert set(_EXCLUDED_ELEMENT_TYPES) <= element_oneofs, (
+        "_EXCLUDED_ELEMENT_TYPES names that are no longer Element oneofs: "
+        f"{sorted(set(_EXCLUDED_ELEMENT_TYPES) - element_oneofs)}"
     )
-    assert set(EXCLUDED_BLOCK_TYPES) <= block_oneofs, (
-        "EXCLUDED_BLOCK_TYPES names that are no longer Block oneofs: "
-        f"{sorted(set(EXCLUDED_BLOCK_TYPES) - block_oneofs)}"
+    assert set(_EXCLUDED_BLOCK_TYPES) <= block_oneofs, (
+        "_EXCLUDED_BLOCK_TYPES names that are no longer Block oneofs: "
+        f"{sorted(set(_EXCLUDED_BLOCK_TYPES) - block_oneofs)}"
     )
-    missing_elements = element_oneofs - covered - set(EXCLUDED_ELEMENT_TYPES)
-    missing_blocks = block_oneofs - covered - set(EXCLUDED_BLOCK_TYPES)
+    missing_elements = element_oneofs - covered - set(_EXCLUDED_ELEMENT_TYPES)
+    missing_blocks = block_oneofs - covered - set(_EXCLUDED_BLOCK_TYPES)
     assert not missing_elements, (
         f"Element oneofs without a parse smoke case: {sorted(missing_elements)}. "
-        "Add an element_mocks producer, an EXTRA_CASES entry, or an "
-        "EXCLUDED_ELEMENT_TYPES entry with a reason."
+        "Add an element_mocks producer, an _EXTRA_CASES entry, or an "
+        "_EXCLUDED_ELEMENT_TYPES entry with a reason."
     )
     assert not missing_blocks, (
         f"Block oneofs without a parse smoke case: {sorted(missing_blocks)}. "
-        "Add an element_mocks producer, an EXTRA_CASES entry, or an "
-        "EXCLUDED_BLOCK_TYPES entry with a reason."
+        "Add an element_mocks producer, an _EXTRA_CASES entry, or an "
+        "_EXCLUDED_BLOCK_TYPES entry with a reason."
     )
 
     extra = covered - element_oneofs - block_oneofs
@@ -318,7 +326,7 @@ def test_every_public_proto_oneof_has_a_parse_smoke_case() -> None:
 def test_element_mock_proto_overrides_match_oneofs() -> None:
     """Mock names either match a oneof or have an override table entry."""
     oneofs = _all_oneofs()
-    for _, name in MOCK_CASES:
+    for _, name in _MOCK_CASES:
         claimed = _protos_claimed_by_mock(name)
         if name in _MOCK_PROTO_OVERRIDES:
             extra = claimed - oneofs
@@ -335,8 +343,8 @@ def test_element_mock_proto_overrides_match_oneofs() -> None:
 
 @pytest.mark.parametrize(
     ("group", "name"),
-    MOCK_CASES,
-    ids=[f"{group}-{name}" for group, name in MOCK_CASES],
+    _MOCK_CASES,
+    ids=[f"{group}-{name}" for group, name in _MOCK_CASES],
 )
 def test_element_mock_proto_variant_parses(group: str, name: str) -> None:
     """AppTest.run() must parse each element_mocks producer without crashing."""
@@ -347,19 +355,15 @@ def test_element_mock_proto_variant_parses(group: str, name: str) -> None:
     claimed = _protos_claimed_by_mock(name)
     if claimed:
         assert claimed <= _proto_names_from_tree(at), {
-            node.type for node in at if node.type not in _ROOT_TYPES
+            node.type for node in at if node.type not in _NON_PROTO_NODE_TYPES
         }
 
 
-@pytest.mark.parametrize("case", EXTRA_CASES, ids=[c.case_id for c in EXTRA_CASES])
-def test_extra_proto_variant_parses(case: ExtraCase) -> None:
+@pytest.mark.parametrize("case", _EXTRA_CASES, ids=[c.case_id for c in _EXTRA_CASES])
+def test_extra_proto_variant_parses(case: _ExtraCase) -> None:
     """AppTest.run() must parse oneofs that element_mocks do not emit."""
     at = AppTest.from_function(case.script, default_timeout=10).run()
     _run_ok(at)
     tree_types = {node.type for node in at}
     assert case.tree_types <= tree_types, tree_types
     assert case.absent_types.isdisjoint(tree_types), tree_types
-    if case.proto_names - case.absent_types:
-        assert case.proto_names - case.absent_types <= _proto_names_from_tree(at), (
-            tree_types
-        )


### PR DESCRIPTION
## Describe your changes

AppTest now smoke-tests `.run()` for every public `Element.proto` / `Block.proto` oneof that an `st.*` command can emit, so a new command cannot land without parse coverage.

Implements wiki queue **P0.5** in the [AppTest issue verification and PR queue](https://github.com/streamlit/streamlit/wiki/2026-07-22-app-testing-fixes).

Public commands are exercised through the existing producers in `lib/tests/streamlit/element_mocks.py`. Extra scripts cover proto behavior those producers do not:

- `bidi_component` / `component_instance` (custom components)
- `dialog` (the mock only returns the decorator)
- `transparent` (fragment write into an outside container)

The descriptor inventory excludes variants that AppTest never represents as a first-class tree node:

- `favicon` is sent via `page_config_changed`
- leftover `vertical` / `horizontal` blocks are superseded by `flex_container`
- `spinner` is transient (`new_transient`); a dedicated case asserts it is absent from the tree

## GitHub Issue Link (if applicable)

N/A

## Testing Plan

- [x] `lib/tests/streamlit/testing/proto_variant_parse_test.py` — parametrized `AppTest.run()` over `element_mocks` plus extras, and a lock that every oneof is covered or explicitly excluded
- E2E tests: not applicable (AppTest-only)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

Made with [Cursor](https://cursor.com)