### PR TITLE
[fix] Add helpful errors for unknown st.* names

### DIFF
--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -321,7 +321,10 @@ from streamlit import components as components
 import streamlit.components.v1  # noqa: F401
 import streamlit.components.v2  # noqa: F401
 
-# Runtime-only: type checkers must still error on unknown ``st.*`` attributes.
+# Runtime-only module ``__getattr__``. Hide it from type checkers so unknown
+# ``st.*`` names stay type errors. mypy only honors the unaliased
+# ``TYPE_CHECKING`` name here; an alias made unknown names type-check as
+# valid. Deleting it afterward keeps it off the public ``st`` surface.
 from typing import TYPE_CHECKING
 
 if not TYPE_CHECKING:

--- a/lib/streamlit/__init__.py
+++ b/lib/streamlit/__init__.py
@@ -320,3 +320,17 @@ from streamlit.starlette import App as App
 from streamlit import components as components
 import streamlit.components.v1  # noqa: F401
 import streamlit.components.v2  # noqa: F401
+
+# Runtime-only: type checkers must still error on unknown ``st.*`` attributes.
+from typing import TYPE_CHECKING
+
+if not TYPE_CHECKING:
+
+    def __getattr__(name: str) -> object:
+        from streamlit.command_suggestions import raise_missing_streamlit_attribute
+
+        raise_missing_streamlit_attribute(name)
+
+
+# Drop TYPE_CHECKING so it is not a public ``st`` name.
+del TYPE_CHECKING

--- a/lib/streamlit/command_suggestions.py
+++ b/lib/streamlit/command_suggestions.py
@@ -1,0 +1,148 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from difflib import get_close_matches
+from typing import TYPE_CHECKING, Final, NoReturn
+
+if TYPE_CHECKING:
+    from collections.abc import Collection, Mapping
+    from types import ModuleType
+
+# Exact former public names and the current public replacements they map to.
+# Ambiguous retired APIs (for example ``st.cache``) list every valid successor
+# rather than picking one alias.
+_REMOVED_STREAMLIT_ATTRIBUTES: Final[Mapping[str, tuple[str, ...]]] = {
+    "beta_color_picker": ("color_picker",),
+    "beta_columns": ("columns",),
+    "beta_container": ("container",),
+    "beta_expander": ("expander",),
+    "beta_secrets": ("secrets",),
+    "cache": ("cache_data", "cache_resource"),
+    "experimental_audio_input": ("audio_input",),
+    "experimental_connection": ("connection",),
+    "experimental_data_editor": ("data_editor",),
+    "experimental_dialog": ("dialog",),
+    "experimental_fragment": ("fragment",),
+    "experimental_get_query_params": ("query_params",),
+    "experimental_memo": ("cache_data",),
+    "experimental_rerun": ("rerun",),
+    "experimental_set_query_params": ("query_params",),
+    "experimental_singleton": ("cache_resource",),
+    "experimental_user": ("user",),
+}
+
+# Public namespaces that are modules, so they are excluded by the non-module
+# command filter used for the rest of the ``st`` surface.
+_PUBLIC_STREAMLIT_NAMESPACES: Final[frozenset[str]] = frozenset(
+    {"column_config", "components", "typing"}
+)
+
+_CLOSE_MATCH_CUTOFF: Final = 0.8
+_MAX_CLOSE_MATCHES: Final = 3
+_MAX_SUGGESTION_LENGTH_DELTA: Final = 1
+
+
+def public_streamlit_names(module: ModuleType) -> frozenset[str]:
+    """Return the curated public ``st.*`` surface used for typo suggestions.
+
+    Includes public commands and objects plus the documented public
+    namespaces. Internal modules that leak into ``st.__dict__`` are omitted.
+    """
+    names = {
+        key
+        for key, value in module.__dict__.items()
+        if not key.startswith("_") and not isinstance(value, type(module))
+    }
+    names.update(
+        namespace
+        for namespace in _PUBLIC_STREAMLIT_NAMESPACES
+        if namespace in module.__dict__
+    )
+    return frozenset(names)
+
+
+def suggest_streamlit_commands(name: str, catalog: Collection[str]) -> tuple[str, ...]:
+    """Return conservative close matches for ``name`` from ``catalog``.
+
+    Matches must be at least ``_CLOSE_MATCH_CUTOFF`` similar and differ in
+    length by at most one character so suggestions stay typo-like.
+    """
+    close_matches = get_close_matches(
+        name,
+        catalog,
+        n=_MAX_CLOSE_MATCHES,
+        cutoff=_CLOSE_MATCH_CUTOFF,
+    )
+    return tuple(
+        match
+        for match in close_matches
+        if abs(len(match) - len(name)) <= _MAX_SUGGESTION_LENGTH_DELTA
+    )
+
+
+def missing_streamlit_attribute_message(name: str, module: ModuleType) -> str:
+    """Return an AttributeError message for a missing top-level ``st.*`` name."""
+    prefix = f"module 'streamlit' has no attribute '{name}'"
+    if name.startswith("_"):
+        return prefix
+
+    replacements = _REMOVED_STREAMLIT_ATTRIBUTES.get(name)
+    if replacements is not None:
+        return (
+            f"{prefix}. `{_st_name(name)}` has been removed. "
+            f"Use {_format_st_names(replacements)} instead."
+        )
+
+    catalog = public_streamlit_names(module)
+    if name == "input":
+        input_commands = tuple(
+            sorted(command for command in catalog if command.endswith("_input"))
+        )
+        return (
+            f"{prefix}. Streamlit has no `{_st_name(name)}`. "
+            "Use a specific input command such as "
+            f"{_format_st_names(input_commands)}."
+        )
+
+    suggestions = suggest_streamlit_commands(name, catalog)
+    if suggestions:
+        return f"{prefix}. Did you mean {_format_st_names(suggestions)}?"
+
+    return prefix
+
+
+def raise_missing_streamlit_attribute(name: str) -> NoReturn:
+    """Raise AttributeError for a missing top-level ``st.*`` name."""
+    import streamlit as st
+
+    raise AttributeError(
+        missing_streamlit_attribute_message(name, st),
+        name=name,
+        obj=st,
+    )
+
+
+def _st_name(name: str) -> str:
+    return f"st.{name}"
+
+
+def _format_st_names(names: Collection[str]) -> str:
+    labeled = [f"`{_st_name(name)}`" for name in names]
+    if len(labeled) == 1:
+        return labeled[0]
+    if len(labeled) == 2:
+        return f"{labeled[0]} or {labeled[1]}"
+    return f"{', '.join(labeled[:-1])}, or {labeled[-1]}"

--- a/lib/streamlit/command_suggestions.py
+++ b/lib/streamlit/command_suggestions.py
@@ -15,11 +15,11 @@
 from __future__ import annotations
 
 from difflib import get_close_matches
+from types import ModuleType
 from typing import TYPE_CHECKING, Final, NoReturn
 
 if TYPE_CHECKING:
     from collections.abc import Collection, Mapping
-    from types import ModuleType
 
 # Exact former public names and the current public replacements they map to.
 # Ambiguous retired APIs (for example ``st.cache``) list every valid successor
@@ -30,6 +30,7 @@ _REMOVED_STREAMLIT_ATTRIBUTES: Final[Mapping[str, tuple[str, ...]]] = {
     "beta_container": ("container",),
     "beta_expander": ("expander",),
     "beta_secrets": ("secrets",),
+    "beta_set_page_config": ("set_page_config",),
     "cache": ("cache_data", "cache_resource"),
     "experimental_audio_input": ("audio_input",),
     "experimental_connection": ("connection",),
@@ -40,12 +41,13 @@ _REMOVED_STREAMLIT_ATTRIBUTES: Final[Mapping[str, tuple[str, ...]]] = {
     "experimental_memo": ("cache_data",),
     "experimental_rerun": ("rerun",),
     "experimental_set_query_params": ("query_params",),
+    "experimental_show": ("write",),
     "experimental_singleton": ("cache_resource",),
     "experimental_user": ("user",),
 }
 
-# Public namespaces that are modules, so they are excluded by the non-module
-# command filter used for the rest of the ``st`` surface.
+# Include these public module namespaces in typo suggestions; the non-module
+# filter below would otherwise drop them.
 _PUBLIC_STREAMLIT_NAMESPACES: Final[frozenset[str]] = frozenset(
     {"column_config", "components", "typing"}
 )
@@ -64,7 +66,7 @@ def public_streamlit_names(module: ModuleType) -> frozenset[str]:
     names = {
         key
         for key, value in module.__dict__.items()
-        if not key.startswith("_") and not isinstance(value, type(module))
+        if not key.startswith("_") and not isinstance(value, ModuleType)
     }
     names.update(
         namespace
@@ -102,18 +104,20 @@ def missing_streamlit_attribute_message(name: str, module: ModuleType) -> str:
     replacements = _REMOVED_STREAMLIT_ATTRIBUTES.get(name)
     if replacements is not None:
         return (
-            f"{prefix}. `{_st_name(name)}` has been removed. "
+            f"{prefix}. {_st_name(name)} has been removed. "
             f"Use {_format_st_names(replacements)} instead."
         )
 
     catalog = public_streamlit_names(module)
+    # st.input is a close match for st.info; list input widgets instead.
     if name == "input":
         input_commands = tuple(
             sorted(command for command in catalog if command.endswith("_input"))
         )
+        if not input_commands:
+            return prefix
         return (
-            f"{prefix}. Streamlit has no `{_st_name(name)}`. "
-            "Use a specific input command such as "
+            f"{prefix}. Use a specific input command such as "
             f"{_format_st_names(input_commands)}."
         )
 
@@ -140,7 +144,9 @@ def _st_name(name: str) -> str:
 
 
 def _format_st_names(names: Collection[str]) -> str:
-    labeled = [f"`{_st_name(name)}`" for name in names]
+    labeled = [_st_name(name) for name in names]
+    if not labeled:
+        return ""
     if len(labeled) == 1:
         return labeled[0]
     if len(labeled) == 2:

--- a/lib/streamlit/command_suggestions.py
+++ b/lib/streamlit/command_suggestions.py
@@ -21,9 +21,11 @@ from typing import TYPE_CHECKING, Final, NoReturn
 if TYPE_CHECKING:
     from collections.abc import Collection, Mapping
 
-# Exact former public names and the current public replacements they map to.
-# Ambiguous retired APIs (for example ``st.cache``) list every valid successor
-# rather than picking one alias.
+# Exact former public names and the current public ``st.*`` successors they
+# map to. Ambiguous retired APIs (for example ``st.cache``) list every valid
+# successor rather than picking one alias. Removals whose replacement is not
+# an ``st.*`` name (for example ``st.bokeh_chart`` → the ``streamlit-bokeh``
+# component) stay on the default AttributeError.
 _REMOVED_STREAMLIT_ATTRIBUTES: Final[Mapping[str, tuple[str, ...]]] = {
     "beta_color_picker": ("color_picker",),
     "beta_columns": ("columns",),
@@ -58,20 +60,23 @@ _MAX_SUGGESTION_LENGTH_DELTA: Final = 1
 
 
 def public_streamlit_names(module: ModuleType) -> frozenset[str]:
-    """Return the curated public ``st.*`` surface used for typo suggestions.
+    """Return the public top-level ``st.*`` names used for typo suggestions.
 
     Includes public commands and objects plus the documented public
     namespaces. Internal modules that leak into ``st.__dict__`` are omitted.
     """
+    # Snapshot so a concurrent first-time submodule import cannot raise
+    # ``RuntimeError: dictionary changed size during iteration``.
+    module_dict = dict(vars(module))
     names = {
         key
-        for key, value in module.__dict__.items()
+        for key, value in module_dict.items()
         if not key.startswith("_") and not isinstance(value, ModuleType)
     }
     names.update(
         namespace
         for namespace in _PUBLIC_STREAMLIT_NAMESPACES
-        if namespace in module.__dict__
+        if namespace in module_dict
     )
     return frozenset(names)
 
@@ -109,12 +114,13 @@ def missing_streamlit_attribute_message(name: str, module: ModuleType) -> str:
         )
 
     catalog = public_streamlit_names(module)
-    # st.input is a close match for st.info; list input widgets instead.
+    # ``st.input`` has no close match and no single successor. Point at the
+    # input-widget family instead of failing with no advice.
     if name == "input":
         input_commands = tuple(
             sorted(command for command in catalog if command.endswith("_input"))
         )
-        if not input_commands:
+        if not input_commands:  # pragma: no cover - defensive
             return prefix
         return (
             f"{prefix}. Use a specific input command such as "
@@ -129,11 +135,20 @@ def missing_streamlit_attribute_message(name: str, module: ModuleType) -> str:
 
 
 def raise_missing_streamlit_attribute(name: str) -> NoReturn:
-    """Raise AttributeError for a missing top-level ``st.*`` name."""
+    """Raise ``AttributeError`` for a missing top-level ``st.*`` name.
+
+    Sets ``name`` and ``obj`` so uncaught-exception telemetry records
+    ``AttributeError:<attribute>`` instead of parsing the message.
+    """
     import streamlit as st
 
+    try:
+        message = missing_streamlit_attribute_message(name, st)
+    except Exception:  # pragma: no cover - defensive
+        message = f"module 'streamlit' has no attribute '{name}'"
+
     raise AttributeError(
-        missing_streamlit_attribute_message(name, st),
+        message,
         name=name,
         obj=st,
     )

--- a/lib/tests/streamlit/command_suggestions_test.py
+++ b/lib/tests/streamlit/command_suggestions_test.py
@@ -20,6 +20,7 @@ import pytest
 
 import streamlit as st
 from streamlit.command_suggestions import (
+    _format_st_names,
     missing_streamlit_attribute_message,
     public_streamlit_names,
     suggest_streamlit_commands,
@@ -38,22 +39,24 @@ def _missing_attr(name: str) -> AttributeError:
 @pytest.mark.parametrize(
     ("old_name", "expected_replacement"),
     [
-        ("experimental_rerun", "`st.rerun`"),
-        ("experimental_memo", "`st.cache_data`"),
-        ("experimental_singleton", "`st.cache_resource`"),
-        ("experimental_data_editor", "`st.data_editor`"),
-        ("experimental_connection", "`st.connection`"),
-        ("experimental_user", "`st.user`"),
-        ("experimental_dialog", "`st.dialog`"),
-        ("experimental_fragment", "`st.fragment`"),
-        ("experimental_audio_input", "`st.audio_input`"),
-        ("experimental_get_query_params", "`st.query_params`"),
-        ("experimental_set_query_params", "`st.query_params`"),
-        ("beta_columns", "`st.columns`"),
-        ("beta_expander", "`st.expander`"),
-        ("beta_container", "`st.container`"),
-        ("beta_secrets", "`st.secrets`"),
-        ("beta_color_picker", "`st.color_picker`"),
+        ("experimental_rerun", "st.rerun"),
+        ("experimental_memo", "st.cache_data"),
+        ("experimental_singleton", "st.cache_resource"),
+        ("experimental_data_editor", "st.data_editor"),
+        ("experimental_connection", "st.connection"),
+        ("experimental_user", "st.user"),
+        ("experimental_dialog", "st.dialog"),
+        ("experimental_fragment", "st.fragment"),
+        ("experimental_audio_input", "st.audio_input"),
+        ("experimental_get_query_params", "st.query_params"),
+        ("experimental_set_query_params", "st.query_params"),
+        ("experimental_show", "st.write"),
+        ("beta_columns", "st.columns"),
+        ("beta_expander", "st.expander"),
+        ("beta_container", "st.container"),
+        ("beta_secrets", "st.secrets"),
+        ("beta_color_picker", "st.color_picker"),
+        ("beta_set_page_config", "st.set_page_config"),
     ],
 )
 def test_removed_attributes_name_the_replacement(
@@ -67,7 +70,6 @@ def test_removed_attributes_name_the_replacement(
     assert f"module 'streamlit' has no attribute '{old_name}'" in message
     assert error.name == old_name
     assert error.obj is st
-    assert not hasattr(st, old_name)
     assert not isinstance(error, StreamlitAPIException)
     assert format_uncaught_exception(error) == f"AttributeError:{old_name}"
 
@@ -77,8 +79,8 @@ def test_removed_cache_lists_both_successors() -> None:
     error = _missing_attr("cache")
     message = str(error)
     assert "has been removed" in message
-    assert "`st.cache_data`" in message
-    assert "`st.cache_resource`" in message
+    assert "st.cache_data" in message
+    assert "st.cache_resource" in message
     assert format_uncaught_exception(error) == "AttributeError:cache"
 
 
@@ -86,8 +88,8 @@ def test_ambiguous_input_lists_input_commands() -> None:
     """``st.input`` lists the input-command family instead of one alias."""
     error = _missing_attr("input")
     message = str(error)
-    assert "Streamlit has no `st.input`" in message
-    assert "`st.info`" not in message
+    assert "Use a specific input command" in message
+    assert "st.info" not in message
     for command in (
         "audio_input",
         "camera_input",
@@ -98,8 +100,7 @@ def test_ambiguous_input_lists_input_commands() -> None:
         "text_input",
         "time_input",
     ):
-        assert f"`st.{command}`" in message
-    assert not hasattr(st, "input")
+        assert f"st.{command}" in message
     assert format_uncaught_exception(error) == "AttributeError:input"
 
 
@@ -117,7 +118,7 @@ def test_typo_suggestions_use_the_public_command(typo: str, expected: str) -> No
     """Close typos suggest the matching public command."""
     error = _missing_attr(typo)
     assert "Did you mean" in str(error)
-    assert f"`st.{expected}`" in str(error)
+    assert f"st.{expected}" in str(error)
     assert format_uncaught_exception(error) == f"AttributeError:{typo}"
 
 
@@ -182,13 +183,18 @@ def test_suggest_streamlit_commands_is_conservative() -> None:
     assert suggest_streamlit_commands("text_inpt", catalog) == ("text_input",)
 
 
+def test_format_st_names_empty_is_safe() -> None:
+    """Joining zero command names does not raise."""
+    assert _format_st_names(()) == ""
+
+
 def test_missing_streamlit_attribute_message_keeps_standard_prefix() -> None:
     """Helper messages stay AttributeError-shaped for telemetry fallbacks."""
     message = missing_streamlit_attribute_message("experimental_rerun", st)
     assert message.startswith(
         "module 'streamlit' has no attribute 'experimental_rerun'"
     )
-    assert "`st.rerun`" in message
+    assert "st.rerun" in message
 
 
 def test_telemetry_uses_name_and_obj_not_message_text() -> None:

--- a/lib/tests/streamlit/command_suggestions_test.py
+++ b/lib/tests/streamlit/command_suggestions_test.py
@@ -1,0 +1,198 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+import streamlit as st
+from streamlit.command_suggestions import (
+    missing_streamlit_attribute_message,
+    public_streamlit_names,
+    suggest_streamlit_commands,
+)
+from streamlit.errors import StreamlitAPIException
+from streamlit.runtime.metrics_util import format_uncaught_exception
+
+
+def _missing_attr(name: str) -> AttributeError:
+    """Access a missing ``st.*`` name and return the raised AttributeError."""
+    with pytest.raises(AttributeError) as exc_info:
+        getattr(st, name)
+    return exc_info.value
+
+
+@pytest.mark.parametrize(
+    ("old_name", "expected_replacement"),
+    [
+        ("experimental_rerun", "`st.rerun`"),
+        ("experimental_memo", "`st.cache_data`"),
+        ("experimental_singleton", "`st.cache_resource`"),
+        ("experimental_data_editor", "`st.data_editor`"),
+        ("experimental_connection", "`st.connection`"),
+        ("experimental_user", "`st.user`"),
+        ("experimental_dialog", "`st.dialog`"),
+        ("experimental_fragment", "`st.fragment`"),
+        ("experimental_audio_input", "`st.audio_input`"),
+        ("experimental_get_query_params", "`st.query_params`"),
+        ("experimental_set_query_params", "`st.query_params`"),
+        ("beta_columns", "`st.columns`"),
+        ("beta_expander", "`st.expander`"),
+        ("beta_container", "`st.container`"),
+        ("beta_secrets", "`st.secrets`"),
+        ("beta_color_picker", "`st.color_picker`"),
+    ],
+)
+def test_removed_attributes_name_the_replacement(
+    old_name: str, expected_replacement: str
+) -> None:
+    """Removed public names raise AttributeError pointing at the successor API."""
+    error = _missing_attr(old_name)
+    message = str(error)
+    assert "has been removed" in message
+    assert expected_replacement in message
+    assert f"module 'streamlit' has no attribute '{old_name}'" in message
+    assert error.name == old_name
+    assert error.obj is st
+    assert not hasattr(st, old_name)
+    assert not isinstance(error, StreamlitAPIException)
+    assert format_uncaught_exception(error) == f"AttributeError:{old_name}"
+
+
+def test_removed_cache_lists_both_successors() -> None:
+    """``st.cache`` names both replacements instead of choosing one alias."""
+    error = _missing_attr("cache")
+    message = str(error)
+    assert "has been removed" in message
+    assert "`st.cache_data`" in message
+    assert "`st.cache_resource`" in message
+    assert format_uncaught_exception(error) == "AttributeError:cache"
+
+
+def test_ambiguous_input_lists_input_commands() -> None:
+    """``st.input`` lists the input-command family instead of one alias."""
+    error = _missing_attr("input")
+    message = str(error)
+    assert "Streamlit has no `st.input`" in message
+    assert "`st.info`" not in message
+    for command in (
+        "audio_input",
+        "camera_input",
+        "chat_input",
+        "date_input",
+        "datetime_input",
+        "number_input",
+        "text_input",
+        "time_input",
+    ):
+        assert f"`st.{command}`" in message
+    assert not hasattr(st, "input")
+    assert format_uncaught_exception(error) == "AttributeError:input"
+
+
+@pytest.mark.parametrize(
+    ("typo", "expected"),
+    [
+        ("text_inpt", "text_input"),
+        ("numberinput", "number_input"),
+        ("sessionstate", "session_state"),
+        ("wrtie", "write"),
+        ("colums", "columns"),
+    ],
+)
+def test_typo_suggestions_use_the_public_command(typo: str, expected: str) -> None:
+    """Close typos suggest the matching public command."""
+    error = _missing_attr(typo)
+    assert "Did you mean" in str(error)
+    assert f"`st.{expected}`" in str(error)
+    assert format_uncaught_exception(error) == f"AttributeError:{typo}"
+
+
+def test_unrelated_names_keep_the_standard_attribute_error() -> None:
+    """Unknown names with no close public match keep the standard message."""
+    error = _missing_attr("zzzz_not_a_command")
+    assert str(error) == "module 'streamlit' has no attribute 'zzzz_not_a_command'"
+    assert error.name == "zzzz_not_a_command"
+    assert error.obj is st
+    assert format_uncaught_exception(error) == "AttributeError:zzzz_not_a_command"
+
+
+def test_format_does_not_suggest_form() -> None:
+    """``st.format`` is not a one-character typo of ``st.form``."""
+    error = _missing_attr("format")
+    assert str(error) == "module 'streamlit' has no attribute 'format'"
+    assert "st.form" not in str(error)
+
+
+def test_suggestions_exclude_internal_modules() -> None:
+    """Leaked internal modules are not part of the suggestion catalog."""
+    catalog = public_streamlit_names(st)
+    assert "error_util" not in catalog
+    assert "config_util" not in catalog
+    assert "logger" not in catalog
+    assert "button" in catalog
+    assert "session_state" in catalog
+    assert "column_config" in catalog
+    assert "components" in catalog
+    assert "typing" in catalog
+    assert suggest_streamlit_commands("error_util", catalog) == ()
+
+    error = _missing_attr("erro_util")
+    assert "Did you mean" not in str(error)
+
+
+def test_existing_public_attributes_are_unchanged() -> None:
+    """``__getattr__`` is not consulted for names that already exist on ``st``."""
+    assert st.button is st.__dict__["button"]
+    assert hasattr(st, "button")
+    assert hasattr(st, "session_state")
+    assert hasattr(st, "column_config")
+
+
+def test_private_names_do_not_get_suggestions() -> None:
+    """Underscore names keep a plain AttributeError."""
+    error = _missing_attr("_not_a_public_command")
+    assert str(error) == "module 'streamlit' has no attribute '_not_a_public_command'"
+
+
+def test_from_import_missing_name_is_import_error() -> None:
+    """``from streamlit import missing`` follows Python's ImportError conversion."""
+    with pytest.raises(ImportError, match="experimental_rerun"):
+        exec("from streamlit import experimental_rerun")
+
+
+def test_suggest_streamlit_commands_is_conservative() -> None:
+    """Close-match helper drops matches that differ by more than one character."""
+    catalog = ("form", "text_input", "write")
+    assert suggest_streamlit_commands("format", catalog) == ()
+    assert suggest_streamlit_commands("wrtie", catalog) == ("write",)
+    assert suggest_streamlit_commands("text_inpt", catalog) == ("text_input",)
+
+
+def test_missing_streamlit_attribute_message_keeps_standard_prefix() -> None:
+    """Helper messages stay AttributeError-shaped for telemetry fallbacks."""
+    message = missing_streamlit_attribute_message("experimental_rerun", st)
+    assert message.startswith(
+        "module 'streamlit' has no attribute 'experimental_rerun'"
+    )
+    assert "`st.rerun`" in message
+
+
+def test_telemetry_uses_name_and_obj_not_message_text() -> None:
+    """A customized message still suffixes the missing attribute, not the advice."""
+    error = _missing_attr("experimental_rerun")
+    assert format_uncaught_exception(error) == "AttributeError:experimental_rerun"
+    assert error.obj is sys.modules["streamlit"]

--- a/lib/tests/streamlit/command_suggestions_test.py
+++ b/lib/tests/streamlit/command_suggestions_test.py
@@ -14,12 +14,12 @@
 
 from __future__ import annotations
 
-import sys
-
 import pytest
 
 import streamlit as st
 from streamlit.command_suggestions import (
+    _PUBLIC_STREAMLIT_NAMESPACES,
+    _REMOVED_STREAMLIT_ATTRIBUTES,
     _format_st_names,
     missing_streamlit_attribute_message,
     public_streamlit_names,
@@ -84,8 +84,8 @@ def test_removed_cache_lists_both_successors() -> None:
     assert format_uncaught_exception(error) == "AttributeError:cache"
 
 
-def test_ambiguous_input_lists_input_commands() -> None:
-    """``st.input`` lists the input-command family instead of one alias."""
+def test_input_lists_input_widget_commands() -> None:
+    """``st.input`` lists the input-widget family instead of failing with no advice."""
     error = _missing_attr("input")
     message = str(error)
     assert "Use a specific input command" in message
@@ -129,6 +129,16 @@ def test_unrelated_names_keep_the_standard_attribute_error() -> None:
     assert error.name == "zzzz_not_a_command"
     assert error.obj is st
     assert format_uncaught_exception(error) == "AttributeError:zzzz_not_a_command"
+
+
+def test_mapped_successors_and_namespaces_still_exist() -> None:
+    """Advertised replacements and public namespaces remain on ``st``."""
+    catalog = public_streamlit_names(st)
+    for replacements in _REMOVED_STREAMLIT_ATTRIBUTES.values():
+        for replacement in replacements:
+            assert replacement in catalog
+    for namespace in _PUBLIC_STREAMLIT_NAMESPACES:
+        assert namespace in catalog
 
 
 def test_format_does_not_suggest_form() -> None:
@@ -189,16 +199,9 @@ def test_format_st_names_empty_is_safe() -> None:
 
 
 def test_missing_streamlit_attribute_message_keeps_standard_prefix() -> None:
-    """Helper messages stay AttributeError-shaped for telemetry fallbacks."""
+    """The enriched message still opens with Python's standard wording."""
     message = missing_streamlit_attribute_message("experimental_rerun", st)
     assert message.startswith(
         "module 'streamlit' has no attribute 'experimental_rerun'"
     )
     assert "st.rerun" in message
-
-
-def test_telemetry_uses_name_and_obj_not_message_text() -> None:
-    """A customized message still suffixes the missing attribute, not the advice."""
-    error = _missing_attr("experimental_rerun")
-    assert format_uncaught_exception(error) == "AttributeError:experimental_rerun"
-    assert error.obj is sys.modules["streamlit"]

--- a/lib/tests/streamlit/typing/module_getattr_types.py
+++ b/lib/tests/streamlit/typing/module_getattr_types.py
@@ -1,0 +1,24 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+# Unknown top-level ``st.*`` names must remain type errors. The runtime
+# ``__getattr__`` is hidden from type checkers so PEP 561 checking is preserved.
+if TYPE_CHECKING:
+    import streamlit as st
+
+    _unknown = st.not_a_streamlit_command  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]


### PR DESCRIPTION
## Describe your changes

Unknown top-level `st.*` names with an exact migration or a conservative typo match now raise `AttributeError` with a replacement or suggestion so removed commands and near-miss names can be fixed from the first failure. Other misses keep Python's standard error.

Native `AttributeError` is preserved so `hasattr` stays false, `from streamlit import missing` stays `ImportError`, and type checkers still error on unknown names.

Example: `st.experimental_rerun` now says it was removed and to use `st.rerun` instead.

Implements exception optimization queue **P0.1**.
https://github.com/streamlit/streamlit/wiki/2026-08-08-optimizing-exception-handling

## GitHub Issue Link (if applicable)

## Testing Plan

- [x] Unit Tests (JS and/or Python)
- `lib/tests/streamlit/command_suggestions_test.py` — removed APIs, `st.input`, typos, telemetry suffixes
- `lib/tests/streamlit/typing/module_getattr_types.py` — unknown `st.*` names stay type errors

No e2e changes; this is a Python-side message improvement.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.