### PR TITLE
[fix] Preserve leading decimals in data editor

### DIFF
--- a/e2e_playwright/st_data_editor_editing.py
+++ b/e2e_playwright/st_data_editor_editing.py
@@ -141,7 +141,6 @@ cell_overlay_test_column_config = {
     # The e2e interaction testing logic requires all cells to be medium width to
     # calculate the cell positions correctly.
     "big_numbers": st.column_config.NumberColumn(
-        step=0.0001,
         width="medium",
     ),
     "text": st.column_config.TextColumn(

--- a/e2e_playwright/st_data_editor_editing.py
+++ b/e2e_playwright/st_data_editor_editing.py
@@ -141,6 +141,7 @@ cell_overlay_test_column_config = {
     # The e2e interaction testing logic requires all cells to be medium width to
     # calculate the cell positions correctly.
     "big_numbers": st.column_config.NumberColumn(
+        step=0.0001,
         width="medium",
     ),
     "text": st.column_config.TextColumn(

--- a/e2e_playwright/st_data_editor_editing_test.py
+++ b/e2e_playwright/st_data_editor_editing_test.py
@@ -396,13 +396,21 @@ def test_number_cell_editing(themed_app: Page, assert_snapshot: ImageCompareFunc
 
 
 def test_number_cell_editing_preserves_leading_decimal(app: Page) -> None:
-    """Test that sequential ".07" input stays literal and commits as 0.07."""
+    """Test that a leading decimal point survives sequential input.
+
+    Regression test for streamlit/streamlit#16909: the number overlay editor
+    reset its text from the parsed cell value on every keystroke, so typing
+    ".07" lost the leading "." and committed 7.
+    """
     cell_editor = _get_editor(app, "cell_editor")
     expect_canvas_to_be_visible(cell_editor)
 
     click_on_cell(cell_editor, 1, 0, double_click=True, column_width="medium")
-    input_field = get_open_cell_overlay(app).locator(".gdg-input")
-    input_field.press("ControlOrMeta+A")
+    cell_overlay = get_open_cell_overlay(app)
+    cell_overlay.click()
+    cell_overlay.press("ControlOrMeta+A")
+    input_field = cell_overlay.locator(".gdg-input")
+    # Sequential input reproduces the per-keystroke reset; fill() does not.
     input_field.press_sequentially(".07", delay=50)
 
     expect(input_field).to_have_value(".07")

--- a/e2e_playwright/st_data_editor_editing_test.py
+++ b/e2e_playwright/st_data_editor_editing_test.py
@@ -395,6 +395,23 @@ def test_number_cell_editing(themed_app: Page, assert_snapshot: ImageCompareFunc
     _test_number_cell_editing(themed_app, assert_snapshot)
 
 
+def test_number_cell_editing_preserves_leading_decimal(app: Page) -> None:
+    """Test that sequential ".07" input stays literal and commits as 0.07."""
+    cell_editor = _get_editor(app, "cell_editor")
+    expect_canvas_to_be_visible(cell_editor)
+
+    click_on_cell(cell_editor, 1, 0, double_click=True, column_width="medium")
+    input_field = get_open_cell_overlay(app).locator(".gdg-input")
+    input_field.press("ControlOrMeta+A")
+    input_field.press_sequentially(".07", delay=50)
+
+    expect(input_field).to_have_value(".07")
+    input_field.press("Enter")
+    wait_for_app_run(app)
+
+    expect_prefixed_markdown(app, "Edited DF:", "0.07", exact_match=False)
+
+
 @pytest.mark.performance
 def test_number_cell_editing_performance(
     app: Page, assert_snapshot: ImageCompareFunction

--- a/frontend/.yarn/patches/@glideapps-glide-data-grid-npm-6.0.4-alpha24-9c1a40557b.patch
+++ b/frontend/.yarn/patches/@glideapps-glide-data-grid-npm-6.0.4-alpha24-9c1a40557b.patch
@@ -16,6 +16,72 @@ index face64122d35e884020eeabc6d96514141fc18d1..1e71f5198f0685882e1282cc2abd606d
          let save = false;
          if (event.key === "Escape") {
              event.stopPropagation();
+diff --git a/dist/cjs/internal/data-grid-overlay-editor/private/number-overlay-editor.js b/dist/cjs/internal/data-grid-overlay-editor/private/number-overlay-editor.js
+--- a/dist/cjs/internal/data-grid-overlay-editor/private/number-overlay-editor.js
++++ b/dist/cjs/internal/data-grid-overlay-editor/private/number-overlay-editor.js
+@@ -13,6 +13,21 @@ function getThousandSeprator() {
+ const NumberOverlayEditor = p => {
+-    const { value, onChange, disabled, highlight, validatedSelection, fixedDecimals, allowNegative, thousandSeparator, decimalSeparator, } = p;
++    const { value: cellValue, onChange, disabled, highlight, validatedSelection, fixedDecimals, allowNegative, thousandSeparator, decimalSeparator, } = p;
+     const inputRef = React.useRef();
++    const [value, setValue] = React.useState(() => Object.is(cellValue, -0) ? "-" : cellValue ?? "");
++    const lastEmittedFloatValueRef = React.useRef(cellValue);
++    React.useEffect(() => {
++        // Preserve literal input when the parent echoes its parsed value. Replace
++        // it when validation or another parent update supplies a different number.
++        if (!Object.is(cellValue, lastEmittedFloatValueRef.current)) {
++            lastEmittedFloatValueRef.current = cellValue;
++            setValue(Object.is(cellValue, -0) ? "-" : cellValue ?? "");
++        }
++    }, [cellValue]);
++    const handleValueChange = React.useCallback(nextValue => {
++        lastEmittedFloatValueRef.current = nextValue.floatValue;
++        setValue(nextValue.value);
++        onChange(nextValue);
++    }, [onChange]);
+     React.useLayoutEffect(() => {
+         if (validatedSelection !== undefined) {
+             const range = typeof validatedSelection === "number" ? [validatedSelection, null] : validatedSelection;
+@@ -24,5 +39,5 @@ const NumberOverlayEditor = p => {
+             // decimalScale={3}
+             // prefix={"$"}
+-            onValueChange: onChange })));
++            onValueChange: handleValueChange })));
+ };
+ export default NumberOverlayEditor;
+diff --git a/dist/esm/internal/data-grid-overlay-editor/private/number-overlay-editor.js b/dist/esm/internal/data-grid-overlay-editor/private/number-overlay-editor.js
+--- a/dist/esm/internal/data-grid-overlay-editor/private/number-overlay-editor.js
++++ b/dist/esm/internal/data-grid-overlay-editor/private/number-overlay-editor.js
+@@ -13,6 +13,21 @@ function getThousandSeprator() {
+ const NumberOverlayEditor = p => {
+-    const { value, onChange, disabled, highlight, validatedSelection, fixedDecimals, allowNegative, thousandSeparator, decimalSeparator, } = p;
++    const { value: cellValue, onChange, disabled, highlight, validatedSelection, fixedDecimals, allowNegative, thousandSeparator, decimalSeparator, } = p;
+     const inputRef = React.useRef();
++    const [value, setValue] = React.useState(() => Object.is(cellValue, -0) ? "-" : cellValue ?? "");
++    const lastEmittedFloatValueRef = React.useRef(cellValue);
++    React.useEffect(() => {
++        // Preserve literal input when the parent echoes its parsed value. Replace
++        // it when validation or another parent update supplies a different number.
++        if (!Object.is(cellValue, lastEmittedFloatValueRef.current)) {
++            lastEmittedFloatValueRef.current = cellValue;
++            setValue(Object.is(cellValue, -0) ? "-" : cellValue ?? "");
++        }
++    }, [cellValue]);
++    const handleValueChange = React.useCallback(nextValue => {
++        lastEmittedFloatValueRef.current = nextValue.floatValue;
++        setValue(nextValue.value);
++        onChange(nextValue);
++    }, [onChange]);
+     React.useLayoutEffect(() => {
+         if (validatedSelection !== undefined) {
+             const range = typeof validatedSelection === "number" ? [validatedSelection, null] : validatedSelection;
+@@ -24,5 +39,5 @@ const NumberOverlayEditor = p => {
+             // decimalScale={3}
+             // prefix={"$"}
+-            onValueChange: onChange })));
++            onValueChange: handleValueChange })));
+ };
+ export default NumberOverlayEditor;
 diff --git a/dist/esm/internal/data-grid-overlay-editor/data-grid-overlay-editor.js b/dist/esm/internal/data-grid-overlay-editor/data-grid-overlay-editor.js
 index face64122d35e884020eeabc6d96514141fc18d1..1e71f5198f0685882e1282cc2abd606d6d64a68b 100644
 --- a/dist/esm/internal/data-grid-overlay-editor/data-grid-overlay-editor.js

--- a/frontend/.yarn/patches/@glideapps-glide-data-grid-npm-6.0.4-alpha24-9c1a40557b.patch
+++ b/frontend/.yarn/patches/@glideapps-glide-data-grid-npm-6.0.4-alpha24-9c1a40557b.patch
@@ -19,16 +19,17 @@ index face64122d35e884020eeabc6d96514141fc18d1..1e71f5198f0685882e1282cc2abd606d
 diff --git a/dist/cjs/internal/data-grid-overlay-editor/private/number-overlay-editor.js b/dist/cjs/internal/data-grid-overlay-editor/private/number-overlay-editor.js
 --- a/dist/cjs/internal/data-grid-overlay-editor/private/number-overlay-editor.js
 +++ b/dist/cjs/internal/data-grid-overlay-editor/private/number-overlay-editor.js
-@@ -13,6 +13,21 @@ function getThousandSeprator() {
+@@ -13,6 +13,22 @@ function getThousandSeprator() {
  const NumberOverlayEditor = p => {
 -    const { value, onChange, disabled, highlight, validatedSelection, fixedDecimals, allowNegative, thousandSeparator, decimalSeparator, } = p;
 +    const { value: cellValue, onChange, disabled, highlight, validatedSelection, fixedDecimals, allowNegative, thousandSeparator, decimalSeparator, } = p;
      const inputRef = React.useRef();
 +    const [value, setValue] = React.useState(() => Object.is(cellValue, -0) ? "-" : cellValue ?? "");
 +    const lastEmittedFloatValueRef = React.useRef(cellValue);
-+    React.useEffect(() => {
-+        // Preserve literal input when the parent echoes its parsed value. Replace
-+        // it when validation or another parent update supplies a different number.
++    React.useLayoutEffect(() => {
++        // Keep typed text when Glide re-renders with the same parsed float.
++        // Replace it when validation or another update sends a different number.
++        // See streamlit/streamlit#16909.
 +        if (!Object.is(cellValue, lastEmittedFloatValueRef.current)) {
 +            lastEmittedFloatValueRef.current = cellValue;
 +            setValue(Object.is(cellValue, -0) ? "-" : cellValue ?? "");
@@ -42,7 +43,7 @@ diff --git a/dist/cjs/internal/data-grid-overlay-editor/private/number-overlay-e
      React.useLayoutEffect(() => {
          if (validatedSelection !== undefined) {
              const range = typeof validatedSelection === "number" ? [validatedSelection, null] : validatedSelection;
-@@ -24,5 +39,5 @@ const NumberOverlayEditor = p => {
+@@ -24,5 +40,5 @@ const NumberOverlayEditor = p => {
              // decimalScale={3}
              // prefix={"$"}
 -            onValueChange: onChange })));
@@ -52,16 +53,17 @@ diff --git a/dist/cjs/internal/data-grid-overlay-editor/private/number-overlay-e
 diff --git a/dist/esm/internal/data-grid-overlay-editor/private/number-overlay-editor.js b/dist/esm/internal/data-grid-overlay-editor/private/number-overlay-editor.js
 --- a/dist/esm/internal/data-grid-overlay-editor/private/number-overlay-editor.js
 +++ b/dist/esm/internal/data-grid-overlay-editor/private/number-overlay-editor.js
-@@ -13,6 +13,21 @@ function getThousandSeprator() {
+@@ -13,6 +13,22 @@ function getThousandSeprator() {
  const NumberOverlayEditor = p => {
 -    const { value, onChange, disabled, highlight, validatedSelection, fixedDecimals, allowNegative, thousandSeparator, decimalSeparator, } = p;
 +    const { value: cellValue, onChange, disabled, highlight, validatedSelection, fixedDecimals, allowNegative, thousandSeparator, decimalSeparator, } = p;
      const inputRef = React.useRef();
 +    const [value, setValue] = React.useState(() => Object.is(cellValue, -0) ? "-" : cellValue ?? "");
 +    const lastEmittedFloatValueRef = React.useRef(cellValue);
-+    React.useEffect(() => {
-+        // Preserve literal input when the parent echoes its parsed value. Replace
-+        // it when validation or another parent update supplies a different number.
++    React.useLayoutEffect(() => {
++        // Keep typed text when Glide re-renders with the same parsed float.
++        // Replace it when validation or another update sends a different number.
++        // See streamlit/streamlit#16909.
 +        if (!Object.is(cellValue, lastEmittedFloatValueRef.current)) {
 +            lastEmittedFloatValueRef.current = cellValue;
 +            setValue(Object.is(cellValue, -0) ? "-" : cellValue ?? "");
@@ -75,7 +77,7 @@ diff --git a/dist/esm/internal/data-grid-overlay-editor/private/number-overlay-e
      React.useLayoutEffect(() => {
          if (validatedSelection !== undefined) {
              const range = typeof validatedSelection === "number" ? [validatedSelection, null] : validatedSelection;
-@@ -24,5 +39,5 @@ const NumberOverlayEditor = p => {
+@@ -24,5 +40,5 @@ const NumberOverlayEditor = p => {
              // decimalScale={3}
              // prefix={"$"}
 -            onValueChange: onChange })));

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -30,6 +30,7 @@
     "@emotion/serialize": "^1.1.3",
     "@emotion/styled": "^11.14.1",
     "@floating-ui/react": "^0.27.20",
+    "@linaria/react": "^6.3.0",
     "@streamlit/connection": "workspace:^",
     "@streamlit/lib": "workspace:^",
     "@streamlit/protobuf": "workspace:^",
@@ -45,6 +46,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-helmet-async": "^3.0.0",
+    "react-number-format": "^5.4.4",
     "react-transition-group": "^4.4.5",
     "typed-signals": "^3.0.0"
   },

--- a/frontend/knip.json
+++ b/frontend/knip.json
@@ -7,12 +7,14 @@
   },
   "ignoreDependencies": [
     "@bufbuild/buf",
+    "@linaria/react",
     "@playwright/cli",
     "@swc/plugin-emotion",
     "eslint-plugin-streamlit-custom",
     "oxfmt",
     "protobufjs",
     "protobufjs-cli",
+    "react-number-format",
     "typescript-v7"
   ],
   "workspaces": {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1182,7 +1182,7 @@ __metadata:
 
 "@glideapps/glide-data-grid@patch:@glideapps/glide-data-grid@npm%3A6.0.4-alpha24#~/.yarn/patches/@glideapps-glide-data-grid-npm-6.0.4-alpha24-9c1a40557b.patch":
   version: 6.0.4-alpha24
-  resolution: "@glideapps/glide-data-grid@patch:@glideapps/glide-data-grid@npm%3A6.0.4-alpha24#~/.yarn/patches/@glideapps-glide-data-grid-npm-6.0.4-alpha24-9c1a40557b.patch::version=6.0.4-alpha24&hash=8b6f4e"
+  resolution: "@glideapps/glide-data-grid@patch:@glideapps/glide-data-grid@npm%3A6.0.4-alpha24#~/.yarn/patches/@glideapps-glide-data-grid-npm-6.0.4-alpha24-9c1a40557b.patch::version=6.0.4-alpha24&hash=c1ac07"
   dependencies:
     "@linaria/react": "npm:^6.3.0"
     canvas-hypertxt: "npm:^1.0.3"
@@ -1193,7 +1193,7 @@ __metadata:
     react: ^16.12.0 || 17.x || 18.x || 19.x
     react-dom: ^16.12.0 || 17.x || 18.x || 19.x
     react-responsive-carousel: ^3.2.7
-  checksum: 10c0/caf10dc82f75567e918f58cca10c960aec481e4f2c5cf6c9881984dbadf521a7a32c27199e6758dbf142b503b6c49bd064ced5286e498e11c05c8b00558e7155
+  checksum: 10c0/66594e7a363aff0859099e5adc9fd6977b42a16ae1efe400e55b1f4010d552f8df7590f7ed86f116dfb1cd53e763f1427091537d0372134b3f1794e27f2cc3c4
   languageName: node
   linkType: hard
 

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1182,7 +1182,7 @@ __metadata:
 
 "@glideapps/glide-data-grid@patch:@glideapps/glide-data-grid@npm%3A6.0.4-alpha24#~/.yarn/patches/@glideapps-glide-data-grid-npm-6.0.4-alpha24-9c1a40557b.patch":
   version: 6.0.4-alpha24
-  resolution: "@glideapps/glide-data-grid@patch:@glideapps/glide-data-grid@npm%3A6.0.4-alpha24#~/.yarn/patches/@glideapps-glide-data-grid-npm-6.0.4-alpha24-9c1a40557b.patch::version=6.0.4-alpha24&hash=c1ac07"
+  resolution: "@glideapps/glide-data-grid@patch:@glideapps/glide-data-grid@npm%3A6.0.4-alpha24#~/.yarn/patches/@glideapps-glide-data-grid-npm-6.0.4-alpha24-9c1a40557b.patch::version=6.0.4-alpha24&hash=21d05a"
   dependencies:
     "@linaria/react": "npm:^6.3.0"
     canvas-hypertxt: "npm:^1.0.3"
@@ -1193,7 +1193,7 @@ __metadata:
     react: ^16.12.0 || 17.x || 18.x || 19.x
     react-dom: ^16.12.0 || 17.x || 18.x || 19.x
     react-responsive-carousel: ^3.2.7
-  checksum: 10c0/66594e7a363aff0859099e5adc9fd6977b42a16ae1efe400e55b1f4010d552f8df7590f7ed86f116dfb1cd53e763f1427091537d0372134b3f1794e27f2cc3c4
+  checksum: 10c0/d22d11c7b04818456a5d1b4ae3ea6ca8f80915146116eb1210bc6e858fc19267c2b87674b203d3a443fc1cee8170ca601739cb855bf175c671619d10b4bd51dd
   languageName: node
   linkType: hard
 
@@ -3317,6 +3317,7 @@ __metadata:
     "@emotion/serialize": "npm:^1.1.3"
     "@emotion/styled": "npm:^11.14.1"
     "@floating-ui/react": "npm:^0.27.20"
+    "@linaria/react": "npm:^6.3.0"
     "@streamlit/connection": "workspace:^"
     "@streamlit/lib": "workspace:^"
     "@streamlit/protobuf": "workspace:^"
@@ -3348,6 +3349,7 @@ __metadata:
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
     react-helmet-async: "npm:^3.0.0"
+    react-number-format: "npm:^5.4.4"
     react-transition-group: "npm:^4.4.5"
     tree-kill: "npm:^1.2.2"
     typed-signals: "npm:^3.0.0"


### PR DESCRIPTION
## Describe your changes

Preserves leading-decimal values typed into `st.data_editor` number cells so `.07` stays visible during editing and commits as `0.07` instead of `7`.

- Keeps the numeric overlay’s raw in-progress text while continuing to send parsed numbers to the grid. Differing values from validation or another parent update still replace the editor text.
- Extends the existing Glide Data Grid patch rather than duplicating its numeric editor in Streamlit; a custom editor would need to reimplement locale, precision, selection, validation, and keyboard behavior.
- Adds an explicit NOTICE fallback for `@linaria/react` and `react-number-format`, which the current license plugin can omit when they are reached through a patched virtual package. The fallback reads the installed packages' license files and fails once the generator includes them again, so the workaround cannot silently remain after it becomes unnecessary.

Repro: https://issues.streamlit.app/?issue=gh-16909

## GitHub Issue Link (if applicable)

- Closes #16909

## Testing Plan

- [ ] Unit Tests (JS and/or Python) — not applicable; the bug is in the vendored browser interaction path.
- [x] E2E Tests — `st_data_editor_editing_test.py` enters `.07` through sequential key presses, verifies the literal editor text, and verifies the committed `0.07` value.
- [x] Manual testing — reproduced `7.0000` before the patch and verified `0.0700` after it with the published repro app.
- [x] NOTICE generation — regenerated twice for deterministic output, verified the fallback's obsolete-override guard, and ran formatting, lint, lockfile, and repository checks.

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to vendored Glide number-overlay editing and license NOTICE generation; behavior change is intentional bugfix with a targeted e2e regression test.
> 
> **Overview**
> Fixes **#16909** so `st.data_editor` number cells keep in-progress text (e.g. `.07`) instead of resetting from the parsed float on every keystroke and committing `7`.
> 
> The change extends the existing **Glide Data Grid** yarn patch: the number overlay editor holds local display state and only replaces it when the parent supplies a **different** parsed number (validation or external updates still win). Parsed values continue to flow to the grid via the existing `onChange` path.
> 
> Adds a Playwright regression that types `.07` sequentially, asserts the overlay shows `.07`, and asserts the committed value is `0.07`.
> 
> Separately, **`make update-notices`** now runs a new `append_missing_dependency_license.mjs` fallback for `@linaria/react` and `react-number-format` when the license plugin omits them through the patched virtual package; the script errors if those packages are already listed so stale fallbacks can be removed. **`NOTICES`** is regenerated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 558785fb91519236a014bf87eeee9f97a623571b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->