### PR TITLE
[fix] Prevent KeyError during local module reload

### DIFF
--- a/.claude/skills/understanding-streamlit-architecture/SKILL.md
+++ b/.claude/skills/understanding-streamlit-architecture/SKILL.md
@@ -108,7 +108,7 @@ Streamlit's execution model differs from traditional web frameworks:
 |-----------|------|---------|
 | Runtime | `lib/streamlit/runtime/runtime.py` | Singleton managing app lifecycle and sessions |
 | AppSession | `lib/streamlit/runtime/app_session.py` | Per-browser-tab: ScriptRunner + SessionState + ForwardMsgQueue |
-| ScriptRunner | `lib/streamlit/runtime/scriptrunner/script_runner.py` | Executes user scripts in a separate thread; another ScriptRunner's flush cannot pop `sys.modules` during import |
+| ScriptRunner | `lib/streamlit/runtime/scriptrunner/script_runner.py` | Executes user scripts in separate thread |
 | LocalSourcesWatcher | `lib/streamlit/watcher/local_sources_watcher.py` | Watches local sources; defers `sys.modules` eviction until no ScriptRunner is inside `exec()` |
 | DeltaGenerator | `lib/streamlit/delta_generator.py` | API entry point using mixin pattern |
 | SessionState | `lib/streamlit/runtime/state/session_state.py` | Widget values and user variables |

--- a/.claude/skills/understanding-streamlit-architecture/SKILL.md
+++ b/.claude/skills/understanding-streamlit-architecture/SKILL.md
@@ -73,7 +73,7 @@ Streamlit's execution model differs from traditional web frameworks:
 
 **Rerun triggers**:
 1. **Widget interaction**: User clicks button, moves slider, etc. (widgets with `on_change="ignore"` update without a rerun)
-2. **Source code change**: File watcher detects script modification
+2. **Source code change**: File watcher detects script modification. Watched modules are evicted from `sys.modules` at the next run start, after any in-flight user `exec()` finishes
 3. **`st.rerun()`**: Explicit programmatic rerun
 4. **Fragment timer**: `@st.fragment(run_every=...)` periodic reruns
 
@@ -108,7 +108,8 @@ Streamlit's execution model differs from traditional web frameworks:
 |-----------|------|---------|
 | Runtime | `lib/streamlit/runtime/runtime.py` | Singleton managing app lifecycle and sessions |
 | AppSession | `lib/streamlit/runtime/app_session.py` | Per-browser-tab: ScriptRunner + SessionState + ForwardMsgQueue |
-| ScriptRunner | `lib/streamlit/runtime/scriptrunner/script_runner.py` | Executes user scripts in separate thread |
+| ScriptRunner | `lib/streamlit/runtime/scriptrunner/script_runner.py` | Executes user scripts in a separate thread; another ScriptRunner's flush cannot pop `sys.modules` during import |
+| LocalSourcesWatcher | `lib/streamlit/watcher/local_sources_watcher.py` | Watches local sources; defers `sys.modules` eviction until no ScriptRunner is inside `exec()` |
 | DeltaGenerator | `lib/streamlit/delta_generator.py` | API entry point using mixin pattern |
 | SessionState | `lib/streamlit/runtime/state/session_state.py` | Widget values and user variables |
 | Elements | `lib/streamlit/elements/` | Backend implementation of `st.*` commands |

--- a/.claude/skills/understanding-streamlit-architecture/references/backend.md
+++ b/.claude/skills/understanding-streamlit-architecture/references/backend.md
@@ -52,7 +52,7 @@ Represents a single browser tab.
 4. Script produces ForwardMsgs -> queued -> flushed to browser
 5. WebSocket disconnects -> cleanup
 
-**File watchers**: Monitors script, config.toml, secrets.toml, pages/ for changes.
+**File watchers**: Monitors script, config.toml, secrets.toml, pages/ for changes. On source change, `LocalSourcesWatcher` queues `sys.modules` evictions and flushes them at the next script-run start, waiting if any ScriptRunner is inside user `exec()`.
 
 **Script event loop**: Owns one non-running asyncio loop for the script thread, reused across `ScriptRunner` instances and closed on session shutdown.
 
@@ -72,12 +72,14 @@ This ordering explains why `connect_session()` alone does not start user code ex
 Executes user scripts in isolated thread.
 
 **Execution flow**:
-1. Compile script to bytecode (cached via ScriptCache)
-2. Create fake `__main__` module
-3. Attach `ScriptRunContext` to thread
-4. Execute with `exec()` in modified sys.path
-5. Process widget callbacks before execution
+1. Flush deferred `sys.modules` evictions (`LocalSourcesWatcher.on_script_run`), before any user `exec()`
+2. Compile script to bytecode (cached via ScriptCache)
+3. Create fake `__main__` module
+4. Attach `ScriptRunContext` to thread
+5. Inside `_set_execing_flag` / `script_execution()`: run widget callbacks, then `exec()` the main script in a modified `sys.path`
 6. Handle fragments for partial reruns
+
+User `exec()` (main script and callbacks) runs inside `_set_execing_flag` / `script_execution()`. `flush_pending_evictions()` waits until that barrier is clear before popping `sys.modules`, so a file-change reload cannot race an overlapping ScriptRunner when `runner.fastReruns` is on.
 
 **Script events**:
 - `SCRIPT_STARTED`

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -568,12 +568,18 @@ class ScriptRunner:
         """A context for setting the ScriptRunner._execing flag.
 
         Used by _maybe_handle_execution_control_request to ensure that
-        we only handle requests while we're inside an exec() call
+        we only handle requests while we're inside an exec() call.
+
+        Also holds ``local_sources_watcher.script_execution()`` so
+        ``sys.modules`` eviction cannot run concurrently. Flush
+        (``on_script_run``) must stay outside this context; calling it
+        from here deadlocks.
         """
         if self._execing:
             raise RuntimeError("Nested set_execing_flag call")
         self._execing = True
         try:
+            # User exec() runs inside script_execution(); flush must stay outside.
             with local_sources_watcher.script_execution():
                 yield
         finally:

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -61,6 +61,7 @@ from streamlit.runtime.state import (
 )
 from streamlit.signal_util import Signal
 from streamlit.source_util import page_sort_key
+from streamlit.watcher import local_sources_watcher
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Generator
@@ -573,7 +574,8 @@ class ScriptRunner:
             raise RuntimeError("Nested set_execing_flag call")
         self._execing = True
         try:
-            yield
+            with local_sources_watcher.script_execution():
+                yield
         finally:
             self._execing = False
 

--- a/lib/streamlit/watcher/local_sources_watcher.py
+++ b/lib/streamlit/watcher/local_sources_watcher.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import os
 import sys
 import threading
+from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Final, NamedTuple, cast
 
 from streamlit import config, env_util, file_util
@@ -30,12 +31,38 @@ from streamlit.watcher.path_watcher import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Generator
     from types import ModuleType
 
     from streamlit.runtime.pages_manager import PagesManager
 
 _LOGGER: Final = get_logger(__name__)
+
+# Process-wide barrier so flush_pending_evictions never pops sys.modules
+# while any ScriptRunner thread is inside user exec() (gh-6404).
+_SCRIPT_EXEC_CONDITION: Final = threading.Condition()
+_script_exec_count = 0
+
+
+@contextmanager
+def script_execution() -> Generator[None, None, None]:
+    """Register that a ScriptRunner thread is inside user ``exec()``.
+
+    Process-wide: every ScriptRunner ``exec()`` holds this.
+    ``flush_pending_evictions`` waits until the count is 0, then pops
+    ``sys.modules`` under the same lock. Do not call flush from inside
+    this context (self-deadlock).
+    """
+    global _script_exec_count  # noqa: PLW0603
+    try:
+        with _SCRIPT_EXEC_CONDITION:
+            _script_exec_count += 1
+        yield
+    finally:
+        with _SCRIPT_EXEC_CONDITION:
+            _script_exec_count -= 1
+            if _script_exec_count == 0:
+                _SCRIPT_EXEC_CONDITION.notify_all()
 
 
 class WatchedModule(NamedTuple):
@@ -184,18 +211,25 @@ class LocalSourcesWatcher:
     def on_script_run(self) -> None:
         """Hook called by ``ScriptRunner`` at the start of each script run.
 
-        Runs on the script thread before any user code executes.  Currently
-        flushes deferred ``sys.modules`` evictions so that the watcher thread
-        never mutates ``sys.modules`` while user code is running.
+        Flushes deferred evictions on the script thread before this run's
+        ``exec()``. Waits if any other ScriptRunner is still inside
+        ``script_execution()`` (fastReruns overlap, gh-6404).
         """
         self.flush_pending_evictions()
 
     def flush_pending_evictions(self) -> None:
         """Remove pending watched modules from ``sys.modules``.
 
-        Called at the start of each script run on the script thread so that
-        ``sys.modules`` is not mutated from the file watcher thread while user
-        code (or cache serialization) is executing.
+        Called at the start of each script run on the script thread. The
+        watcher thread only queues names; this method performs the pops.
+
+        If any ScriptRunner is inside ``script_execution()``, waits until
+        every such context exits (the full in-flight ``exec()``, not just
+        import), then pops while holding the barrier so a new ``exec()``
+        cannot start mid-eviction. A runaway script that never leaves
+        ``exec()`` therefore delays file-change reruns until it ends.
+        Returns immediately when nothing is pending. Must not be called
+        from a thread that already holds ``script_execution()``.
         """
         with self._pending_evictions_lock:
             pending = self._pending_evictions
@@ -204,14 +238,15 @@ class LocalSourcesWatcher:
         if not pending:
             return
 
-        prefixes = tuple(f"{name}." for name in pending)
-        all_to_evict = set(pending)
-        for key in list(sys.modules.keys()):
-            if key.startswith(prefixes):
-                all_to_evict.add(key)
-
-        for name in all_to_evict:
-            sys.modules.pop(name, None)
+        with _SCRIPT_EXEC_CONDITION:
+            _SCRIPT_EXEC_CONDITION.wait_for(lambda: _script_exec_count == 0)
+            prefixes = tuple(f"{name}." for name in pending)
+            all_to_evict = set(pending)
+            for key in list(sys.modules.keys()):
+                if key.startswith(prefixes):
+                    all_to_evict.add(key)
+            for name in all_to_evict:
+                sys.modules.pop(name, None)
 
     def close(self) -> None:
         for wm in self._watched_modules.values():

--- a/lib/streamlit/watcher/local_sources_watcher.py
+++ b/lib/streamlit/watcher/local_sources_watcher.py
@@ -46,22 +46,22 @@ _script_exec_count = 0
 
 @contextmanager
 def script_execution() -> Generator[None, None, None]:
-    """Register that a ScriptRunner thread is inside user ``exec()``.
+    """Keep ``flush_pending_evictions`` from popping ``sys.modules`` during this ``exec()``.
 
-    Process-wide: every ScriptRunner ``exec()`` holds this.
-    ``flush_pending_evictions`` waits until the count is 0, then pops
-    ``sys.modules`` under the same lock. Do not call flush from inside
-    this context (self-deadlock).
+    The counter is process-wide — every ScriptRunner ``exec()`` in this process
+    holds it, not just those of one session. Flush waits until the count is 0,
+    then pops under the same lock. Do not call flush from inside this context
+    (self-deadlock).
     """
     global _script_exec_count  # noqa: PLW0603
+    with _SCRIPT_EXEC_CONDITION:
+        _script_exec_count += 1
     try:
-        with _SCRIPT_EXEC_CONDITION:
-            _script_exec_count += 1
         yield
     finally:
         with _SCRIPT_EXEC_CONDITION:
             _script_exec_count -= 1
-            if _script_exec_count == 0:
+            if _script_exec_count <= 0:
                 _SCRIPT_EXEC_CONDITION.notify_all()
 
 
@@ -209,37 +209,43 @@ class LocalSourcesWatcher:
             cb(filepath)
 
     def on_script_run(self) -> None:
-        """Hook called by ``ScriptRunner`` at the start of each script run.
+        """Flush deferred evictions on this script thread before ``exec()``.
 
-        Flushes deferred evictions on the script thread before this run's
-        ``exec()``. Waits if any other ScriptRunner is still inside
-        ``script_execution()`` (fastReruns overlap, gh-6404).
+        Waits only when names are queued and another ScriptRunner still holds
+        ``script_execution()`` (fastReruns overlap, gh-6404). Widget reruns with
+        an empty pending set return immediately.
         """
         self.flush_pending_evictions()
 
     def flush_pending_evictions(self) -> None:
-        """Remove pending watched modules from ``sys.modules``.
+        """Pop queued watched modules only when no ScriptRunner is inside ``exec()``.
 
-        Called at the start of each script run on the script thread. The
-        watcher thread only queues names; this method performs the pops.
+        Called at the start of each script run, on the script thread. Blocks
+        until no ScriptRunner is inside ``script_execution()``, then pops while
+        holding the barrier. Returns immediately when nothing is pending.
 
-        If any ScriptRunner is inside ``script_execution()``, waits until
-        every such context exits (the full in-flight ``exec()``, not just
-        import), then pops while holding the barrier so a new ``exec()``
-        cannot start mid-eviction. A runaway script that never leaves
-        ``exec()`` therefore delays file-change reruns until it ends.
-        Returns immediately when nothing is pending. Must not be called
-        from a thread that already holds ``script_execution()``.
+        Must not be called from a thread that already holds
+        ``script_execution()``; doing so deadlocks.
         """
         with self._pending_evictions_lock:
-            pending = self._pending_evictions
-            self._pending_evictions = set()
-
-        if not pending:
-            return
+            if not self._pending_evictions:
+                return
 
         with _SCRIPT_EXEC_CONDITION:
-            _SCRIPT_EXEC_CONDITION.wait_for(lambda: _script_exec_count == 0)
+            # A runaway script that never leaves exec() delays file-change
+            # reruns until it ends. Claim pending only after the wait so a
+            # concurrent ScriptRunner cannot skip these evictions.
+            if _script_exec_count > 0:
+                _LOGGER.debug(
+                    "Waiting to evict watched modules until in-flight "
+                    "script execution ends"
+                )
+            _SCRIPT_EXEC_CONDITION.wait_for(lambda: _script_exec_count <= 0)
+            with self._pending_evictions_lock:
+                pending = self._pending_evictions
+                self._pending_evictions = set()
+            if not pending:
+                return
             prefixes = tuple(f"{name}." for name in pending)
             all_to_evict = set(pending)
             for key in list(sys.modules.keys()):

--- a/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py
@@ -20,6 +20,7 @@ import asyncio
 import os
 import sys
 import time
+import types
 import unittest
 from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, call, patch
@@ -67,6 +68,7 @@ from streamlit.runtime.scriptrunner_utils.script_run_context import (
     get_script_run_ctx,
 )
 from streamlit.runtime.state.session_state import SessionState
+from streamlit.watcher import local_sources_watcher
 from tests import testutil
 
 if TYPE_CHECKING:
@@ -75,6 +77,7 @@ if TYPE_CHECKING:
     from streamlit.proto.Delta_pb2 import Delta
     from streamlit.proto.Element_pb2 import Element
     from streamlit.proto.ForwardMsg_pb2 import ForwardMsg
+    from streamlit.watcher.local_sources_watcher import LocalSourcesWatcher
 
 text_utf = "complete! 👨‍🎤"
 text_utf2 = "complete2! 👨‍🎤"
@@ -1999,7 +2002,8 @@ class TestScriptRunner(ScriptRunner):
         script_name: str,
         initial_rerun_data: RerunData | None = None,
         event_loop: asyncio.AbstractEventLoop | None = None,
-    ):
+        local_sources_watcher: LocalSourcesWatcher | None = None,
+    ) -> None:
         """Initialize the ScriptRunner for the given script_name.
 
         ``initial_rerun_data`` defaults to a full-app rerun; supply data with a
@@ -2034,6 +2038,7 @@ class TestScriptRunner(ScriptRunner):
             fragment_storage=MemoryFragmentStorage(),
             pages_manager=PagesManager(main_script_path, script_cache),
             event_loop=event_loop,
+            local_sources_watcher=local_sources_watcher,
         )
 
         # Accumulates uncaught exceptions thrown by our run thread.
@@ -2078,10 +2083,10 @@ class TestScriptRunner(ScriptRunner):
         # Set the _dg_stack here to the one belonging to the thread context
         self._dg_stack = context_dg_stack.get()
 
-    def join(self) -> None:
+    def join(self, timeout: float | None = None) -> None:
         """Join the script_thread if it's running."""
         if self._script_thread is not None:
-            self._script_thread.join()
+            self._script_thread.join(timeout=timeout)
 
     def clear_forward_msgs(self) -> None:
         """Clear all messages from our ForwardMsgQueue."""
@@ -2236,3 +2241,99 @@ def test_log_if_error_logs_exception_and_does_not_raise() -> None:
         _log_if_error(raises)
 
     mock_logger.warning.assert_called_once()
+
+
+_GH6404_SLEEP_MODULE_NAME = "tests.streamlit.watcher.test_data.import_sleep_module"
+_GH6404_SLEEP_MODULE_PATH = os.path.realpath(
+    os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "watcher",
+        "test_data",
+        "import_sleep_module.py",
+    )
+)
+
+
+def _exception_summaries(runner: TestScriptRunner) -> list[str]:
+    """Return ``type: message`` for each exception element on ``runner``."""
+    summaries: list[str] = []
+    for element in runner.elements():
+        if element.WhichOneof("type") == "exception":
+            summaries.append(f"{element.exception.type}: {element.exception.message}")
+    return summaries
+
+
+def _join_or_fail(runner: TestScriptRunner, timeout: float) -> None:
+    """Join ``runner`` and fail the test if it is still alive after ``timeout``."""
+    runner.join(timeout=timeout)
+    thread = runner._script_thread
+    if thread is not None and thread.is_alive():
+        runner.request_stop()
+        runner.join(timeout=2.0)
+        pytest.fail(f"ScriptRunner did not finish within {timeout}s")
+
+
+def test_gh6404_scriptrunner_overlap_flush_does_not_keyerror() -> None:
+    """Two ScriptRunners sharing a watcher must not KeyError on overlapping import.
+
+    Mirrors fastRerun overlap: the old runner is inside ``import`` when the new
+    runner flushes pending ``sys.modules`` evictions at ``on_script_run``.
+    """
+    # Imported inside the test so collection does not load test_data modules
+    # that LocalSourcesWatcherTest would then treat as newly watched sources.
+    from tests.streamlit.watcher.test_data import import_sleep_gate
+
+    import_sleep_gate.reset(sleep=0.15)
+    sys.modules.pop(_GH6404_SLEEP_MODULE_NAME, None)
+
+    mock_runtime = MagicMock(spec=Runtime)
+    mock_runtime.media_file_mgr = MediaFileManager(
+        MemoryMediaFileStorage("/mock/media")
+    )
+    mock_runtime.media_file_mgr.clear_session_refs = MagicMock()
+    Runtime._instance = mock_runtime
+
+    app_path = os.path.join(
+        os.path.dirname(__file__), "test_data", "gh6404_import_sleep_app.py"
+    )
+    watcher = local_sources_watcher.LocalSourcesWatcher(PagesManager(app_path))
+    watcher._watched_modules[_GH6404_SLEEP_MODULE_PATH] = (
+        local_sources_watcher.WatchedModule(MagicMock(), _GH6404_SLEEP_MODULE_NAME)
+    )
+
+    old: TestScriptRunner | None = None
+    new: TestScriptRunner | None = None
+    try:
+        old = TestScriptRunner(
+            "gh6404_import_sleep_app.py", local_sources_watcher=watcher
+        )
+        old.start()
+        assert import_sleep_gate.started.wait(timeout=3)
+
+        sys.modules.setdefault(
+            _GH6404_SLEEP_MODULE_NAME, types.ModuleType(_GH6404_SLEEP_MODULE_NAME)
+        )
+        watcher.on_path_changed(_GH6404_SLEEP_MODULE_PATH)
+
+        new = TestScriptRunner(
+            "gh6404_import_sleep_app.py", local_sources_watcher=watcher
+        )
+        new.start()
+
+        for runner in (old, new):
+            _join_or_fail(runner, timeout=10.0)
+        for runner in (old, new):
+            assert runner.script_thread_exceptions == []
+            assert _exception_summaries(runner) == []
+    finally:
+        for runner in (old, new):
+            if runner is not None:
+                runner.request_stop()
+                runner.join(timeout=2.0)
+        watcher.close()
+        sys.modules.pop(_GH6404_SLEEP_MODULE_NAME, None)
+        import_sleep_gate.reset()
+        sys.modules.pop("tests.streamlit.watcher.test_data.import_sleep_gate", None)
+        Runtime._instance = None

--- a/lib/tests/streamlit/runtime/scriptrunner/test_data/gh6404_import_sleep_app.py
+++ b/lib/tests/streamlit/runtime/scriptrunner/test_data/gh6404_import_sleep_app.py
@@ -1,0 +1,17 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ScriptRunner app that imports the gh-6404 sleep-on-import helper."""
+
+import tests.streamlit.watcher.test_data.import_sleep_module  # noqa: F401

--- a/lib/tests/streamlit/watcher/local_sources_watcher_test.py
+++ b/lib/tests/streamlit/watcher/local_sources_watcher_test.py
@@ -69,6 +69,16 @@ class LocalSourcesWatcherTest(unittest.TestCase):
             with contextlib.suppress(Exception):
                 del sys.modules[name]
 
+        # gh-6404 helpers live in test_data/; drop them if another test file
+        # imported the gate so update_watched_modules does not watch them.
+        for name in (
+            "tests.streamlit.watcher.test_data.import_sleep_gate",
+            "tests.streamlit.watcher.test_data.import_sleep_module",
+            "tests.streamlit.watcher.test_data.import_sleep_pkg",
+            "tests.streamlit.watcher.test_data.import_sleep_pkg.child",
+        ):
+            sys.modules.pop(name, None)
+
     @patch("streamlit.watcher.local_sources_watcher.PathWatcher")
     def test_just_script(self, fob):
         lsw = local_sources_watcher.LocalSourcesWatcher(PagesManager(SCRIPT_PATH))

--- a/lib/tests/streamlit/watcher/sys_modules_eviction_race_test.py
+++ b/lib/tests/streamlit/watcher/sys_modules_eviction_race_test.py
@@ -173,6 +173,42 @@ def test_flush_is_immediate_when_no_script_is_execing() -> None:
         watcher.close()
 
 
+def test_flush_is_immediate_when_pending_empty_and_script_is_execing() -> None:
+    """Empty pending set returns immediately even if another thread holds exec."""
+    watcher = _make_watcher()
+    entered = threading.Event()
+    release = threading.Event()
+    flush_done = threading.Event()
+
+    def _hold() -> None:
+        with local_sources_watcher.script_execution():
+            entered.set()
+            release.wait(timeout=5)
+
+    def _flush() -> None:
+        watcher.flush_pending_evictions()
+        flush_done.set()
+
+    try:
+        holder = threading.Thread(target=_hold)
+        holder.start()
+        assert entered.wait(timeout=2)
+
+        flusher = threading.Thread(target=_flush)
+        flusher.start()
+        assert flush_done.wait(timeout=2)
+        assert not release.is_set()
+
+        release.set()
+        holder.join(timeout=2)
+        flusher.join(timeout=2)
+        assert not holder.is_alive()
+        assert not flusher.is_alive()
+    finally:
+        release.set()
+        watcher.close()
+
+
 def test_flush_waits_until_script_execution_exits() -> None:
     """Flush blocks while another thread holds ``script_execution``, then pops."""
     dummy_name = "_gh6404_wait_flush_mod"
@@ -208,6 +244,59 @@ def test_flush_waits_until_script_execution_exits() -> None:
         flusher.join(timeout=2)
         holder.join(timeout=2)
         assert flush_done.is_set()
+        assert dummy_name not in sys.modules
+    finally:
+        release.set()
+        sys.modules.pop(dummy_name, None)
+        watcher.close()
+
+
+def test_second_flush_waits_until_first_flush_finishes_eviction() -> None:
+    """A concurrent flush must not skip evictions held by a waiting flush."""
+    dummy_name = "_gh6404_concurrent_flush_mod"
+    watcher = _make_watcher()
+    entered = threading.Event()
+    release = threading.Event()
+    first_flush_done = threading.Event()
+    second_flush_done = threading.Event()
+
+    def _hold() -> None:
+        with local_sources_watcher.script_execution():
+            entered.set()
+            release.wait(timeout=5)
+
+    def _flush_first() -> None:
+        watcher.flush_pending_evictions()
+        first_flush_done.set()
+
+    def _flush_second() -> None:
+        watcher.flush_pending_evictions()
+        second_flush_done.set()
+
+    try:
+        _register_watched(watcher, _TRIGGER_PATH, dummy_name)
+        _queue_eviction(watcher, _TRIGGER_PATH, dummy_name)
+
+        holder = threading.Thread(target=_hold)
+        holder.start()
+        assert entered.wait(timeout=2)
+
+        first = threading.Thread(target=_flush_first)
+        first.start()
+        assert not first_flush_done.wait(timeout=0.3)
+        assert first.is_alive()
+
+        second = threading.Thread(target=_flush_second)
+        second.start()
+        assert not second_flush_done.wait(timeout=0.3)
+        assert dummy_name in sys.modules
+
+        release.set()
+        first.join(timeout=2)
+        second.join(timeout=2)
+        holder.join(timeout=2)
+        assert first_flush_done.is_set()
+        assert second_flush_done.is_set()
         assert dummy_name not in sys.modules
     finally:
         release.set()

--- a/lib/tests/streamlit/watcher/sys_modules_eviction_race_test.py
+++ b/lib/tests/streamlit/watcher/sys_modules_eviction_race_test.py
@@ -1,0 +1,285 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Designed races for gh-6404: flush_pending_evictions vs in-flight import.
+
+``import_sleep_gate`` lives under ``test_data/`` and must not be imported at
+collection time: ``LocalSourcesWatcher.update_watched_modules`` would then
+treat it as a newly watched source and break existing PathWatcher counts.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import threading
+import types
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+
+from streamlit.runtime.pages_manager import PagesManager
+from streamlit.watcher import local_sources_watcher
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from types import ModuleType
+
+_SLEEP_MODULE_NAME = "tests.streamlit.watcher.test_data.import_sleep_module"
+_SLEEP_PKG_NAME = "tests.streamlit.watcher.test_data.import_sleep_pkg"
+_SLEEP_PKG_CHILD_NAME = "tests.streamlit.watcher.test_data.import_sleep_pkg.child"
+_SLEEP_GATE_NAME = "tests.streamlit.watcher.test_data.import_sleep_gate"
+
+_TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "test_data")
+_SCRIPT_PATH = os.path.realpath(os.path.join(_TEST_DATA_DIR, "dummy_module1.py"))
+_TRIGGER_PATH = os.path.realpath(os.path.join(_TEST_DATA_DIR, "dummy_module2.py"))
+_SLEEP_MODULE_PATH = os.path.realpath(
+    os.path.join(_TEST_DATA_DIR, "import_sleep_module.py")
+)
+_SLEEP_PKG_INIT_PATH = os.path.realpath(
+    os.path.join(_TEST_DATA_DIR, "import_sleep_pkg", "__init__.py")
+)
+
+
+def _import_sleep_gate() -> ModuleType:
+    """Import the side channel. Not at collection time (see module docstring)."""
+    from tests.streamlit.watcher.test_data import import_sleep_gate
+
+    return import_sleep_gate
+
+
+def _cleanup_sleep_modules(*, unload_gate: bool = False) -> None:
+    """Drop sleep helpers from ``sys.modules`` and reset the side channel."""
+    for name in (_SLEEP_MODULE_NAME, _SLEEP_PKG_CHILD_NAME, _SLEEP_PKG_NAME):
+        sys.modules.pop(name, None)
+    importlib.invalidate_caches()
+    if _SLEEP_GATE_NAME in sys.modules:
+        _import_sleep_gate().reset()
+    if unload_gate:
+        sys.modules.pop(_SLEEP_GATE_NAME, None)
+
+
+@pytest.fixture(autouse=True)
+def _assert_script_exec_count_clean() -> Iterator[None]:
+    """Fail fast if ``_script_exec_count`` leaks instead of hanging ``wait``."""
+    assert local_sources_watcher._script_exec_count == 0
+    _cleanup_sleep_modules()
+    yield
+    _cleanup_sleep_modules(unload_gate=True)
+    assert local_sources_watcher._script_exec_count == 0
+
+
+def _make_watcher() -> local_sources_watcher.LocalSourcesWatcher:
+    """Return a watcher for the dummy script path."""
+    return local_sources_watcher.LocalSourcesWatcher(PagesManager(_SCRIPT_PATH))
+
+
+def _register_watched(
+    watcher: local_sources_watcher.LocalSourcesWatcher,
+    path: str,
+    module_name: str,
+) -> None:
+    """Register ``path`` as a watched module without starting a real path watcher."""
+    watcher._watched_modules[os.path.realpath(path)] = (
+        local_sources_watcher.WatchedModule(MagicMock(), module_name)
+    )
+
+
+def _queue_eviction(
+    watcher: local_sources_watcher.LocalSourcesWatcher,
+    path: str,
+    module_name: str,
+) -> None:
+    """Seed ``sys.modules`` so ``on_path_changed`` queues ``module_name``."""
+    sys.modules[module_name] = types.ModuleType(module_name)
+    watcher.on_path_changed(path)
+
+
+def _start_import_under_exec(
+    module_name: str, errors: list[BaseException]
+) -> threading.Thread:
+    """Import ``module_name`` inside ``script_execution`` on a new thread."""
+
+    def _importer() -> None:
+        try:
+            with local_sources_watcher.script_execution():
+                importlib.import_module(module_name)
+        except BaseException as exc:
+            errors.append(exc)
+
+    thread = threading.Thread(target=_importer)
+    thread.start()
+    return thread
+
+
+def _join_importer(thread: threading.Thread, errors: list[BaseException]) -> None:
+    """Wait for the importer thread and assert it finished without errors."""
+    thread.join(timeout=2)
+    assert not thread.is_alive()
+    assert errors == []
+
+
+def test_script_execution_increments_and_decrements_count() -> None:
+    """Count is 1 inside the context, 0 after; two threads can both hold it."""
+    with local_sources_watcher.script_execution():
+        assert local_sources_watcher._script_exec_count == 1
+    assert local_sources_watcher._script_exec_count == 0
+
+    ready = threading.Barrier(3)
+    release = threading.Event()
+
+    def _hold() -> None:
+        with local_sources_watcher.script_execution():
+            ready.wait(timeout=2)
+            release.wait(timeout=2)
+
+    threads = [threading.Thread(target=_hold) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    ready.wait(timeout=2)
+    assert local_sources_watcher._script_exec_count == 2
+    release.set()
+    for thread in threads:
+        thread.join(timeout=2)
+        assert not thread.is_alive()
+    assert local_sources_watcher._script_exec_count == 0
+
+
+def test_flush_is_immediate_when_no_script_is_execing() -> None:
+    """Queue plus flush pops without blocking when no script is execing."""
+    dummy_name = "_gh6404_immediate_flush_mod"
+    watcher = _make_watcher()
+    try:
+        _register_watched(watcher, _TRIGGER_PATH, dummy_name)
+        _queue_eviction(watcher, _TRIGGER_PATH, dummy_name)
+        assert dummy_name in sys.modules
+        watcher.flush_pending_evictions()
+        assert dummy_name not in sys.modules
+    finally:
+        sys.modules.pop(dummy_name, None)
+        watcher.close()
+
+
+def test_flush_waits_until_script_execution_exits() -> None:
+    """Flush blocks while another thread holds ``script_execution``, then pops."""
+    dummy_name = "_gh6404_wait_flush_mod"
+    watcher = _make_watcher()
+    entered = threading.Event()
+    release = threading.Event()
+    flush_done = threading.Event()
+
+    def _hold() -> None:
+        with local_sources_watcher.script_execution():
+            entered.set()
+            release.wait(timeout=5)
+
+    def _flush() -> None:
+        watcher.flush_pending_evictions()
+        flush_done.set()
+
+    try:
+        _register_watched(watcher, _TRIGGER_PATH, dummy_name)
+        _queue_eviction(watcher, _TRIGGER_PATH, dummy_name)
+
+        holder = threading.Thread(target=_hold)
+        holder.start()
+        assert entered.wait(timeout=2)
+
+        flusher = threading.Thread(target=_flush)
+        flusher.start()
+        assert not flush_done.wait(timeout=0.3)
+        assert dummy_name in sys.modules
+        assert flusher.is_alive()
+
+        release.set()
+        flusher.join(timeout=2)
+        holder.join(timeout=2)
+        assert flush_done.is_set()
+        assert dummy_name not in sys.modules
+    finally:
+        release.set()
+        sys.modules.pop(dummy_name, None)
+        watcher.close()
+
+
+def test_flush_during_import_does_not_keyerror() -> None:
+    """Flush during a sleeping import must not KeyError (gh-6404)."""
+    gate = _import_sleep_gate()
+    gate.reset(sleep=0.15)
+    watcher = _make_watcher()
+    errors: list[BaseException] = []
+
+    try:
+        _register_watched(watcher, _SLEEP_MODULE_PATH, _SLEEP_MODULE_NAME)
+        _queue_eviction(watcher, _SLEEP_MODULE_PATH, _SLEEP_MODULE_NAME)
+        sys.modules.pop(_SLEEP_MODULE_NAME, None)
+
+        importer = _start_import_under_exec(_SLEEP_MODULE_NAME, errors)
+        assert gate.started.wait(timeout=3)
+
+        watcher.flush_pending_evictions()
+        _join_importer(importer, errors)
+        assert _SLEEP_MODULE_NAME not in sys.modules
+    finally:
+        watcher.close()
+
+
+def test_flush_parent_during_nested_import_does_not_keyerror() -> None:
+    """Flushing a parent package mid ``import pkg.child`` must not KeyError."""
+    gate = _import_sleep_gate()
+    gate.reset(sleep=0.15)
+    watcher = _make_watcher()
+    errors: list[BaseException] = []
+
+    try:
+        _register_watched(watcher, _SLEEP_PKG_INIT_PATH, _SLEEP_PKG_NAME)
+        _queue_eviction(watcher, _SLEEP_PKG_INIT_PATH, _SLEEP_PKG_NAME)
+        sys.modules.pop(_SLEEP_PKG_NAME, None)
+
+        importer = _start_import_under_exec(_SLEEP_PKG_CHILD_NAME, errors)
+        assert gate.started.wait(timeout=3)
+
+        watcher.flush_pending_evictions()
+        _join_importer(importer, errors)
+        assert _SLEEP_PKG_NAME not in sys.modules
+        assert _SLEEP_PKG_CHILD_NAME not in sys.modules
+    finally:
+        watcher.close()
+
+
+def test_flush_on_one_watcher_waits_for_exec_registered_by_another() -> None:
+    """Barrier is process-wide: watcher B's flush waits for exec from watcher A."""
+    gate = _import_sleep_gate()
+    gate.reset(sleep=0.15)
+    watcher_a = _make_watcher()
+    watcher_b = _make_watcher()
+    errors: list[BaseException] = []
+
+    try:
+        _register_watched(watcher_a, _SLEEP_MODULE_PATH, _SLEEP_MODULE_NAME)
+        _register_watched(watcher_b, _SLEEP_MODULE_PATH, _SLEEP_MODULE_NAME)
+        _queue_eviction(watcher_b, _SLEEP_MODULE_PATH, _SLEEP_MODULE_NAME)
+        sys.modules.pop(_SLEEP_MODULE_NAME, None)
+
+        importer = _start_import_under_exec(_SLEEP_MODULE_NAME, errors)
+        assert gate.started.wait(timeout=3)
+
+        watcher_b.flush_pending_evictions()
+        _join_importer(importer, errors)
+        assert _SLEEP_MODULE_NAME not in sys.modules
+    finally:
+        watcher_a.close()
+        watcher_b.close()

--- a/lib/tests/streamlit/watcher/test_data/import_sleep_gate.py
+++ b/lib/tests/streamlit/watcher/test_data/import_sleep_gate.py
@@ -1,0 +1,41 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Side channel for sleep-on-import helpers used by gh-6404 tests.
+
+This module must not sleep on import. Tests reset it between trials and wait
+on ``started`` after kicking off an ``importlib.import_module`` of a sibling
+helper that *does* sleep.
+"""
+
+from __future__ import annotations
+
+import threading
+
+started = threading.Event()
+sleep_s = 0.1
+
+
+def reset(sleep: float = 0.1) -> None:
+    """Clear ``started`` and set the import-sleep duration.
+
+    Parameters
+    ----------
+    sleep : float
+        Seconds the next sleeping helper import should block. Default is
+        ``0.1``.
+    """
+    global sleep_s  # noqa: PLW0603
+    sleep_s = sleep
+    started.clear()

--- a/lib/tests/streamlit/watcher/test_data/import_sleep_module.py
+++ b/lib/tests/streamlit/watcher/test_data/import_sleep_module.py
@@ -1,0 +1,28 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Sleeping helper imported mid-test to reproduce gh-6404.
+
+Do not import this module at pytest collection time: import sets
+``import_sleep_gate.started`` and then sleeps.
+"""
+
+from __future__ import annotations
+
+import time
+
+from tests.streamlit.watcher.test_data import import_sleep_gate
+
+import_sleep_gate.started.set()
+time.sleep(import_sleep_gate.sleep_s)

--- a/lib/tests/streamlit/watcher/test_data/import_sleep_pkg/__init__.py
+++ b/lib/tests/streamlit/watcher/test_data/import_sleep_pkg/__init__.py
@@ -1,0 +1,28 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Parent package that sleeps on import (gh-6404 nested KeyError case).
+
+``import import_sleep_pkg.child`` execs this module first. Do not import at
+pytest collection time.
+"""
+
+from __future__ import annotations
+
+import time
+
+from tests.streamlit.watcher.test_data import import_sleep_gate
+
+import_sleep_gate.started.set()
+time.sleep(import_sleep_gate.sleep_s)

--- a/lib/tests/streamlit/watcher/test_data/import_sleep_pkg/child.py
+++ b/lib/tests/streamlit/watcher/test_data/import_sleep_pkg/child.py
@@ -1,0 +1,19 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022-2026)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Child module so ``import import_sleep_pkg.child`` execs the parent first."""
+
+from __future__ import annotations
+
+x = 1


### PR DESCRIPTION
## Describe your changes

Defers watched-module eviction until no ScriptRunner is executing user code, preventing CPython import `KeyError` failures during local reloads.

- The watcher thread still only queues names; the script thread pops them under a process-wide barrier
- File-change reruns wait until every in-flight user `exec()` in the process finishes — including another session's long-running script or a runaway loop with no `st.*` yield. Widget reruns still return immediately when nothing is pending

## GitHub Issue Link (if applicable)

- Closes #6404

## Testing Plan

- [x] Unit Tests (JS and/or Python)
- [ ] E2E Tests — backend thread race during `import`; not a UI path

- `lib/tests/streamlit/watcher/sys_modules_eviction_race_test.py` — designed flush-vs-import races, including parent-package and two-watcher cases
- `lib/tests/streamlit/runtime/scriptrunner/script_runner_test.py` — two ScriptRunners sharing a watcher (fastReruns overlap)

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

Made with [Cursor](https://cursor.com)