### PR TITLE
[fix] Reject awaitables from synchronous cached functions

### DIFF
--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/performance.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/performance.md
@@ -103,6 +103,9 @@ keys](server-asgi.md#scheduled-background-refresh-for-specific-keys).
 call returns an awaitable; you must await it (for example with `asyncio.run()` in a Streamlit
 script). Streamlit caches the awaited return value, not the coroutine.
 
+Streamlit raises an error if a synchronous cached function returns an awaitable. Define the
+function with `async def` and await the asynchronous operation before returning its result.
+
 ```python
 import asyncio
 

--- a/lib/streamlit/.agents/skills/developing-with-streamlit/references/performance.md
+++ b/lib/streamlit/.agents/skills/developing-with-streamlit/references/performance.md
@@ -103,8 +103,11 @@ keys](server-asgi.md#scheduled-background-refresh-for-specific-keys).
 call returns an awaitable; you must await it (for example with `asyncio.run()` in a Streamlit
 script). Streamlit caches the awaited return value, not the coroutine.
 
-Streamlit raises an error if a synchronous cached function returns an awaitable. Define the
-function with `async def` and await the asynchronous operation before returning its result.
+Streamlit raises an error if a synchronous cached function returns an awaitable. Prefer
+defining the function with `async def` and awaiting the asynchronous operation before
+returning its result. If you use `refresh_mode="background"`, switch to `"foreground"` first.
+In a synchronous script context without an active event loop, you can instead run the
+operation to completion with `asyncio.run()` before returning.
 
 ```python
 import asyncio

--- a/lib/streamlit/runtime/caching/cache_errors.py
+++ b/lib/streamlit/runtime/caching/cache_errors.py
@@ -144,20 +144,27 @@ class UnserializableReturnValueError(MarkdownFormattedException, Generic[R]):
 
 
 class CachedFunctionReturnedAwaitableError(StreamlitAPIException):
-    """Raised when a synchronous cached function returns an awaitable."""
+    """Raised when a synchronous cached function returns an awaitable.
 
-    def __init__(self, cache_type: CacheType, func: Callable[..., Any]) -> None:
+    This includes non-coroutine objects implementing ``__await__``.
+    """
+
+    def __init__(
+        self, cache_type: CacheType, func: Callable[..., Any], value: Any
+    ) -> None:
         func_name = get_cached_func_name_md(func)
         decorator_name = get_decorator_api_name(cache_type)
         super().__init__(
             f"{func_name} is a synchronous function decorated with "
-            f"`st.{decorator_name}`, but it returned an awaitable. The function may "
-            "have returned an asynchronous operation without awaiting it, or the "
-            "returned object may itself be awaitable.\n\n"
-            "Return a non-awaitable value instead. For example, run the asynchronous "
-            "operation to completion (such as with `asyncio.run`) before returning, "
-            "or define the cached function with `async def` and `await` the operation. "
-            'Coroutine cached functions require `refresh_mode="foreground"`.'
+            f"`st.{decorator_name}`, but it returned an awaitable of type "
+            f"{get_return_value_type(value)}. The function may have returned an "
+            "asynchronous operation without awaiting it, or the returned object may "
+            "itself be awaitable.\n\n"
+            "Return a non-awaitable value instead. Prefer defining the cached function "
+            "with `async def` and `await` the operation. If you use "
+            '`refresh_mode="background"`, switch to `"foreground"` first. In a '
+            "synchronous script context without an active event loop, you can instead "
+            "run the operation to completion with `asyncio.run` before returning."
         )
 
 

--- a/lib/streamlit/runtime/caching/cache_errors.py
+++ b/lib/streamlit/runtime/caching/cache_errors.py
@@ -143,6 +143,20 @@ class UnserializableReturnValueError(MarkdownFormattedException, Generic[R]):
         )
 
 
+class CachedFunctionReturnedAwaitableError(StreamlitAPIException):
+    def __init__(self, cache_type: CacheType, func: Callable[..., Any]) -> None:
+        func_name = get_cached_func_name_md(func)
+        decorator_name = get_decorator_api_name(cache_type)
+        super().__init__(
+            f"{func_name} is a synchronous function decorated with "
+            f"`st.{decorator_name}`, but it returned an awaitable. This can happen "
+            "when the function is missing an `async def` declaration or when an "
+            "asynchronous operation is returned without being awaited.\n\n"
+            "Define the cached function with `async def` and `await` the asynchronous "
+            "operation before returning its result."
+        )
+
+
 class UnevaluatedDataFrameError(StreamlitAPIException):
     """Used to display a message about uncollected dataframe being used."""
 

--- a/lib/streamlit/runtime/caching/cache_errors.py
+++ b/lib/streamlit/runtime/caching/cache_errors.py
@@ -144,16 +144,20 @@ class UnserializableReturnValueError(MarkdownFormattedException, Generic[R]):
 
 
 class CachedFunctionReturnedAwaitableError(StreamlitAPIException):
+    """Raised when a synchronous cached function returns an awaitable."""
+
     def __init__(self, cache_type: CacheType, func: Callable[..., Any]) -> None:
         func_name = get_cached_func_name_md(func)
         decorator_name = get_decorator_api_name(cache_type)
         super().__init__(
             f"{func_name} is a synchronous function decorated with "
-            f"`st.{decorator_name}`, but it returned an awaitable. This can happen "
-            "when the function is missing an `async def` declaration or when an "
-            "asynchronous operation is returned without being awaited.\n\n"
-            "Define the cached function with `async def` and `await` the asynchronous "
-            "operation before returning its result."
+            f"`st.{decorator_name}`, but it returned an awaitable. The function may "
+            "have returned an asynchronous operation without awaiting it, or the "
+            "returned object may itself be awaitable.\n\n"
+            "Return a non-awaitable value instead. For example, run the asynchronous "
+            "operation to completion (such as with `asyncio.run`) before returning, "
+            "or define the cached function with `async def` and `await` the operation. "
+            'Coroutine cached functions require `refresh_mode="foreground"`.'
         )
 
 

--- a/lib/streamlit/runtime/caching/cache_utils.py
+++ b/lib/streamlit/runtime/caching/cache_utils.py
@@ -53,6 +53,7 @@ from streamlit.errors import (
 from streamlit.logger import get_logger
 from streamlit.runtime.caching import cache_background_refresh
 from streamlit.runtime.caching.cache_errors import (
+    CachedFunctionReturnedAwaitableError,
     CachedStFunctionInBackgroundModeWarning,
     CacheError,
     CacheKeyNotFoundError,
@@ -87,6 +88,24 @@ TTLCACHE_TIMER = time.monotonic
 # Type-annotate the cached function.
 P = ParamSpec("P")
 R = TypeVar("R")
+
+
+def _validate_sync_return_value(
+    cache_type: CacheType, func: Callable[..., Any], value: Any
+) -> None:
+    if not inspect.isawaitable(value):
+        return
+
+    if (
+        inspect.iscoroutine(value)
+        and inspect.getcoroutinestate(value) == inspect.CORO_CREATED
+    ):
+        # New native coroutines warn when discarded without being awaited. Started
+        # coroutines and other awaitables may have user-managed lifecycles.
+        value.close()
+
+    raise CachedFunctionReturnedAwaitableError(cache_type, func)
+
 
 # A function called with a cache entry as the argument when cache entries are removed.
 OnRelease: TypeAlias = Callable[[Any], None]
@@ -822,6 +841,9 @@ class CachedFunc(Generic[P, R]):
             ):
                 computed_value = self._info.func(*func_args, **func_kwargs)
 
+            _validate_sync_return_value(
+                self._info.cache_type, self._info.func, computed_value
+            )
             return self._store_computed_value(cache, value_key, computed_value)
 
     def _store_computed_value(
@@ -1072,6 +1094,9 @@ class CachedFunc(Generic[P, R]):
         """
         try:
             new_value = self._info.func(*func_args, **func_kwargs)
+            _validate_sync_return_value(
+                self._info.cache_type, self._info.func, new_value
+            )
             cache.write_background_refresh_result(
                 value_key,
                 new_value,

--- a/lib/streamlit/runtime/caching/cache_utils.py
+++ b/lib/streamlit/runtime/caching/cache_utils.py
@@ -104,7 +104,10 @@ RefreshMode: TypeAlias = Literal["foreground", "background"]
 def _reject_awaitable_return_value(
     cache_type: CacheType, func: Callable[..., Any], value: Any
 ) -> None:
-    """Reject awaitables returned by synchronous cached functions."""
+    """Raise if a synchronous cached function returned an awaitable.
+
+    Closes unstarted native coroutines before raising; other awaitables are left as-is.
+    """
     if not inspect.isawaitable(value):
         return
 
@@ -117,7 +120,7 @@ def _reject_awaitable_return_value(
         # untouched; the caller may still own their lifecycle.
         value.close()
 
-    raise CachedFunctionReturnedAwaitableError(cache_type, func)
+    raise CachedFunctionReturnedAwaitableError(cache_type, func, value)
 
 
 # Unset or invalid config still hard-expires background caches at 2 * ttl.

--- a/lib/streamlit/runtime/caching/cache_utils.py
+++ b/lib/streamlit/runtime/caching/cache_utils.py
@@ -89,24 +89,6 @@ TTLCACHE_TIMER = time.monotonic
 P = ParamSpec("P")
 R = TypeVar("R")
 
-
-def _validate_sync_return_value(
-    cache_type: CacheType, func: Callable[..., Any], value: Any
-) -> None:
-    if not inspect.isawaitable(value):
-        return
-
-    if (
-        inspect.iscoroutine(value)
-        and inspect.getcoroutinestate(value) == inspect.CORO_CREATED
-    ):
-        # New native coroutines warn when discarded without being awaited. Started
-        # coroutines and other awaitables may have user-managed lifecycles.
-        value.close()
-
-    raise CachedFunctionReturnedAwaitableError(cache_type, func)
-
-
 # A function called with a cache entry as the argument when cache entries are removed.
 OnRelease: TypeAlias = Callable[[Any], None]
 
@@ -117,6 +99,26 @@ CacheScope: TypeAlias = Literal["global", "session"]
 
 # How a cache entry is refreshed once its ttl expires.
 RefreshMode: TypeAlias = Literal["foreground", "background"]
+
+
+def _reject_awaitable_return_value(
+    cache_type: CacheType, func: Callable[..., Any], value: Any
+) -> None:
+    """Reject awaitables returned by synchronous cached functions."""
+    if not inspect.isawaitable(value):
+        return
+
+    if (
+        inspect.iscoroutine(value)
+        and inspect.getcoroutinestate(value) == inspect.CORO_CREATED
+    ):
+        # Close unstarted native coroutines so Python does not emit an
+        # unawaited-coroutine warning. Leave started coroutines and other awaitables
+        # untouched; the caller may still own their lifecycle.
+        value.close()
+
+    raise CachedFunctionReturnedAwaitableError(cache_type, func)
+
 
 # Unset or invalid config still hard-expires background caches at 2 * ttl.
 _DEFAULT_BACKGROUND_REFRESH_TTL_MULTIPLIER: Final = 2.0
@@ -841,7 +843,7 @@ class CachedFunc(Generic[P, R]):
             ):
                 computed_value = self._info.func(*func_args, **func_kwargs)
 
-            _validate_sync_return_value(
+            _reject_awaitable_return_value(
                 self._info.cache_type, self._info.func, computed_value
             )
             return self._store_computed_value(cache, value_key, computed_value)
@@ -1094,7 +1096,7 @@ class CachedFunc(Generic[P, R]):
         """
         try:
             new_value = self._info.func(*func_args, **func_kwargs)
-            _validate_sync_return_value(
+            _reject_awaitable_return_value(
                 self._info.cache_type, self._info.func, new_value
             )
             cache.write_background_refresh_result(

--- a/lib/tests/streamlit/runtime/caching/async_cache_test.py
+++ b/lib/tests/streamlit/runtime/caching/async_cache_test.py
@@ -23,8 +23,10 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures
+import gc
 import inspect
 import threading
+import warnings
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -32,6 +34,9 @@ import pytest
 import streamlit as st
 from streamlit.errors import StreamlitAPIException, StreamlitValueError
 from streamlit.runtime.caching import cache_utils
+from streamlit.runtime.caching.cache_errors import (
+    CachedFunctionReturnedAwaitableError,
+)
 from streamlit.testing.v1 import AppTest
 
 if TYPE_CHECKING:
@@ -711,6 +716,162 @@ def test_sync_function_path_is_unchanged() -> None:
     result = load(1)
     assert result == 2
     assert not inspect.isawaitable(result)
+
+
+@pytest.mark.parametrize(("name", "decorator"), CACHE_DECORATORS)
+def test_sync_function_returning_coroutine_raises_without_caching(
+    name: str, decorator: Callable
+) -> None:
+    """Sync cached functions reject and close returned native coroutines."""
+    calls = 0
+    created_coroutines: list[Any] = []
+
+    async def operation() -> int:
+        return 42
+
+    @decorator
+    def load() -> Any:
+        nonlocal calls
+        calls += 1
+        coroutine = operation()
+        created_coroutines.append(coroutine)
+        return coroutine
+
+    with warnings.catch_warnings(record=True) as caught_warnings:
+        warnings.simplefilter("always")
+        for _ in range(2):
+            with pytest.raises(CachedFunctionReturnedAwaitableError) as exc_info:
+                load()
+
+            message = str(exc_info.value)
+            assert "synchronous function" in message
+            assert "returned an awaitable" in message
+            assert f"`st.{name}`" in message
+            assert "`async def`" in message
+            assert "`await`" in message
+            assert "use `st.cache_resource` instead" not in message
+
+        assert calls == 2
+        assert all(
+            inspect.getcoroutinestate(coroutine) == inspect.CORO_CLOSED
+            for coroutine in created_coroutines
+        )
+        created_coroutines.clear()
+        gc.collect()
+
+    assert not any(
+        "was never awaited" in str(warning.message) for warning in caught_warnings
+    )
+
+
+@pytest.mark.parametrize(("name", "decorator"), CACHE_DECORATORS)
+def test_sync_function_does_not_close_started_coroutine(
+    name: str, decorator: Callable
+) -> None:
+    """A started coroutine retains its user-managed lifecycle after rejection."""
+
+    async def operation() -> int:
+        await asyncio.sleep(0)
+        return 42
+
+    coroutine = operation()
+    coroutine.send(None)
+
+    @decorator
+    def load() -> Any:
+        return coroutine
+
+    try:
+        with pytest.raises(
+            CachedFunctionReturnedAwaitableError, match=rf"`st\.{name}`"
+        ):
+            load()
+        assert inspect.getcoroutinestate(coroutine) == inspect.CORO_SUSPENDED
+    finally:
+        coroutine.close()
+
+
+@pytest.mark.parametrize(("name", "decorator"), CACHE_DECORATORS)
+@pytest.mark.parametrize("awaitable_kind", ["future", "task"])
+def test_sync_function_rejects_future_or_task_without_mutating_it(
+    name: str, decorator: Callable, awaitable_kind: str
+) -> None:
+    """Rejected Futures and Tasks retain their state and remain usable."""
+
+    async def exercise_awaitables() -> None:
+        task_release_event = asyncio.Event()
+        returned_values: list[asyncio.Future[int]] = []
+
+        async def operation(value: int) -> int:
+            await task_release_event.wait()
+            return value
+
+        @decorator
+        def load() -> asyncio.Future[int]:
+            value_index = len(returned_values)
+            value: asyncio.Future[int]
+            if awaitable_kind == "future":
+                value = asyncio.get_running_loop().create_future()
+            else:
+                value = asyncio.create_task(operation(value_index))
+            returned_values.append(value)
+            return value
+
+        for _ in range(2):
+            with pytest.raises(
+                CachedFunctionReturnedAwaitableError, match=rf"`st\.{name}`"
+            ):
+                load()
+
+        assert len(returned_values) == 2
+        assert all(
+            not value.done() and not value.cancelled() for value in returned_values
+        )
+
+        if awaitable_kind == "future":
+            for value_index, value in enumerate(returned_values):
+                value.set_result(value_index)
+        else:
+            task_release_event.set()
+
+        assert await asyncio.gather(*returned_values) == [0, 1]
+
+    asyncio.run(exercise_awaitables())
+
+
+@pytest.mark.parametrize(("name", "decorator"), CACHE_DECORATORS)
+def test_sync_function_rejects_custom_awaitable_without_mutating_it(
+    name: str, decorator: Callable
+) -> None:
+    """Rejected custom awaitables are not awaited or closed."""
+
+    class CustomAwaitable:
+        def __init__(self) -> None:
+            self.awaited = False
+            self.closed = False
+
+        def __await__(self) -> Any:
+            self.awaited = True
+            yield
+            return 42
+
+        def close(self) -> None:
+            self.closed = True
+
+    returned_values: list[CustomAwaitable] = []
+
+    @decorator
+    def load() -> CustomAwaitable:
+        value = CustomAwaitable()
+        returned_values.append(value)
+        return value
+
+    for _ in range(2):
+        with pytest.raises(CachedFunctionReturnedAwaitableError):
+            load()
+
+    assert len(returned_values) == 2
+    assert all(not value.awaited and not value.closed for value in returned_values)
 
 
 def test_async_cached_value_survives_script_rerun() -> None:

--- a/lib/tests/streamlit/runtime/caching/async_cache_test.py
+++ b/lib/tests/streamlit/runtime/caching/async_cache_test.py
@@ -749,13 +749,14 @@ def test_sync_function_returning_coroutine_raises_without_caching(
             assert f"`st.{name}`" in message
             assert "`async def`" in message
             assert "`await`" in message
-            assert "use `st.cache_resource` instead" not in message
 
         assert calls == 2
         assert all(
             inspect.getcoroutinestate(coroutine) == inspect.CORO_CLOSED
             for coroutine in created_coroutines
         )
+        # Drop references and collect so an unclosed coroutine would warn inside
+        # this catch_warnings block.
         created_coroutines.clear()
         gc.collect()
 

--- a/lib/tests/streamlit/runtime/caching/common_cache_test.py
+++ b/lib/tests/streamlit/runtime/caching/common_cache_test.py
@@ -1407,7 +1407,7 @@ class CommonCacheBackgroundRefreshTest(DeltaGeneratorTestCase):
     def test_background_refresh_rejects_awaitable(
         self, _, cache_decorator, timer_patch: Mock
     ):
-        """An invalid refresh result is closed and never replaces the stale value."""
+        """A rejected coroutine is closed, keeps stale data, and starts cooldown."""
         call_count = [0]
         created_coroutines = []
 

--- a/lib/tests/streamlit/runtime/caching/common_cache_test.py
+++ b/lib/tests/streamlit/runtime/caching/common_cache_test.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import threading
 import time
 import unittest
@@ -40,6 +41,7 @@ from streamlit.runtime.caching import (
     clear_session_resource_cache,
 )
 from streamlit.runtime.caching.cache_errors import (
+    CachedFunctionReturnedAwaitableError,
     CachedStFunctionInBackgroundModeWarning,
     CacheReplayClosureError,
 )
@@ -1397,6 +1399,48 @@ class CommonCacheBackgroundRefreshTest(DeltaGeneratorTestCase):
         timer_patch.return_value = _BG_TTL * 1.5
         assert foo() == 2
         assert call_count[0] == 2
+
+    @parameterized.expand(
+        [("cache_data", cache_data), ("cache_resource", cache_resource)]
+    )
+    @patch("streamlit.runtime.caching.cache_utils.TTLCACHE_TIMER")
+    def test_background_refresh_rejects_awaitable(
+        self, _, cache_decorator, timer_patch: Mock
+    ):
+        """An invalid refresh result is closed and never replaces the stale value."""
+        call_count = [0]
+        created_coroutines = []
+
+        async def operation() -> int:
+            return 42
+
+        @cache_decorator(ttl=_BG_TTL, refresh_mode="background", show_spinner=False)
+        def foo() -> Any:
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return 1
+            coroutine = operation()
+            created_coroutines.append(coroutine)
+            return coroutine
+
+        timer_patch.return_value = 0
+        assert foo() == 1
+
+        with (
+            self._patch_sync_submit(),
+            patch.object(_LOGGER, "warning") as warning_mock,
+        ):
+            timer_patch.return_value = _BG_TTL * 1.5
+            assert foo() == 1
+
+        assert call_count[0] == 2
+        assert len(created_coroutines) == 1
+        assert inspect.getcoroutinestate(created_coroutines[0]) == inspect.CORO_CLOSED
+        assert isinstance(
+            warning_mock.call_args.args[2], CachedFunctionReturnedAwaitableError
+        )
+        timer_patch.return_value = _BG_TTL * 1.5
+        assert foo() == 1
 
     @parameterized.expand(
         [("cache_data", cache_data), ("cache_resource", cache_resource)]

--- a/lib/tests/streamlit/runtime/caching/common_cache_test.py
+++ b/lib/tests/streamlit/runtime/caching/common_cache_test.py
@@ -1441,6 +1441,7 @@ class CommonCacheBackgroundRefreshTest(DeltaGeneratorTestCase):
         )
         timer_patch.return_value = _BG_TTL * 1.5
         assert foo() == 1
+        assert call_count[0] == 2
 
     @parameterized.expand(
         [("cache_data", cache_data), ("cache_resource", cache_resource)]


### PR DESCRIPTION
## Describe your changes

Rejects awaitable values returned by synchronous `st.cache_data` and `st.cache_resource` functions before serialization or storage, replacing misleading serialization and coroutine-reuse failures with guidance to return completed, non-awaitable values.

- Close unstarted native coroutines before raising so Python does not warn that they were never awaited. Leave started coroutines, Tasks, Futures, and custom awaitables untouched.
- Applies the validation to foreground misses and background refreshes so one-shot async objects never enter either cache.

The check uses `inspect.isawaitable()`, so `st.cache_resource` also rejects non-coroutine objects that implement `__await__` (for example, an initialized async pool). Caching event-loop-bound objects is already documented as unsupported in #16801; this makes the failure explicit instead of deferred.

## GitHub Issue Link (if applicable)

- Not applicable

## Testing Plan

- `lib/tests/streamlit/runtime/caching/async_cache_test.py` — covers both decorators, error guidance, cache misses after rejection, coroutine cleanup, and non-mutation of other awaitables.
- `lib/tests/streamlit/runtime/caching/common_cache_test.py` — verifies invalid background refresh values never replace stale entries and that failed refreshes enter cooldown.
- [x] Unit Tests (JS and/or Python)
- [ ] E2E Tests — not needed for backend cache validation.
- [ ] Manual testing needed

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.

Made with [Cursor](https://cursor.com)