### PR TITLE
[chore] Note downstream uv compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,9 @@ dependencies = ["streamlit"]
 [tool.uv]
 # The development toolchain is the default local environment.
 default-groups = ["dev"]
-# Keep this floor low enough for Dependabot's bundled uv.
-# Raise it when Dependabot ships a newer uv and we want a tighter floor.
+# Keep this floor compatible with Dependabot's bundled uv and downstream CI
+# consumers that create environments from this repository.
+# Check their compatibility before raising it.
 required-version = ">=0.11.8"
 # Resolve the development lock only for the currently supported Python range.
 environments = ["python_version < '3.15'"]


### PR DESCRIPTION
## Describe your changes

Documents that changes to Streamlit's minimum uv version should account for downstream CI consumers that create environments directly from the repository.

## GitHub Issue Link (if applicable)

Not applicable.

## Testing Plan

- Explanation of why no additional tests are needed: Comment-only change; `make check` passes.
- Unit Tests (JS and/or Python): Not applicable.
- E2E Tests: Not applicable.
- Any manual testing needed? No.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change with no behavior or dependency impact.
> 
> **Overview**
> Updates the **`[tool.uv]` `required-version`** comment in root `pyproject.toml` so maintainers know the floor must stay compatible with **Dependabot’s bundled uv** and **downstream CI** that builds environments from this repo—not only with Streamlit’s own tooling.
> 
> The **`>=0.11.8`** constraint is unchanged; this is documentation only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71ca94b59131b42ef6c968aa0ff34af51b50ca3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->